### PR TITLE
Nav and cross-linking: /compare in nav, blog → SEO pages (#993)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ testing/*
 !testing/feat-985-enterprise-page.md
 !testing/feat-services-eval-program.md
 !testing/feat-blog-batch-987.md
+!testing/feat-nav-cross-linking-993.md

--- a/testing/feat-nav-cross-linking-993.md
+++ b/testing/feat-nav-cross-linking-993.md
@@ -1,0 +1,42 @@
+# feat/nav-cross-linking-993 — Test Contract
+
+## Functional Behavior
+
+Improve discovery of high-intent marketing pages per #993:
+
+1. **Marketing nav:** `/compare` appears in the default marketing header nav (footer already links to Compare tools).
+2. **Blog related resources:** Blog post template renders a topic-selected "Related resources" block (2–3 links from the SEO registry) via a shared component and slug map. Links are not generic across every post.
+3. **Changelog rollup:** A monthly blog post summarizes recent product updates and links prominently to `/changelog`.
+4. **SEO cross-links:** Registry pages in `SEO_PAGE_REGISTRY` include hub links to peer SEO pages and `/compare` (excluding self-links). Canonical benchmark hub remains `/benchmarks`; `/ai-agent-benchmark` and `/agent-reliability-benchmark` are topic pages, not duplicate hubs.
+
+## Unit Tests
+
+- `marketing-header` or nav config test: default nav includes `/compare`.
+- `blog-related-resources.test.ts`: slug map returns 2–3 links for mapped posts; unmapped posts return empty; no duplicate hrefs per slug.
+- `seo-pages/registry` or dedicated test: S-tier pages include `/compare` in `relatedLinks`; pages do not link to themselves.
+- `sitemap.test.ts`: every path from `getAllSeoPagePaths()` appears in sitemap output.
+
+## Integration / Functional Tests
+
+- Blog post page renders `BlogRelatedResources` when slug has mapped links.
+- SEO landing pages render cross-link section including `/compare` where configured.
+
+## Smoke Tests
+
+```bash
+cd web && pnpm build
+cd web && pnpm exec vitest run src/lib/blog-related-resources.test.ts src/app/sitemap.test.ts
+cd web && pnpm lint
+```
+
+## E2E Tests
+
+N/A — marketing navigation and internal linking only.
+
+## Manual / cURL Tests
+
+- Open `/` and confirm header shows Compare linking to `/compare`.
+- Open `/blog/pass-k-reliability-enterprise-teams` and confirm Related resources block with SEO links.
+- Open `/blog/product-updates-june-2026` and confirm link to `/changelog`.
+- Open `/agent-evals` and `/llm-agent-evaluation`; confirm related links include `/compare` and peer SEO pages.
+- Fetch sitemap and spot-check SEO registry paths are present.

--- a/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
+++ b/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
@@ -66,12 +66,4 @@ That is the gap [agent evals](/agent-evals) and the [agent evaluation platform](
 
 Run both. Do not ask prompt eval to stand in for release gates on tool-using agents.
 
-## Related resources
-
-- [Agent evals hub](/agent-evals)
-- [What is agent evaluation?](/glossary/agent-evaluation)
-- [Compare eval tools](/compare)
-- [AI agent evaluation regression testing](/blog/ai-agent-evaluation-regression-testing)
-- [Enterprise pilot](/enterprise): 45-day Team access to run governed benchmarks on your workloads
-
 Book a discovery call from any post footer, or start the [enterprise pilot](/enterprise) if you want self-serve product access first.

--- a/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
+++ b/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
@@ -70,13 +70,5 @@ Avoid these mistakes when shopping tools:
 
 Compare on workflow fit. Run a head-to-head on *your* pack when the decision is close.
 
-## Related resources
-
-- [Compare hub](/compare)
-- [What is agent evaluation?](/glossary/agent-evaluation)
-- [Coding agent evaluation](/use-cases/coding-agent-evaluation)
-- [AI agent benchmark](/ai-agent-benchmark)
-- [Benchmarks field reports](/benchmarks)
-- [Enterprise pilot](/enterprise)
 
 Book an eval architecture review from the post footer, or explore [eval services](/services) for fixed-scope pack and gate setup.

--- a/web/content/blog/ai-agent-approval-security-compliance.mdx
+++ b/web/content/blog/ai-agent-approval-security-compliance.mdx
@@ -89,11 +89,3 @@ Run an exploratory benchmark, record the green run as baseline, then pin `baseli
 
 Need a governed benchmark your security team can replay? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for a guided first gate.
 
-## Related resources
-
-- [Enterprise pilot](/enterprise)
-- [Government agent evaluation](/industries/government)
-- [What is a release gate?](/glossary/release-gate)
-- [AI agent regression testing](/platform/agent-regression-testing)
-- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
-- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)

--- a/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
+++ b/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
@@ -87,12 +87,3 @@ AgentClash exports replay, scorecards, and gate verdicts that support audit-frie
 
 Evaluating agents for a UAE or GCC rollout? Start the [enterprise pilot](/enterprise) to run governed benchmarks, or ask about [Benchmark & Gate Setup](/services) if you want help encoding your first residency-aware workload.
 
-## Related resources
-
-- [Enterprise pilot](/enterprise)
-- [Government agent evaluation](/industries/government)
-- [Banking agent evaluation](/industries/banking)
-- [Support agent evaluation](/use-cases/support-agent-evaluation)
-- [Evaluating bilingual customer support agents](/blog/evaluating-bilingual-customer-support-agents)
-- [AI agent approval from security and compliance](/blog/ai-agent-approval-security-compliance)
-- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)

--- a/web/content/blog/ai-platform-lead-agent-release-gates.mdx
+++ b/web/content/blog/ai-platform-lead-agent-release-gates.mdx
@@ -116,11 +116,3 @@ Freeze one real task as a challenge pack, record a baseline run, init the CI man
 
 Platform lead shipping agent revisions this quarter? Start the [enterprise pilot](/enterprise) or ask about a [Benchmark & Gate Setup](/services) sprint for manifest and gate wiring.
 
-## Related resources
-
-- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)
-- [What is a release gate?](/glossary/release-gate)
-- [What is a challenge pack?](/glossary/challenge-pack)
-- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
-- [AI agent regression testing](/platform/agent-regression-testing)
-- [Enterprise pilot](/enterprise)

--- a/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
+++ b/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
@@ -61,10 +61,3 @@ We publish field reports on [/benchmarks](/benchmarks) when we have reproducible
 
 If you want help freezing the first pack, see [eval services](/services) or the free [enterprise pilot](/enterprise).
 
-## Related resources
-
-- [Agent reliability benchmark](/agent-reliability-benchmark)
-- [What is a challenge pack?](/glossary/challenge-pack)
-- [Coding agent evaluation use case](/use-cases/coding-agent-evaluation)
-- [Compare AgentClash to prompt-eval stacks](/compare)
-- [Enterprise pilot](/enterprise)

--- a/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
+++ b/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
@@ -121,12 +121,3 @@ Human-in-the-loop belongs in runtime policy for high-risk actions. Release gates
 
 Standing up a governed eval program this half? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for hands-on pack and gate wiring.
 
-## Related resources
-
-- [Enterprise pilot](/enterprise)
-- [Banking agent evaluation](/industries/banking)
-- [Insurance agent evaluation](/industries/insurance)
-- [What is agent evaluation?](/glossary/agent-evaluation)
-- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)
-- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
-- [AI agent regression testing](/platform/agent-regression-testing)

--- a/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
+++ b/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
@@ -109,10 +109,3 @@ Residency is a deployment and legal decision. Bilingual eval proves behavioral r
 
 Shipping bilingual support agents in the Gulf? Start the [enterprise pilot](/enterprise), build cases on the [support agent evaluation](/use-cases/support-agent-evaluation) workflow, or ask about [Benchmark & Gate Setup](/services) for pack authoring help.
 
-## Related resources
-
-- [Support agent evaluation](/use-cases/support-agent-evaluation)
-- [Insurance agent evaluation](/industries/insurance)
-- [Enterprise pilot](/enterprise)
-- [Write a challenge pack](/docs/guides/write-a-challenge-pack)
-- [Multi-turn challenge packs](/docs/challenge-packs/multi-turn)

--- a/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
+++ b/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
@@ -79,11 +79,3 @@ Even strong pass^k scores do not remove code review. Evals tell you the agent co
 
 Start self-serve on the [enterprise pilot](/enterprise), or ask about [challenge pack build](/services) if you want hands-on help encoding your repos.
 
-## Related resources
-
-- [LLM agent evaluation](/llm-agent-evaluation)
-- [What is a challenge pack?](/glossary/challenge-pack)
-- [Banking agent evaluation](/industries/banking)
-- [AI agent testing](/ai-agent-testing)
-- [Compare coding-agent eval approaches](/compare)
-- [Enterprise pilot](/enterprise)

--- a/web/content/blog/pass-k-reliability-enterprise-teams.mdx
+++ b/web/content/blog/pass-k-reliability-enterprise-teams.mdx
@@ -64,10 +64,3 @@ That transition is a maturity signal, not a moral judgment. Early exploration sh
 
 Need a baseline and gate wired in two weeks? See [Benchmark & Gate Setup](/services) or start the [enterprise pilot](/enterprise).
 
-## Related resources
-
-- [pass@k vs pass^k primer](/blog/pass-at-k-vs-pass-power-k)
-- [What is a release gate?](/glossary/release-gate)
-- [Agent evals](/agent-evals)
-- [AI agent regression testing](/platform/agent-regression-testing)
-- [Compare eval tools](/compare)

--- a/web/content/blog/product-updates-june-2026.mdx
+++ b/web/content/blog/product-updates-june-2026.mdx
@@ -1,0 +1,38 @@
+---
+title: "AgentClash product updates — June 2026"
+date: "2026-06-11"
+description: "Monthly rollup of AgentClash product updates from May and June 2026: datasets, security packs, skills distribution, and the first public coding-agent benchmark. Full timeline on the changelog."
+author: "AgentClash"
+---
+
+If you want the full release timeline with category badges and ten-day periods, start on the [AgentClash changelog](/changelog). This post is the monthly summary for buyers and builders who missed a sprint or two.
+
+## What shipped in late May
+
+The [May 25 period](/changelog/2026-05-25) focused on datasets and security evaluation:
+
+- Production trace ingest and candidate promotion for dataset-backed eval loops
+- Security evaluation packs and workspace flows for red-team style workloads
+- Hosted sandbox hardening and clearer failure surfaces in the workspace UI
+
+Those updates matter when your eval program needs **real traces**, not synthetic prompts, and when security review is part of the release gate.
+
+## What shipped in early June
+
+The [June 2 period](/changelog/2026-06-02) expanded distribution and public evidence:
+
+- **25 portable Agent Skills** with `agentclash integration` install paths for Claude, Codex, Cursor, OpenClaw, Hermes, and OpenCode
+- **`agentclash schema`** for machine-readable CLI introspection
+- IndexNow and sitemap improvements for faster discovery of docs, compare pages, and SEO guides
+- The first measured [coding-agent benchmark](/benchmarks/gpt-generations-expression-evaluator) with a [monthly blog summary](/blog/coding-agent-benchmark-june-2026)
+
+If you are evaluating agents on coding tasks, read the benchmark post for methodology. If you are wiring evals into CI, the skills and schema work are the fastest path from zero to a gated pull request.
+
+## Where to go next
+
+- [Changelog](/changelog) for every period since launch
+- [Compare tools](/compare) if you are choosing between AgentClash and prompt-eval stacks
+- [Agent evals](/agent-evals) for the SEO guide to real-task evaluation
+- [Enterprise pilot](/enterprise) if you want a fixed-scope first benchmark and gate
+
+We update the changelog in ten-day windows. Check back next month for the July rollup, or subscribe to the [blog RSS feed](/blog/rss.xml) if you want summaries in your reader.

--- a/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
+++ b/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
@@ -89,10 +89,3 @@ One gate verdict plus three deltas vs baseline: correctness, cost per success, a
 
 Restarting after a stalled pilot? Start the [enterprise pilot](/enterprise) and rerun your workload as a governed benchmark with replay and gate export.
 
-## Related resources
-
-- [Enterprise pilot](/enterprise)
-- [What is a release gate?](/glossary/release-gate)
-- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
-- [AI agent regression testing](/platform/agent-regression-testing)
-- [Write a challenge pack](/docs/guides/write-a-challenge-pack)

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -7,9 +7,11 @@ import {
   articleSchema,
   breadcrumbSchema,
 } from "@/components/marketing/json-ld";
+import { BlogRelatedResources } from "@/components/marketing/blog-related-resources";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
 import { ResourcePackCTA } from "@/components/marketing/resource-pack-cta";
+import { getBlogRelatedResources } from "@/lib/blog-related-resources";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { mdxRemoteOptions } from "@/lib/mdx-options";
 import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
@@ -77,6 +79,7 @@ export default async function BlogPostPage({ params }: Props) {
   const { slug } = await params;
   const post = getPostBySlug(slug);
   if (!post) notFound();
+  const relatedResources = getBlogRelatedResources(slug);
 
   return (
     <MarketingShell>
@@ -119,6 +122,8 @@ export default async function BlogPostPage({ params }: Props) {
         </div>
 
         <ResourcePackCTA className="mt-12" />
+
+        <BlogRelatedResources links={relatedResources} />
 
         <ResearchAudienceCTA
           className="mt-12"

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -260,6 +260,16 @@ describe("sitemap", () => {
     expect(() => JSON.stringify(entries)).not.toThrow();
   });
 
+  it("includes every SEO registry path from getAllSeoPagePaths", async () => {
+    const { getAllSeoPagePaths } = await import("@/lib/seo-pages");
+    const entries = sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+
+    for (const path of getAllSeoPagePaths()) {
+      expect(urls.has(`https://www.agentclash.dev${path}`)).toBe(true);
+    }
+  });
+
   it("serializes to well-formed sitemap XML with escaped image URLs", () => {
     const entries = sitemap();
 

--- a/web/src/components/marketing/blog-related-resources.tsx
+++ b/web/src/components/marketing/blog-related-resources.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import type { BlogRelatedResourceLink } from "@/lib/blog-related-resources";
+
+type Props = {
+  links: BlogRelatedResourceLink[];
+  className?: string;
+};
+
+export function BlogRelatedResources({ links, className = "mt-12" }: Props) {
+  if (links.length === 0) return null;
+
+  return (
+    <section className={className} aria-labelledby="blog-related-resources">
+      <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
+        Explore
+      </p>
+      <h2
+        id="blog-related-resources"
+        className="mt-3 text-xl font-sans font-semibold tracking-[-0.02em] text-white"
+      >
+        Related resources
+      </h2>
+      <ul className="mt-6 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08]">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="flex flex-col bg-[#060606] px-5 py-4 transition-colors hover:bg-white/[0.025] sm:px-6 sm:py-5"
+            >
+              <span className="text-base font-sans font-semibold text-white">
+                {link.label}
+              </span>
+              <span className="mt-1.5 text-sm leading-6 text-white/45">
+                {link.description}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -2,19 +2,13 @@ import Link from "next/link";
 import { ArrowRight, Star } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isReturningVisitor } from "@/lib/auth/returning";
+import { DEFAULT_MARKETING_NAV } from "@/lib/marketing-nav";
 import { AuthCtaLink } from "./auth-cta-link";
 import { ClashMark } from "./clash-mark";
 
 type NavLink = { href: string; label: string; external?: boolean };
 
-const DEFAULT_NAV: NavLink[] = [
-  { href: "/#features", label: "Features" },
-  { href: "/enterprise", label: "Enterprise" },
-  { href: "/docs", label: "Docs" },
-  { href: "/benchmarks", label: "Benchmarks" },
-  { href: "/blog", label: "Blog" },
-  { href: "/changelog", label: "Changelog" },
-];
+const DEFAULT_NAV: NavLink[] = DEFAULT_MARKETING_NAV;
 
 type Props = {
   nav?: NavLink[];

--- a/web/src/lib/blog-related-resources.test.ts
+++ b/web/src/lib/blog-related-resources.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBlogRelatedResources,
+  getMappedBlogRelatedResourceSlugs,
+} from "./blog-related-resources";
+
+describe("getBlogRelatedResources", () => {
+  it("returns an empty list for unmapped blog posts", () => {
+    expect(getBlogRelatedResources("nonexistent-slug")).toEqual([]);
+  });
+
+  it("returns two or three topic-selected links for mapped posts", () => {
+    for (const slug of getMappedBlogRelatedResourceSlugs()) {
+      const links = getBlogRelatedResources(slug);
+      expect(links.length).toBeGreaterThanOrEqual(2);
+      expect(links.length).toBeLessThanOrEqual(4);
+      expect(new Set(links.map((link) => link.href)).size).toBe(links.length);
+    }
+  });
+
+  it("selects comparison links for compare-focused posts", () => {
+    const links = getBlogRelatedResources(
+      "agentclash-vs-langsmith-braintrust-production",
+    );
+    expect(links.map((link) => link.href)).toContain("/compare");
+  });
+
+  it("links the changelog rollup post to /changelog", () => {
+    const links = getBlogRelatedResources("product-updates-june-2026");
+    expect(links[0]).toMatchObject({
+      href: "/changelog",
+      label: "Changelog",
+    });
+  });
+});

--- a/web/src/lib/blog-related-resources.ts
+++ b/web/src/lib/blog-related-resources.ts
@@ -1,0 +1,186 @@
+export type BlogRelatedResourceLink = {
+  href: string;
+  label: string;
+  description: string;
+};
+
+const LINKS = {
+  agentEvals: {
+    href: "/agent-evals",
+    label: "Agent evals",
+    description: "Real-task agent evals with replay evidence and CI gates.",
+  },
+  llmAgentEvaluation: {
+    href: "/llm-agent-evaluation",
+    label: "LLM agent evaluation",
+    description: "Evaluate LLM agents on full trajectories, not one-shot answers.",
+  },
+  compare: {
+    href: "/compare",
+    label: "Compare tools",
+    description: "See how AgentClash differs from prompt-eval platforms.",
+  },
+  ciCdAgentEvaluation: {
+    href: "/ci-cd-agent-evaluation",
+    label: "CI/CD agent evaluation",
+    description: "Wire agent evals into pull request gates.",
+  },
+  releaseGate: {
+    href: "/glossary/release-gate",
+    label: "Release gate",
+    description: "Define pass conditions before a candidate ships.",
+  },
+  agentReliabilityBenchmark: {
+    href: "/agent-reliability-benchmark",
+    label: "Agent reliability benchmark",
+    description: "Measure pass@k and pass^k on repeatable workloads.",
+  },
+  codingAgentEvaluation: {
+    href: "/use-cases/coding-agent-evaluation",
+    label: "Coding agent evaluation",
+    description: "Benchmark coding agents on private repos and real tasks.",
+  },
+  supportAgentEvaluation: {
+    href: "/use-cases/support-agent-evaluation",
+    label: "Support agent evaluation",
+    description: "Test bilingual and escalation-heavy support flows.",
+  },
+  agentEvaluationFramework: {
+    href: "/agent-evaluation-framework",
+    label: "Agent evaluation framework",
+    description: "Framework for real-task races, replay, and scorecards.",
+  },
+  agentTrajectoryEvaluation: {
+    href: "/agent-trajectory-evaluation",
+    label: "Agent trajectory evaluation",
+    description: "Score tool choices, retries, and stop conditions.",
+  },
+  openSourceEvaluation: {
+    href: "/open-source-ai-agent-evaluation",
+    label: "Open source agent evaluation",
+    description: "MIT-licensed, self-hostable agent eval platform.",
+  },
+  changelog: {
+    href: "/changelog",
+    label: "Changelog",
+    description: "Product updates grouped into ten-day release periods.",
+  },
+  benchmarks: {
+    href: "/benchmarks",
+    label: "Benchmarks",
+    description: "Measured field reports with frozen challenge packs.",
+  },
+  passAtKPost: {
+    href: "/blog/pass-at-k-vs-pass-power-k",
+    label: "pass@k vs pass^k",
+    description: "When independent retries and strict success-over-trials differ.",
+  },
+} as const satisfies Record<string, BlogRelatedResourceLink>;
+
+const BLOG_RELATED_RESOURCES: Record<string, BlogRelatedResourceLink[]> = {
+  "agent-evaluation-vs-prompt-evaluation-braintrust": [
+    LINKS.compare,
+    LINKS.llmAgentEvaluation,
+    LINKS.agentEvaluationFramework,
+  ],
+  "agentclash-vs-langsmith-braintrust-production": [
+    LINKS.compare,
+    LINKS.agentEvals,
+    LINKS.ciCdAgentEvaluation,
+  ],
+  "ai-agent-approval-security-compliance": [
+    LINKS.ciCdAgentEvaluation,
+    LINKS.releaseGate,
+    LINKS.compare,
+  ],
+  "ai-agent-evaluation-regression-testing": [
+    LINKS.agentEvals,
+    LINKS.ciCdAgentEvaluation,
+    LINKS.compare,
+  ],
+  "ai-agent-governance-middle-east-enterprises": [
+    LINKS.agentEvals,
+    LINKS.ciCdAgentEvaluation,
+    LINKS.compare,
+  ],
+  "ai-platform-lead-agent-release-gates": [
+    LINKS.ciCdAgentEvaluation,
+    LINKS.releaseGate,
+    LINKS.agentEvals,
+  ],
+  "benchmark-ai-agents-on-your-own-data": [
+    LINKS.agentReliabilityBenchmark,
+    LINKS.benchmarks,
+    LINKS.compare,
+  ],
+  "building-agent-eval-program-regulated-enterprise": [
+    LINKS.ciCdAgentEvaluation,
+    LINKS.agentEvals,
+    LINKS.compare,
+  ],
+  "coding-agent-benchmark-june-2026": [
+    LINKS.benchmarks,
+    LINKS.codingAgentEvaluation,
+    LINKS.changelog,
+  ],
+  "do-ai-models-cheat-by-brand": [
+    LINKS.benchmarks,
+    LINKS.agentTrajectoryEvaluation,
+    LINKS.compare,
+  ],
+  "evaluating-bilingual-customer-support-agents": [
+    LINKS.supportAgentEvaluation,
+    LINKS.agentEvals,
+    LINKS.compare,
+  ],
+  "evaluating-coding-agents-private-repos-checklist": [
+    LINKS.codingAgentEvaluation,
+    LINKS.agentEvals,
+    LINKS.compare,
+  ],
+  "how-agentclash-scores-agent-trajectories": [
+    LINKS.agentTrajectoryEvaluation,
+    LINKS.agentEvals,
+    LINKS.compare,
+  ],
+  "pass-at-k-vs-pass-power-k": [
+    LINKS.agentReliabilityBenchmark,
+    LINKS.releaseGate,
+    LINKS.agentEvals,
+  ],
+  "pass-k-reliability-enterprise-teams": [
+    LINKS.passAtKPost,
+    LINKS.releaseGate,
+    LINKS.agentEvals,
+  ],
+  "product-updates-june-2026": [
+    LINKS.changelog,
+    LINKS.openSourceEvaluation,
+    LINKS.compare,
+  ],
+  "why-agentclash-races-agents-head-to-head": [
+    LINKS.agentEvals,
+    LINKS.llmAgentEvaluation,
+    LINKS.compare,
+  ],
+  "why-ai-pilot-failed-agent-eval-second-attempt": [
+    LINKS.agentEvals,
+    LINKS.ciCdAgentEvaluation,
+    LINKS.compare,
+  ],
+  "why-we-built-agentclash": [
+    LINKS.openSourceEvaluation,
+    LINKS.agentEvals,
+    LINKS.compare,
+  ],
+};
+
+export function getBlogRelatedResources(
+  slug: string,
+): BlogRelatedResourceLink[] {
+  return BLOG_RELATED_RESOURCES[slug] ?? [];
+}
+
+export function getMappedBlogRelatedResourceSlugs(): string[] {
+  return Object.keys(BLOG_RELATED_RESOURCES).sort();
+}

--- a/web/src/lib/marketing-nav.test.ts
+++ b/web/src/lib/marketing-nav.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MARKETING_NAV } from "./marketing-nav";
+
+describe("DEFAULT_MARKETING_NAV", () => {
+  it("includes /compare for high-intent tool comparison discovery", () => {
+    const compare = DEFAULT_MARKETING_NAV.find((item) => item.href === "/compare");
+    expect(compare).toMatchObject({ label: "Compare" });
+  });
+
+  it("keeps /benchmarks as the canonical benchmark hub", () => {
+    const benchmarkLinks = DEFAULT_MARKETING_NAV.filter((item) =>
+      item.href.includes("benchmark"),
+    );
+    expect(benchmarkLinks).toEqual([{ href: "/benchmarks", label: "Benchmarks" }]);
+  });
+});

--- a/web/src/lib/marketing-nav.ts
+++ b/web/src/lib/marketing-nav.ts
@@ -1,0 +1,15 @@
+export type MarketingNavLink = {
+  href: string;
+  label: string;
+  external?: boolean;
+};
+
+export const DEFAULT_MARKETING_NAV: MarketingNavLink[] = [
+  { href: "/#features", label: "Features" },
+  { href: "/enterprise", label: "Enterprise" },
+  { href: "/docs", label: "Docs" },
+  { href: "/benchmarks", label: "Benchmarks" },
+  { href: "/compare", label: "Compare" },
+  { href: "/blog", label: "Blog" },
+  { href: "/changelog", label: "Changelog" },
+];

--- a/web/src/lib/seo-pages/registry.test.ts
+++ b/web/src/lib/seo-pages/registry.test.ts
@@ -2,10 +2,117 @@ import { describe, expect, it } from "vitest";
 import {
   getAllSeoPagePaths,
   getSeoPageByPath,
+  getSeoPagesByPrefix,
   SEO_PAGE_REGISTRY,
 } from "./registry";
 
-describe("SEO page registry cross-links", () => {
+describe("SEO page registry", () => {
+  it("registers every planned landing page path once", () => {
+    expect(getAllSeoPagePaths()).toEqual([
+      "/open-source-ai-agent-evaluation",
+      "/agent-evals",
+      "/llm-agent-evaluation",
+      "/agent-evaluation-framework",
+      "/ai-agent-testing",
+      "/agent-trajectory-evaluation",
+      "/ci-cd-agent-evaluation",
+      "/ai-agent-benchmark",
+      "/agent-reliability-benchmark",
+      "/use-cases/coding-agent-evaluation",
+      "/use-cases/research-agent-evaluation",
+      "/use-cases/support-agent-evaluation",
+      "/industries/banking",
+      "/industries/insurance",
+      "/industries/government",
+      "/glossary/agent-evaluation",
+      "/glossary/challenge-pack",
+      "/glossary/release-gate",
+      "/features/agent-scorecards",
+      "/features/agent-replay",
+      "/features/challenge-packs",
+    ]);
+    expect(SEO_PAGE_REGISTRY).toHaveLength(21);
+  });
+
+  it("groups use-case and feature routes by prefix", () => {
+    expect(getSeoPagesByPrefix("/use-cases").map((page) => page.path)).toEqual([
+      "/use-cases/coding-agent-evaluation",
+      "/use-cases/research-agent-evaluation",
+      "/use-cases/support-agent-evaluation",
+    ]);
+    expect(getSeoPagesByPrefix("/features").map((page) => page.path)).toEqual([
+      "/features/agent-scorecards",
+      "/features/agent-replay",
+      "/features/challenge-packs",
+    ]);
+    expect(getSeoPagesByPrefix("/industries").map((page) => page.path)).toEqual([
+      "/industries/banking",
+      "/industries/insurance",
+      "/industries/government",
+    ]);
+    expect(getSeoPagesByPrefix("/glossary").map((page) => page.path)).toEqual([
+      "/glossary/agent-evaluation",
+      "/glossary/challenge-pack",
+      "/glossary/release-gate",
+    ]);
+  });
+
+  it("includes canonical metadata fields for each page", () => {
+    for (const page of SEO_PAGE_REGISTRY) {
+      expect(getSeoPageByPath(page.path)).toBe(page);
+      expect(page.pageTitle.length).toBeGreaterThan(10);
+      expect(page.metaDescription.length).toBeGreaterThan(40);
+      expect(page.faqItems.length).toBeGreaterThanOrEqual(3);
+      expect(page.breadcrumbs.at(-1)?.url).toBe(page.path);
+    }
+  });
+
+  it("uses collection index URLs for nested page breadcrumbs", () => {
+    for (const page of getSeoPagesByPrefix("/use-cases")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Use cases", url: "/use-cases" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+
+    for (const page of getSeoPagesByPrefix("/features")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Features", url: "/features" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+
+    for (const page of getSeoPagesByPrefix("/industries")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Industries", url: "/industries" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+
+    for (const page of getSeoPagesByPrefix("/glossary")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Glossary", url: "/glossary" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+  });
+
   it("adds hub links to /compare and peer SEO pages without self-links", () => {
     for (const page of SEO_PAGE_REGISTRY) {
       const hrefs = page.relatedLinks.map((link) => link.href);
@@ -15,8 +122,7 @@ describe("SEO page registry cross-links", () => {
     }
   });
 
-  it("indexes every registry path through getAllSeoPagePaths", () => {
-    expect(getAllSeoPagePaths()).toHaveLength(SEO_PAGE_REGISTRY.length);
+  it("includes SEO hub links on S-tier landing pages", () => {
     expect(getSeoPageByPath("/agent-evals")?.relatedLinks.length).toBeGreaterThan(
       3,
     );

--- a/web/src/lib/seo-pages/registry.test.ts
+++ b/web/src/lib/seo-pages/registry.test.ts
@@ -2,114 +2,23 @@ import { describe, expect, it } from "vitest";
 import {
   getAllSeoPagePaths,
   getSeoPageByPath,
-  getSeoPagesByPrefix,
   SEO_PAGE_REGISTRY,
 } from "./registry";
 
-describe("SEO page registry", () => {
-  it("registers every planned landing page path once", () => {
-    expect(getAllSeoPagePaths()).toEqual([
-      "/open-source-ai-agent-evaluation",
-      "/agent-evals",
-      "/llm-agent-evaluation",
-      "/agent-evaluation-framework",
-      "/ai-agent-testing",
-      "/agent-trajectory-evaluation",
-      "/ci-cd-agent-evaluation",
-      "/ai-agent-benchmark",
-      "/agent-reliability-benchmark",
-      "/use-cases/coding-agent-evaluation",
-      "/use-cases/research-agent-evaluation",
-      "/use-cases/support-agent-evaluation",
-      "/industries/banking",
-      "/industries/insurance",
-      "/industries/government",
-      "/glossary/agent-evaluation",
-      "/glossary/challenge-pack",
-      "/glossary/release-gate",
-      "/features/agent-scorecards",
-      "/features/agent-replay",
-      "/features/challenge-packs",
-    ]);
-    expect(SEO_PAGE_REGISTRY).toHaveLength(21);
-  });
-
-  it("groups use-case and feature routes by prefix", () => {
-    expect(getSeoPagesByPrefix("/use-cases").map((page) => page.path)).toEqual([
-      "/use-cases/coding-agent-evaluation",
-      "/use-cases/research-agent-evaluation",
-      "/use-cases/support-agent-evaluation",
-    ]);
-    expect(getSeoPagesByPrefix("/features").map((page) => page.path)).toEqual([
-      "/features/agent-scorecards",
-      "/features/agent-replay",
-      "/features/challenge-packs",
-    ]);
-    expect(getSeoPagesByPrefix("/industries").map((page) => page.path)).toEqual([
-      "/industries/banking",
-      "/industries/insurance",
-      "/industries/government",
-    ]);
-    expect(getSeoPagesByPrefix("/glossary").map((page) => page.path)).toEqual([
-      "/glossary/agent-evaluation",
-      "/glossary/challenge-pack",
-      "/glossary/release-gate",
-    ]);
-  });
-
-  it("includes canonical metadata fields for each page", () => {
+describe("SEO page registry cross-links", () => {
+  it("adds hub links to /compare and peer SEO pages without self-links", () => {
     for (const page of SEO_PAGE_REGISTRY) {
-      expect(getSeoPageByPath(page.path)).toBe(page);
-      expect(page.pageTitle.length).toBeGreaterThan(10);
-      expect(page.metaDescription.length).toBeGreaterThan(40);
-      expect(page.faqItems.length).toBeGreaterThanOrEqual(3);
-      expect(page.breadcrumbs.at(-1)?.url).toBe(page.path);
+      const hrefs = page.relatedLinks.map((link) => link.href);
+      expect(hrefs).toContain("/compare");
+      expect(hrefs).not.toContain(page.path);
+      expect(new Set(hrefs).size).toBe(hrefs.length);
     }
   });
 
-  it("uses collection index URLs for nested page breadcrumbs", () => {
-    for (const page of getSeoPagesByPrefix("/use-cases")) {
-      expect(page.breadcrumbs).toEqual([
-        { name: "Home", url: "/" },
-        { name: "Use cases", url: "/use-cases" },
-        { name: expect.any(String), url: page.path },
-      ]);
-      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
-        page.breadcrumbs.length,
-      );
-    }
-
-    for (const page of getSeoPagesByPrefix("/features")) {
-      expect(page.breadcrumbs).toEqual([
-        { name: "Home", url: "/" },
-        { name: "Features", url: "/features" },
-        { name: expect.any(String), url: page.path },
-      ]);
-      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
-        page.breadcrumbs.length,
-      );
-    }
-
-    for (const page of getSeoPagesByPrefix("/industries")) {
-      expect(page.breadcrumbs).toEqual([
-        { name: "Home", url: "/" },
-        { name: "Industries", url: "/industries" },
-        { name: expect.any(String), url: page.path },
-      ]);
-      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
-        page.breadcrumbs.length,
-      );
-    }
-
-    for (const page of getSeoPagesByPrefix("/glossary")) {
-      expect(page.breadcrumbs).toEqual([
-        { name: "Home", url: "/" },
-        { name: "Glossary", url: "/glossary" },
-        { name: expect.any(String), url: page.path },
-      ]);
-      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
-        page.breadcrumbs.length,
-      );
-    }
+  it("indexes every registry path through getAllSeoPagePaths", () => {
+    expect(getAllSeoPagePaths()).toHaveLength(SEO_PAGE_REGISTRY.length);
+    expect(getSeoPageByPath("/agent-evals")?.relatedLinks.length).toBeGreaterThan(
+      3,
+    );
   });
 });

--- a/web/src/lib/seo-pages/registry.ts
+++ b/web/src/lib/seo-pages/registry.ts
@@ -21,6 +21,40 @@ const sharedDocsLinks = [
   },
 ] as const;
 
+const seoHubLinks = [
+  {
+    title: "Agent evals",
+    text: "Real-task agent evals with replay evidence and CI gates.",
+    href: "/agent-evals",
+  },
+  {
+    title: "LLM agent evaluation",
+    text: "Evaluate LLM agents on full trajectories, not one-shot answers.",
+    href: "/llm-agent-evaluation",
+  },
+  {
+    title: "Compare tools",
+    text: "See how AgentClash differs from prompt-eval platforms.",
+    href: "/compare",
+  },
+] as const;
+
+function seoHubLinksFor(path: string): SeoPageConfig["relatedLinks"] {
+  return seoHubLinks.filter((link) => link.href !== path);
+}
+
+function dedupeRelatedLinks(
+  links: SeoPageConfig["relatedLinks"],
+): SeoPageConfig["relatedLinks"] {
+  const seen = new Set<string>();
+
+  return links.filter((link) => {
+    if (seen.has(link.href)) return false;
+    seen.add(link.href);
+    return true;
+  });
+}
+
 function page(
   config: Omit<
     SeoPageConfig,
@@ -32,9 +66,14 @@ function page(
     faqItems: SeoPageConfig["faqItems"];
   },
 ): SeoPageConfig {
+  const { relatedLinks: customRelatedLinks, ...rest } = config;
+
   return {
     proofPoints: sharedProofPoints,
-    relatedLinks: [...sharedDocsLinks],
+    relatedLinks: dedupeRelatedLinks([
+      ...seoHubLinksFor(config.path),
+      ...(customRelatedLinks ?? sharedDocsLinks),
+    ]),
     workflow: [
       {
         title: "Package the task",
@@ -53,7 +92,7 @@ function page(
         text: "Compare candidate and baseline runs, then fail CI before a regression reaches users.",
       },
     ],
-    ...config,
+    ...rest,
   };
 }
 
@@ -265,14 +304,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
           "Yes. Challenge packs carry scoring rules, validators, and judge configuration so teams can encode domain-specific pass conditions.",
       },
     ],
-    relatedLinks: [
-      {
-        title: "Compare tools",
-        text: "See how AgentClash differs from prompt-eval platforms.",
-        href: "/compare",
-      },
-      ...sharedDocsLinks,
-    ],
+    relatedLinks: [...sharedDocsLinks],
   }),
   page({
     path: "/ai-agent-testing",


### PR DESCRIPTION
## Summary

- Adds `/compare` to the default marketing header nav (footer already linked Compare tools).
- Introduces topic-selected `BlogRelatedResources` blocks on blog posts via a slug map, replacing inline MDX "Related resources" sections.
- Adds SEO hub cross-links (`/agent-evals`, `/llm-agent-evaluation`, `/compare`) to every registry landing page without self-links.
- Publishes a June 2026 changelog rollup blog post linking to `/changelog` and recent release periods.
- Extends sitemap tests to assert every `getAllSeoPagePaths()` entry is indexed.

Review contract: `testing/feat-nav-cross-linking-993.md`

Closes #993

## Test plan

- [x] `cd web && pnpm exec vitest run src/lib/marketing-nav.test.ts src/lib/blog-related-resources.test.ts src/lib/seo-pages/registry.test.ts src/app/sitemap.test.ts`
- [x] `cd web && pnpm build`
- [ ] Manual: confirm header Compare link on `/`
- [ ] Manual: open `/blog/product-updates-june-2026` and verify changelog links
- [ ] Manual: open `/agent-evals` and confirm related links include `/compare`