### PR TITLE
[codex] Add AI agent opportunity report scanner

### DIFF
--- a/testing/codex-agent-opportunity-report.md
+++ b/testing/codex-agent-opportunity-report.md
@@ -1,0 +1,31 @@
+# codex/agent-opportunity-report — Test Contract
+
+## Functional Behavior
+- A public marketing page lets a prospect enter a company URL and request an AI Agent Opportunity Report for AgentClash.
+- The client sends the URL to a public API route without requiring authentication.
+- The API accepts only absolute http/https URLs with public hostnames, blocks localhost/private/link-local hosts, normalizes the submitted URL, and limits input length.
+- The API fetches the target company homepage with a timeout, extracts bounded readable text and page signals, and does not forward raw secrets or internal headers.
+- The API calls OpenAI using a server-side API key and asks for structured JSON covering agent fit, honest verdict, use cases, savings ranges, risks, and suggested AgentClash evaluation pack.
+- The API returns a typed JSON report on success and clear JSON errors for invalid URLs, unreachable pages, missing OpenAI configuration, and model failures.
+- The UI renders loading, error, and completed report states. It must not promise every company needs an AI agent.
+
+## Unit Tests
+- Public analyzer URL validation blocks private and local targets and accepts normal https URLs.
+- HTML extraction removes scripts/styles, truncates content, and keeps useful title/meta/body signals.
+- OpenAI response parsing accepts valid structured JSON and rejects malformed report payloads.
+
+## Integration / Functional Tests
+- The route returns 400 for invalid URLs before fetching.
+- The route returns 503 when OpenAI is not configured.
+- With mocked page fetch and mocked OpenAI response, the route returns a complete report payload.
+
+## Smoke Tests
+- `cd web && pnpm exec vitest run src/lib/agent-opportunity.test.ts src/app/api/agent-opportunity/route.test.ts`
+- `cd web && pnpm lint`
+
+## E2E Tests
+- N/A — this change adds a public page and API route; browser E2E can be added after the lead magnet copy is finalized.
+
+## Manual / cURL Tests
+- `curl -s -X POST http://localhost:3000/api/agent-opportunity -H "content-type: application/json" -d "{\"url\":\"https://example.com\"}"`
+- Visit `/agent-opportunity` locally, submit a public company URL, and confirm the report renders or a useful configuration error appears.

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  ClipboardCheck,
+  Download,
+  Gauge,
+  Loader2,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
+
+type ReportResponse =
+  | { ok: true; report: AgentOpportunityReport }
+  | { ok: false; code: string; error: string };
+
+const fitCopy: Record<AgentOpportunityReport["shouldBuildAgent"], string> = {
+  not_yet: "Do not build yet",
+  narrow_pilot: "Pilot narrowly",
+  strong_fit: "Strong fit",
+  eval_first: "Evaluate first",
+};
+
+const painOptions = [
+  "Support",
+  "Sales qualification",
+  "Onboarding",
+  "Developer docs",
+  "Internal operations",
+  "Not sure yet",
+];
+
+function scoreBand(score: number) {
+  if (score >= 75) return "text-emerald-200";
+  if (score >= 45) return "text-amber-200";
+  return "text-white/70";
+}
+
+function ReportPanel({ report }: { report: AgentOpportunityReport }) {
+  const verdict = fitCopy[report.shouldBuildAgent];
+
+  return (
+    <section className="mt-14 border-t border-white/[0.08] pt-10">
+      <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+        <div>
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
+            Agent opportunity report
+          </p>
+          <h2 className="mt-4 text-3xl font-sans font-semibold tracking-tight text-white sm:text-4xl">
+            {report.companyName}
+          </h2>
+          <p className="mt-4 text-sm leading-6 text-white/55">
+            {report.summary}
+          </p>
+          <div className="mt-7 grid grid-cols-2 gap-3">
+            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4">
+              <Gauge className="size-4 text-white/45" />
+              <p className={`mt-5 text-4xl font-semibold ${scoreBand(report.agentFitScore)}`}>
+                {report.agentFitScore}
+              </p>
+              <p className="mt-1 text-xs text-white/40">Fit score</p>
+            </div>
+            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4">
+              <ShieldCheck className="size-4 text-white/45" />
+              <p className="mt-5 text-lg font-semibold text-white">{verdict}</p>
+              <p className="mt-1 text-xs capitalize text-white/40">
+                {report.fitLevel} confidence
+              </p>
+            </div>
+          </div>
+          <p className="mt-6 rounded-md border border-white/[0.08] bg-[#0a0a0a] p-4 text-sm leading-6 text-white/65">
+            {report.honestVerdict}
+          </p>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="mt-5 inline-flex items-center gap-2 rounded-md border border-white/[0.1] px-3 py-2 text-sm text-white/70 transition-colors hover:border-white/25 hover:text-white"
+          >
+            <Download className="size-4" />
+            Save report
+          </button>
+        </div>
+
+        <div className="space-y-8">
+          <div>
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-cyan-200" />
+              <h3 className="text-lg font-semibold tracking-tight text-white">
+                Best agent use cases
+              </h3>
+            </div>
+            <div className="mt-4 grid gap-3">
+              {report.useCases.map((useCase) => (
+                <article
+                  key={useCase.title}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-white">
+                        {useCase.title}
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-white/55">
+                        {useCase.workflow}
+                      </p>
+                    </div>
+                    <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.12em] text-white/45">
+                      {useCase.fit} fit
+                    </span>
+                  </div>
+                  <div className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
+                    <p className="text-white/50">
+                      Hours:{" "}
+                      <span className="text-white/80">
+                        {useCase.estimatedMonthlyHoursSaved}
+                      </span>
+                    </p>
+                    <p className="text-white/50">
+                      Savings:{" "}
+                      <span className="text-white/80">
+                        {useCase.estimatedMonthlySavingsUsd}
+                      </span>
+                    </p>
+                    <p className="text-white/50">
+                      Complexity:{" "}
+                      <span className="text-white/80">{useCase.complexity}</span>
+                    </p>
+                  </div>
+                  <p className="mt-4 text-sm leading-6 text-white/50">
+                    {useCase.why}
+                  </p>
+                  <ul className="mt-4 grid gap-2 text-xs text-white/45 sm:grid-cols-2">
+                    {useCase.firstEvalTasks.map((task) => (
+                      <li key={task} className="flex items-start gap-2">
+                        <ClipboardCheck className="mt-0.5 size-3.5 shrink-0" />
+                        <span>{task}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="size-4 text-amber-200" />
+                <h3 className="text-lg font-semibold tracking-tight text-white">
+                  Risks to evaluate
+                </h3>
+              </div>
+              <div className="mt-4 space-y-3">
+                {report.risks.map((risk) => (
+                  <div
+                    key={risk.risk}
+                    className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4"
+                  >
+                    <p className="text-sm font-medium text-white">{risk.risk}</p>
+                    <p className="mt-2 text-xs leading-5 text-white/50">
+                      {risk.mitigation}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <ShieldCheck className="size-4 text-emerald-200" />
+                <h3 className="text-lg font-semibold tracking-tight text-white">
+                  AgentClash eval pack
+                </h3>
+              </div>
+              <div className="mt-4 rounded-md border border-white/[0.08] bg-white/[0.03] p-5">
+                <p className="font-medium text-white">{report.evaluationPack.name}</p>
+                <p className="mt-3 text-sm leading-6 text-white/55">
+                  {report.evaluationPack.recommendedCases} realistic cases,{" "}
+                  {report.evaluationPack.adversarialCases} adversarial cases.
+                </p>
+                <ul className="mt-4 space-y-2 text-xs leading-5 text-white/45">
+                  {report.evaluationPack.successCriteria.map((criterion) => (
+                    <li key={criterion}>{criterion}</li>
+                  ))}
+                </ul>
+                <a
+                  href="/auth/login"
+                  className="mt-5 inline-flex items-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+                >
+                  Create eval workspace
+                  <ArrowRight className="size-4" />
+                </a>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 border-t border-white/[0.08] pt-6 md:grid-cols-2">
+            <div>
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+                Next steps
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-white/55">
+                {report.nextSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+                Evidence limits
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-white/45">
+                {report.evidenceLimitations.map((limit) => (
+                  <li key={limit}>{limit}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AgentOpportunityClient() {
+  const [url, setUrl] = useState("");
+  const [companySize, setCompanySize] = useState("");
+  const [currentPain, setCurrentPain] = useState("");
+  const [monthlySupportVolume, setMonthlySupportVolume] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [report, setReport] = useState<AgentOpportunityReport | null>(null);
+
+  const canSubmit = useMemo(() => url.trim().length > 0 && !loading, [loading, url]);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setLoading(true);
+    setError("");
+    setReport(null);
+
+    try {
+      const response = await fetch("/api/agent-opportunity", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          url,
+          companySize,
+          currentPain,
+          monthlySupportVolume,
+        }),
+      });
+      const payload = (await response.json()) as ReportResponse;
+      if (!payload.ok) {
+        setError(payload.error);
+        return;
+      }
+      setReport(payload.report);
+    } catch {
+      setError("The report request failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <section className="px-6 pt-16 sm:px-12 sm:pt-24">
+        <div className="mx-auto grid max-w-[1180px] gap-12 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
+          <div>
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
+              AI agent opportunity scanner
+            </p>
+            <h1 className="mt-6 max-w-[13ch] text-[clamp(2.75rem,7vw,5.8rem)] font-sans font-semibold leading-[0.98] tracking-tight text-white">
+              Should your company have an AI agent?
+            </h1>
+            <p className="mt-7 max-w-[58ch] text-lg leading-8 text-white/60">
+              Get an honest URL-based report on where agents could save time,
+              where they would fail, and what AgentClash should test before
+              anyone ships one to customers.
+            </p>
+            <div className="mt-9 grid gap-3 border-t border-white/[0.08] pt-6 text-sm leading-6 text-white/55 sm:grid-cols-3">
+              <p>Conservative savings ranges</p>
+              <p>Risk and eval requirements</p>
+              <p>A real not-yet verdict</p>
+            </div>
+          </div>
+
+          <form
+            onSubmit={onSubmit}
+            className="rounded-md border border-white/[0.1] bg-[#0a0a0a] p-5 shadow-2xl shadow-black/30 sm:p-6"
+          >
+            <label className="block text-sm font-medium text-white" htmlFor="url">
+              Company URL
+            </label>
+            <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+              <input
+                id="url"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="https://example.com"
+                className="min-h-11 flex-1 rounded-md border border-white/[0.1] bg-white/[0.04] px-3 text-sm text-white outline-none transition-colors placeholder:text-white/25 focus:border-white/30"
+              />
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-white px-4 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? <Loader2 className="size-4 animate-spin" /> : null}
+                Analyze
+              </button>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <label className="block">
+                <span className="text-xs text-white/45">Company size</span>
+                <select
+                  value={companySize}
+                  onChange={(event) => setCompanySize(event.target.value)}
+                  className="mt-2 min-h-10 w-full rounded-md border border-white/[0.1] bg-[#111] px-3 text-sm text-white/75 outline-none focus:border-white/30"
+                >
+                  <option value="">Unknown</option>
+                  <option value="1-10">1-10</option>
+                  <option value="11-50">11-50</option>
+                  <option value="51-200">51-200</option>
+                  <option value="201-1000">201-1000</option>
+                  <option value="1000+">1000+</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs text-white/45">Main pain</span>
+                <select
+                  value={currentPain}
+                  onChange={(event) => setCurrentPain(event.target.value)}
+                  className="mt-2 min-h-10 w-full rounded-md border border-white/[0.1] bg-[#111] px-3 text-sm text-white/75 outline-none focus:border-white/30"
+                >
+                  <option value="">Unknown</option>
+                  {painOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs text-white/45">Support volume</span>
+                <select
+                  value={monthlySupportVolume}
+                  onChange={(event) =>
+                    setMonthlySupportVolume(event.target.value)
+                  }
+                  className="mt-2 min-h-10 w-full rounded-md border border-white/[0.1] bg-[#111] px-3 text-sm text-white/75 outline-none focus:border-white/30"
+                >
+                  <option value="">Unknown</option>
+                  <option value="0-100/month">0-100/month</option>
+                  <option value="100-500/month">100-500/month</option>
+                  <option value="500-2000/month">500-2000/month</option>
+                  <option value="2000+/month">2000+/month</option>
+                </select>
+              </label>
+            </div>
+
+            {error ? (
+              <p className="mt-5 rounded-md border border-amber-300/20 bg-amber-300/10 p-3 text-sm leading-6 text-amber-100">
+                {error}
+              </p>
+            ) : null}
+
+            <div className="mt-6 grid gap-px overflow-hidden rounded-md border border-white/[0.08] bg-white/[0.08] sm:grid-cols-3">
+              {[
+                ["1", "Find the repeatable workflow"],
+                ["2", "Estimate ROI and failure risk"],
+                ["3", "Generate the eval pack"],
+              ].map(([step, label]) => (
+                <div key={step} className="bg-[#0a0a0a] p-4">
+                  <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+                    {step}
+                  </p>
+                  <p className="mt-3 text-sm leading-5 text-white/60">{label}</p>
+                </div>
+              ))}
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <div className="px-6 pb-20 sm:px-12">
+        <div className="mx-auto max-w-[1180px]">
+          {report ? <ReportPanel report={report} /> : null}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
@@ -233,7 +233,7 @@ export function AgentOpportunityClient() {
   const [error, setError] = useState("");
   const [report, setReport] = useState<AgentOpportunityReport | null>(null);
 
-  const canSubmit = useMemo(() => url.trim().length > 0 && !loading, [loading, url]);
+  const canSubmit = url.trim().length > 0 && !loading;
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/web/src/app/agent-opportunity/page.tsx
+++ b/web/src/app/agent-opportunity/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { JsonLd, breadcrumbSchema } from "@/components/marketing/json-ld";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { ogImageUrl } from "@/lib/seo";
+import { AgentOpportunityClient } from "./agent-opportunity-client";
+
+const PAGE_PATH = "/agent-opportunity";
+const PAGE_TITLE = "AI Agent Opportunity Report | AgentClash";
+const PAGE_DESCRIPTION =
+  "Enter a company URL and get an honest AI agent opportunity report with ROI ranges, risks, and an AgentClash evaluation pack.";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: ogImageUrl({
+          title: "Should your company have an AI agent?",
+          subtitle: "ROI, risk, and eval plan from a URL",
+          kind: "Report",
+        }),
+        width: 1200,
+        height: 630,
+        alt: PAGE_TITLE,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+};
+
+export default function AgentOpportunityPage() {
+  return (
+    <MarketingShell>
+      <JsonLd
+        id="agent-opportunity-breadcrumb-schema"
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "AI Agent Opportunity Report", url: PAGE_PATH },
+          ]),
+        ]}
+      />
+      <AgentOpportunityClient />
+    </MarketingShell>
+  );
+}

--- a/web/src/app/api/agent-opportunity/route.test.ts
+++ b/web/src/app/api/agent-opportunity/route.test.ts
@@ -97,6 +97,41 @@ describe("POST /api/agent-opportunity", () => {
     });
   });
 
+  it("rate limits by the proxy-appended forwarded IP, not spoofed leftmost values", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const { POST } = await import("./route");
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await POST(
+        new Request("https://agentclash.dev/api/agent-opportunity", {
+          method: "POST",
+          headers: {
+            "x-forwarded-for": `203.0.113.${index}, 198.51.100.42`,
+          },
+          body: JSON.stringify({ url: "http://93.184.216.34" }),
+        }),
+      );
+
+      expect(response.status).toBe(503);
+    }
+
+    const limited = await POST(
+      new Request("https://agentclash.dev/api/agent-opportunity", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.250, 198.51.100.42",
+        },
+        body: JSON.stringify({ url: "http://93.184.216.34" }),
+      }),
+    );
+
+    expect(limited.status).toBe(429);
+    await expect(limited.json()).resolves.toMatchObject({
+      ok: false,
+      code: "rate_limited",
+    });
+  });
+
   it("returns a complete report with mocked page and OpenAI fetches", async () => {
     process.env.OPENAI_API_KEY = "sk-test";
     fetchMock

--- a/web/src/app/api/agent-opportunity/route.test.ts
+++ b/web/src/app/api/agent-opportunity/route.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const report = {
+  analyzedUrl: "http://93.184.216.34/",
+  companyName: "Example",
+  generatedAt: "2026-06-12T00:00:00.000Z",
+  agentFitScore: 68,
+  fitLevel: "moderate",
+  shouldBuildAgent: "narrow_pilot",
+  honestVerdict: "A narrow support workflow is worth testing first.",
+  summary: "The site suggests repeatable customer education work.",
+  useCases: [
+    {
+      title: "Support triage",
+      workflow: "Classify inbound requests and draft replies.",
+      fit: "high",
+      estimatedMonthlyHoursSaved: "15-35",
+      estimatedMonthlySavingsUsd: "$1,000-$3,500",
+      complexity: "medium",
+      why: "The homepage describes support-heavy customer workflows.",
+      firstEvalTasks: ["Pricing question", "Refund escalation"],
+    },
+  ],
+  risks: [
+    {
+      risk: "Wrong policy answer",
+      severity: "high",
+      mitigation: "Evaluate policy edge cases before deployment.",
+    },
+    {
+      risk: "Low-confidence routing",
+      severity: "medium",
+      mitigation: "Escalate uncertain turns to a human.",
+    },
+  ],
+  evaluationPack: {
+    name: "Support triage starter pack",
+    recommendedCases: 25,
+    adversarialCases: 8,
+    successCriteria: ["No policy hallucinations", "90% correct routing"],
+  },
+  nextSteps: ["Collect real tickets", "Run a same-task AgentClash race"],
+  evidenceLimitations: ["Only public homepage content was available."],
+};
+
+describe("POST /api/agent-opportunity", () => {
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAIKey;
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 for invalid URLs before fetching", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("https://agentclash.dev/api/agent-opportunity", {
+        method: "POST",
+        body: JSON.stringify({ url: "file:///etc/passwd" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "invalid_url",
+    });
+  });
+
+  it("returns 503 when OpenAI is not configured", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("https://agentclash.dev/api/agent-opportunity", {
+        method: "POST",
+        body: JSON.stringify({ url: "http://93.184.216.34" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "openai_not_configured",
+    });
+  });
+
+  it("returns a complete report with mocked page and OpenAI fetches", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          "<html><head><title>Example</title></head><body>Support automation for customer teams.</body></html>",
+          { headers: { "content-type": "text/html" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ output_text: JSON.stringify(report) }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("https://agentclash.dev/api/agent-opportunity", {
+        method: "POST",
+        body: JSON.stringify({
+          url: "http://93.184.216.34",
+          companySize: "11-50",
+          currentPain: "support",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const openAIRequest = fetchMock.mock.calls[1];
+    expect(openAIRequest[0]).toBe("https://api.openai.com/v1/responses");
+    expect(openAIRequest[1].headers.authorization).toBe("Bearer sk-test");
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      report: {
+        companyName: "Example",
+        shouldBuildAgent: "narrow_pilot",
+      },
+    });
+  });
+});

--- a/web/src/app/api/agent-opportunity/route.ts
+++ b/web/src/app/api/agent-opportunity/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import {
+  AgentOpportunityError,
+  analyzeAgentOpportunity,
+  fetchCompanySnapshot,
+  normalizePublicUrl,
+  type AgentOpportunityInput,
+} from "@/lib/agent-opportunity";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function optionalString(value: unknown, maxLength = 160): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : undefined;
+}
+
+function getClientKey(request: Request) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) return forwardedFor.split(",")[0].trim();
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+function rateLimit(request: Request) {
+  const now = Date.now();
+  const key = getClientKey(request);
+  const existing = rateLimitBuckets.get(key);
+  if (!existing || existing.resetAt <= now) {
+    rateLimitBuckets.set(key, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return null;
+  }
+
+  if (existing.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "rate_limited",
+        error: "Too many report requests. Please try again later.",
+      },
+      {
+        status: 429,
+        headers: {
+          "retry-after": String(Math.ceil((existing.resetAt - now) / 1000)),
+        },
+      },
+    );
+  }
+
+  existing.count += 1;
+  return null;
+}
+
+function errorResponse(error: unknown) {
+  if (error instanceof AgentOpportunityError) {
+    return NextResponse.json(
+      { ok: false, code: error.code, error: error.message },
+      { status: error.status },
+    );
+  }
+
+  console.error("Unexpected agent opportunity error:", error);
+  return NextResponse.json(
+    {
+      ok: false,
+      code: "internal_error",
+      error: "We could not generate the report.",
+    },
+    { status: 500 },
+  );
+}
+
+export async function POST(request: Request) {
+  try {
+    const limited = rateLimit(request);
+    if (limited) return limited;
+
+    const payload = await request.json().catch(() => null);
+    if (!payload || typeof payload !== "object") {
+      return NextResponse.json(
+        { ok: false, code: "invalid_request", error: "Invalid request body." },
+        { status: 400 },
+      );
+    }
+
+    const rawUrl = optionalString((payload as { url?: unknown }).url, 2048);
+    if (!rawUrl) {
+      return NextResponse.json(
+        { ok: false, code: "invalid_url", error: "Enter a company URL." },
+        { status: 400 },
+      );
+    }
+
+    const input: AgentOpportunityInput = {
+      url: rawUrl,
+      companySize: optionalString(
+        (payload as { companySize?: unknown }).companySize,
+      ),
+      currentPain: optionalString((payload as { currentPain?: unknown }).currentPain),
+      monthlySupportVolume: optionalString(
+        (payload as { monthlySupportVolume?: unknown }).monthlySupportVolume,
+      ),
+    };
+    const normalizedUrl = await normalizePublicUrl(input.url);
+
+    if (!process.env.OPENAI_API_KEY) {
+      throw new AgentOpportunityError(
+        "openai_not_configured",
+        "OpenAI is not configured for this endpoint.",
+        503,
+      );
+    }
+
+    const snapshot = await fetchCompanySnapshot(normalizedUrl);
+    const report = await analyzeAgentOpportunity({
+      input: { ...input, url: normalizedUrl },
+      snapshot,
+    });
+
+    return NextResponse.json({ ok: true, report });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/web/src/app/api/agent-opportunity/route.ts
+++ b/web/src/app/api/agent-opportunity/route.ts
@@ -12,6 +12,7 @@ export const dynamic = "force-dynamic";
 
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_MAX_BUCKETS = 10000;
 const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
 
 function optionalString(value: unknown, maxLength = 160): string | undefined {
@@ -22,12 +23,29 @@ function optionalString(value: unknown, maxLength = 160): string | undefined {
 
 function getClientKey(request: Request) {
   const forwardedFor = request.headers.get("x-forwarded-for");
-  if (forwardedFor) return forwardedFor.split(",")[0].trim();
+  if (forwardedFor) {
+    const proxyAppendedIp = forwardedFor.split(",").pop()?.trim();
+    if (proxyAppendedIp) return proxyAppendedIp;
+  }
   return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+function pruneRateLimitBuckets(now: number) {
+  for (const [key, bucket] of rateLimitBuckets) {
+    if (bucket.resetAt <= now) rateLimitBuckets.delete(key);
+  }
+
+  while (rateLimitBuckets.size >= RATE_LIMIT_MAX_BUCKETS) {
+    const oldestKey = rateLimitBuckets.keys().next().value as string | undefined;
+    if (!oldestKey) break;
+    rateLimitBuckets.delete(oldestKey);
+  }
 }
 
 function rateLimit(request: Request) {
   const now = Date.now();
+  pruneRateLimitBuckets(now);
+
   const key = getClientKey(request);
   const existing = rateLimitBuckets.get(key);
   if (!existing || existing.resetAt <= now) {

--- a/web/src/lib/agent-opportunity.test.ts
+++ b/web/src/lib/agent-opportunity.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentOpportunityError,
+  extractPageSnapshot,
+  isPrivateIPAddress,
+  normalizePublicUrl,
+  parseAgentOpportunityReport,
+} from "./agent-opportunity";
+
+const resolvePublic = async () => ["93.184.216.34"];
+const resolvePrivate = async () => ["127.0.0.1"];
+
+describe("normalizePublicUrl", () => {
+  it("accepts normal public https URLs and strips credentials/hash", async () => {
+    await expect(
+      normalizePublicUrl("https://user:pass@example.com/path#frag", resolvePublic),
+    ).resolves.toBe("https://example.com/path");
+  });
+
+  it("blocks localhost and private DNS results", async () => {
+    await expect(
+      normalizePublicUrl("http://localhost:3000", resolvePublic),
+    ).rejects.toMatchObject({ code: "blocked_url" });
+    await expect(
+      normalizePublicUrl("https://internal.example.com", resolvePrivate),
+    ).rejects.toMatchObject({ code: "blocked_url" });
+  });
+
+  it("rejects non-http URLs", async () => {
+    await expect(
+      normalizePublicUrl("file:///etc/passwd", resolvePublic),
+    ).rejects.toMatchObject({ code: "invalid_url" });
+  });
+});
+
+describe("isPrivateIPAddress", () => {
+  it("detects common private and loopback ranges", () => {
+    expect(isPrivateIPAddress("127.0.0.1")).toBe(true);
+    expect(isPrivateIPAddress("10.0.0.5")).toBe(true);
+    expect(isPrivateIPAddress("172.20.1.1")).toBe(true);
+    expect(isPrivateIPAddress("192.168.1.1")).toBe(true);
+    expect(isPrivateIPAddress("::1")).toBe(true);
+    expect(isPrivateIPAddress("8.8.8.8")).toBe(false);
+  });
+});
+
+describe("extractPageSnapshot", () => {
+  it("removes scripts and styles while preserving useful page signals", () => {
+    const snapshot = extractPageSnapshot(
+      "https://example.com",
+      `<!doctype html>
+        <html>
+          <head>
+            <title>Example Co</title>
+            <meta name="description" content="AI support for commerce teams">
+            <style>.hidden { color: red; }</style>
+          </head>
+          <body>
+            <h1>Support automation</h1>
+            <script>window.secret = "nope"</script>
+            <p>Resolve customer questions faster &amp; route edge cases.</p>
+          </body>
+        </html>`,
+    );
+
+    expect(snapshot.title).toBe("Example Co");
+    expect(snapshot.description).toBe("AI support for commerce teams");
+    expect(snapshot.text).toContain("Support automation");
+    expect(snapshot.text).toContain("faster & route");
+    expect(snapshot.text).not.toContain("window.secret");
+    expect(snapshot.text).not.toContain("hidden");
+  });
+});
+
+describe("parseAgentOpportunityReport", () => {
+  const validReport = {
+    analyzedUrl: "https://example.com/",
+    companyName: "Example",
+    generatedAt: "2026-06-12T00:00:00.000Z",
+    agentFitScore: 72,
+    fitLevel: "moderate",
+    shouldBuildAgent: "narrow_pilot",
+    honestVerdict: "A narrow support triage pilot is worth testing.",
+    summary: "The site shows repeatable support and onboarding workflows.",
+    useCases: [
+      {
+        title: "Support triage",
+        workflow: "Classify inbound questions and draft replies.",
+        fit: "high",
+        estimatedMonthlyHoursSaved: "20-40",
+        estimatedMonthlySavingsUsd: "$1,500-$4,000",
+        complexity: "medium",
+        why: "The site has docs and clear support categories.",
+        firstEvalTasks: ["Refund request", "Pricing question"],
+      },
+    ],
+    risks: [
+      {
+        risk: "Incorrect customer advice",
+        severity: "medium",
+        mitigation: "Route low-confidence answers to humans.",
+      },
+      {
+        risk: "Unclear escalation boundaries",
+        severity: "medium",
+        mitigation: "Evaluate edge cases before launch.",
+      },
+    ],
+    evaluationPack: {
+      name: "Support triage pilot",
+      recommendedCases: 25,
+      adversarialCases: 8,
+      successCriteria: ["90% correct routing", "No policy hallucinations"],
+    },
+    nextSteps: ["Collect real tickets", "Run an AgentClash race"],
+    evidenceLimitations: ["Only public homepage content was analyzed."],
+  };
+
+  it("returns valid structured reports", () => {
+    expect(parseAgentOpportunityReport(validReport).companyName).toBe("Example");
+  });
+
+  it("rejects malformed report payloads", () => {
+    expect(() =>
+      parseAgentOpportunityReport({ ...validReport, agentFitScore: 140 }),
+    ).toThrow(AgentOpportunityError);
+  });
+});

--- a/web/src/lib/agent-opportunity.test.ts
+++ b/web/src/lib/agent-opportunity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   AgentOpportunityError,
   extractPageSnapshot,
+  fetchCompanySnapshot,
   isPrivateIPAddress,
   normalizePublicUrl,
   parseAgentOpportunityReport,
@@ -59,6 +60,7 @@ describe("extractPageSnapshot", () => {
             <h1>Support automation</h1>
             <script>window.secret = "nope"</script>
             <p>Resolve customer questions faster &amp; route edge cases.</p>
+            <p>Safety &lt; speed &#8217; support &#x2019; routing &apos;done&apos;.</p>
           </body>
         </html>`,
     );
@@ -67,8 +69,29 @@ describe("extractPageSnapshot", () => {
     expect(snapshot.description).toBe("AI support for commerce teams");
     expect(snapshot.text).toContain("Support automation");
     expect(snapshot.text).toContain("faster & route");
+    expect(snapshot.text).toContain(
+      `Safety < speed ${String.fromCodePoint(8217)} support ${String.fromCodePoint(
+        8217,
+      )} routing 'done'.`,
+    );
     expect(snapshot.text).not.toContain("window.secret");
     expect(snapshot.text).not.toContain("hidden");
+  });
+});
+
+describe("fetchCompanySnapshot", () => {
+  it("rejects pages with oversized content-length before reading the body", async () => {
+    const response = new Response("tiny", {
+      headers: {
+        "content-type": "text/html",
+        "content-length": String(1024 * 1024),
+      },
+    });
+    const fetchImpl = async () => response;
+
+    await expect(
+      fetchCompanySnapshot("https://example.com", fetchImpl as typeof fetch),
+    ).rejects.toMatchObject({ code: "fetch_failed" });
   });
 });
 

--- a/web/src/lib/agent-opportunity.ts
+++ b/web/src/lib/agent-opportunity.ts
@@ -1,0 +1,618 @@
+import { lookup } from "node:dns/promises";
+import net from "node:net";
+
+export type AgentOpportunityUseCase = {
+  title: string;
+  workflow: string;
+  fit: "low" | "medium" | "high";
+  estimatedMonthlyHoursSaved: string;
+  estimatedMonthlySavingsUsd: string;
+  complexity: "low" | "medium" | "high";
+  why: string;
+  firstEvalTasks: string[];
+};
+
+export type AgentOpportunityRisk = {
+  risk: string;
+  severity: "low" | "medium" | "high";
+  mitigation: string;
+};
+
+export type AgentOpportunityReport = {
+  analyzedUrl: string;
+  companyName: string;
+  generatedAt: string;
+  agentFitScore: number;
+  fitLevel: "low" | "moderate" | "high";
+  shouldBuildAgent: "not_yet" | "narrow_pilot" | "strong_fit" | "eval_first";
+  honestVerdict: string;
+  summary: string;
+  useCases: AgentOpportunityUseCase[];
+  risks: AgentOpportunityRisk[];
+  evaluationPack: {
+    name: string;
+    recommendedCases: number;
+    adversarialCases: number;
+    successCriteria: string[];
+  };
+  nextSteps: string[];
+  evidenceLimitations: string[];
+};
+
+export type PageSnapshot = {
+  url: string;
+  title: string;
+  description: string;
+  text: string;
+};
+
+export type AgentOpportunityInput = {
+  url: string;
+  companySize?: string;
+  currentPain?: string;
+  monthlySupportVolume?: string;
+};
+
+export class AgentOpportunityError extends Error {
+  constructor(
+    public code:
+      | "invalid_url"
+      | "blocked_url"
+      | "fetch_failed"
+      | "openai_not_configured"
+      | "openai_failed"
+      | "invalid_model_response",
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+    this.name = "AgentOpportunityError";
+  }
+}
+
+const MAX_URL_LENGTH = 2048;
+const MAX_TEXT_CHARS = 12000;
+const USER_AGENT =
+  "AgentClash-Agent-Opportunity-Report/1.0 (+https://agentclash.dev)";
+
+export function isPrivateIPAddress(address: string): boolean {
+  const mappedV4 = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mappedV4) return isPrivateIPAddress(mappedV4[1]);
+
+  const ipVersion = net.isIP(address);
+  if (ipVersion === 4) {
+    const octets = address.split(".").map(Number);
+    const [a, b] = octets;
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 192 && b === 0) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      (a === 198 && b === 51 && octets[2] === 100) ||
+      (a === 203 && b === 0 && octets[2] === 113) ||
+      a >= 224
+    );
+  }
+
+  if (ipVersion === 6) {
+    const normalized = address.toLowerCase();
+    return (
+      normalized === "::" ||
+      normalized === "::1" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd") ||
+      normalized.startsWith("fe8") ||
+      normalized.startsWith("fe9") ||
+      normalized.startsWith("fea") ||
+      normalized.startsWith("feb")
+    );
+  }
+
+  return true;
+}
+
+function hasBlockedHostname(hostname: string): boolean {
+  const value = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    value === "localhost" ||
+    value.endsWith(".localhost") ||
+    value.endsWith(".local") ||
+    value.endsWith(".internal") ||
+    value.endsWith(".test") ||
+    value.endsWith(".invalid")
+  );
+}
+
+export async function normalizePublicUrl(
+  input: string,
+  resolveHostname: (hostname: string) => Promise<string[]> = async (hostname) => {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    return records.map((record) => record.address);
+  },
+): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.length > MAX_URL_LENGTH) {
+    throw new AgentOpportunityError(
+      "invalid_url",
+      "Enter a valid company URL.",
+      400,
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new AgentOpportunityError(
+      "invalid_url",
+      "Enter a full URL, including https://.",
+      400,
+    );
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new AgentOpportunityError(
+      "invalid_url",
+      "Only http and https URLs can be analyzed.",
+      400,
+    );
+  }
+  parsed.username = "";
+  parsed.password = "";
+  parsed.hash = "";
+
+  if (hasBlockedHostname(parsed.hostname)) {
+    throw new AgentOpportunityError(
+      "blocked_url",
+      "That hostname cannot be analyzed from this public endpoint.",
+      400,
+    );
+  }
+
+  if (net.isIP(parsed.hostname)) {
+    if (isPrivateIPAddress(parsed.hostname)) {
+      throw new AgentOpportunityError(
+        "blocked_url",
+        "Private network URLs cannot be analyzed.",
+        400,
+      );
+    }
+    return parsed.toString();
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await resolveHostname(parsed.hostname);
+  } catch {
+    throw new AgentOpportunityError(
+      "invalid_url",
+      "We could not resolve that company URL.",
+      400,
+    );
+  }
+
+  if (addresses.length === 0 || addresses.some(isPrivateIPAddress)) {
+    throw new AgentOpportunityError(
+      "blocked_url",
+      "That URL resolves to a private or restricted network address.",
+      400,
+    );
+  }
+
+  return parsed.toString();
+}
+
+export function extractPageSnapshot(url: string, html: string): PageSnapshot {
+  const title =
+    html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]?.trim() ?? "";
+  const description =
+    html.match(
+      /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+    )?.[1] ??
+    html.match(
+      /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']description["'][^>]*>/i,
+    )?.[1] ??
+    "";
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_TEXT_CHARS);
+
+  return {
+    url,
+    title: title.replace(/\s+/g, " ").slice(0, 180),
+    description: description.replace(/\s+/g, " ").slice(0, 300),
+    text,
+  };
+}
+
+export async function fetchCompanySnapshot(
+  normalizedUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PageSnapshot> {
+  let currentUrl = normalizedUrl;
+
+  for (let redirectCount = 0; redirectCount < 3; redirectCount += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    let response: Response;
+    try {
+      response = await fetchImpl(currentUrl, {
+        headers: { "user-agent": USER_AGENT, accept: "text/html" },
+        redirect: "manual",
+        signal: controller.signal,
+      });
+    } catch {
+      throw new AgentOpportunityError(
+        "fetch_failed",
+        "We could not fetch that company site.",
+        502,
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.headers.get("location")
+    ) {
+      const redirected = new URL(response.headers.get("location")!, currentUrl);
+      currentUrl = await normalizePublicUrl(redirected.toString());
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new AgentOpportunityError(
+        "fetch_failed",
+        `The company site returned HTTP ${response.status}.`,
+        502,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.includes("text/html")) {
+      throw new AgentOpportunityError(
+        "fetch_failed",
+        "That URL did not return an HTML page we can analyze.",
+        502,
+      );
+    }
+
+    return extractPageSnapshot(currentUrl, await response.text());
+  }
+
+  throw new AgentOpportunityError(
+    "fetch_failed",
+    "The company site redirected too many times.",
+    502,
+  );
+}
+
+function assertString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function assertStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(assertString);
+}
+
+function isUseCase(value: unknown): value is AgentOpportunityUseCase {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<AgentOpportunityUseCase>;
+  return (
+    assertString(item.title) &&
+    assertString(item.workflow) &&
+    ["low", "medium", "high"].includes(item.fit ?? "") &&
+    assertString(item.estimatedMonthlyHoursSaved) &&
+    assertString(item.estimatedMonthlySavingsUsd) &&
+    ["low", "medium", "high"].includes(item.complexity ?? "") &&
+    assertString(item.why) &&
+    assertStringArray(item.firstEvalTasks)
+  );
+}
+
+function isRisk(value: unknown): value is AgentOpportunityRisk {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<AgentOpportunityRisk>;
+  return (
+    assertString(item.risk) &&
+    ["low", "medium", "high"].includes(item.severity ?? "") &&
+    assertString(item.mitigation)
+  );
+}
+
+export function parseAgentOpportunityReport(
+  value: unknown,
+): AgentOpportunityReport {
+  if (!value || typeof value !== "object") {
+    throw new AgentOpportunityError(
+      "invalid_model_response",
+      "The model returned an invalid report.",
+      502,
+    );
+  }
+
+  const report = value as Partial<AgentOpportunityReport>;
+  const fitLevels = ["low", "moderate", "high"];
+  const verdicts = ["not_yet", "narrow_pilot", "strong_fit", "eval_first"];
+
+  if (
+    !assertString(report.analyzedUrl) ||
+    !assertString(report.companyName) ||
+    !assertString(report.generatedAt) ||
+    typeof report.agentFitScore !== "number" ||
+    report.agentFitScore < 0 ||
+    report.agentFitScore > 100 ||
+    !fitLevels.includes(report.fitLevel ?? "") ||
+    !verdicts.includes(report.shouldBuildAgent ?? "") ||
+    !assertString(report.honestVerdict) ||
+    !assertString(report.summary) ||
+    !Array.isArray(report.useCases) ||
+    !report.useCases.every(isUseCase) ||
+    !Array.isArray(report.risks) ||
+    !report.risks.every(isRisk) ||
+    !report.evaluationPack ||
+    typeof report.evaluationPack !== "object" ||
+    !assertString(report.evaluationPack.name) ||
+    typeof report.evaluationPack.recommendedCases !== "number" ||
+    typeof report.evaluationPack.adversarialCases !== "number" ||
+    !assertStringArray(report.evaluationPack.successCriteria) ||
+    !assertStringArray(report.nextSteps) ||
+    !assertStringArray(report.evidenceLimitations)
+  ) {
+    throw new AgentOpportunityError(
+      "invalid_model_response",
+      "The model returned an incomplete report.",
+      502,
+    );
+  }
+
+  return report as AgentOpportunityReport;
+}
+
+const REPORT_SCHEMA = {
+  name: "agent_opportunity_report",
+  strict: true,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "analyzedUrl",
+      "companyName",
+      "generatedAt",
+      "agentFitScore",
+      "fitLevel",
+      "shouldBuildAgent",
+      "honestVerdict",
+      "summary",
+      "useCases",
+      "risks",
+      "evaluationPack",
+      "nextSteps",
+      "evidenceLimitations",
+    ],
+    properties: {
+      analyzedUrl: { type: "string" },
+      companyName: { type: "string" },
+      generatedAt: { type: "string" },
+      agentFitScore: { type: "number", minimum: 0, maximum: 100 },
+      fitLevel: { type: "string", enum: ["low", "moderate", "high"] },
+      shouldBuildAgent: {
+        type: "string",
+        enum: ["not_yet", "narrow_pilot", "strong_fit", "eval_first"],
+      },
+      honestVerdict: { type: "string" },
+      summary: { type: "string" },
+      useCases: {
+        type: "array",
+        minItems: 1,
+        maxItems: 4,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "title",
+            "workflow",
+            "fit",
+            "estimatedMonthlyHoursSaved",
+            "estimatedMonthlySavingsUsd",
+            "complexity",
+            "why",
+            "firstEvalTasks",
+          ],
+          properties: {
+            title: { type: "string" },
+            workflow: { type: "string" },
+            fit: { type: "string", enum: ["low", "medium", "high"] },
+            estimatedMonthlyHoursSaved: { type: "string" },
+            estimatedMonthlySavingsUsd: { type: "string" },
+            complexity: { type: "string", enum: ["low", "medium", "high"] },
+            why: { type: "string" },
+            firstEvalTasks: {
+              type: "array",
+              minItems: 2,
+              maxItems: 5,
+              items: { type: "string" },
+            },
+          },
+        },
+      },
+      risks: {
+        type: "array",
+        minItems: 2,
+        maxItems: 5,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["risk", "severity", "mitigation"],
+          properties: {
+            risk: { type: "string" },
+            severity: { type: "string", enum: ["low", "medium", "high"] },
+            mitigation: { type: "string" },
+          },
+        },
+      },
+      evaluationPack: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "name",
+          "recommendedCases",
+          "adversarialCases",
+          "successCriteria",
+        ],
+        properties: {
+          name: { type: "string" },
+          recommendedCases: { type: "number" },
+          adversarialCases: { type: "number" },
+          successCriteria: {
+            type: "array",
+            minItems: 2,
+            maxItems: 5,
+            items: { type: "string" },
+          },
+        },
+      },
+      nextSteps: {
+        type: "array",
+        minItems: 2,
+        maxItems: 5,
+        items: { type: "string" },
+      },
+      evidenceLimitations: {
+        type: "array",
+        minItems: 1,
+        maxItems: 4,
+        items: { type: "string" },
+      },
+    },
+  },
+} as const;
+
+function extractOpenAIText(payload: unknown): string {
+  if (!payload || typeof payload !== "object") return "";
+  const root = payload as { output_text?: unknown; output?: unknown };
+  if (typeof root.output_text === "string") return root.output_text;
+
+  if (Array.isArray(root.output)) {
+    for (const item of root.output) {
+      if (!item || typeof item !== "object") continue;
+      const content = (item as { content?: unknown }).content;
+      if (!Array.isArray(content)) continue;
+      for (const part of content) {
+        if (
+          part &&
+          typeof part === "object" &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          return (part as { text: string }).text;
+        }
+      }
+    }
+  }
+
+  return "";
+}
+
+export async function analyzeAgentOpportunity({
+  input,
+  snapshot,
+  apiKey = process.env.OPENAI_API_KEY,
+  model = process.env.AGENT_OPPORTUNITY_OPENAI_MODEL || "gpt-5.4-mini",
+  fetchImpl = fetch,
+}: {
+  input: AgentOpportunityInput;
+  snapshot: PageSnapshot;
+  apiKey?: string;
+  model?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<AgentOpportunityReport> {
+  if (!apiKey) {
+    throw new AgentOpportunityError(
+      "openai_not_configured",
+      "OpenAI is not configured for this endpoint.",
+      503,
+    );
+  }
+
+  const response = await fetchImpl("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        {
+          role: "system",
+          content:
+            "You are an honest AI agent automation analyst for AgentClash. Decide whether a company should build an AI agent, where it would help, where it would fail, and how AgentClash should evaluate it before deployment. Do not overstate savings. If the company does not clearly need an agent, say so.",
+        },
+        {
+          role: "user",
+          content: JSON.stringify({
+            submitted: input,
+            page: snapshot,
+            instructions: [
+              "Base your analysis only on the public page snapshot and user-provided context.",
+              "Use conservative savings ranges. Avoid fake precision.",
+              "Tie recommended evaluation cases to real workflows visible from the site.",
+              "Return JSON matching the schema exactly.",
+            ],
+          }),
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          ...REPORT_SCHEMA,
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new AgentOpportunityError(
+      "openai_failed",
+      "OpenAI could not generate the report.",
+      502,
+    );
+  }
+
+  const payload = await response.json().catch(() => null);
+  const text = extractOpenAIText(payload);
+  if (!text) {
+    throw new AgentOpportunityError(
+      "invalid_model_response",
+      "OpenAI returned an empty report.",
+      502,
+    );
+  }
+
+  try {
+    return parseAgentOpportunityReport(JSON.parse(text));
+  } catch (error) {
+    if (error instanceof AgentOpportunityError) throw error;
+    throw new AgentOpportunityError(
+      "invalid_model_response",
+      "OpenAI returned malformed JSON.",
+      502,
+    );
+  }
+}

--- a/web/src/lib/agent-opportunity.ts
+++ b/web/src/lib/agent-opportunity.ts
@@ -72,6 +72,7 @@ export class AgentOpportunityError extends Error {
 
 const MAX_URL_LENGTH = 2048;
 const MAX_TEXT_CHARS = 12000;
+const MAX_HTML_BYTES = 256 * 1024;
 const USER_AGENT =
   "AgentClash-Agent-Opportunity-Report/1.0 (+https://agentclash.dev)";
 
@@ -228,6 +229,21 @@ export function extractPageSnapshot(url: string, html: string): PageSnapshot {
     .replace(/&amp;/gi, "&")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&#(\d+);/g, (_match, code: string) => {
+      const parsed = Number(code);
+      return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= 0x10ffff
+        ? String.fromCodePoint(parsed)
+        : " ";
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) => {
+      const parsed = Number.parseInt(hex, 16);
+      return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= 0x10ffff
+        ? String.fromCodePoint(parsed)
+        : " ";
+    })
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, MAX_TEXT_CHARS);
@@ -238,6 +254,47 @@ export function extractPageSnapshot(url: string, html: string): PageSnapshot {
     description: description.replace(/\s+/g, " ").slice(0, 300),
     text,
   };
+}
+
+async function readLimitedResponseText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_HTML_BYTES) {
+      throw new AgentOpportunityError(
+        "fetch_failed",
+        "That page is too large to analyze from this public endpoint.",
+        502,
+      );
+    }
+  }
+
+  if (!response.body) {
+    return (await response.text()).slice(0, MAX_HTML_BYTES);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let bytesRead = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytesRead += value.byteLength;
+    if (bytesRead > MAX_HTML_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new AgentOpportunityError(
+        "fetch_failed",
+        "That page is too large to analyze from this public endpoint.",
+        502,
+      );
+    }
+    chunks.push(decoder.decode(value, { stream: true }));
+  }
+
+  chunks.push(decoder.decode());
+  return chunks.join("");
 }
 
 export async function fetchCompanySnapshot(
@@ -293,7 +350,7 @@ export async function fetchCompanySnapshot(
       );
     }
 
-    return extractPageSnapshot(currentUrl, await response.text());
+    return extractPageSnapshot(currentUrl, await readLimitedResponseText(response));
   }
 
   throw new AgentOpportunityError(


### PR DESCRIPTION
## Summary

Adds a public AI Agent Opportunity Report lead magnet for AgentClash.

Prospects can enter a company URL at `/agent-opportunity`, optionally add context, and receive an honest report on whether an AI agent is worth building, what workflows are plausible, what savings ranges are realistic, what risks need evaluation, and what AgentClash eval pack should be run before deployment.

## What changed

- Added `/agent-opportunity` marketing/report page with loading, error, report, and print/save states.
- Added unauthenticated `POST /api/agent-opportunity` endpoint.
- Added SSRF-conscious URL normalization that rejects localhost, private, link-local, and restricted hostnames/IPs.
- Added bounded HTML extraction for title, meta description, and readable homepage text.
- Added OpenAI Responses API integration using server-side `OPENAI_API_KEY` and structured JSON schema output.
- Added typed validation for model responses.
- Added a small in-memory IP rate limit to protect the public endpoint from accidental token burn.
- Added focused Vitest coverage for validation, extraction, parsing, and route behavior.

## Configuration

Required for live report generation:

```bash
OPENAI_API_KEY=...
```

Optional model override:

```bash
AGENT_OPPORTUNITY_OPENAI_MODEL=gpt-5.4-mini
```

## Validation

- `cd web && npm exec -- vitest run src/lib/agent-opportunity.test.ts src/app/api/agent-opportunity/route.test.ts`
- `cd web && npm run lint`
- `cd web && npm run build`
- Local smoke: `GET /agent-opportunity` returns 200 with the expected scanner copy.
- Local smoke: invalid URL returns `invalid_url`.
- Local smoke: missing OpenAI key returns `openai_not_configured` before fetching the target URL.

Notes: lint/build still report existing unrelated warnings in other files, but exit successfully.
