### PR TITLE
fix: clean eval checklist resource UI

### DIFF
--- a/testing/codex-clean-eval-resource-ui.md
+++ b/testing/codex-clean-eval-resource-ui.md
@@ -1,0 +1,27 @@
+# codex/clean-eval-resource-ui — Test Contract
+
+## Functional Behavior
+- `/resources/eval-checklist` should present the lead magnet without the "Search intent covered" section.
+- `/resources/eval-checklist` should not show the global footer link columns after the content.
+- `/resources/eval-checklist/thank-you` should not show the global footer link columns.
+- The email form should use clean, direct copy: no awkward separate "WORK EMAIL" label above the button area and no spammy product-updates sentence.
+- Layout should not leave large empty sections after removed content.
+
+## Unit Tests
+- N/A — this is a presentational cleanup with existing metadata tests unchanged.
+
+## Integration / Functional Tests
+- `pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts` should continue to pass.
+
+## Smoke Tests
+- `pnpm build` should pass.
+- Browser check `/resources/eval-checklist` at desktop and mobile widths.
+- Browser check `/resources/eval-checklist/thank-you` at desktop width.
+
+## E2E Tests
+- N/A — live form submission is covered manually in production after deploy.
+
+## Manual / cURL Tests
+- Confirm landing page no longer contains "Search intent covered".
+- Confirm resource and thank-you pages no longer contain footer column headings like Product, Guides, Company.
+- Confirm form CTA reads cleanly and no longer shows the disliked copy.

--- a/web/src/app/resources/eval-checklist/page.tsx
+++ b/web/src/app/resources/eval-checklist/page.tsx
@@ -28,14 +28,6 @@ const proofPoints = [
   "30-day rollout plan for the first governed eval program",
 ];
 
-const searchIntents = [
-  "AI agent evaluation checklist",
-  "AI agent release gate template",
-  "AI agent pilot scorecard",
-  "agent procurement questions",
-  "AI agent evaluation framework PDF",
-];
-
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
@@ -62,7 +54,7 @@ const eyebrowClass =
 
 export default function EvalChecklistResourcePage() {
   return (
-    <MarketingShell>
+    <MarketingShell showFooter={false}>
       <JsonLd
         id="agentclash-eval-checklist-resource-schema"
         data={[
@@ -120,59 +112,35 @@ export default function EvalChecklistResourcePage() {
         </div>
       </section>
 
-      <section className="px-6 pt-24 sm:px-12 sm:pt-32">
+      <section className="px-6 py-20 sm:px-12 sm:py-28">
         <div className="mx-auto max-w-[1120px]">
           <p className={eyebrowClass}>Included downloads</p>
           <h2 className="mt-4 max-w-[18ch] text-3xl font-sans font-semibold tracking-tight text-white sm:text-4xl">
             Practical guides, not generic AI advice
           </h2>
-          <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08] md:grid-cols-2">
+          <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
             {RESOURCE_LIBRARY.map((resource) => (
               <article
                 key={resource.slug}
-                className="bg-[#060606] p-6 transition-colors hover:bg-white/[0.025]"
+                className="grid gap-5 py-7 md:grid-cols-[0.85fr_1.15fr] md:gap-10"
               >
-                <p className={eyebrowClass}>{resource.kicker}</p>
-                <h3 className="mt-3 text-xl font-sans font-semibold tracking-tight text-white">
-                  {resource.title}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-white/50">
-                  {resource.description}
-                </p>
-                <dl className="mt-5 grid gap-3 text-xs text-white/40 sm:grid-cols-2">
-                  <div>
-                    <dt className="text-white/25">Audience</dt>
-                    <dd className="mt-1 text-white/55">{resource.audience}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-white/25">Use in</dt>
-                    <dd className="mt-1 text-white/55">{resource.readTime}</dd>
-                  </div>
-                </dl>
+                <div>
+                  <p className={eyebrowClass}>{resource.kicker}</p>
+                  <h3 className="mt-3 text-xl font-sans font-semibold tracking-tight text-white">
+                    {resource.title}
+                  </h3>
+                </div>
+                <div>
+                  <p className="text-sm leading-6 text-white/55">
+                    {resource.description}
+                  </p>
+                  <p className="mt-3 text-xs leading-5 text-white/35">
+                    {resource.audience}, {resource.readTime}
+                  </p>
+                </div>
               </article>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="px-6 py-24 sm:px-12 sm:py-32">
-        <div className="mx-auto grid max-w-[1120px] gap-12 border-t border-white/[0.08] pt-12 lg:grid-cols-[0.8fr_1.2fr]">
-          <div>
-            <p className={eyebrowClass}>Search intent covered</p>
-            <h2 className="mt-4 text-3xl font-sans font-semibold tracking-tight text-white">
-              Built for the questions teams actually search
-            </h2>
-          </div>
-          <ul className="grid gap-3 sm:grid-cols-2">
-            {searchIntents.map((intent) => (
-              <li
-                key={intent}
-                className="rounded-lg border border-white/[0.08] px-4 py-3 text-sm text-white/60"
-              >
-                {intent}
-              </li>
-            ))}
-          </ul>
         </div>
       </section>
     </MarketingShell>

--- a/web/src/app/resources/eval-checklist/thank-you/page.tsx
+++ b/web/src/app/resources/eval-checklist/thank-you/page.tsx
@@ -16,7 +16,7 @@ const eyebrowClass =
 
 export default function EvalChecklistThankYouPage() {
   return (
-    <MarketingShell>
+    <MarketingShell showFooter={false}>
       <section className="px-6 py-20 sm:px-12 sm:py-28">
         <div className="mx-auto max-w-[980px]">
           <p className={eyebrowClass}>Resource pack unlocked</p>

--- a/web/src/components/marketing/marketing-shell.tsx
+++ b/web/src/components/marketing/marketing-shell.tsx
@@ -4,14 +4,15 @@ import { MarketingFooter } from "./marketing-footer";
 
 type Props = {
   children: ReactNode;
+  showFooter?: boolean;
 };
 
-export function MarketingShell({ children }: Props) {
+export function MarketingShell({ children, showFooter = true }: Props) {
   return (
     <main className="main min-h-screen flex flex-col">
       <MarketingHeader />
       {children}
-      <MarketingFooter />
+      {showFooter ? <MarketingFooter /> : null}
     </main>
   );
 }

--- a/web/src/components/marketing/resource-lead-form.tsx
+++ b/web/src/components/marketing/resource-lead-form.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function ResourceLeadForm({
   source,
   resource,
-  ctaLabel = "Get the resource pack",
+  ctaLabel = "Download the PDFs",
   className = "",
 }: Props) {
   const router = useRouter();
@@ -62,15 +62,15 @@ export function ResourceLeadForm({
   return (
     <form
       onSubmit={submit}
-      className={`rounded-lg border border-white/[0.1] bg-white/[0.035] p-4 sm:p-5 ${className}`}
+      className={`rounded-lg border border-white/[0.1] bg-white/[0.03] p-4 sm:p-5 ${className}`}
     >
       <label
         htmlFor={`resource-email-${source}`}
-        className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/45"
+        className="sr-only"
       >
-        Work email
+        Email address
       </label>
-      <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+      <div className="flex flex-col gap-3 sm:flex-row">
         <input
           id={`resource-email-${source}`}
           type="email"
@@ -78,7 +78,7 @@ export function ResourceLeadForm({
           autoComplete="email"
           value={email}
           onChange={(event) => setEmail(event.target.value)}
-          placeholder="you@company.com"
+          placeholder="Work email"
           className="min-h-12 flex-1 rounded-lg border border-white/[0.12] bg-black/30 px-4 text-sm text-white outline-none transition-colors placeholder:text-white/25 focus:border-white/35"
         />
         <button
@@ -93,8 +93,8 @@ export function ResourceLeadForm({
         <p className="mt-3 text-sm leading-6 text-red-300">{error}</p>
       ) : (
         <p className="mt-3 text-xs leading-5 text-white/40">
-          Instant access. We also use this to send product evaluation updates,
-          not spam.
+          Immediate access to the checklist, worksheet, scorecard, procurement
+          guide, and rollout plan.
         </p>
       )}
     </form>


### PR DESCRIPTION
## Summary
- Removes the internal "Search intent covered" section from `/resources/eval-checklist`.
- Hides the inherited marketing footer on the resource landing and thank-you pages so Product/Guides/Company columns do not trail the funnel.
- Replaces the uneven download card grid with compact rows and rewrites the email form copy/button.

## Verification
- `cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts`
- `cd web && pnpm build`
- Browser checked `/resources/eval-checklist` on desktop and mobile.
- Browser checked `/resources/eval-checklist/thank-you` and confirmed no footer columns render.
- String checks confirmed removed copy is absent.

Test contract: `testing/codex-clean-eval-resource-ui.md`