### PR TITLE
feat(web): expand /benchmarks into flagship methodology hub (#990)

### DIFF
--- a/web/src/app/benchmarks/benchmarks-metadata.test.ts
+++ b/web/src/app/benchmarks/benchmarks-metadata.test.ts
@@ -4,7 +4,6 @@ import { generateMetadata as benchmarksIndexMetadata } from "./page";
 import { generateMetadata } from "./[slug]/page";
 
 const getReportBySlugMock = vi.hoisted(() => vi.fn());
-const hasPublishedBenchmarksMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@workos-inc/authkit-nextjs", () => ({
   withAuth: vi.fn(),
@@ -18,7 +17,6 @@ vi.mock("@/lib/benchmarks", () => ({
   getAllReports: vi.fn(() => []),
   getAllSlugs: vi.fn(() => []),
   getReportBySlug: getReportBySlugMock,
-  hasPublishedBenchmarks: hasPublishedBenchmarksMock,
 }));
 
 describe("benchmarks RSS autodiscovery metadata", () => {
@@ -67,17 +65,8 @@ describe("benchmarks index social metadata", () => {
   });
 });
 
-describe("benchmarks index indexability (coming-soon gate)", () => {
-  it("noindexes the index while no real benchmark is published", () => {
-    hasPublishedBenchmarksMock.mockReturnValueOnce(false);
-    expect(benchmarksIndexMetadata().robots).toEqual({
-      index: false,
-      follow: true,
-    });
-  });
-
-  it("leaves the index indexable once a real benchmark ships", () => {
-    hasPublishedBenchmarksMock.mockReturnValueOnce(true);
+describe("benchmarks index indexability", () => {
+  it("leaves the hub indexable as a methodology landing page", () => {
     expect(benchmarksIndexMetadata().robots).toBeUndefined();
   });
 });

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -1,22 +1,22 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
-import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
-import { JsonLd, benchmarkIndexSchema } from "@/components/marketing/json-ld";
-import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
+import { BenchmarksHubContent } from "@/components/marketing/benchmarks/benchmarks-hub-content";
+import { JsonLd, benchmarkHubSchema } from "@/components/marketing/json-ld";
+import { getAllReports } from "@/lib/benchmarks";
+import { BENCHMARKS_HUB_FAQ } from "@/lib/benchmarks-hub";
 import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
 
-const PAGE_TITLE = "AI Agent Benchmarks - Models Raced Head-to-Head | AgentClash";
+const PAGE_TITLE = "AI Agent Benchmarks Hub | Head-to-Head Races | AgentClash";
 const PAGE_DESCRIPTION =
-  "Head-to-head AI agent benchmarks: every major model launch raced against the field on real agentic tasks, scored on correctness, reliability, latency, and cost.";
+  "Public AI agent benchmarks hub: frozen challenge packs, head-to-head races, replay evidence, scorecards, and monthly reports. Run the same benchmark on your agents.";
 const SOCIAL_IMAGE = ogImageUrl({
   title: "AI Agent Benchmarks",
-  subtitle: "New models raced against the field on real agentic tasks",
+  subtitle: "Frozen packs, head-to-head races, replay evidence",
   kind: "Benchmark",
 });
 
 export function generateMetadata(): Metadata {
-  const metadata: Metadata = {
+  return {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,
     alternates: {
@@ -39,111 +39,26 @@ export function generateMetadata(): Metadata {
       images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
     },
   };
-
-  // Until a real race ships, the page shows a "coming soon" state — keep it
-  // crawlable (so engines actually read the noindex) but out of the index, the
-  // same way individual `sample` reports are handled. Indexability returns
-  // automatically when the first measured benchmark is published.
-  if (!hasPublishedBenchmarks()) {
-    metadata.robots = { index: false, follow: true };
-  }
-
-  return metadata;
 }
 
 export default function BenchmarksPage() {
   const reports = getAllReports();
-  // `sample` reports are illustrative only — never list them publicly. With no
-  // real report yet, the section shows a "coming soon" state instead.
   const published = reports.filter((report) => !report.sample);
-
-  if (published.length === 0) {
-    return (
-      <MarketingShell>
-        <section className="mx-auto w-full max-w-3xl px-6 py-16">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
-            Benchmarks
-          </p>
-          <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
-            Models, raced head-to-head
-          </h1>
-          <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/45">
-            When a new model ships, we race it against the field on real agentic
-            tasks — same challenge, same tools — and score the whole trajectory
-            on correctness, reliability, latency, and cost.
-          </p>
-
-          <ResearchAudienceCTA
-            className="mt-8"
-            headline="Want this benchmark on your agents?"
-            body="Book an eval workshop and we'll reproduce the race on your workloads with the same challenge pack, tools, and scorecard."
-          />
-
-          <div className="mt-10 rounded-lg border border-white/[0.08] bg-white/[0.03] px-6 py-8">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
-              Coming soon
-            </p>
-            <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/55">
-              We&apos;re lining up the first head-to-head. The opening race drops
-              soon — real models on real agentic tasks, with the full scorecard
-              and replay. Check back shortly.
-            </p>
-          </div>
-        </section>
-      </MarketingShell>
-    );
-  }
 
   return (
     <MarketingShell>
       <JsonLd
-        id="agentclash-benchmarks-index-schema"
-        data={benchmarkIndexSchema(published)}
+        id="agentclash-benchmarks-hub-schema"
+        data={benchmarkHubSchema(
+          published.map((report) => ({
+            slug: report.slug,
+            title: report.title,
+            description: report.description,
+          })),
+          [...BENCHMARKS_HUB_FAQ],
+        )}
       />
-      <section className="mx-auto w-full max-w-3xl px-6 py-16">
-        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
-          Benchmarks
-        </p>
-        <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
-          Models, raced head-to-head
-        </h1>
-        <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/45">
-          When a new model ships, we race it against the field on real agentic
-          tasks — same challenge, same tools — and score the whole trajectory on
-          correctness, reliability, latency, and cost. Here is who won.
-        </p>
-
-        <ResearchAudienceCTA
-          className="mt-8"
-          headline="Want this benchmark on your agents?"
-          body="Book an eval workshop and we'll reproduce the race on your workloads with the same challenge pack, tools, and scorecard."
-        />
-
-        <div className="mt-10 flex flex-col gap-3">
-          {reports.map((report) => (
-            <Link
-              key={report.slug}
-              href={`/benchmarks/${report.slug}`}
-              className="group flex flex-col gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
-            >
-              <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
-                {report.date} &middot; {report.featuredModel}
-                {report.sample && (
-                  <span className="ml-2 rounded-full border border-amber-400/25 bg-amber-400/[0.06] px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em] text-amber-200/80">
-                    Sample
-                  </span>
-                )}
-              </span>
-              <span className="text-base font-medium text-white group-hover:text-white/90">
-                {report.title}
-              </span>
-              <span className="text-xs leading-relaxed text-white/40">
-                {report.verdict}
-              </span>
-            </Link>
-          ))}
-        </div>
-      </section>
+      <BenchmarksHubContent published={published} />
     </MarketingShell>
   );
 }

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -1391,12 +1391,8 @@ const LANDING_FEATURES: Array<{
 // shared with the /compare pages so the matrix never drifts between surfaces.
 
 export default function HomePage({
-  showBenchmarks = false,
   returning = false,
 }: {
-  // Gated by the server page off `hasPublishedBenchmarks()`: hide the Benchmarks
-  // nav link while the section is in its coming-soon state.
-  showBenchmarks?: boolean;
   returning?: boolean;
 }) {
   const { user, loading: authLoading } = useAuth();
@@ -1461,14 +1457,12 @@ export default function HomePage({
             >
               Docs
             </Link>
-            {showBenchmarks && (
-              <Link
-                href="/benchmarks"
-                className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
-              >
-                Benchmarks
-              </Link>
-            )}
+            <Link
+              href="/benchmarks"
+              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Benchmarks
+            </Link>
             <Link
               href="/blog"
               className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -10,7 +10,6 @@ import {
   softwareSourceCodeSchema,
   websiteSchema,
 } from "@/components/marketing/json-ld";
-import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { getChangelogPeriods } from "@/lib/changelog";
 import { HOME_FAQ } from "@/lib/home-faq";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
@@ -64,7 +63,7 @@ export default async function RootPage() {
           faqSchema(HOME_FAQ),
         ]}
       />
-      <HomePage showBenchmarks={hasPublishedBenchmarks()} returning={returning} />
+      <HomePage returning={returning} />
     </>
   );
 }

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { getChangelogLatestModified, getChangelogPeriods } from "@/lib/changelog";
 import sitemap from "./sitemap";
 
@@ -46,9 +45,6 @@ vi.mock("@/lib/benchmarks", () => ({
       sample: false,
     },
   ]),
-  // Two of the mocked reports are non-sample, so the section is "live" and the
-  // /benchmarks index belongs in the sitemap.
-  hasPublishedBenchmarks: vi.fn(() => true),
 }));
 
 describe("sitemap", () => {
@@ -173,7 +169,7 @@ describe("sitemap", () => {
     });
   });
 
-  it("includes the benchmarks index and per-report pages", () => {
+  it("always includes the benchmarks hub index", () => {
     const entries = sitemap();
     const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
 
@@ -183,6 +179,11 @@ describe("sitemap", () => {
       changeFrequency: "weekly",
       priority: 0.8,
     });
+  });
+
+  it("includes per-report pages when measured reports exist", () => {
+    const entries = sitemap();
+    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
     const report = byUrl.get(
       "https://www.agentclash.dev/benchmarks/claude-opus-4-8-vs-the-field",
     );
@@ -194,14 +195,6 @@ describe("sitemap", () => {
     const image = report?.images?.[0] ?? "";
     expect(image.startsWith("https://www.agentclash.dev/og?")).toBe(true);
     expect(image).toContain("kind=Benchmark");
-  });
-
-  it("omits the benchmarks index while the section is coming-soon", () => {
-    vi.mocked(hasPublishedBenchmarks).mockReturnValueOnce(false);
-    const entries = sitemap();
-    const urls = new Set(entries.map((entry) => entry.url));
-
-    expect(urls.has("https://www.agentclash.dev/benchmarks")).toBe(false);
   });
 
   it("includes the comparison hub and per-competitor pages", () => {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
-import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
+import { getAllReports } from "@/lib/benchmarks";
 import {
   getChangelogLatestModified,
   getChangelogPeriodHref,
@@ -57,10 +57,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ogImage({ title: post.title, subtitle: post.description, kind: "Blog" }),
     ],
   }));
-  // Exclude `sample` reports (illustrative numbers) so search engines never
-  // index fabricated data. Guard the date: a report whose `date` does not parse
-  // would become an Invalid Date and make Next's serializer throw on
-  // .toISOString(), taking down the entire sitemap.xml.
+  // Only list measured reports in the sitemap. Sample reports stay reachable but
+  // out of the index; guard dates so Invalid Date cannot take down sitemap.xml.
   const benchmarks = getAllReports()
     .filter((report) => !report.sample)
     .map((report) => {
@@ -79,27 +77,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
         ],
       };
     });
-  // Only list the /benchmarks index while a real report is published. With just
-  // illustrative `sample` reports, the page is a noindexed "coming soon" state,
-  // and a sitemap must never advertise a noindexed URL (Search Console flags it).
-  const benchmarkIndex = hasPublishedBenchmarks()
-    ? [
-        {
-          url: `${DOCS_ORIGIN}/benchmarks`,
-          lastModified: new Date(),
-          changeFrequency: "weekly" as const,
-          priority: 0.8,
-          images: [
-            ogImage({
-              title: "AI Agent Benchmarks",
-              subtitle:
-                "New models raced against the field on real agentic tasks",
-              kind: "Benchmark",
-            }),
-          ],
-        },
-      ]
-    : [];
+  const benchmarkIndex = [
+    {
+      url: `${DOCS_ORIGIN}/benchmarks`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+      images: [
+        ogImage({
+          title: "AI Agent Benchmarks",
+          subtitle: "Frozen packs, head-to-head races, replay evidence",
+          kind: "Benchmark",
+        }),
+      ],
+    },
+  ];
   const docs = getAllDocPaths().map((docPath) => ({
     url: `${DOCS_ORIGIN}${docPath}`,
     lastModified: new Date(),

--- a/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
+++ b/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
@@ -1,0 +1,296 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
+import { BenchmarkScoreboard } from "@/components/marketing/benchmark-scoreboard";
+import { BenchmarkRunCTA } from "@/components/marketing/research-audience-cta";
+import type { BenchmarkReport } from "@/lib/benchmarks";
+import {
+  BENCHMARKS_CHILD_PAGES,
+  BENCHMARKS_METHODOLOGY,
+  BENCHMARKS_MONTHLY_PROCESS,
+  BENCHMARKS_PACK_LINKS,
+  BENCHMARKS_READING,
+} from "@/lib/benchmarks-hub";
+
+type Props = {
+  published: BenchmarkReport[];
+};
+
+function SectionEyebrow({ children }: { children: ReactNode }) {
+  return (
+    <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+      {children}
+    </p>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="mt-3 text-xl font-semibold tracking-tight text-white sm:text-2xl">
+      {children}
+    </h2>
+  );
+}
+
+function LinkCard({
+  href,
+  title,
+  text,
+  external,
+}: {
+  href: string;
+  title: string;
+  text: string;
+  external?: boolean;
+}) {
+  const className =
+    "group flex flex-col gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15";
+
+  const content = (
+    <>
+      <span className="inline-flex items-center gap-1 text-sm font-medium text-white group-hover:text-white/90">
+        {title}
+        {external ? (
+          <ArrowUpRight className="size-3.5 text-white/35" />
+        ) : (
+          <ArrowRight className="size-3.5 text-white/35 transition-transform group-hover:translate-x-0.5" />
+        )}
+      </span>
+      <span className="text-xs leading-relaxed text-white/40">{text}</span>
+    </>
+  );
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={className}>
+      {content}
+    </Link>
+  );
+}
+
+export function BenchmarksHubContent({ published }: Props) {
+  const latest = published[0];
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-16">
+      <SectionEyebrow>Benchmarks</SectionEyebrow>
+      <h1 className="mt-3 text-3xl font-semibold tracking-tight leading-[1.15] text-white sm:text-4xl">
+        Head-to-head AI agent benchmarks you can reproduce
+      </h1>
+      <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/50 sm:text-base">
+        Public races on frozen challenge packs: same tools, same constraints,
+        full trajectory scoring, and replay evidence. Not a vibes leaderboard.
+        Run the same benchmark on your agents when you are ready to gate releases.
+      </p>
+
+      <BenchmarkRunCTA className="mt-8" />
+
+      {latest ? (
+        <section className="mt-14" aria-labelledby="latest-report-heading">
+          <SectionEyebrow>Latest report</SectionEyebrow>
+          <SectionTitle>
+            <span id="latest-report-heading">{latest.title}</span>
+          </SectionTitle>
+          <p className="mt-3 text-sm leading-relaxed text-white/50">
+            {latest.verdict}
+          </p>
+          <p className="mt-2 font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+            {latest.date}
+            {latest.challengePack ? ` · ${latest.challengePack}` : ""}
+            {latest.featuredModel ? ` · ${latest.featuredModel}` : ""}
+          </p>
+
+          {latest.results.length > 0 && (
+            <div className="mt-6">
+              <BenchmarkScoreboard
+                results={latest.results}
+                featuredModel={latest.featuredModel}
+              />
+            </div>
+          )}
+
+          <Link
+            href={`/benchmarks/${latest.slug}`}
+            className="mt-4 inline-flex items-center gap-1.5 text-sm text-white/70 transition-colors hover:text-white"
+          >
+            Read the full report
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </section>
+      ) : (
+        <section className="mt-14" aria-labelledby="monthly-process-heading">
+          <SectionEyebrow>Monthly reports</SectionEyebrow>
+          <SectionTitle>
+            <span id="monthly-process-heading">How we publish benchmark reports</span>
+          </SectionTitle>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/50">
+            The first measured head-to-head is in progress. When it ships, this
+            hub will summarize winners, scorecards, and replay links. Until then,
+            here is the process we follow for every public race and monthly
+            reliability report.
+          </p>
+          <ol className="mt-6 flex flex-col gap-3">
+            {BENCHMARKS_MONTHLY_PROCESS.map((step, index) => (
+              <li
+                key={step}
+                className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
+              >
+                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="text-sm leading-relaxed text-white/55">
+                  {step}
+                </span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-4 text-xs text-white/35">
+            Subscribe via{" "}
+            <Link
+              href="/benchmarks/feed.xml"
+              className="text-white/55 underline-offset-2 hover:text-white/75 hover:underline"
+            >
+              benchmarks RSS
+            </Link>{" "}
+            for new reports.
+          </p>
+        </section>
+      )}
+
+      <section className="mt-14" aria-labelledby="methodology-heading">
+        <SectionEyebrow>Methodology</SectionEyebrow>
+        <SectionTitle>
+          <span id="methodology-heading">Races, not leaderboard snapshots</span>
+        </SectionTitle>
+        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/50">
+          Static leaderboards hide setup drift. AgentClash benchmarks are
+          head-to-head races on pinned packs so you can compare models, replay
+          evidence, and promote the same workload to a CI gate.
+        </p>
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          {BENCHMARKS_METHODOLOGY.map((item) => (
+            <div
+              key={item.title}
+              className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-4"
+            >
+              <h3 className="text-sm font-medium text-white/90">{item.title}</h3>
+              <p className="mt-2 text-xs leading-relaxed text-white/45">
+                {item.text}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {latest && (
+        <section className="mt-14" aria-labelledby="monthly-cadence-heading">
+          <SectionEyebrow>Monthly cadence</SectionEyebrow>
+          <SectionTitle>
+            <span id="monthly-cadence-heading">How reports stay reproducible</span>
+          </SectionTitle>
+          <ol className="mt-6 flex flex-col gap-3">
+            {BENCHMARKS_MONTHLY_PROCESS.map((step, index) => (
+              <li
+                key={step}
+                className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
+              >
+                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="text-sm leading-relaxed text-white/55">
+                  {step}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      <section className="mt-14" aria-labelledby="child-benchmarks-heading">
+        <SectionEyebrow>Go deeper</SectionEyebrow>
+        <SectionTitle>
+          <span id="child-benchmarks-heading">Benchmark pages for your team</span>
+        </SectionTitle>
+        <div className="mt-6 flex flex-col gap-3">
+          {BENCHMARKS_CHILD_PAGES.map((page) => (
+            <LinkCard key={page.href} {...page} />
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14" aria-labelledby="packs-heading">
+        <SectionEyebrow>Challenge packs</SectionEyebrow>
+        <SectionTitle>
+          <span id="packs-heading">Reproduce the workload</span>
+        </SectionTitle>
+        <div className="mt-6 flex flex-col gap-3">
+          {BENCHMARKS_PACK_LINKS.map((link) => (
+            <LinkCard key={link.href} {...link} />
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14" aria-labelledby="reading-heading">
+        <SectionEyebrow>Further reading</SectionEyebrow>
+        <SectionTitle>
+          <span id="reading-heading">Blog posts on benchmarking agents</span>
+        </SectionTitle>
+        <ul className="mt-6 flex flex-col gap-2">
+          {BENCHMARKS_READING.map((post) => (
+            <li key={post.href}>
+              <Link
+                href={post.href}
+                className="inline-flex items-center gap-1.5 text-sm text-white/60 transition-colors hover:text-white/85"
+              >
+                {post.title}
+                <ArrowRight className="size-3.5 text-white/30" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {published.length > 0 && (
+        <section className="mt-14" aria-labelledby="all-reports-heading">
+          <SectionEyebrow>All reports</SectionEyebrow>
+          <SectionTitle>
+            <span id="all-reports-heading">Every head-to-head we have published</span>
+          </SectionTitle>
+          <div className="mt-6 flex flex-col gap-3">
+            {published.map((report) => (
+              <Link
+                key={report.slug}
+                href={`/benchmarks/${report.slug}`}
+                className="group flex flex-col gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
+              >
+                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+                  {report.date} · {report.featuredModel}
+                </span>
+                <span className="text-base font-medium text-white group-hover:text-white/90">
+                  {report.title}
+                </span>
+                <span className="text-xs leading-relaxed text-white/40">
+                  {report.verdict}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <BenchmarkRunCTA className="mt-14" />
+    </div>
+  );
+}

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -409,6 +409,13 @@ type BenchmarkIndexReport = {
 export function benchmarkIndexSchema(
   reports: BenchmarkIndexReport[],
 ): Record<string, unknown>[] {
+  return benchmarkHubSchema(reports);
+}
+
+export function benchmarkHubSchema(
+  reports: BenchmarkIndexReport[],
+  faqItems: Array<{ question: string; answer: string }> = [],
+): Record<string, unknown>[] {
   const pageUrl = `${SITE_URL}/benchmarks`;
   const items = reports.map((report) => ({
     url: `${SITE_URL}/benchmarks/${report.slug}`,
@@ -416,7 +423,7 @@ export function benchmarkIndexSchema(
     description: report.description,
   }));
 
-  return [
+  const schemas: Record<string, unknown>[] = [
     breadcrumbSchema([
       { name: "Home", url: "/" },
       { name: "Benchmarks", url: "/benchmarks" },
@@ -424,9 +431,9 @@ export function benchmarkIndexSchema(
     {
       "@context": "https://schema.org",
       "@type": "CollectionPage",
-      name: "AgentClash Model Benchmarks",
+      name: "AgentClash AI Agent Benchmarks",
       description:
-        "Head-to-head AI agent benchmarks — new models raced against the field on real agentic tasks with deterministic, behavioral, and cost scoring.",
+        "Public AI agent benchmarks hub with frozen challenge packs, head-to-head races, replay evidence, scorecards, and monthly reports.",
       url: pageUrl,
       isPartOf: {
         "@type": "WebSite",
@@ -435,7 +442,14 @@ export function benchmarkIndexSchema(
       },
       publisher: publisherSchema(),
     },
-    {
+  ];
+
+  if (faqItems.length > 0) {
+    schemas.push(faqSchema(faqItems));
+  }
+
+  if (items.length > 0) {
+    schemas.push({
       "@context": "https://schema.org",
       "@type": "ItemList",
       name: "AgentClash Model Benchmarks",
@@ -449,8 +463,10 @@ export function benchmarkIndexSchema(
         url: item.url,
         item: { "@id": item.url },
       })),
-    },
-  ];
+    });
+  }
+
+  return schemas;
 }
 
 type ChangelogIndexPeriod = {

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 
 const COLUMNS: Array<{
   heading: string;
@@ -43,20 +42,11 @@ const COLUMNS: Array<{
 ];
 
 export function MarketingFooter() {
-  // Drop the Benchmarks link while the section is in its coming-soon state; it
-  // returns automatically once a real report is published.
-  const columns = hasPublishedBenchmarks()
-    ? COLUMNS
-    : COLUMNS.map((col) => ({
-        ...col,
-        links: col.links.filter((link) => link.href !== "/benchmarks"),
-      }));
-
   return (
     <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 pt-20 pb-10">
       <div className="mx-auto max-w-[1440px]">
         <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
-          {columns.map((col) => (
+          {COLUMNS.map((col) => (
             <div key={col.heading}>
               <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
                 {col.heading}

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { ArrowRight, Star } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isReturningVisitor } from "@/lib/auth/returning";
-import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { AuthCtaLink } from "./auth-cta-link";
 import { ClashMark } from "./clash-mark";
 
@@ -24,11 +23,6 @@ type Props = {
 export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
   const { user } = await withAuth();
   const returning = await isReturningVisitor();
-  // Hide Benchmarks until a real report ships (coming-soon state) so we never
-  // funnel visitors to a placeholder; it reappears automatically once live.
-  const visibleNav = hasPublishedBenchmarks()
-    ? nav
-    : nav.filter((item) => item.href !== "/benchmarks");
 
   return (
     <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
@@ -43,7 +37,7 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
           </span>
         </Link>
         <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
-          {visibleNav.map((item) =>
+          {nav.map((item) =>
             item.external ? (
               <a
                 key={item.href}

--- a/web/src/lib/benchmarks-hub.ts
+++ b/web/src/lib/benchmarks-hub.ts
@@ -1,0 +1,108 @@
+export const BENCHMARKS_HUB_FAQ = [
+  {
+    question: "How is AgentClash different from a static leaderboard?",
+    answer:
+      "Leaderboards summarize one-off scores on generic tasks. AgentClash runs head-to-head races on frozen challenge packs with the same tools, sandbox policy, and iteration budget, then publishes replay evidence and scorecards you can reuse as regression gates.",
+  },
+  {
+    question: "What gets frozen in a public benchmark?",
+    answer:
+      "The challenge pack version, runtime constraints, tool policy, scoring spec, and input cases. Every model in a race sees the same workload so differences show up in trajectories, not setup drift.",
+  },
+  {
+    question: "Can we run the same benchmark on our agents?",
+    answer:
+      "Yes. Book an eval workshop or start a Team pilot. We pin the same pack on your workloads, baseline your current agent, and deliver scorecards and CI gates your platform team can ship on.",
+  },
+  {
+    question: "How often do you publish benchmark reports?",
+    answer:
+      "We publish when major models ship and on a monthly reliability cadence. Subscribe to the benchmarks RSS feed or check this hub for the latest head-to-head summary and links to full replays.",
+  },
+] as const;
+
+export const BENCHMARKS_METHODOLOGY = [
+  {
+    title: "Frozen challenge pack",
+    text: "Each race pins a versioned YAML pack: prompts, tools, sandbox, evaluation spec, and input cases. No moving targets mid-benchmark.",
+  },
+  {
+    title: "Same runtime constraints",
+    text: "Every candidate gets the same sandbox, tool policy, network rules, and iteration budget so comparisons stay fair.",
+  },
+  {
+    title: "Baseline vs candidate",
+    text: "Enterprise teams reuse the same packs to compare a ship candidate against a known baseline and fail CI when scorecards regress.",
+  },
+  {
+    title: "Scorecard dimensions",
+    text: "Composite scores fold in correctness, reliability, latency, cost, behavioral signals, and judge evidence from the full trajectory.",
+  },
+  {
+    title: "Replay and evidence",
+    text: "Runs preserve tool calls, artifacts, and judge rationale so reviewers can audit a verdict without rerunning the race.",
+  },
+  {
+    title: "Gate verdict",
+    text: "The same workload can power a public benchmark today and a release gate tomorrow once your team trusts the scoring rules.",
+  },
+] as const;
+
+export const BENCHMARKS_CHILD_PAGES = [
+  {
+    href: "/ai-agent-benchmark",
+    title: "AI agent benchmark",
+    text: "Benchmark agents on workloads your team owns, with replay and scorecards instead of leaderboard-only snapshots.",
+  },
+  {
+    href: "/agent-reliability-benchmark",
+    title: "Agent reliability benchmark",
+    text: "Track pass rates, cost drift, and promoted failures with repeatable packs and CI regression gates.",
+  },
+] as const;
+
+export const BENCHMARKS_READING = [
+  {
+    href: "/blog/benchmark-ai-agents-on-your-own-data",
+    title: "Benchmark AI agents on your own data",
+  },
+  {
+    href: "/blog/how-agentclash-scores-agent-trajectories",
+    title: "How AgentClash scores agent trajectories",
+  },
+  {
+    href: "/blog/pass-k-reliability-enterprise-teams",
+    title: "Pass@k reliability for enterprise teams",
+  },
+  {
+    href: "/blog/why-agentclash-races-agents-head-to-head",
+    title: "Why AgentClash races agents head-to-head",
+  },
+] as const;
+
+export const BENCHMARKS_PACK_LINKS = [
+  {
+    href: "/docs/challenge-packs",
+    title: "Challenge pack reference",
+    text: "Author versioned YAML packs with scoring, tools, sandbox policy, and eval workflows.",
+  },
+  {
+    href: "/docs/challenge-packs/eval-workflows-and-gates",
+    title: "Eval workflows and gates",
+    text: "Wire baseline versus candidate comparisons into CI release policy.",
+  },
+  {
+    href: "https://github.com/agentclash/agentclash/tree/main/examples/challenge-packs",
+    title: "Example packs in the repo",
+    text: "Start from expression evaluators, refund recovery, incident response, and security stress packs.",
+    external: true,
+  },
+] as const;
+
+export const BENCHMARKS_MONTHLY_PROCESS = [
+  "Pin a challenge pack version and publish the runtime constraints up front.",
+  "Race every candidate on the same pack with identical tools, sandbox, and budgets.",
+  "Score the full trajectory across correctness, reliability, latency, cost, and judge evidence.",
+  "Attach replay links and artifact references reviewers can audit without rerunning.",
+  "Summarize winners, regressions, and gate verdicts on this hub and in the RSS feed.",
+] as const;


### PR DESCRIPTION
## Summary
- Rebuild `/benchmarks` as a flagship process hub: methodology (frozen packs, same constraints, baseline vs candidate, scorecards, replay, gates), monthly report cadence, latest report summary with scoreboard, and cross-links to child SEO pages, docs, example packs, and blog posts.
- Add `BenchmarkRunCTA` ("Run on your agents") with demo + `/enterprise` on the hub.
- Always expose `/benchmarks` in nav, footer, homepage, sitemap, and indexable metadata with FAQ + CollectionPage JSON-LD (ItemList when reports exist).

## Test plan
- [x] `pnpm exec vitest run src/app/benchmarks/benchmarks-metadata.test.ts src/app/sitemap.test.ts src/app/public-canonical-metadata.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [ ] Spot-check `/benchmarks` locally: methodology sections, latest GPT generations report, child links, CTAs

Closes #990