### PR TITLE
[codex] Fix public tryout artifacts and model selection

### DIFF
--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -56,18 +56,9 @@ type tryoutModelPolicy struct {
 // ErrAgentTryoutModelPolicyInvalid for malformed input and
 // ErrAgentTryoutModelUnavailable for unknown providers / empty model ids.
 func validateTryoutModelPolicy(raw json.RawMessage) error {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed == "null" {
-		return fmt.Errorf("%w: model policy is required", ErrAgentTryoutModelPolicyInvalid)
-	}
-	if trimmed[0] != '{' {
-		return fmt.Errorf("%w: model policy must be a JSON object", ErrAgentTryoutModelPolicyInvalid)
-	}
-	var policy tryoutModelPolicy
-	decoder := json.NewDecoder(strings.NewReader(trimmed))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&policy); err != nil {
-		return fmt.Errorf("%w: %v", ErrAgentTryoutModelPolicyInvalid, err)
+	policy, err := parseTryoutModelPolicy(raw)
+	if err != nil {
+		return err
 	}
 	mode := strings.TrimSpace(policy.Mode)
 	if mode == "" && len(policy.Models) == 0 {
@@ -87,6 +78,23 @@ func validateTryoutModelPolicy(raw json.RawMessage) error {
 		}
 	}
 	return nil
+}
+
+func parseTryoutModelPolicy(raw json.RawMessage) (tryoutModelPolicy, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return tryoutModelPolicy{}, fmt.Errorf("%w: model policy is required", ErrAgentTryoutModelPolicyInvalid)
+	}
+	if trimmed[0] != '{' {
+		return tryoutModelPolicy{}, fmt.Errorf("%w: model policy must be a JSON object", ErrAgentTryoutModelPolicyInvalid)
+	}
+	var policy tryoutModelPolicy
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return tryoutModelPolicy{}, fmt.Errorf("%w: %v", ErrAgentTryoutModelPolicyInvalid, err)
+	}
+	return policy, nil
 }
 
 // RerunAgentTryoutInput requests a rerun of an existing workspace tryout with a

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -116,6 +116,7 @@ type CreateAnonymousAgentTryoutInput struct {
 	TemplateSlug         string
 	Input                json.RawMessage
 	SelectedHarnessKind  string
+	SelectedModelPolicy  json.RawMessage
 	AnonymousFingerprint string
 	Now                  time.Time
 }
@@ -277,6 +278,13 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	if err != nil {
 		return repository.AgentTryout{}, err
 	}
+	selectedModelPolicy := template.DefaultModelPolicy
+	if len(input.SelectedModelPolicy) > 0 {
+		selectedModelPolicy = input.SelectedModelPolicy
+	}
+	if err := validatePublicTryoutModelSelection(selectedHarness, selectedModelPolicy); err != nil {
+		return repository.AgentTryout{}, err
+	}
 	now := input.Now
 	if now.IsZero() {
 		now = m.now()
@@ -290,7 +298,7 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		TemplateSnapshot:         templateSnapshot(template),
 		ToolPolicySnapshot:       template.ToolPolicy,
 		EvaluationSpecSnapshot:   template.EvaluationSpec,
-		SelectedModelPolicy:      template.DefaultModelPolicy,
+		SelectedModelPolicy:      selectedModelPolicy,
 		SelectedHarnessKind:      selectedHarness,
 		Summary:                  json.RawMessage(`{}`),
 		RedactionStatus:          repository.AgentTryoutRedactionPending,
@@ -979,6 +987,7 @@ type createAgentTryoutRequest struct {
 	TemplateSlug        string          `json:"template_slug"`
 	Input               json.RawMessage `json:"input"`
 	SelectedHarnessKind string          `json:"selected_harness_kind,omitempty"`
+	SelectedModelPolicy json.RawMessage `json:"selected_model_policy,omitempty"`
 }
 
 type claimAgentTryoutRequest struct {
@@ -1092,6 +1101,7 @@ func createAnonymousAgentTryoutHandler(logger *slog.Logger, service AgentTryoutS
 			TemplateSlug:         req.TemplateSlug,
 			Input:                req.Input,
 			SelectedHarnessKind:  req.SelectedHarnessKind,
+			SelectedModelPolicy:  req.SelectedModelPolicy,
 			AnonymousFingerprint: anonymousFingerprintFromRequest(r),
 		})
 		if err != nil {
@@ -1477,6 +1487,39 @@ func agentTryoutTemplateUnavailableMessage(err error) string {
 		return "agent tryout template is unavailable"
 	}
 	return message
+}
+
+func validatePublicTryoutModelSelection(selectedHarness *string, policy json.RawMessage) error {
+	if err := validateTryoutModelPolicy(policy); err != nil {
+		return err
+	}
+	parsed, err := parseTryoutModelPolicy(policy)
+	if err != nil {
+		return err
+	}
+	if len(parsed.Models) == 0 {
+		return nil
+	}
+	harnessKind := domain.NormalizeAgentHarnessKind("")
+	if selectedHarness != nil {
+		harnessKind = domain.NormalizeAgentHarnessKind(*selectedHarness)
+	}
+	provider := strings.TrimSpace(parsed.Models[0].Provider)
+	switch harnessKind {
+	case domain.AgentHarnessKindClaudeE2B:
+		if provider != "anthropic" {
+			return fmt.Errorf("%w: claude tryouts require an anthropic model", ErrAgentTryoutModelUnavailable)
+		}
+	case domain.AgentHarnessKindOpenClawE2B:
+		if provider != "openrouter" {
+			return fmt.Errorf("%w: OpenRouter Gemini tryouts require provider openrouter", ErrAgentTryoutModelUnavailable)
+		}
+	default:
+		if provider != "openai" {
+			return fmt.Errorf("%w: codex tryouts require an openai model", ErrAgentTryoutModelUnavailable)
+		}
+	}
+	return nil
 }
 
 func mapAgentTryoutResponse(tryout repository.AgentTryout) agentTryoutResponse {

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -55,6 +55,47 @@ func TestAgentTryoutManagerCreateAnonymousPersistsGuardrailSnapshots(t *testing.
 	}
 }
 
+func TestAgentTryoutManagerCreateAnonymousPersistsSelectedModelPolicy(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "slide-deck",
+		Input:                json.RawMessage(`{"brief":"make a launch deck"}`),
+		SelectedHarnessKind:  "claude_e2b",
+		SelectedModelPolicy:  json.RawMessage(`{"mode":"explicit","max_models":1,"models":[{"provider":"anthropic","model":"claude-sonnet-4-5"}]}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.SelectedHarnessKind == nil || *tryout.SelectedHarnessKind != "claude_e2b" {
+		t.Fatalf("selected harness = %v, want claude_e2b", tryout.SelectedHarnessKind)
+	}
+	if !bytes.Contains(tryout.SelectedModelPolicy, []byte(`"provider":"anthropic"`)) ||
+		!bytes.Contains(tryout.SelectedModelPolicy, []byte(`"model":"claude-sonnet-4-5"`)) {
+		t.Fatalf("selected model policy = %s", tryout.SelectedModelPolicy)
+	}
+}
+
+func TestAgentTryoutManagerRejectsPublicModelHarnessMismatch(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "slide-deck",
+		Input:                json.RawMessage(`{"brief":"make a launch deck"}`),
+		SelectedHarnessKind:  "claude_e2b",
+		SelectedModelPolicy:  json.RawMessage(`{"mode":"explicit","models":[{"provider":"openai","model":"gpt-5"}]}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrAgentTryoutModelUnavailable) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutModelUnavailable", err)
+	}
+}
+
 func TestAgentTryoutManagerRejectsAnonymousWhenTemplateDisabled(t *testing.T) {
 	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
 	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
@@ -1104,6 +1145,7 @@ func (r *fakeAgentTryoutRepository) CreateAgentTryout(_ context.Context, params 
 		ToolPolicySnapshot:       params.ToolPolicySnapshot,
 		EvaluationSpecSnapshot:   params.EvaluationSpecSnapshot,
 		SelectedModelPolicy:      params.SelectedModelPolicy,
+		SelectedHarnessKind:      params.SelectedHarnessKind,
 		Summary:                  params.Summary,
 		RedactionStatus:          params.RedactionStatus,
 		RunID:                    params.RunID,

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -129,6 +129,10 @@ func (a *Activities) executePublicTryoutSandbox(ctx context.Context, tryout repo
 
 	harness := publicTryoutHarnessSnapshot(config, tryout, harnessKind, credentialRef)
 	env := publicTryoutRunnerEnv(harnessKind, harness, credential)
+	selectedModel := publicTryoutSelectedModel(tryout.SelectedModelPolicy)
+	if selectedModel != "" {
+		env["AGENTCLASH_SELECTED_MODEL"] = selectedModel
+	}
 
 	sessionCap := publicTryoutSessionCap
 
@@ -167,6 +171,11 @@ func (a *Activities) executePublicTryoutSandbox(ctx context.Context, tryout repo
 		return nil, err
 	}
 	outputs = a.publicTryoutOutputPreviews(ctx, tryout.ID, session, harness.ExecutionConfig)
+	if len(outputs) > 0 {
+		if err := a.updatePublicTryoutOutputSnapshot(ctx, tryout, outputs, harnessKind, selectedModel); err != nil {
+			return nil, err
+		}
+	}
 
 	// Conversational turns: drain user messages until end / idle / cap.
 	lastActivity := time.Now()
@@ -197,6 +206,11 @@ func (a *Activities) executePublicTryoutSandbox(ctx context.Context, tryout repo
 		}
 		_ = a.publicTryoutRepo.MarkAgentTryoutTurnProcessed(ctx, turn.ID)
 		outputs = a.publicTryoutOutputPreviews(ctx, tryout.ID, session, harness.ExecutionConfig)
+		if len(outputs) > 0 {
+			if err := a.updatePublicTryoutOutputSnapshot(ctx, tryout, outputs, harnessKind, selectedModel); err != nil {
+				return nil, err
+			}
+		}
 		lastActivity = time.Now()
 	}
 
@@ -211,7 +225,7 @@ func (a *Activities) executePublicTryoutSandbox(ctx context.Context, tryout repo
 // runPublicTryoutTurn executes one agent turn in the live sandbox, streaming the
 // agent's reasoning + tool calls into the tryout event log as it runs.
 func (a *Activities) runPublicTryoutTurn(ctx context.Context, tryout repository.AgentTryout, session sandbox.Session, harnessKind string, env map[string]string, message string, firstTurn bool) error {
-	command, err := publicTurnCommand(harnessKind, agentHarnessWorkspaceDir, message, firstTurn)
+	command, err := publicTurnCommand(harnessKind, agentHarnessWorkspaceDir, message, firstTurn, env["AGENTCLASH_SELECTED_MODEL"])
 	if err != nil {
 		return err
 	}
@@ -280,10 +294,14 @@ func turnLabel(firstTurn bool) string {
 // the session; later turns resume it so conversation state carries across turns
 // (verified live: codex `exec resume --last`, claude `--continue`, openclaw
 // reuses --session-id).
-func publicTurnCommand(harnessKind, workdir, message string, firstTurn bool) ([]string, error) {
+func publicTurnCommand(harnessKind, workdir, message string, firstTurn bool, selectedModel string) ([]string, error) {
+	selectedModel = strings.TrimSpace(selectedModel)
 	switch domain.NormalizeAgentHarnessKind(harnessKind) {
 	case domain.AgentHarnessKindClaudeE2B:
 		cmd := []string{"claude", "-p", "--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions"}
+		if selectedModel != "" {
+			cmd = append(cmd, "--model", selectedModel)
+		}
 		if !firstTurn {
 			cmd = append(cmd, "--continue")
 		}
@@ -296,14 +314,18 @@ func publicTurnCommand(harnessKind, workdir, message string, firstTurn bool) ([]
 				`elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then AUTH_CHOICE=apiKey`,
 				`elif [ -n "${OPENROUTER_API_KEY:-}" ]; then AUTH_CHOICE=openrouter-api-key`,
 				`else echo "missing OpenClaw provider API key" >&2; exit 1; fi`,
+				`MODEL_ARGS=()`,
+				`if [ -n "${AGENTCLASH_SELECTED_MODEL:-}" ]; then MODEL_ARGS=(--model "$AGENTCLASH_SELECTED_MODEL"); fi`,
 				`openclaw setup --workspace "$PWD" --mode local --non-interactive --accept-risk`,
 				`openclaw onboard --non-interactive --mode local --auth-choice "$AUTH_CHOICE" --secret-input-mode ref --accept-risk --skip-bootstrap --skip-health`,
-				`exec openclaw agent --local --session-id agentclash-tryout --json --timeout "${AGENTCLASH_HARNESS_TIMEOUT_SECONDS:-1800}" -m "$AGENTCLASH_HARNESS_TASK"`,
+				`exec openclaw agent --local --session-id agentclash-tryout --json --timeout "${AGENTCLASH_HARNESS_TIMEOUT_SECONDS:-1800}" "${MODEL_ARGS[@]}" -m "$AGENTCLASH_HARNESS_TASK"`,
 			}, "\n")
 			return []string{"bash", "-lc", script}, nil
 		}
 		script := `set -euo pipefail
-exec openclaw agent --local --session-id agentclash-tryout --json --timeout "${AGENTCLASH_HARNESS_TIMEOUT_SECONDS:-1800}" -m "$AGENTCLASH_TURN_MESSAGE"`
+MODEL_ARGS=()
+if [ -n "${AGENTCLASH_SELECTED_MODEL:-}" ]; then MODEL_ARGS=(--model "$AGENTCLASH_SELECTED_MODEL"); fi
+exec openclaw agent --local --session-id agentclash-tryout --json --timeout "${AGENTCLASH_HARNESS_TIMEOUT_SECONDS:-1800}" "${MODEL_ARGS[@]}" -m "$AGENTCLASH_TURN_MESSAGE"`
 		return []string{"bash", "-lc", script}, nil
 	default: // codex_e2b
 		// E2B already isolates the sandbox; Codex's own OS sandbox fails nested
@@ -312,17 +334,25 @@ exec openclaw agent --local --session-id agentclash-tryout --json --timeout "${A
 		if !firstTurn {
 			// `codex exec resume` restores the session's original cwd and does
 			// NOT accept -C (passing it exits 2). Verified live.
-			return []string{
+			cmd := []string{
 				"codex", "exec", "resume", "--last",
 				"--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check",
-				"--json", message,
-			}, nil
+				"--json",
+			}
+			if selectedModel != "" {
+				cmd = append(cmd, "--model", selectedModel)
+			}
+			return append(cmd, message), nil
 		}
-		return []string{
+		cmd := []string{
 			"codex", "exec",
 			"--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check",
-			"--json", "-C", workdir, message,
-		}, nil
+			"--json",
+		}
+		if selectedModel != "" {
+			cmd = append(cmd, "--model", selectedModel)
+		}
+		return append(cmd, "-C", workdir, message), nil
 	}
 }
 
@@ -430,6 +460,15 @@ func maputilClone(in map[string]string) map[string]string {
 	return out
 }
 
+func (a *Activities) updatePublicTryoutOutputSnapshot(ctx context.Context, tryout repository.AgentTryout, outputs []map[string]any, harnessKind string, selectedModel string) error {
+	_, err := a.publicTryoutRepo.UpdateAgentTryoutStatus(ctx, repository.UpdateAgentTryoutStatusParams{
+		ID:      tryout.ID,
+		Status:  repository.AgentTryoutStatusRunning,
+		Summary: publicTryoutRunningSummary(outputs, harnessKind, selectedModel),
+	})
+	return err
+}
+
 func (a *Activities) publicTryoutOutputPreviews(ctx context.Context, tryoutID uuid.UUID, session sandbox.Session, executionConfig json.RawMessage) []map[string]any {
 	specs := expectedArtifactsFromExecutionConfig(executionConfig)
 	outputs := make([]map[string]any, 0, len(specs))
@@ -486,6 +525,21 @@ func publicTryoutOutputIsTextPreviewable(templateType, rel, contentType string) 
 		return true
 	}
 	return strings.HasPrefix(contentType, "text/")
+}
+
+func publicTryoutSelectedModel(policy json.RawMessage) string {
+	var parsed struct {
+		Models []struct {
+			Model string `json:"model"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(policy, &parsed); err != nil {
+		return ""
+	}
+	if len(parsed.Models) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Models[0].Model)
 }
 
 func publicTryoutHarnessSnapshot(config PublicAgentTryoutConfig, tryout repository.AgentTryout, harnessKind string, credentialRef string) agentHarnessSnapshot {
@@ -585,6 +639,17 @@ func publicTryoutSecretName(credentialRef string) string {
 
 func publicTryoutSummary(code string, message string) json.RawMessage {
 	payload, _ := json.Marshal(map[string]string{"code": code, "message": message})
+	return payload
+}
+
+func publicTryoutRunningSummary(outputs []map[string]any, harnessKind string, selectedModel string) json.RawMessage {
+	payload, _ := json.Marshal(map[string]any{
+		"code":                  "outputs_ready",
+		"message":               "The hosted agent produced downloadable outputs. You can keep chatting to request edits, or end the session to finalize scoring.",
+		"outputs":               outputs,
+		"selected_harness_kind": strings.TrimSpace(harnessKind),
+		"selected_model":        strings.TrimSpace(selectedModel),
+	})
 	return payload
 }
 

--- a/backend/internal/workflow/public_agent_tryout_workflow_test.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow_test.go
@@ -70,8 +70,8 @@ func TestPublicTurnCommandResumesSessionAfterFirstTurn(t *testing.T) {
 	join := func(parts []string) string { return strings.Join(parts, " ") }
 
 	// Codex: opening turn vs resume.
-	first, _ := publicTurnCommand(domain.AgentHarnessKindCodexE2B, "/workspace", "hi", true)
-	resume, _ := publicTurnCommand(domain.AgentHarnessKindCodexE2B, "/workspace", "next", false)
+	first, _ := publicTurnCommand(domain.AgentHarnessKindCodexE2B, "/workspace", "hi", true, "")
+	resume, _ := publicTurnCommand(domain.AgentHarnessKindCodexE2B, "/workspace", "next", false, "")
 	if strings.Contains(join(first), "resume") {
 		t.Fatalf("codex opening turn should not resume: %v", first)
 	}
@@ -80,8 +80,8 @@ func TestPublicTurnCommandResumesSessionAfterFirstTurn(t *testing.T) {
 	}
 
 	// Claude: --continue only on follow-ups.
-	cFirst, _ := publicTurnCommand(domain.AgentHarnessKindClaudeE2B, "/workspace", "hi", true)
-	cResume, _ := publicTurnCommand(domain.AgentHarnessKindClaudeE2B, "/workspace", "next", false)
+	cFirst, _ := publicTurnCommand(domain.AgentHarnessKindClaudeE2B, "/workspace", "hi", true, "")
+	cResume, _ := publicTurnCommand(domain.AgentHarnessKindClaudeE2B, "/workspace", "next", false, "")
 	if strings.Contains(join(cFirst), "--continue") {
 		t.Fatalf("claude opening turn should not continue: %v", cFirst)
 	}
@@ -90,13 +90,60 @@ func TestPublicTurnCommandResumesSessionAfterFirstTurn(t *testing.T) {
 	}
 
 	// OpenClaw: same session id across turns.
-	oFirst, _ := publicTurnCommand(domain.AgentHarnessKindOpenClawE2B, "/workspace", "hi", true)
-	oResume, _ := publicTurnCommand(domain.AgentHarnessKindOpenClawE2B, "/workspace", "next", false)
+	oFirst, _ := publicTurnCommand(domain.AgentHarnessKindOpenClawE2B, "/workspace", "hi", true, "")
+	oResume, _ := publicTurnCommand(domain.AgentHarnessKindOpenClawE2B, "/workspace", "next", false, "")
 	if !strings.Contains(join(oFirst), "session-id agentclash-tryout") || !strings.Contains(join(oResume), "session-id agentclash-tryout") {
 		t.Fatalf("openclaw turns must reuse session id: %v / %v", oFirst, oResume)
 	}
 	if !strings.Contains(join(oFirst), "onboard") || strings.Contains(join(oResume), "onboard") {
 		t.Fatalf("openclaw onboard should run only on opening turn: %v / %v", oFirst, oResume)
+	}
+}
+
+func TestPublicTurnCommandAppliesSelectedModel(t *testing.T) {
+	codex, _ := publicTurnCommand(domain.AgentHarnessKindCodexE2B, "/workspace", "hi", true, "gpt-5")
+	if !strings.Contains(strings.Join(codex, " "), "--model gpt-5") {
+		t.Fatalf("codex command missing selected model: %v", codex)
+	}
+
+	claude, _ := publicTurnCommand(domain.AgentHarnessKindClaudeE2B, "/workspace", "hi", true, "claude-sonnet-4-5")
+	if !strings.Contains(strings.Join(claude, " "), "--model claude-sonnet-4-5") {
+		t.Fatalf("claude command missing selected model: %v", claude)
+	}
+
+	openclaw, _ := publicTurnCommand(domain.AgentHarnessKindOpenClawE2B, "/workspace", "hi", true, "google/gemini-2.5-pro")
+	if !strings.Contains(strings.Join(openclaw, " "), "AGENTCLASH_SELECTED_MODEL") ||
+		!strings.Contains(strings.Join(openclaw, " "), "--model") {
+		t.Fatalf("openclaw command missing selected model routing: %v", openclaw)
+	}
+}
+
+func TestPublicTryoutRunningSummaryExposesOutputsWhileActive(t *testing.T) {
+	summary := publicTryoutRunningSummary(
+		[]map[string]any{{
+			"key":           "presentation",
+			"type":          "pptx",
+			"relative_path": "deck.pptx",
+			"preview":       "UEsDB",
+			"encoding":      "base64",
+		}},
+		domain.AgentHarnessKindCodexE2B,
+		"gpt-5",
+	)
+
+	var decoded map[string]any
+	if err := json.Unmarshal(summary, &decoded); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	if decoded["code"] != "outputs_ready" {
+		t.Fatalf("code = %v, want outputs_ready", decoded["code"])
+	}
+	if decoded["selected_model"] != "gpt-5" {
+		t.Fatalf("selected_model = %v, want gpt-5", decoded["selected_model"])
+	}
+	outputs, ok := decoded["outputs"].([]any)
+	if !ok || len(outputs) != 1 {
+		t.Fatalf("outputs = %#v, want one output", decoded["outputs"])
 	}
 }
 

--- a/testing/codex-tryouts-artifacts-model-selection.md
+++ b/testing/codex-tryouts-artifacts-model-selection.md
@@ -1,0 +1,35 @@
+# codex/tryouts-artifacts-model-selection — Test Contract
+
+## Functional Behavior
+- Public tryouts expose a concrete agent/model choice in the UI and API input.
+- Supported public agent choices cover OpenAI/Codex, Anthropic/Claude, and OpenRouter/Gemini.
+- If no choice is made, the tryout keeps the existing hosted default behavior.
+- After any successful agent turn writes expected artifacts, the public tryout response includes the latest artifact previews even while the chat session remains open.
+- A user can download or preview the latest artifacts after the opening turn, then send follow-up edit messages.
+- After follow-up edit messages, downloadable artifacts update to the newest artifact snapshot.
+- If the user sends several messages and then stops, artifacts remain downloadable while the session idles and later finalizes.
+- Terminal completed summaries still include outputs and scorecards as before.
+- The slide deck template no longer leaves users trapped behind a generic Thinking state after files are ready.
+
+## Unit Tests
+- Backend workflow tests cover successful opening turn with artifacts and verify outputs are persisted before terminal completion.
+- Backend API tests cover selected public harness/model validation for OpenAI, Anthropic, and OpenRouter/Gemini choices.
+- Frontend tests or focused type checks cover model option payload construction and artifact rendering from non-terminal summaries.
+
+## Integration / Functional Tests
+- Public create tryout accepts a selected model policy and selected harness kind.
+- Public get tryout returns `summary.outputs` while status is still `running` when an artifact snapshot exists.
+- Public events continue to show tool/model progress without leaking secrets.
+
+## Smoke Tests
+- `go test ./internal/api ./internal/workflow` from `backend/`.
+- `pnpm exec vitest run` for the relevant tryouts or API tests from `web/`, if matching test harness exists.
+- `pnpm exec tsc --noEmit` or the repo's equivalent web type check if no focused frontend test exists.
+
+## E2E Tests
+- Manual/live path: open `/tryouts`, choose slide deck, select an agent/model, submit a deck prompt, verify files become downloadable after the first successful turn without waiting for idle finalization, then send an edit and verify the session remains usable.
+
+## Manual / cURL Tests
+- `curl https://api.agentclash.dev/v1/agent-tryout-templates` should show public templates and model metadata once deployed.
+- For local API, POST `/v1/agent-tryouts` with `template_slug=slide-deck`, `selected_harness_kind=codex_e2b`, and an OpenAI model policy should create a queued tryout.
+- Repeat with `claude_e2b` and `openclaw_e2b`/OpenRouter Gemini policy validation.

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -36,6 +36,7 @@ import { ApiError } from "@/lib/api/errors";
 import type {
   AgentHarnessKind,
   AgentTryout,
+  AgentTryoutModelPolicy,
   AgentTryoutTemplate,
   TryoutTimelineEvent,
 } from "@/lib/api/types";
@@ -74,15 +75,93 @@ type AgentOption = {
   hint: string;
 };
 
-const AGENT_OPTIONS: AgentOption[] = [
-  { value: "", label: "Auto", hint: "Hosted default agent" },
-  { value: "codex_e2b", label: "Codex", hint: "OpenAI Codex CLI" },
-  { value: "claude_e2b", label: "Claude", hint: "Anthropic Claude Code" },
-  { value: "openclaw_e2b", label: "OpenClaw", hint: "OpenRouter-routed" },
+type ModelOption = AgentOption & {
+  provider?: "openai" | "anthropic" | "openrouter";
+  model?: string;
+};
+
+const MODEL_OPTIONS: ModelOption[] = [
+  { value: "", label: "Auto", hint: "Hosted default agent and model" },
+  {
+    value: "codex_e2b",
+    label: "GPT-5",
+    hint: "OpenAI via Codex",
+    provider: "openai",
+    model: "gpt-5",
+  },
+  {
+    value: "codex_e2b",
+    label: "GPT-5 mini",
+    hint: "OpenAI via Codex",
+    provider: "openai",
+    model: "gpt-5-mini",
+  },
+  {
+    value: "claude_e2b",
+    label: "Claude Sonnet 4.5",
+    hint: "Anthropic via Claude Code",
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+  },
+  {
+    value: "claude_e2b",
+    label: "Claude Opus 4.1",
+    hint: "Anthropic via Claude Code",
+    provider: "anthropic",
+    model: "claude-opus-4-1",
+  },
+  {
+    value: "openclaw_e2b",
+    label: "Gemini 2.5 Pro",
+    hint: "Google Gemini via OpenRouter",
+    provider: "openrouter",
+    model: "google/gemini-2.5-pro",
+  },
+  {
+    value: "openclaw_e2b",
+    label: "Gemini 2.5 Flash",
+    hint: "Google Gemini via OpenRouter",
+    provider: "openrouter",
+    model: "google/gemini-2.5-flash",
+  },
 ];
 
 function agentLabel(value: string): string {
-  return AGENT_OPTIONS.find((option) => option.value === value)?.label ?? "Auto";
+  switch (value) {
+    case "codex_e2b":
+      return "Codex";
+    case "claude_e2b":
+      return "Claude";
+    case "openclaw_e2b":
+      return "OpenClaw";
+    default:
+      return "Auto";
+  }
+}
+
+function modelOptionKey(option: ModelOption): string {
+  return option.model ? `${option.provider}:${option.model}` : "auto";
+}
+
+function modelPolicyFor(option: ModelOption): AgentTryoutModelPolicy | undefined {
+  if (!option.provider || !option.model) return undefined;
+  return {
+    mode: "explicit",
+    max_models: 1,
+    models: [{ provider: option.provider, model: option.model }],
+  };
+}
+
+function modelLabelFromPolicy(policy: unknown): string {
+  if (!policy || typeof policy !== "object") return "Auto";
+  const models = (policy as { models?: unknown }).models;
+  if (!Array.isArray(models) || models.length === 0) return "Auto";
+  const first = models[0] as { provider?: unknown; model?: unknown };
+  if (typeof first.model !== "string" || first.model.trim() === "") return "Auto";
+  const match = MODEL_OPTIONS.find(
+    (option) => option.provider === first.provider && option.model === first.model,
+  );
+  return match?.label ?? first.model;
 }
 
 const TASK_SUGGESTIONS: Record<string, string[]> = {
@@ -161,7 +240,7 @@ export function PublicTryoutsClient() {
 
   const [templates, setTemplates] = useState<AgentTryoutTemplate[]>([]);
   const [templateSlug, setTemplateSlug] = useState("");
-  const [agent, setAgent] = useState<"" | AgentHarnessKind>("");
+  const [selectedModelKey, setSelectedModelKey] = useState("auto");
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [templatesLoading, setTemplatesLoading] = useState(true);
   const [launching, setLaunching] = useState(false);
@@ -300,6 +379,10 @@ export function PublicTryoutsClient() {
       setMessage(input.error);
       return;
     }
+    const selectedModel =
+      MODEL_OPTIONS.find((option) => modelOptionKey(option) === selectedModelKey) ??
+      MODEL_OPTIONS[0];
+    const selectedPolicy = modelPolicyFor(selectedModel);
 
     setLaunching(true);
     setMessage(null);
@@ -308,7 +391,8 @@ export function PublicTryoutsClient() {
       const nextTryout = await createAnonymousAgentTryout(api, {
         template_slug: template.slug,
         input: input.value,
-        ...(agent ? { selected_harness_kind: agent } : {}),
+        ...(selectedModel.value ? { selected_harness_kind: selectedModel.value } : {}),
+        ...(selectedPolicy ? { selected_model_policy: selectedPolicy } : {}),
       });
       setTryout(nextTryout);
       setEvents([]);
@@ -402,8 +486,8 @@ export function PublicTryoutsClient() {
           templates={templates}
           templateSlug={templateSlug}
           setTemplateSlug={setTemplateSlug}
-          agent={agent}
-          setAgent={setAgent}
+          selectedModelKey={selectedModelKey}
+          setSelectedModelKey={setSelectedModelKey}
           primaryField={primaryField}
           secondaryFields={secondaryFields}
           fieldValues={fieldValues}
@@ -427,8 +511,8 @@ function TryoutWelcome({
   templates,
   templateSlug,
   setTemplateSlug,
-  agent,
-  setAgent,
+  selectedModelKey,
+  setSelectedModelKey,
   primaryField,
   secondaryFields,
   fieldValues,
@@ -446,8 +530,8 @@ function TryoutWelcome({
   templates: AgentTryoutTemplate[];
   templateSlug: string;
   setTemplateSlug: (value: string) => void;
-  agent: "" | AgentHarnessKind;
-  setAgent: (value: "" | AgentHarnessKind) => void;
+  selectedModelKey: string;
+  setSelectedModelKey: (value: string) => void;
   primaryField: [string, FieldSpec] | null;
   secondaryFields: [string, FieldSpec][];
   fieldValues: Record<string, string>;
@@ -496,10 +580,10 @@ function TryoutWelcome({
               />
               <AnimatedPillSelect
                 icon={<Gauge className="size-3.5" />}
-                value={agent}
-                onChange={(value) => setAgent(value as "" | AgentHarnessKind)}
-                options={AGENT_OPTIONS.map((option) => ({
-                  value: option.value,
+                value={selectedModelKey}
+                onChange={setSelectedModelKey}
+                options={MODEL_OPTIONS.map((option) => ({
+                  value: modelOptionKey(option),
                   label: option.label,
                 }))}
               />
@@ -538,7 +622,10 @@ function TryoutWelcome({
 
         {template ? (
           <p className="mt-3 text-center text-xs text-white/40">
-            {template.description} · {agentLabel(agent)} · cap{" "}
+            {template.description} ·{" "}
+            {MODEL_OPTIONS.find((option) => modelOptionKey(option) === selectedModelKey)?.hint ??
+              "Hosted default agent and model"}{" "}
+            · cap{" "}
             {`$${template.max_cost_usd.toFixed(2)}`}
           </p>
         ) : null}
@@ -692,9 +779,10 @@ function TryoutSidebar({
   loginHref: string;
   compact?: boolean;
 }) {
+  const modelRan = modelLabelFromPolicy(tryout.selected_model_policy);
   const agentRan = tryout.selected_harness_kind
-    ? agentLabel(tryout.selected_harness_kind)
-    : "Auto";
+    ? `${modelRan} · ${agentLabel(tryout.selected_harness_kind)}`
+    : modelRan;
 
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", compact ? "pt-2" : "p-4")}>
@@ -905,7 +993,7 @@ function TryoutChatThread({
 
           {active && events.length === 0 ? <ThinkingIndicator label="Starting" /> : null}
 
-          {active && timeline.length > 0 && timeline[timeline.length - 1]?.kind === "agent" ? (
+          {active && outputs.length === 0 && timeline.length > 0 && timeline[timeline.length - 1]?.kind === "agent" ? (
             <ThinkingIndicator />
           ) : null}
 
@@ -937,7 +1025,9 @@ function TryoutChatThread({
             <>
               <div className="mb-2 flex items-center justify-between">
                 <p className="text-xs text-white/40">
-                  Reply to steer the agent, or let it finish on its own.
+                  {outputs.length > 0
+                    ? "Outputs are ready. Reply to request edits, or end the session to finalize scoring."
+                    : "Reply to steer the agent, or let it finish on its own."}
                 </p>
                 <button
                   type="button"
@@ -1623,7 +1713,7 @@ function tryoutOutputs(summary: unknown): TryoutOutputPreview[] {
   const outputs = (summary as { outputs?: unknown }).outputs;
   if (!Array.isArray(outputs)) return [];
   return outputs
-    .map((item) => {
+    .map((item): TryoutOutputPreview | null => {
       if (!item || typeof item !== "object") return null;
       const output = item as Partial<TryoutOutputPreview>;
       if (typeof output.preview !== "string" || output.preview.trim() === "") {
@@ -1636,6 +1726,14 @@ function tryoutOutputs(summary: unknown): TryoutOutputPreview[] {
           typeof output.relative_path === "string" ? output.relative_path : "",
         preview: output.preview,
         truncated: output.truncated === true,
+        encoding:
+          output.encoding === "base64" || output.encoding === "utf-8"
+            ? output.encoding
+            : undefined,
+        content_type:
+          typeof output.content_type === "string" ? output.content_type : undefined,
+        size_bytes:
+          typeof output.size_bytes === "number" ? output.size_bytes : undefined,
       };
     })
     .filter((item): item is TryoutOutputPreview => item !== null);

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2764,6 +2764,7 @@ export interface CreateAgentTryoutInput {
   template_slug: string;
   input: Record<string, unknown>;
   selected_harness_kind?: AgentHarnessKind;
+  selected_model_policy?: AgentTryoutModelPolicy;
 }
 
 export interface RerunAgentTryoutInput {


### PR DESCRIPTION
## Summary

Fixes the public tryout lifecycle that left users stuck on `Thinking` after the agent had already produced files. The worker now stores the latest expected artifact previews in the tryout summary after every successful turn while keeping the chat session open for edits.

Also adds an explicit public model picker:

- OpenAI models route through Codex
- Anthropic models route through Claude
- Gemini models route through OpenRouter/OpenClaw

## Why

The production audit showed slide deck artifacts were written around two minutes in, but the UI could not preview or download them until the interactive session finalized later. Users should be able to download the latest deck immediately and still ask for edits.

## What changed

- Public create requests accept `selected_model_policy`.
- Backend validates model provider against the selected public harness.
- Worker passes selected models to Codex/Claude/OpenClaw command paths.
- Worker writes `summary.outputs` while status remains `running` whenever expected artifacts exist.
- Tryouts UI replaces the vague agent picker with model choices for GPT, Claude, and Gemini.
- Active chat suppresses generic `Thinking` once outputs are ready and tells users they can request edits or finalize scoring.
- Artifact parsing preserves encoding, content type, and size metadata.

## Validation

- `cd backend && go test ./internal/api ./internal/workflow`
- `cd web && npx tsc --noEmit`
- `cd web && npx eslint src/app/tryouts/tryouts-client.tsx src/lib/api/types.ts`
- `cd web && npm run build`
- Local browser check: `/tryouts` renders and the model dropdown shows Auto, GPT-5, GPT-5 mini, Claude Sonnet 4.5, Claude Opus 4.1, Gemini 2.5 Pro, and Gemini 2.5 Flash.

Notes: `npm run build` still reports pre-existing warnings in unrelated files and WorkOS Edge-runtime imports. Local template loading against hosted API was not exercised because the hosted API did not load public templates from the local browser context.

Test contract: `testing/codex-tryouts-artifacts-model-selection.md`.
