### PR TITLE
feat(web): monthly public benchmark report process (#992)

### DIFF
--- a/docs/marketing/model-benchmark-workflow.md
+++ b/docs/marketing/model-benchmark-workflow.md
@@ -1,28 +1,55 @@
-# Model Benchmark Workflow (Race Report Runbook)
+# Model Benchmark Workflow (Monthly Public Report Runbook)
 
-This is the repeatable process for turning an AgentClash race into a published
-benchmark report on the marketing site. Run it **every time a major model
-launches** (≈ monthly) to ride the launch-week attention.
+Repeatable process for turning an AgentClash race into a **monthly public benchmark**:
+a measured report on `/benchmarks/<slug>`, a shareable blog summary, and a changelog
+entry. Run it when major models ship and on a **monthly reliability cadence**.
 
-The published surface is `/benchmarks` (index) and `/benchmarks/<slug>` (report),
-backed by MDX files in `web/content/benchmarks/`. There are no backend changes —
-a report is a content file with a structured scoreboard in its frontmatter plus a
-narrative body.
+Reference implementation: [Coding agent benchmark — June 2026](https://www.agentclash.dev/blog/coding-agent-benchmark-june-2026) and the [full scoreboard](https://www.agentclash.dev/benchmarks/gpt-generations-expression-evaluator).
 
-## Why this exists
+## Roles and cadence
 
-AgentClash already produces the asset the AI ecosystem shares: head-to-head agent
-races on real tasks with defensible scoring. A "We raced **\<new model\>** against
-the field on 5 real agentic tasks — here's who won" post is high-signal, evergreen,
-and SEO-friendly. The workflow below makes producing one fast and consistent.
+| Role | Responsibility |
+| ---- | ---------------- |
+| **Monthly owner** | Picks the pack, runs the race, exports ranking JSON, drafts MDX + blog |
+| **Review approver** | Verifies numbers against replay, checks caveats and sample size honesty |
+| **Distribution** | Posts share URL to X / HN / LinkedIn on publish day; pings benchmarks RSS |
+
+**Target window:** publish by the **second week** of each month (or within 48h of a major model launch if that falls mid-month).
+
+**Checklist (copy each cycle):**
+
+- [ ] Pin challenge pack version **and** git commit SHA in the report appendix
+- [ ] Race every candidate on the same pack (tools, sandbox, budgets)
+- [ ] Export ranking JSON and attach replay / validator evidence per lane
+- [ ] Set `sample: false` only when numbers are measured
+- [ ] Write narrative + methodology appendix; add monthly blog summary
+- [ ] Link from `/benchmarks` hub and add changelog entry for the period
+- [ ] Promote meaningful failures into pack coverage or regression suites
+- [ ] Run web verification (`tsc`, `lint`, `test`, spot-check OG cards)
+
+## Public fixtures to use
+
+Start from versioned packs in `examples/challenge-packs/`. The first published report uses:
+
+| Pack | Path | Why |
+| ---- | ---- | --- |
+| Expression Evaluator Arena v1 | `examples/challenge-packs/expr-eval-arena.yaml` | Real coding task with hidden tiers; separates efficiency and contract adherence |
+
+Other packs suitable for future months (rotate or expand field size):
+
+- `multi-turn-refund-recovery.yaml` (multi-turn reliability)
+- `incident-response-*.yaml` (ops / tool use)
+- Security and eval-awareness packs as they stabilize
+
+Record in every report:
+
+- `pack.slug`, `evaluation_spec.name`, execution mode, tool policy, runtime limits
+- Git commit SHA of the repo when the race ran
 
 ## One-time setup
 
-- A workspace on the hosted backend with a challenge pack of **real agentic tasks**
-  (not trivia). The seed report uses five: an auth bug fix, a p99 latency hunt, a
-  flaky-test triage, a safe schema migration, and a log-driven incident RCA.
-- The `agentclash` CLI pointed at the hosted backend (see the repo `CLAUDE.md`,
-  "CLI Against Hosted Backend"):
+- Workspace on the hosted backend with the chosen challenge pack imported
+- CLI pointed at production (see repo `CLAUDE.md`, "CLI Against Hosted Backend"):
 
   ```bash
   export AGENTCLASH_API_URL="https://api.agentclash.dev"
@@ -30,100 +57,122 @@ and SEO-friendly. The workflow below makes producing one fast and consistent.
   go run . workspace use <workspace-id>
   ```
 
-## Per-launch steps
+## Per-report steps
 
 ### 1. Run the race
 
-Create a run with the model lineup (the new model plus the current field) on the
-challenge pack and follow it to completion:
-
 ```bash
 cd cli
-go run . run create --follow   # pick the pack + the models when prompted
+go run . run create --follow   # pick pack + model lineup
 ```
 
-Note the **run ID** when it finishes.
+Note the **run ID** when it finishes. Every lane must use the same pack version and deployment policy.
 
 ### 2. Export the ranking JSON
 
-Fetch the run's ranking (the scoreboard the backend computes — see
-`backend/internal/api/run_ranking.go`). Either save the CLI/API output to a file
-or pipe it straight into the scaffold:
+The scoreboard comes from the run ranking API (`backend/internal/api/run_ranking.go`).
 
 ```bash
-# via the API directly:
+# CLI (preferred):
+go run . run ranking <run-id> --json > ranking.json
+
+# or HTTP:
 curl -s -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
   "$AGENTCLASH_API_URL/workspaces/$AGENTCLASH_WORKSPACE/runs/<run-id>/ranking" \
   > ranking.json
 ```
 
-The scaffold accepts either the full response (`{ state, ranking: {...} }`) or the
-bare `ranking` payload.
+The scaffold accepts either the full response (`{ state, ranking: {...} }`) or the bare `ranking` payload.
 
-### 3. Scaffold the report
+**Required fields per report:** rank, composite, correctness, reliability, latency, cost, cost per correct (when available), winner flag, provider (confirm manually).
+
+### 3. Scaffold the benchmark MDX
 
 ```bash
 node scripts/benchmarks/scaffold.mjs \
   --ranking ranking.json \
-  --title "We raced <Model> against the field on 5 real agentic tasks" \
+  --title "We raced <Model> on <task headline>" \
   --model "<Model>" \
-  --slug <model>-vs-the-field \
+  --slug <kebab-slug> \
   --share-url "https://www.agentclash.dev/share/<token>"   # optional
 ```
 
-This writes `web/content/benchmarks/<slug>.mdx` with:
+Writes `web/content/benchmarks/<slug>.mdx` with `sample: false` and a prose skeleton. Refuses to overwrite unless `--force`.
 
-- `sample: false` (real data),
-- the **scoreboard pre-filled** from the ranking (rank, winner, composite,
-  correctness, reliability, latency, cost, $/correct), with a provider hint per
-  model, and
-- a prose skeleton (`How the race worked`, `The tasks`, `What we saw`, `Takeaway`).
+### 4. Public share link (recommended)
 
-It refuses to overwrite an existing file unless you pass `--force`.
+Create a public share of the run scorecard and set `runShareUrl` in frontmatter. The report page renders "View the live race scorecard".
 
-### 4. Make a public share link (optional but recommended)
+### 5. Edit narrative + methodology appendix
 
-So readers can drill into the live race, create a public share of the run
-scorecard and paste its URL into the report's `runShareUrl` frontmatter (the
-scaffold's `--share-url` does this for you). The report page renders a
-"View the live race scorecard" link to `/share/<token>`.
+In the MDX body, include:
 
-### 5. Edit the narrative
+- How the race worked (lineup, constraints, n per model)
+- Task description and why it was chosen
+- What we saw (story behind the scoreboard)
+- Caveats (sample size, provider scope, judge variance)
+- **Methodology appendix:** frozen pack, models, scoring dimensions, reproduction commands
 
-Fill in every `TODO` in the frontmatter (`verdict`, `challengePack`, each task's
-`name`/`summary`) and the body. Keep the verdict to one line — it's the OG-card
-subtitle and the index-card blurb. Confirm the provider on each scoreboard row.
+Keep `verdict` to one line (OG subtitle and hub blurb).
 
-### 6. Verify locally
+### 6. Publish the monthly blog summary
+
+Add `web/content/blog/coding-agent-benchmark-<month>-<year>.mdx` (or launch-week variant) with:
+
+- Shareable headline and scoreboard snapshot
+- Link to `/benchmarks/<slug>`
+- Methodology appendix (can mirror the report)
+- Distribution-ready caveats
+
+Update `BENCHMARKS_READING` / hub links in `web/src/lib/benchmarks-hub.ts`.
+
+### 7. Verify locally
 
 ```bash
 cd web
-npx tsc --noEmit
+pnpm exec tsc --noEmit
 pnpm lint
 pnpm test
 pnpm build
-pnpm dev    # open /benchmarks and /benchmarks/<slug>
+pnpm dev    # /benchmarks, /benchmarks/<slug>, blog post, OG cards
 ```
 
-Check: the scoreboard renders with the winner highlighted, the OG card
-(`/og?title=...&kind=Benchmark`) looks right, and the sample-data banner is
-**absent** (since `sample: false`).
+Confirm: scoreboard renders, sample banner absent when `sample: false`, hub shows latest report.
 
-### 7. Publish & syndicate
+### 8. Changelog + syndicate
 
-Merge to `main`. The report is automatically picked up by:
+- Add an **Added** entry to the current period in `web/src/lib/changelog.ts` linking to the blog or `/benchmarks`.
+- Merge to `main`. Surfaces update automatically: `/benchmarks`, sitemap, `/benchmarks/feed.xml`, JSON-LD.
+- Post the **blog URL** (primary share link) to X, HN, LinkedIn. Use the verdict line as the hook; link the full scoreboard for proof.
 
-- `/benchmarks` index and `/benchmarks/<slug>` page,
-- `sitemap.xml` (with a tailored OG image),
-- `/benchmarks/feed.xml` (RSS),
-- JSON-LD (`Article` + `Dataset`) for search/answer-engine discovery.
+## Promote failures into coverage
 
-Then post the link to X and Hacker News on launch day. The verdict line is your
-hook; the scoreboard is the proof.
+When a model fails or regresses on a dimension that should not recur:
 
-## Authoring a report by hand
+1. Capture replay + validator evidence from the run
+2. Add or tighten validators / cases in the pack (or promote to a regression suite)
+3. Reference the promoted case in the next month's appendix
 
-You don't need a real run to publish — set `sample: true` in the frontmatter and
-the page shows a clear "Sample data" banner. This is how the seed report
-(`claude-opus-4-8-vs-the-field.mdx`) works. Flip it to `false` once the numbers
-are real.
+This keeps public benchmarks aligned with the same gates enterprise teams use in CI.
+
+## Authoring without a live run
+
+Set `sample: true` for illustrative scoreboards. The page shows a "Sample data" banner and is `noindex`. Flip to `sample: false` once numbers are measured.
+
+## Scorecard export schema (reference)
+
+Ranking items map to scoreboard rows:
+
+| Ranking field | Report field |
+| ------------- | ------------ |
+| `label` | `model` |
+| `rank` | `rank` |
+| `run_agent_id === winner.run_agent_id` | `winner: true` |
+| `composite_score` | `composite` |
+| `correctness_score` | `correctness` |
+| `reliability_score` | `reliability` |
+| `latency_score` | `latency` |
+| `cost_score` | `cost` |
+| `cost_per_correct_usd` | `costPerCorrectUsd` |
+
+Provider is not in the ranking document; confirm in frontmatter after scaffold guess.

--- a/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
+++ b/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
@@ -115,4 +115,30 @@ you ship. On this task every passing model was "correct" — but one solved it i
 two turns and another couldn't solve it at all. Race them on *your* tasks, with
 your tools, and read the whole scoreboard before you pick.
 
+For the shareable monthly summary and full methodology appendix, see [Coding agent benchmark — June 2026](/blog/coding-agent-benchmark-june-2026).
+
+## Methodology appendix
+
+| Field | Value |
+| ----- | ----- |
+| Pack | Expression Evaluator Arena (`expr-eval-arena`) |
+| Eval spec | `expr-eval-arena-v1` |
+| Fixture | [`examples/challenge-packs/expr-eval-arena.yaml`](https://github.com/agentclash/agentclash/blob/main/examples/challenge-packs/expr-eval-arena.yaml) |
+| Sandbox | Native, shell + file tools, network off |
+| Budget | 10 iterations, 240s max duration, 40K token cap |
+
+**Models (n=1 each):** GPT-4.1, GPT-5, GPT-5.4, GPT-5.5 (OpenAI).
+
+**Scorecard dimensions:** correctness (gated hidden tests), output contract, code quality (LLM judge), explanation clarity (LLM judge), plus reliability and token-efficiency cost on the public board.
+
+**Reproduce:**
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+cd cli && go run . run create --follow
+go run . run ranking <run-id> --json
+```
+
+Monthly checklist and ownership: [`docs/marketing/model-benchmark-workflow.md`](https://github.com/agentclash/agentclash/blob/main/docs/marketing/model-benchmark-workflow.md).
+
 [Run your own race →](/try)

--- a/web/content/blog/coding-agent-benchmark-june-2026.mdx
+++ b/web/content/blog/coding-agent-benchmark-june-2026.mdx
@@ -1,0 +1,112 @@
+---
+title: "Coding agent benchmark — June 2026"
+date: "2026-06-11"
+description: "Our first measured public benchmark: four GPT generations on a real coding task with frozen challenge packs, full trajectory scoring, and replay evidence. Methodology, scoreboard, and reproduction steps."
+author: "AgentClash"
+---
+
+This is the first monthly coding-agent benchmark we publish on [/benchmarks](/benchmarks): a head-to-head race on a frozen challenge pack, scored on the full trajectory, with numbers you can reproduce.
+
+**Headline:** GPT-5.4 solved an integer expression evaluator in two model calls and about 8K tokens. GPT-5 and GPT-5.5 also passed. GPT-4.1 burned its full ten-iteration budget and never submitted a valid solution.
+
+Read the [full scoreboard and narrative](/benchmarks/gpt-generations-expression-evaluator) for task details, caveats, and the token table.
+
+## Why this task
+
+Public leaderboards often hide setup drift. We picked one workload from the repo's public fixtures: [Expression Evaluator Arena](https://github.com/agentclash/agentclash/blob/main/examples/challenge-packs/expr-eval-arena.yaml). It is a real agentic coding slice, not trivia.
+
+The trap is deliberate: lazy implementations reach for Python's `//` or `eval`, pass basic tiers, then fail when division must **truncate toward zero** on negative operands (`-7/2 == -3`, not `-4`). Correctness is graded across three hidden test tiers so partial credit produces a ranking spread instead of an all-pass tie.
+
+## Scoreboard snapshot
+
+| Rank | Model   | Composite | Correctness | Reliability | Cost (token efficiency) |
+| ---- | ------- | --------- | ----------- | ----------- | ----------------------- |
+| 1    | GPT-5.4 | 1.00      | 1.00        | 1.00        | 1.00                    |
+| 2    | GPT-5   | 1.00      | 1.00        | 1.00        | 0.55                    |
+| 3    | GPT-5.5 | 0.88      | 1.00        | 1.00        | 0.46                    |
+| 4    | GPT-4.1 | 0.00      | 0.00        | 0.00        | 0.20                    |
+
+Every passing model was "correct" on the hidden tests. The separation showed up in **efficiency** (model calls and tokens) and **output contract** adherence. GPT-5.5 slipped on the strict JSON shape and dropped its composite to 0.88.
+
+## Methodology appendix
+
+Use this block when you cite the report or rerun the race internally.
+
+### Frozen challenge pack
+
+| Field | Value |
+| ----- | ----- |
+| Pack | Expression Evaluator Arena (`expr-eval-arena`) |
+| Version | v1 (`evaluation_spec`: `expr-eval-arena-v1`) |
+| Fixture path | `examples/challenge-packs/expr-eval-arena.yaml` on `main` |
+| Execution mode | Native sandbox, shell + file tools, network off |
+| Iteration budget | 10 model turns; 240s wall clock; 40K token cap per run |
+
+Pin the git commit when you reproduce. This report was authored against the pack on `main` as of June 2026.
+
+### Models tested
+
+| Model | Provider | Runs |
+| ----- | -------- | ---- |
+| GPT-4.1 | OpenAI | n=1 |
+| GPT-5 | OpenAI | n=1 |
+| GPT-5.4 | OpenAI | n=1 |
+| GPT-5.5 | OpenAI | n=1 |
+
+This is a small first field (OpenAI-only, one task). Wider cross-provider races follow as we expand hosted lineup support.
+
+### Scoring dimensions
+
+Composite score folds these scorecard dimensions from the pack:
+
+1. **Correctness** (gate, weight 0.6): hidden `code_execution` tiers (basic precedence, unary minus, truncating division) plus `solution.py` defines `evaluate`.
+2. **Output contract** (weight 0.15): final JSON mentions precedence, matches schema, states `truncate-toward-zero` division semantics.
+3. **Code quality** (LLM judge, weight 0.15): rubric vs reference solution; penalizes `eval`, floor division, unsafe parsing.
+4. **Explanation clarity** (LLM judge, weight 0.1): plain-language parsing approach, not one-sentence hand-waving.
+
+Reliability reflects run completion. **Cost** on the public scoreboard is token-efficiency normalized to the leanest run (not a dollar price).
+
+### Evidence we attach to every report
+
+- Scoreboard rows exported from `GET .../runs/{id}/ranking` (or `agentclash run ranking <run-id> --json`)
+- Replay / trajectory for each lane (tool calls, artifacts, judge rationale)
+- Validator pass/fail per dimension
+- Latency and token totals per run
+- Gate verdict (`pass_threshold: 0.5` on the pack)
+
+### Reproduce the race
+
+Hosted path (recommended):
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+cd cli
+go run . auth login --device
+go run . workspace use <workspace-id>
+go run . run create --follow   # select Expression Evaluator Arena + your model lineup
+go run . run ranking <run-id> --json > ranking.json
+```
+
+Then scaffold or hand-edit the MDX report:
+
+```bash
+node scripts/benchmarks/scaffold.mjs \
+  --ranking ranking.json \
+  --title "Your headline" \
+  --model "GPT-5.4" \
+  --slug your-slug
+```
+
+Full monthly checklist, ownership, and syndication steps live in the repo runbook: [`docs/marketing/model-benchmark-workflow.md`](https://github.com/agentclash/agentclash/blob/main/docs/marketing/model-benchmark-workflow.md).
+
+## Caveats (read before you tweet)
+
+- **n=1 per model** on a **single task**. LLM judges add per-run variance.
+- Not a general model ranking. It is a worked example of a reproducible public benchmark format.
+- Promote meaningful failures back into challenge-pack coverage so the next month's report gates on real regressions.
+
+## What we do next month
+
+We follow the same five-step cadence on [/benchmarks](/benchmarks): pin the pack, race every candidate on identical constraints, export scorecards, attach replay evidence, summarize on the hub and RSS feed. Subscribe at [/benchmarks/feed.xml](/benchmarks/feed.xml).
+
+Want the same discipline on your workloads? [Book an eval workshop](/enterprise) or [run your own race](/try).

--- a/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
+++ b/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
@@ -7,9 +7,11 @@ import type { BenchmarkReport } from "@/lib/benchmarks";
 import {
   BENCHMARKS_CHILD_PAGES,
   BENCHMARKS_METHODOLOGY,
+  BENCHMARKS_MONTHLY_BLOG,
   BENCHMARKS_MONTHLY_PROCESS,
   BENCHMARKS_PACK_LINKS,
   BENCHMARKS_READING,
+  BENCHMARKS_RUNBOOK_HREF,
 } from "@/lib/benchmarks-hub";
 
 type Props = {
@@ -121,13 +123,22 @@ export function BenchmarksHubContent({ published }: Props) {
             </div>
           )}
 
-          <Link
-            href={`/benchmarks/${latest.slug}`}
-            className="mt-4 inline-flex items-center gap-1.5 text-sm text-white/70 transition-colors hover:text-white"
-          >
-            Read the full report
-            <ArrowRight className="size-3.5" />
-          </Link>
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+            <Link
+              href={`/benchmarks/${latest.slug}`}
+              className="inline-flex items-center gap-1.5 text-sm text-white/70 transition-colors hover:text-white"
+            >
+              Read the full report
+              <ArrowRight className="size-3.5" />
+            </Link>
+            <Link
+              href={BENCHMARKS_MONTHLY_BLOG.href}
+              className="inline-flex items-center gap-1.5 text-sm text-white/55 transition-colors hover:text-white/80"
+            >
+              {BENCHMARKS_MONTHLY_BLOG.title}
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </div>
         </section>
       ) : (
         <section className="mt-14" aria-labelledby="monthly-process-heading">
@@ -215,6 +226,18 @@ export function BenchmarksHubContent({ published }: Props) {
               </li>
             ))}
           </ol>
+          <p className="mt-4 text-xs text-white/35">
+            Owner checklist and scorecard export format:{" "}
+            <a
+              href={BENCHMARKS_RUNBOOK_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/55 underline-offset-2 hover:text-white/75 hover:underline"
+            >
+              monthly benchmark runbook
+            </a>
+            .
+          </p>
         </section>
       )}
 

--- a/web/src/lib/benchmarks-hub.ts
+++ b/web/src/lib/benchmarks-hub.ts
@@ -61,7 +61,20 @@ export const BENCHMARKS_CHILD_PAGES = [
   },
 ] as const;
 
+export const BENCHMARKS_MONTHLY_BLOG = {
+  href: "/blog/coding-agent-benchmark-june-2026",
+  title: "Coding agent benchmark — June 2026",
+  text: "Shareable monthly summary with methodology appendix and reproduction steps.",
+} as const;
+
+export const BENCHMARKS_RUNBOOK_HREF =
+  "https://github.com/agentclash/agentclash/blob/main/docs/marketing/model-benchmark-workflow.md" as const;
+
 export const BENCHMARKS_READING = [
+  {
+    href: BENCHMARKS_MONTHLY_BLOG.href,
+    title: BENCHMARKS_MONTHLY_BLOG.title,
+  },
   {
     href: "/blog/benchmark-ai-agents-on-your-own-data",
     title: "Benchmark AI agents on your own data",
@@ -100,9 +113,9 @@ export const BENCHMARKS_PACK_LINKS = [
 ] as const;
 
 export const BENCHMARKS_MONTHLY_PROCESS = [
-  "Pin a challenge pack version and publish the runtime constraints up front.",
+  "Pin a challenge pack version, git commit, and runtime constraints in the report appendix.",
   "Race every candidate on the same pack with identical tools, sandbox, and budgets.",
-  "Score the full trajectory across correctness, reliability, latency, cost, and judge evidence.",
-  "Attach replay links and artifact references reviewers can audit without rerunning.",
-  "Summarize winners, regressions, and gate verdicts on this hub and in the RSS feed.",
+  "Export ranking JSON (`agentclash run ranking`) and attach replay plus validator evidence.",
+  "Publish measured MDX on /benchmarks and a shareable monthly blog summary.",
+  "Summarize on this hub, RSS feed, and changelog; promote failures into pack coverage.",
 ] as const;

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -381,6 +381,16 @@ export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
         category: "improved",
         text: "IndexNow pings and sitemap image entries for faster search-engine discovery.",
       },
+      {
+        category: "added",
+        text: "First public coding-agent benchmark report with frozen Expression Evaluator Arena pack, monthly blog summary, and reproducible scorecard export workflow.",
+        href: "/blog/coding-agent-benchmark-june-2026",
+      },
+      {
+        category: "added",
+        text: "/benchmarks hub summarizes the measured GPT generations race with replay-backed scoreboard and methodology appendix.",
+        href: "/benchmarks/gpt-generations-expression-evaluator",
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- Publish the first monthly coding-agent benchmark blog (`/blog/coding-agent-benchmark-june-2026`) with scoreboard snapshot, methodology appendix, and reproduction steps.
- Extend the measured GPT generations report and `/benchmarks` hub with cross-links, updated monthly cadence copy, and a runbook link.
- Rewrite `docs/marketing/model-benchmark-workflow.md` with owner/approver roles, checklist, fixture guidance, and scorecard export schema; add changelog entries linking to the blog and full report.

Closes #992.

## Test plan
- [x] `cd web && pnpm exec tsc --noEmit`
- [x] `cd web && pnpm exec vitest run src/lib/changelog.test.ts src/app/sitemap.test.ts src/lib/benchmarks.test.ts`
- [ ] Spot-check `/benchmarks`, `/benchmarks/gpt-generations-expression-evaluator`, and `/blog/coding-agent-benchmark-june-2026` after deploy
- [ ] Verify OG cards and changelog period page show the new entries