### PR TITLE
feat(web): agent opportunity scanner UI, web research, and SEO

### DIFF
--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -1,28 +1,40 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
   ClipboardCheck,
   Download,
-  Gauge,
+  FlaskConical,
   Loader2,
+  Search,
   ShieldCheck,
   Sparkles,
+  Target,
+  TrendingUp,
 } from "lucide-react";
 import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
+import { FitScoreRing } from "./components/fit-score-ring";
+import { MetricTile } from "./components/metric-tile";
+import {
+  AGENT_OPPORTUNITY_FAQ,
+  AGENT_OPPORTUNITY_H1,
+  AGENT_OPPORTUNITY_LEDE,
+  AGENT_OPPORTUNITY_SECTIONS,
+} from "./agent-opportunity-seo";
+import {
+  confidenceCopy,
+  deriveOpportunityMetrics,
+  fitCopy,
+  fitTone,
+} from "./report-metrics";
 
 type ReportResponse =
   | { ok: true; report: AgentOpportunityReport }
   | { ok: false; code: string; error: string };
 
-const fitCopy: Record<AgentOpportunityReport["shouldBuildAgent"], string> = {
-  not_yet: "Do not build yet",
-  narrow_pilot: "Pilot narrowly",
-  strong_fit: "Strong fit",
-  eval_first: "Evaluate first",
-};
+type ReportTab = "overview" | "opportunities" | "risks" | "eval";
 
 const painOptions = [
   "Support",
@@ -33,191 +45,440 @@ const painOptions = [
   "Not sure yet",
 ];
 
-function scoreBand(score: number) {
-  if (score >= 75) return "text-emerald-200";
-  if (score >= 45) return "text-amber-200";
-  return "text-white/70";
+const loadingSteps = [
+  "Fetching public pages",
+  "Researching the company on the web",
+  "Scoring workflows and risks",
+];
+
+function toneFromScore(score: number): "good" | "warn" | "bad" | "neutral" {
+  if (score >= 75) return "good";
+  if (score >= 45) return "warn";
+  if (score >= 25) return "neutral";
+  return "bad";
 }
 
-function ReportPanel({ report }: { report: AgentOpportunityReport }) {
+function ReportTabs({
+  active,
+  onChange,
+}: {
+  active: ReportTab;
+  onChange: (tab: ReportTab) => void;
+}) {
+  const tabs: { id: ReportTab; label: string }[] = [
+    { id: "overview", label: "Overview" },
+    { id: "opportunities", label: "Opportunities" },
+    { id: "risks", label: "Risks" },
+    { id: "eval", label: "Eval plan" },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-1 rounded-md border border-white/[0.08] bg-white/[0.02] p-1">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => onChange(tab.id)}
+          className={
+            active === tab.id
+              ? "rounded-sm bg-white px-3 py-1.5 text-xs font-medium text-[#060606]"
+              : "rounded-sm px-3 py-1.5 text-xs text-white/55 transition-colors hover:text-white"
+          }
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function UseCaseCard({ useCase }: { useCase: AgentOpportunityReport["useCases"][number] }) {
+  const fitScore =
+    useCase.fit === "high" ? 88 : useCase.fit === "medium" ? 58 : 28;
+
+  return (
+    <article className="rounded-md border border-white/[0.08] bg-[#060606] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-white">{useCase.title}</p>
+          <p className="mt-2 text-sm leading-6 text-white/55">{useCase.workflow}</p>
+        </div>
+        <span className="rounded-sm border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.12em] text-white/45">
+          {useCase.fit} fit
+        </span>
+      </div>
+      <div className="mt-4 h-[3px] overflow-hidden rounded-full bg-white/[0.05]">
+        <div
+          className="h-full rounded-full bg-cyan-500/80"
+          style={{ width: `${fitScore}%` }}
+        />
+      </div>
+      <div className="mt-4 grid gap-2 text-xs sm:grid-cols-3">
+        <p className="text-white/45">
+          Hours saved{" "}
+          <span className="text-white/75">{useCase.estimatedMonthlyHoursSaved}</span>
+        </p>
+        <p className="text-white/45">
+          Savings{" "}
+          <span className="text-white/75">{useCase.estimatedMonthlySavingsUsd}</span>
+        </p>
+        <p className="text-white/45">
+          Complexity{" "}
+          <span className="capitalize text-white/75">{useCase.complexity}</span>
+        </p>
+      </div>
+      <p className="mt-4 text-sm leading-6 text-white/50">{useCase.why}</p>
+      <ul className="mt-4 grid gap-2 text-xs text-white/45 sm:grid-cols-2">
+        {useCase.firstEvalTasks.map((task) => (
+          <li key={task} className="flex items-start gap-2">
+            <ClipboardCheck className="mt-0.5 size-3.5 shrink-0" />
+            <span>{task}</span>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+function ReportDashboard({ report }: { report: AgentOpportunityReport }) {
+  const [tab, setTab] = useState<ReportTab>("overview");
+  const metrics = useMemo(() => deriveOpportunityMetrics(report), [report]);
   const verdict = fitCopy[report.shouldBuildAgent];
 
   return (
-    <section className="mt-14 border-t border-white/[0.08] pt-10">
-      <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-        <div>
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
-            Agent opportunity report
-          </p>
-          <h2 className="mt-4 text-3xl font-sans font-semibold tracking-tight text-white sm:text-4xl">
-            {report.companyName}
-          </h2>
-          <p className="mt-4 text-sm leading-6 text-white/55">
-            {report.summary}
-          </p>
-          <div className="mt-7 grid grid-cols-2 gap-3">
-            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4">
-              <Gauge className="size-4 text-white/45" />
-              <p className={`mt-5 text-4xl font-semibold ${scoreBand(report.agentFitScore)}`}>
-                {report.agentFitScore}
-              </p>
-              <p className="mt-1 text-xs text-white/40">Fit score</p>
-            </div>
-            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4">
-              <ShieldCheck className="size-4 text-white/45" />
-              <p className="mt-5 text-lg font-semibold text-white">{verdict}</p>
-              <p className="mt-1 text-xs capitalize text-white/40">
-                {report.fitLevel} confidence
-              </p>
+    <section className="mt-10 overflow-hidden rounded-lg border border-white/[0.08] bg-[#080808]">
+      <div className="border-b border-white/[0.08] p-5 sm:p-6">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
+              Agent opportunity report
+            </p>
+            <h2 className="mt-3 truncate text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              {report.companyName}
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/55">
+              {report.summary}
+            </p>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <span
+                className={
+                  fitTone[report.shouldBuildAgent] === "good"
+                    ? "rounded-sm border border-emerald-500/25 bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-200"
+                    : fitTone[report.shouldBuildAgent] === "warn"
+                      ? "rounded-sm border border-amber-500/25 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-200"
+                      : fitTone[report.shouldBuildAgent] === "bad"
+                        ? "rounded-sm border border-red-500/25 bg-red-500/10 px-2.5 py-1 text-xs font-medium text-red-200"
+                        : "rounded-sm border border-white/10 bg-white/[0.04] px-2.5 py-1 text-xs font-medium text-white/75"
+                }
+              >
+                {verdict}
+              </span>
+              <span className="text-xs text-white/40">
+                {confidenceCopy[report.fitLevel]}
+              </span>
             </div>
           </div>
-          <p className="mt-6 rounded-md border border-white/[0.08] bg-[#0a0a0a] p-4 text-sm leading-6 text-white/65">
-            {report.honestVerdict}
-          </p>
-          <button
-            type="button"
-            onClick={() => window.print()}
-            className="mt-5 inline-flex items-center gap-2 rounded-md border border-white/[0.1] px-3 py-2 text-sm text-white/70 transition-colors hover:border-white/25 hover:text-white"
-          >
-            <Download className="size-4" />
-            Save report
-          </button>
+
+          <div className="flex shrink-0 flex-col items-center gap-3 sm:flex-row lg:flex-col">
+            <FitScoreRing score={report.agentFitScore} />
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex items-center gap-2 rounded-md border border-white/[0.1] px-3 py-2 text-xs text-white/70 transition-colors hover:border-white/25 hover:text-white print:hidden"
+            >
+              <Download className="size-3.5" />
+              Save report
+            </button>
+          </div>
         </div>
 
-        <div className="space-y-8">
-          <div>
-            <div className="flex items-center gap-2">
-              <Sparkles className="size-4 text-cyan-200" />
-              <h3 className="text-lg font-semibold tracking-tight text-white">
-                Best agent use cases
-              </h3>
-            </div>
-            <div className="mt-4 grid gap-3">
-              {report.useCases.map((useCase) => (
-                <article
-                  key={useCase.title}
-                  className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-base font-semibold text-white">
-                        {useCase.title}
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-white/55">
-                        {useCase.workflow}
-                      </p>
-                    </div>
-                    <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.12em] text-white/45">
-                      {useCase.fit} fit
-                    </span>
-                  </div>
-                  <div className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
-                    <p className="text-white/50">
-                      Hours:{" "}
-                      <span className="text-white/80">
-                        {useCase.estimatedMonthlyHoursSaved}
-                      </span>
-                    </p>
-                    <p className="text-white/50">
-                      Savings:{" "}
-                      <span className="text-white/80">
-                        {useCase.estimatedMonthlySavingsUsd}
-                      </span>
-                    </p>
-                    <p className="text-white/50">
-                      Complexity:{" "}
-                      <span className="text-white/80">{useCase.complexity}</span>
-                    </p>
-                  </div>
-                  <p className="mt-4 text-sm leading-6 text-white/50">
-                    {useCase.why}
-                  </p>
-                  <ul className="mt-4 grid gap-2 text-xs text-white/45 sm:grid-cols-2">
-                    {useCase.firstEvalTasks.map((task) => (
-                      <li key={task} className="flex items-start gap-2">
-                        <ClipboardCheck className="mt-0.5 size-3.5 shrink-0" />
-                        <span>{task}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </article>
-              ))}
-            </div>
-          </div>
+        <div className="mt-6 grid grid-cols-1 gap-px overflow-hidden rounded-md border border-white/[0.08] bg-white/[0.08] sm:grid-cols-2 xl:grid-cols-4">
+          <MetricTile
+            icon={Target}
+            label="Workflow fit"
+            value={
+              metrics.workflowFit >= 75
+                ? "Repeatable workflows found"
+                : metrics.workflowFit >= 45
+                  ? "Some repeatable work"
+                  : "Weak workflow signal"
+            }
+            hint="How clearly the site exposes agent-ready work."
+            score={metrics.workflowFit}
+            tone={toneFromScore(metrics.workflowFit)}
+          />
+          <MetricTile
+            icon={TrendingUp}
+            label="ROI signal"
+            value={
+              metrics.roiSignal >= 75
+                ? "Conservative upside"
+                : metrics.roiSignal >= 45
+                  ? "Limited upside"
+                  : "Hard to justify now"
+            }
+            hint="Blended fit score and workflow quality."
+            score={metrics.roiSignal}
+            tone={toneFromScore(metrics.roiSignal)}
+          />
+          <MetricTile
+            icon={ShieldCheck}
+            label="Risk profile"
+            value={
+              metrics.riskProfile >= 75
+                ? "Risks look manageable"
+                : metrics.riskProfile >= 45
+                  ? "Needs guardrails"
+                  : "High failure risk"
+            }
+            hint="Higher is safer. Based on severity of listed risks."
+            score={metrics.riskProfile}
+            tone={toneFromScore(metrics.riskProfile)}
+          />
+          <MetricTile
+            icon={FlaskConical}
+            label="Eval readiness"
+            value={
+              metrics.evalReadiness >= 75
+                ? "Ready to test"
+                : metrics.evalReadiness >= 45
+                  ? "Test before building"
+                  : "Do not ship yet"
+            }
+            hint="Whether AgentClash eval should come next."
+            score={metrics.evalReadiness}
+            tone={toneFromScore(metrics.evalReadiness)}
+          />
+        </div>
+      </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <div className="flex items-center gap-2">
-                <AlertTriangle className="size-4 text-amber-200" />
-                <h3 className="text-lg font-semibold tracking-tight text-white">
-                  Risks to evaluate
-                </h3>
-              </div>
-              <div className="mt-4 space-y-3">
-                {report.risks.map((risk) => (
-                  <div
-                    key={risk.risk}
-                    className="rounded-md border border-white/[0.08] bg-white/[0.03] p-4"
-                  >
-                    <p className="text-sm font-medium text-white">{risk.risk}</p>
-                    <p className="mt-2 text-xs leading-5 text-white/50">
-                      {risk.mitigation}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div>
-              <div className="flex items-center gap-2">
-                <ShieldCheck className="size-4 text-emerald-200" />
-                <h3 className="text-lg font-semibold tracking-tight text-white">
-                  AgentClash eval pack
-                </h3>
-              </div>
-              <div className="mt-4 rounded-md border border-white/[0.08] bg-white/[0.03] p-5">
-                <p className="font-medium text-white">{report.evaluationPack.name}</p>
-                <p className="mt-3 text-sm leading-6 text-white/55">
-                  {report.evaluationPack.recommendedCases} realistic cases,{" "}
-                  {report.evaluationPack.adversarialCases} adversarial cases.
-                </p>
-                <ul className="mt-4 space-y-2 text-xs leading-5 text-white/45">
-                  {report.evaluationPack.successCriteria.map((criterion) => (
-                    <li key={criterion}>{criterion}</li>
+      <div className="border-b border-white/[0.08] px-5 py-4 sm:px-6">
+        <ReportTabs active={tab} onChange={setTab} />
+      </div>
+
+      <div className="max-h-[min(70vh,720px)] overflow-y-auto p-5 sm:p-6">
+        {tab === "overview" ? (
+          <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-white">Honest verdict</h3>
+              <p className="rounded-md border border-white/[0.08] bg-[#060606] p-4 text-sm leading-7 text-white/65">
+                {report.honestVerdict}
+              </p>
+              <div>
+                <h3 className="text-sm font-medium text-white">Next steps</h3>
+                <ul className="mt-3 space-y-2 text-sm leading-6 text-white/55">
+                  {report.nextSteps.map((step) => (
+                    <li key={step} className="flex gap-2">
+                      <span className="font-[family-name:var(--font-mono)] text-white/30">
+                        →
+                      </span>
+                      <span>{step}</span>
+                    </li>
                   ))}
                 </ul>
-                <a
-                  href="/auth/login"
-                  className="mt-5 inline-flex items-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
-                >
-                  Create eval workspace
-                  <ArrowRight className="size-4" />
-                </a>
               </div>
             </div>
-          </div>
-
-          <div className="grid gap-4 border-t border-white/[0.08] pt-6 md:grid-cols-2">
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
-                Next steps
-              </p>
-              <ul className="mt-3 space-y-2 text-sm leading-6 text-white/55">
-                {report.nextSteps.map((step) => (
-                  <li key={step}>{step}</li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
-                Evidence limits
-              </p>
+              <h3 className="text-sm font-medium text-white">Evidence limits</h3>
               <ul className="mt-3 space-y-2 text-sm leading-6 text-white/45">
                 {report.evidenceLimitations.map((limit) => (
                   <li key={limit}>{limit}</li>
                 ))}
               </ul>
+              <p className="mt-5 font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.14em] text-white/30">
+                Analyzed {report.analyzedUrl}
+              </p>
             </div>
           </div>
+        ) : null}
+
+        {tab === "opportunities" ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-cyan-200" />
+              <h3 className="text-sm font-medium text-white">Best agent use cases</h3>
+            </div>
+            <div className="grid gap-3">
+              {report.useCases.map((useCase) => (
+                <UseCaseCard key={useCase.title} useCase={useCase} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {tab === "risks" ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            {report.risks.map((risk) => (
+              <article
+                key={risk.risk}
+                className="rounded-md border border-white/[0.08] bg-[#060606] p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-200" />
+                    <p className="text-sm font-medium text-white">{risk.risk}</p>
+                  </div>
+                  <span className="rounded-sm border border-white/[0.08] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-white/40">
+                    {risk.severity}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-white/50">{risk.mitigation}</p>
+              </article>
+            ))}
+          </div>
+        ) : null}
+
+        {tab === "eval" ? (
+          <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+            <div className="rounded-md border border-white/[0.08] bg-[#060606] p-5">
+              <div className="flex items-center gap-2">
+                <ShieldCheck className="size-4 text-emerald-200" />
+                <h3 className="text-sm font-medium text-white">AgentClash eval pack</h3>
+              </div>
+              <p className="mt-4 text-base font-medium text-white">
+                {report.evaluationPack.name}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-white/55">
+                {report.evaluationPack.recommendedCases} realistic cases,{" "}
+                {report.evaluationPack.adversarialCases} adversarial cases.
+              </p>
+              <ul className="mt-4 space-y-2 text-sm leading-6 text-white/45">
+                {report.evaluationPack.successCriteria.map((criterion) => (
+                  <li key={criterion} className="flex gap-2">
+                    <span className="text-white/25">•</span>
+                    <span>{criterion}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="flex flex-col justify-between gap-4 rounded-md border border-white/[0.08] bg-white/[0.02] p-5">
+              <div>
+                <p className="text-sm font-medium text-white">
+                  Race agents on real cases before you ship
+                </p>
+                <p className="mt-2 text-sm leading-6 text-white/50">
+                  Turn this report into a challenge pack and compare models on the
+                  workflows that actually matter for {report.companyName}.
+                </p>
+              </div>
+              <a
+                href="/auth/login"
+                className="inline-flex w-fit items-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Create eval workspace
+                <ArrowRight className="size-4" />
+              </a>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function LoadingPanel({ step }: { step: number }) {
+  return (
+    <section className="mt-10 overflow-hidden rounded-lg border border-white/[0.08] bg-[#080808] p-6">
+      <div className="flex items-center gap-3">
+        <Loader2 className="size-5 animate-spin text-white/60" />
+        <div>
+          <p className="text-sm font-medium text-white">Generating your report</p>
+          <p className="mt-1 text-xs text-white/45">
+            This usually takes 20 to 60 seconds while we search the web.
+          </p>
+        </div>
+      </div>
+      <ol className="mt-6 space-y-3">
+        {loadingSteps.map((label, index) => {
+          const active = index === step;
+          const done = index < step;
+          return (
+            <li
+              key={label}
+              className={
+                done
+                  ? "flex items-center gap-3 text-sm text-emerald-200/80"
+                  : active
+                    ? "flex items-center gap-3 text-sm text-white"
+                    : "flex items-center gap-3 text-sm text-white/35"
+              }
+            >
+              <span className="flex size-6 items-center justify-center rounded-full border border-white/10 font-[family-name:var(--font-mono)] text-[11px]">
+                {done ? "✓" : index + 1}
+              </span>
+              {label}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function SeoContent() {
+  return (
+    <section className="mt-16 border-t border-white/[0.08] pt-12">
+      <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+            Free AI agent ROI calculator and build vs buy assessment
+          </h2>
+          <p className="mt-4 text-sm leading-7 text-white/55">
+            Teams search for AI agent ROI calculators, build vs buy frameworks,
+            and honest answers to &quot;should we build an AI agent?&quot; This
+            page combines those intents into one URL-based report with agentic AI
+            use cases, conservative savings ranges, and eval guidance.
+          </p>
+          <div className="mt-8 grid gap-4">
+            {AGENT_OPPORTUNITY_SECTIONS.map((section) => (
+              <article
+                key={section.title}
+                className="rounded-md border border-white/[0.08] bg-white/[0.02] p-4"
+              >
+                <h3 className="text-sm font-medium text-white">{section.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-white/50">{section.body}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight text-white">
+            AI agent evaluation FAQ
+          </h2>
+          <div className="mt-5 space-y-4">
+            {AGENT_OPPORTUNITY_FAQ.map((item) => (
+              <details
+                key={item.question}
+                className="group rounded-md border border-white/[0.08] bg-[#060606] p-4"
+              >
+                <summary className="cursor-pointer list-none text-sm font-medium text-white marker:content-none [&::-webkit-details-marker]:hidden">
+                  <span className="flex items-start justify-between gap-3">
+                    <span>{item.question}</span>
+                    <span className="text-white/30 transition-transform group-open:rotate-45">
+                      +
+                    </span>
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm leading-6 text-white/50">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+          <p className="mt-6 text-xs leading-6 text-white/35">
+            Ready to test before you ship? Explore{" "}
+            <a href="/platform/agent-evaluation" className="text-white/55 underline-offset-2 hover:text-white hover:underline">
+              AI agent evaluation
+            </a>
+            ,{" "}
+            <a href="/enterprise" className="text-white/55 underline-offset-2 hover:text-white hover:underline">
+              enterprise eval gates
+            </a>
+            , or{" "}
+            <a href="/tryouts" className="text-white/55 underline-offset-2 hover:text-white hover:underline">
+              public agent tryouts
+            </a>
+            .
+          </p>
         </div>
       </div>
     </section>
@@ -230,6 +491,7 @@ export function AgentOpportunityClient() {
   const [currentPain, setCurrentPain] = useState("");
   const [monthlySupportVolume, setMonthlySupportVolume] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loadingStep, setLoadingStep] = useState(0);
   const [error, setError] = useState("");
   const [report, setReport] = useState<AgentOpportunityReport | null>(null);
 
@@ -240,8 +502,13 @@ export function AgentOpportunityClient() {
     if (!canSubmit) return;
 
     setLoading(true);
+    setLoadingStep(0);
     setError("");
     setReport(null);
+
+    const stepTimer = window.setInterval(() => {
+      setLoadingStep((current) => Math.min(current + 1, loadingSteps.length - 1));
+    }, 9000);
 
     try {
       const response = await fetch("/api/agent-opportunity", {
@@ -263,60 +530,54 @@ export function AgentOpportunityClient() {
     } catch {
       setError("The report request failed. Please try again.");
     } finally {
+      window.clearInterval(stepTimer);
       setLoading(false);
     }
   }
 
   return (
     <>
-      <section className="px-6 pt-16 sm:px-12 sm:pt-24">
-        <div className="mx-auto grid max-w-[1180px] gap-12 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
-          <div>
+      <section className="px-6 pt-14 sm:px-12 sm:pt-20">
+        <div className="mx-auto max-w-[980px]">
             <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
-              AI agent opportunity scanner
+              AI agent ROI calculator
             </p>
-            <h1 className="mt-6 max-w-[13ch] text-[clamp(2.75rem,7vw,5.8rem)] font-sans font-semibold leading-[0.98] tracking-tight text-white">
-              Should your company have an AI agent?
+            <h1 className="mt-5 max-w-[16ch] text-[clamp(2.4rem,6vw,4.5rem)] font-sans font-semibold leading-[0.98] tracking-tight text-white">
+              {AGENT_OPPORTUNITY_H1}
             </h1>
-            <p className="mt-7 max-w-[58ch] text-lg leading-8 text-white/60">
-              Get an honest URL-based report on where agents could save time,
-              where they would fail, and what AgentClash should test before
-              anyone ships one to customers.
+            <p className="mt-5 max-w-[52ch] text-base leading-7 text-white/60 sm:text-lg">
+              {AGENT_OPPORTUNITY_LEDE}
             </p>
-            <div className="mt-9 grid gap-3 border-t border-white/[0.08] pt-6 text-sm leading-6 text-white/55 sm:grid-cols-3">
-              <p>Conservative savings ranges</p>
-              <p>Risk and eval requirements</p>
-              <p>A real not-yet verdict</p>
-            </div>
-          </div>
 
           <form
             onSubmit={onSubmit}
-            className="rounded-md border border-white/[0.1] bg-[#0a0a0a] p-5 shadow-2xl shadow-black/30 sm:p-6"
+            className="mt-8 overflow-hidden rounded-lg border border-white/[0.1] bg-[#0a0a0a]"
           >
-            <label className="block text-sm font-medium text-white" htmlFor="url">
-              Company URL
-            </label>
-            <div className="mt-3 flex flex-col gap-3 sm:flex-row">
-              <input
-                id="url"
-                value={url}
-                onChange={(event) => setUrl(event.target.value)}
-                placeholder="https://example.com"
-                className="min-h-11 flex-1 rounded-md border border-white/[0.1] bg-white/[0.04] px-3 text-sm text-white outline-none transition-colors placeholder:text-white/25 focus:border-white/30"
-              />
-              <button
-                type="submit"
-                disabled={!canSubmit}
-                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-white px-4 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loading ? <Loader2 className="size-4 animate-spin" /> : null}
-                Analyze
-              </button>
+            <div className="border-b border-white/[0.08] px-4 py-3 sm:px-5">
+              <label className="block text-sm font-medium text-white" htmlFor="url">
+                Company URL
+              </label>
+              <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+                <input
+                  id="url"
+                  value={url}
+                  onChange={(event) => setUrl(event.target.value)}
+                  placeholder="https://example.com"
+                  className="min-h-11 min-w-0 flex-1 rounded-md border border-white/[0.1] bg-white/[0.04] px-3 text-sm text-white outline-none transition-colors placeholder:text-white/25 focus:border-white/30"
+                />
+                <button
+                  type="submit"
+                  disabled={!canSubmit}
+                  className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-md bg-white px-4 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading ? <Loader2 className="size-4 animate-spin" /> : <Search className="size-4" />}
+                  Analyze
+                </button>
+              </div>
             </div>
 
-            <div className="mt-5 grid gap-3 sm:grid-cols-3">
-              <label className="block">
+            <div className="grid gap-px bg-white/[0.08] sm:grid-cols-3">
+              <label className="block bg-[#0a0a0a] p-4">
                 <span className="text-xs text-white/45">Company size</span>
                 <select
                   value={companySize}
@@ -331,7 +592,7 @@ export function AgentOpportunityClient() {
                   <option value="1000+">1000+</option>
                 </select>
               </label>
-              <label className="block">
+              <label className="block bg-[#0a0a0a] p-4">
                 <span className="text-xs text-white/45">Main pain</span>
                 <select
                   value={currentPain}
@@ -346,13 +607,11 @@ export function AgentOpportunityClient() {
                   ))}
                 </select>
               </label>
-              <label className="block">
+              <label className="block bg-[#0a0a0a] p-4">
                 <span className="text-xs text-white/45">Support volume</span>
                 <select
                   value={monthlySupportVolume}
-                  onChange={(event) =>
-                    setMonthlySupportVolume(event.target.value)
-                  }
+                  onChange={(event) => setMonthlySupportVolume(event.target.value)}
                   className="mt-2 min-h-10 w-full rounded-md border border-white/[0.1] bg-[#111] px-3 text-sm text-white/75 outline-none focus:border-white/30"
                 >
                   <option value="">Unknown</option>
@@ -365,32 +624,19 @@ export function AgentOpportunityClient() {
             </div>
 
             {error ? (
-              <p className="mt-5 rounded-md border border-amber-300/20 bg-amber-300/10 p-3 text-sm leading-6 text-amber-100">
+              <p className="border-t border-amber-300/20 bg-amber-300/10 px-4 py-3 text-sm leading-6 text-amber-100 sm:px-5">
                 {error}
               </p>
             ) : null}
-
-            <div className="mt-6 grid gap-px overflow-hidden rounded-md border border-white/[0.08] bg-white/[0.08] sm:grid-cols-3">
-              {[
-                ["1", "Find the repeatable workflow"],
-                ["2", "Estimate ROI and failure risk"],
-                ["3", "Generate the eval pack"],
-              ].map(([step, label]) => (
-                <div key={step} className="bg-[#0a0a0a] p-4">
-                  <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/35">
-                    {step}
-                  </p>
-                  <p className="mt-3 text-sm leading-5 text-white/60">{label}</p>
-                </div>
-              ))}
-            </div>
           </form>
         </div>
       </section>
 
       <div className="px-6 pb-20 sm:px-12">
-        <div className="mx-auto max-w-[1180px]">
-          {report ? <ReportPanel report={report} /> : null}
+        <div className="mx-auto max-w-[980px]">
+          {loading ? <LoadingPanel step={loadingStep} /> : null}
+          {report ? <ReportDashboard report={report} /> : null}
+          <SeoContent />
         </div>
       </div>
     </>

--- a/web/src/app/agent-opportunity/agent-opportunity-seo.ts
+++ b/web/src/app/agent-opportunity/agent-opportunity-seo.ts
@@ -1,0 +1,79 @@
+export const AGENT_OPPORTUNITY_PATH = "/agent-opportunity";
+
+/** Primary queries: build vs buy, ROI/business case, should-we-build intent. */
+export const AGENT_OPPORTUNITY_TITLE =
+  "AI Agent ROI Calculator & Build vs Buy Assessment | AgentClash";
+
+export const AGENT_OPPORTUNITY_DESCRIPTION =
+  "Free AI agent opportunity report from any company URL. Get agentic AI use cases, conservative ROI ranges, build vs buy guidance, risk scoring, and an AgentClash evaluation plan before you ship.";
+
+export const AGENT_OPPORTUNITY_KEYWORDS = [
+  "AI agent ROI calculator",
+  "AI agent ROI assessment",
+  "should we build an AI agent",
+  "build vs buy AI agent",
+  "agentic AI use cases",
+  "AI agent business case",
+  "AI agent opportunity assessment",
+  "AI agent evaluation",
+  "agentic AI customer support",
+  "AI agent pilot",
+  "AI agent risk assessment",
+  "when to build AI agents",
+  "enterprise AI agents",
+  "agent evaluation framework",
+];
+
+export const AGENT_OPPORTUNITY_H1 =
+  "Should your company build an AI agent?";
+
+export const AGENT_OPPORTUNITY_LEDE =
+  "Paste a company URL for a free AI agent ROI and build vs buy assessment. We research the web, score agentic AI use cases, surface risks, and generate an evaluation plan you can run in AgentClash.";
+
+export const AGENT_OPPORTUNITY_FAQ = [
+  {
+    question: "Should my company build an AI agent?",
+    answer:
+      "Only if you have a repeatable workflow with clear success criteria, acceptable risk, and enough volume to justify automation. Many teams should evaluate first or run a narrow pilot instead of shipping a customer-facing agent. This scanner returns an honest build, pilot, evaluate-first, or not-yet verdict from public evidence.",
+  },
+  {
+    question: "How do you calculate AI agent ROI?",
+    answer:
+      "The report uses conservative ranges, not fake precision. It estimates monthly hours saved and cost impact from workflows visible on your site plus web research, then weighs that against implementation complexity and failure risk. Treat the output as a business-case starting point, not a CFO-ready forecast.",
+  },
+  {
+    question: "What is the build vs buy decision for AI agents?",
+    answer:
+      "Build when the workflow is core IP, highly proprietary, or too niche for vendors. Buy or partner when the workflow is common, speed matters, and vendor boundaries are acceptable. Most enterprises land on a hybrid model. The report calls out which path fits the workflows it finds on your site.",
+  },
+  {
+    question: "What are common agentic AI use cases?",
+    answer:
+      "High-volume support triage, onboarding guidance, sales qualification, developer docs assistance, and internal ops workflows are the most common starting points. Strong candidates have structured inputs, tool access, and measurable outcomes. Weak candidates are open-ended chat on your homepage with no escalation path.",
+  },
+  {
+    question: "When should we run an AI agent evaluation before launch?",
+    answer:
+      "Before any customer-facing agent touches policy, billing, refunds, healthcare, or financial advice. AgentClash recommends realistic and adversarial eval cases tied to the workflow you plan to ship. This report includes a starter eval pack you can turn into a race in AgentClash.",
+  },
+  {
+    question: "How is this different from a chatbot ROI calculator?",
+    answer:
+      "Chatbot calculators assume a bot belongs on your site. This tool starts with whether an agent is worth building at all, then scores agentic workflows, risk, and eval readiness. It is built for teams deciding between pilot, buy, build, or wait.",
+  },
+] as const;
+
+export const AGENT_OPPORTUNITY_SECTIONS = [
+  {
+    title: "AI agent ROI without the hype",
+    body: "Most teams are pressured to ship agentic AI before they can defend the business case. This free AI agent ROI assessment turns a public company URL into workflow fit, savings ranges, and a risk profile you can share with product, support, and finance stakeholders.",
+  },
+  {
+    title: "Build vs buy for enterprise AI agents",
+    body: "The build vs buy AI agent decision depends on workflow uniqueness, data sensitivity, and how fast you need learning. The scanner highlights where a narrow pilot, vendor agent, or custom build is the safer path, and where you should not build yet.",
+  },
+  {
+    title: "Agent evaluation before production",
+    body: "An AI agent evaluation should happen before customers see the workflow. AgentClash turns the recommended cases from this report into head-to-head agent races with replay evidence, so you can compare models and catch failure modes early.",
+  },
+] as const;

--- a/web/src/app/agent-opportunity/components/fit-score-ring.tsx
+++ b/web/src/app/agent-opportunity/components/fit-score-ring.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+function scoreColor(score: number) {
+  if (score >= 75) return "rgb(52, 211, 153)";
+  if (score >= 45) return "rgb(251, 191, 36)";
+  return "rgb(248, 113, 113)";
+}
+
+export function FitScoreRing({
+  score,
+  size = 148,
+  label = "Agent fit",
+}: {
+  score: number;
+  size?: number;
+  label?: string;
+}) {
+  const radius = (size - 16) / 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = Math.max(0, Math.min(100, score)) / 100;
+  const stroke = scoreColor(score);
+
+  return (
+    <div
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} aria-hidden>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="rgba(255,255,255,0.06)"
+          strokeWidth={10}
+        />
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={10}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - progress)}
+          transform={`rotate(-90 ${cx} ${cy})`}
+          style={{ filter: `drop-shadow(0 0 8px ${stroke})` }}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span
+          className={cn(
+            "font-[family-name:var(--font-mono)] text-[34px] leading-none font-medium tabular-nums",
+          )}
+          style={{ color: stroke }}
+        >
+          {score}
+        </span>
+        <span className="mt-1 text-[9px] uppercase tracking-[0.18em] text-white/40">
+          {label}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/agent-opportunity/components/metric-tile.tsx
+++ b/web/src/app/agent-opportunity/components/metric-tile.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function toneClass(tone: "good" | "warn" | "bad" | "neutral") {
+  switch (tone) {
+    case "good":
+      return "text-emerald-300";
+    case "warn":
+      return "text-amber-300";
+    case "bad":
+      return "text-red-300";
+    default:
+      return "text-white/75";
+  }
+}
+
+function barClass(tone: "good" | "warn" | "bad" | "neutral") {
+  switch (tone) {
+    case "good":
+      return "bg-emerald-500";
+    case "warn":
+      return "bg-amber-500";
+    case "bad":
+      return "bg-red-500";
+    default:
+      return "bg-white/40";
+  }
+}
+
+export function MetricTile({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  score,
+  tone,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  hint: string;
+  score: number;
+  tone: "good" | "warn" | "bad" | "neutral";
+}) {
+  return (
+    <article className="flex min-w-0 flex-col gap-3 bg-[#060606] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon className="size-3.5 shrink-0 text-white/35" />
+          <p className="truncate text-[11px] uppercase tracking-[0.14em] text-white/40">
+            {label}
+          </p>
+        </div>
+        <span
+          className={cn(
+            "font-[family-name:var(--font-mono)] text-[11px] tabular-nums",
+            toneClass(tone),
+          )}
+        >
+          {score}
+        </span>
+      </div>
+      <div>
+        <p className="text-sm font-medium text-white">{value}</p>
+        <p className="mt-1 text-xs leading-5 text-white/45">{hint}</p>
+      </div>
+      <div className="h-[3px] overflow-hidden rounded-full bg-white/[0.05]">
+        <div
+          className={cn("h-full rounded-full transition-all", barClass(tone))}
+          style={{ width: `${Math.max(8, Math.min(100, score))}%` }}
+        />
+      </div>
+    </article>
+  );
+}

--- a/web/src/app/agent-opportunity/page.tsx
+++ b/web/src/app/agent-opportunity/page.tsx
@@ -1,42 +1,54 @@
 import type { Metadata } from "next";
-import { JsonLd, breadcrumbSchema } from "@/components/marketing/json-ld";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  faqSchema,
+  productSchema,
+  SITE_URL,
+} from "@/components/marketing/json-ld";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { ogImageUrl } from "@/lib/seo";
 import { AgentOpportunityClient } from "./agent-opportunity-client";
+import {
+  AGENT_OPPORTUNITY_DESCRIPTION,
+  AGENT_OPPORTUNITY_FAQ,
+  AGENT_OPPORTUNITY_KEYWORDS,
+  AGENT_OPPORTUNITY_PATH,
+  AGENT_OPPORTUNITY_TITLE,
+} from "./agent-opportunity-seo";
 
-const PAGE_PATH = "/agent-opportunity";
-const PAGE_TITLE = "AI Agent Opportunity Report | AgentClash";
-const PAGE_DESCRIPTION =
-  "Enter a company URL and get an honest AI agent opportunity report with ROI ranges, risks, and an AgentClash evaluation pack.";
+const SOCIAL_IMAGE = ogImageUrl({
+  title: "AI agent ROI calculator",
+  subtitle: "Build vs buy assessment from a company URL",
+  kind: "Report",
+});
 
 export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  title: AGENT_OPPORTUNITY_TITLE,
+  description: AGENT_OPPORTUNITY_DESCRIPTION,
+  keywords: [...AGENT_OPPORTUNITY_KEYWORDS],
+  alternates: { canonical: AGENT_OPPORTUNITY_PATH },
   openGraph: {
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-    url: PAGE_PATH,
+    title: AGENT_OPPORTUNITY_TITLE,
+    description: AGENT_OPPORTUNITY_DESCRIPTION,
+    url: AGENT_OPPORTUNITY_PATH,
     type: "website",
     locale: "en_US",
     siteName: "AgentClash",
     images: [
       {
-        url: ogImageUrl({
-          title: "Should your company have an AI agent?",
-          subtitle: "ROI, risk, and eval plan from a URL",
-          kind: "Report",
-        }),
+        url: SOCIAL_IMAGE,
         width: 1200,
         height: 630,
-        alt: PAGE_TITLE,
+        alt: AGENT_OPPORTUNITY_TITLE,
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
+    title: AGENT_OPPORTUNITY_TITLE,
+    description: AGENT_OPPORTUNITY_DESCRIPTION,
+    images: [{ url: SOCIAL_IMAGE, alt: AGENT_OPPORTUNITY_TITLE }],
   },
 };
 
@@ -44,12 +56,29 @@ export default function AgentOpportunityPage() {
   return (
     <MarketingShell>
       <JsonLd
-        id="agent-opportunity-breadcrumb-schema"
+        id="agent-opportunity-schema"
         data={[
           breadcrumbSchema([
             { name: "Home", url: "/" },
-            { name: "AI Agent Opportunity Report", url: PAGE_PATH },
+            {
+              name: "AI Agent ROI Calculator",
+              url: AGENT_OPPORTUNITY_PATH,
+            },
           ]),
+          faqSchema([...AGENT_OPPORTUNITY_FAQ]),
+          productSchema({
+            name: "AgentClash AI Agent Opportunity Scanner",
+            description: AGENT_OPPORTUNITY_DESCRIPTION,
+            url: `${SITE_URL}${AGENT_OPPORTUNITY_PATH}`,
+            applicationSubCategory: "AI agent evaluation",
+            featureList: [
+              "AI agent ROI ranges from a company URL",
+              "Build vs buy AI agent guidance",
+              "Agentic AI use case scoring",
+              "Risk and eval readiness scorecard",
+              "AgentClash evaluation pack recommendations",
+            ],
+          }),
         ]}
       />
       <AgentOpportunityClient />

--- a/web/src/app/agent-opportunity/report-metrics.test.ts
+++ b/web/src/app/agent-opportunity/report-metrics.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
+import { deriveOpportunityMetrics, fitCopy } from "./report-metrics";
+
+const sampleReport: AgentOpportunityReport = {
+  analyzedUrl: "https://example.com/",
+  companyName: "Example",
+  generatedAt: "2026-06-12T00:00:00.000Z",
+  agentFitScore: 72,
+  fitLevel: "moderate",
+  shouldBuildAgent: "narrow_pilot",
+  honestVerdict: "Pilot one workflow first.",
+  summary: "Support-heavy business.",
+  useCases: [
+    {
+      title: "Support triage",
+      workflow: "Route tickets",
+      fit: "high",
+      estimatedMonthlyHoursSaved: "20-40",
+      estimatedMonthlySavingsUsd: "$1,500-$4,000",
+      complexity: "medium",
+      why: "Clear support workflows.",
+      firstEvalTasks: ["Refund", "Pricing"],
+    },
+  ],
+  risks: [
+    {
+      risk: "Wrong answer",
+      severity: "medium",
+      mitigation: "Escalate low confidence.",
+    },
+    {
+      risk: "Policy miss",
+      severity: "high",
+      mitigation: "Evaluate edge cases.",
+    },
+  ],
+  evaluationPack: {
+    name: "Support starter",
+    recommendedCases: 25,
+    adversarialCases: 8,
+    successCriteria: ["90% routing"],
+  },
+  nextSteps: ["Collect tickets"],
+  evidenceLimitations: ["Public pages only."],
+};
+
+describe("deriveOpportunityMetrics", () => {
+  it("derives bounded dashboard metrics from a report", () => {
+    const metrics = deriveOpportunityMetrics(sampleReport);
+    expect(metrics.workflowFit).toBe(88);
+    expect(metrics.roiSignal).toBeGreaterThan(0);
+    expect(metrics.roiSignal).toBeLessThanOrEqual(100);
+    expect(metrics.riskProfile).toBe(38);
+    expect(metrics.evalReadiness).toBeGreaterThan(0);
+  });
+});
+
+describe("fitCopy", () => {
+  it("maps verdict enums to readable labels", () => {
+    expect(fitCopy.narrow_pilot).toBe("Pilot narrowly");
+  });
+});

--- a/web/src/app/agent-opportunity/report-metrics.ts
+++ b/web/src/app/agent-opportunity/report-metrics.ts
@@ -1,0 +1,86 @@
+import type {
+  AgentOpportunityReport,
+  AgentOpportunityRisk,
+  AgentOpportunityUseCase,
+} from "@/lib/agent-opportunity";
+
+const fitPoints: Record<AgentOpportunityUseCase["fit"], number> = {
+  high: 88,
+  medium: 58,
+  low: 28,
+};
+
+const severityPoints: Record<AgentOpportunityRisk["severity"], number> = {
+  low: 82,
+  medium: 52,
+  high: 24,
+};
+
+const verdictPoints: Record<AgentOpportunityReport["shouldBuildAgent"], number> = {
+  strong_fit: 90,
+  narrow_pilot: 72,
+  eval_first: 48,
+  not_yet: 22,
+};
+
+export type OpportunityMetrics = {
+  workflowFit: number;
+  roiSignal: number;
+  riskProfile: number;
+  evalReadiness: number;
+};
+
+export function deriveOpportunityMetrics(
+  report: AgentOpportunityReport,
+): OpportunityMetrics {
+  const workflowFit =
+    report.useCases.length === 0
+      ? report.agentFitScore
+      : Math.round(
+          report.useCases.reduce((sum, useCase) => sum + fitPoints[useCase.fit], 0) /
+            report.useCases.length,
+        );
+
+  const roiSignal = Math.round(
+    report.agentFitScore * 0.55 + workflowFit * 0.45,
+  );
+
+  const riskProfile =
+    report.risks.length === 0
+      ? 55
+      : Math.round(
+          report.risks.reduce(
+            (sum, risk) => sum + severityPoints[risk.severity],
+            0,
+          ) / report.risks.length,
+        );
+
+  const evalReadiness = Math.round(
+    verdictPoints[report.shouldBuildAgent] * 0.6 + riskProfile * 0.4,
+  );
+
+  return { workflowFit, roiSignal, riskProfile, evalReadiness };
+}
+
+export const fitCopy: Record<AgentOpportunityReport["shouldBuildAgent"], string> = {
+  not_yet: "Do not build yet",
+  narrow_pilot: "Pilot narrowly",
+  strong_fit: "Strong fit",
+  eval_first: "Evaluate first",
+};
+
+export const fitTone: Record<
+  AgentOpportunityReport["shouldBuildAgent"],
+  "good" | "warn" | "bad" | "neutral"
+> = {
+  not_yet: "bad",
+  narrow_pilot: "warn",
+  strong_fit: "good",
+  eval_first: "neutral",
+};
+
+export const confidenceCopy: Record<AgentOpportunityReport["fitLevel"], string> = {
+  low: "Low confidence",
+  moderate: "Moderate confidence",
+  high: "High confidence",
+};

--- a/web/src/app/api/agent-opportunity/route.test.ts
+++ b/web/src/app/api/agent-opportunity/route.test.ts
@@ -134,18 +134,17 @@ describe("POST /api/agent-opportunity", () => {
 
   it("returns a complete report with mocked page and OpenAI fetches", async () => {
     process.env.OPENAI_API_KEY = "sk-test";
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          "<html><head><title>Example</title></head><body>Support automation for customer teams.</body></html>",
-          { headers: { "content-type": "text/html" } },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ output_text: JSON.stringify(report) }), {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "https://api.openai.com/v1/responses") {
+        return new Response(JSON.stringify({ output_text: JSON.stringify(report) }), {
           headers: { "content-type": "application/json" },
-        }),
+        });
+      }
+      return new Response(
+        "<html><head><title>Example</title></head><body>Support automation for customer teams.</body></html>",
+        { headers: { "content-type": "text/html" } },
       );
+    });
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -160,10 +159,15 @@ describe("POST /api/agent-opportunity", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const openAIRequest = fetchMock.mock.calls[1];
-    expect(openAIRequest[0]).toBe("https://api.openai.com/v1/responses");
-    expect(openAIRequest[1].headers.authorization).toBe("Bearer sk-test");
+    expect(fetchMock.mock.calls[0][0]).toBe("http://93.184.216.34/");
+    const openAIRequest = fetchMock.mock.calls.find(
+      (call) => call[0] === "https://api.openai.com/v1/responses",
+    );
+    expect(openAIRequest).toBeTruthy();
+    expect(openAIRequest?.[1].headers.authorization).toBe("Bearer sk-test");
+    const openAIBody = JSON.parse(openAIRequest?.[1].body as string);
+    expect(openAIBody.tools).toEqual([{ type: "web_search_preview" }]);
+    expect(openAIBody.input[0].content).toContain("Research protocol");
     await expect(response.json()).resolves.toMatchObject({
       ok: true,
       report: {

--- a/web/src/app/api/agent-opportunity/route.test.ts
+++ b/web/src/app/api/agent-opportunity/route.test.ts
@@ -151,7 +151,7 @@ describe("POST /api/agent-opportunity", () => {
       new Request("https://agentclash.dev/api/agent-opportunity", {
         method: "POST",
         body: JSON.stringify({
-          url: "http://93.184.216.34",
+          url: "https://example.com",
           companySize: "11-50",
           currentPain: "support",
         }),
@@ -159,7 +159,7 @@ describe("POST /api/agent-opportunity", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(fetchMock.mock.calls[0][0]).toBe("http://93.184.216.34/");
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/");
     const openAIRequest = fetchMock.mock.calls.find(
       (call) => call[0] === "https://api.openai.com/v1/responses",
     );

--- a/web/src/app/api/agent-opportunity/route.ts
+++ b/web/src/app/api/agent-opportunity/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import {
   AgentOpportunityError,
   analyzeAgentOpportunity,
-  fetchCompanySnapshot,
+  fetchCompanyResearch,
   normalizePublicUrl,
   type AgentOpportunityInput,
 } from "@/lib/agent-opportunity";
@@ -136,10 +136,10 @@ export async function POST(request: Request) {
       );
     }
 
-    const snapshot = await fetchCompanySnapshot(normalizedUrl);
+    const research = await fetchCompanyResearch(normalizedUrl);
     const report = await analyzeAgentOpportunity({
       input: { ...input, url: normalizedUrl },
-      snapshot,
+      research,
     });
 
     return NextResponse.json({ ok: true, report });

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -10,6 +10,7 @@ import { metadata as enterpriseMetadata } from "./enterprise/page";
 import { metadata as evalChecklistMetadata } from "./resources/eval-checklist/page";
 import { metadata as servicesMetadata } from "./services/page";
 import { metadata as tryoutsMetadata } from "./tryouts/page";
+import { metadata as agentOpportunityMetadata } from "./agent-opportunity/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
 import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
 import { metadata as sitemapMetadata } from "./sitemap/page";
@@ -67,6 +68,7 @@ describe("public canonical metadata", () => {
     expectCanonical(evalChecklistMetadata, "/resources/eval-checklist");
     expectCanonical(servicesMetadata, "/services");
     expectCanonical(tryoutsMetadata, "/tryouts");
+    expectCanonical(agentOpportunityMetadata, "/agent-opportunity");
     expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
     expectCanonical(
       agentRegressionTestingMetadata,

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -160,6 +160,12 @@ describe("sitemap", () => {
       changeFrequency: "weekly",
       priority: 0.9,
     });
+    expect(
+      byUrl.get("https://www.agentclash.dev/agent-opportunity"),
+    ).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.91,
+    });
   });
 
   it("includes docs pages and blog posts from source readers", () => {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -302,6 +302,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
         }),
       ],
     },
+    {
+      url: `${DOCS_ORIGIN}/agent-opportunity`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.91,
+      images: [
+        ogImage({
+          title: "AI agent ROI calculator",
+          subtitle: "Build vs buy assessment from a company URL",
+          kind: "Report",
+        }),
+      ],
+    },
     // .txt endpoints are intentionally imageless — they are not HTML pages.
     {
       url: `${DOCS_ORIGIN}/llms.txt`,

--- a/web/src/lib/agent-opportunity.test.ts
+++ b/web/src/lib/agent-opportunity.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AgentOpportunityError,
   extractPageSnapshot,
+  fetchCompanyResearch,
   fetchCompanySnapshot,
   isPrivateIPAddress,
   normalizePublicUrl,
@@ -92,6 +93,28 @@ describe("fetchCompanySnapshot", () => {
     await expect(
       fetchCompanySnapshot("https://example.com", fetchImpl as typeof fetch),
     ).rejects.toMatchObject({ code: "fetch_failed" });
+  });
+});
+
+describe("fetchCompanyResearch", () => {
+  it("returns the primary snapshot and ignores failed supplementary pages", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://example.com/") {
+        return new Response(
+          "<html><head><title>Example</title></head><body>Support automation.</body></html>",
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      throw new Error("missing page");
+    });
+
+    const research = await fetchCompanyResearch(
+      "https://example.com/",
+      fetchImpl as typeof fetch,
+    );
+
+    expect(research.primary.title).toBe("Example");
+    expect(research.supplementary).toHaveLength(0);
   });
 });
 

--- a/web/src/lib/agent-opportunity.test.ts
+++ b/web/src/lib/agent-opportunity.test.ts
@@ -116,6 +116,30 @@ describe("fetchCompanyResearch", () => {
     expect(research.primary.title).toBe("Example");
     expect(research.supplementary).toHaveLength(0);
   });
+
+  it("still fetches other supplementary pages when the primary URL matches one path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (
+        url === "https://example.com/about" ||
+        url === "https://example.com/pricing"
+      ) {
+        return new Response(
+          `<html><head><title>${url}</title></head><body>More context.</body></html>`,
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      throw new Error(`missing page: ${url}`);
+    });
+
+    const research = await fetchCompanyResearch(
+      "https://example.com/about",
+      fetchImpl as typeof fetch,
+    );
+
+    expect(research.primary.url).toBe("https://example.com/about");
+    expect(research.supplementary).toHaveLength(1);
+    expect(research.supplementary[0]?.url).toBe("https://example.com/pricing");
+  });
 });
 
 describe("parseAgentOpportunityReport", () => {

--- a/web/src/lib/agent-opportunity.ts
+++ b/web/src/lib/agent-opportunity.ts
@@ -46,6 +46,11 @@ export type PageSnapshot = {
   text: string;
 };
 
+export type CompanyResearchBundle = {
+  primary: PageSnapshot;
+  supplementary: PageSnapshot[];
+};
+
 export type AgentOpportunityInput = {
   url: string;
   companySize?: string;
@@ -360,6 +365,109 @@ export async function fetchCompanySnapshot(
   );
 }
 
+const SUPPLEMENTARY_PATHS = ["/about", "/pricing", "/docs", "/product", "/solutions"];
+
+export async function fetchCompanyResearch(
+  normalizedUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CompanyResearchBundle> {
+  const primary = await fetchCompanySnapshot(normalizedUrl, fetchImpl);
+  const origin = new URL(normalizedUrl).origin;
+  const primaryPath = new URL(normalizedUrl).pathname.replace(/\/$/, "") || "/";
+  const supplementary: PageSnapshot[] = [];
+
+  for (const path of SUPPLEMENTARY_PATHS) {
+    if (path === primaryPath || supplementary.length >= 2) break;
+    try {
+      const candidate = await normalizePublicUrl(`${origin}${path}`);
+      supplementary.push(await fetchCompanySnapshot(candidate, fetchImpl));
+    } catch {
+      // Optional enrichment only.
+    }
+  }
+
+  return { primary, supplementary };
+}
+
+const AGENT_OPPORTUNITY_SYSTEM_PROMPT = `You are a senior AI agent automation analyst working for AgentClash.
+
+Your job is to decide, with evidence, whether a company should build an AI agent now, later, or not at all. You must be skeptical and conservative. Most companies do not need a customer-facing agent yet.
+
+Research protocol (follow in order):
+1. Use web search to learn what the company sells, who they serve, hiring signals, support/docs posture, and any public automation or AI claims. Prefer primary sources: the company site, docs, careers pages, and reputable news.
+2. Cross-check the provided page snapshots. Call out mismatches between search results and fetched pages.
+3. Identify repeatable workflows with clear inputs, outputs, and success criteria. Ignore vague "AI everywhere" ideas.
+4. Estimate ROI as ranges, never point estimates. Tie hours saved to a plausible team size and ticket/doc volume.
+5. List concrete failure modes (policy errors, PII leakage, wrong escalations, tool misuse) and how AgentClash should test them before launch.
+6. Recommend a narrow AgentClash eval pack: realistic cases, adversarial cases, and measurable success criteria tied to the best workflow candidate.
+
+Verdict rules:
+- not_yet: no repeatable workflow, weak public evidence, or risk outweighs upside.
+- eval_first: plausible workflow but evidence is thin or risks are high; test before building.
+- narrow_pilot: one workflow is credible with bounded scope and clear human escalation.
+- strong_fit: multiple high-fit workflows, strong public evidence, and risks are manageable with eval gates.
+
+Output discipline:
+- Do not flatter the company or assume they need an agent.
+- Cite research gaps in evidenceLimitations when search or snapshots are incomplete.
+- Return JSON matching the schema exactly.`;
+
+const OPENAI_POLL_INTERVAL_MS = 2500;
+const OPENAI_POLL_TIMEOUT_MS = 90_000;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type OpenAIResponsesPayload = {
+  id?: string;
+  status?: string;
+  output_text?: string;
+  output?: unknown;
+  error?: { message?: string };
+};
+
+async function pollOpenAIResponse(
+  responseId: string,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+): Promise<OpenAIResponsesPayload> {
+  const deadline = Date.now() + OPENAI_POLL_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    await sleep(OPENAI_POLL_INTERVAL_MS);
+    const response = await fetchImpl(
+      `https://api.openai.com/v1/responses/${responseId}`,
+      {
+        headers: { authorization: `Bearer ${apiKey}` },
+      },
+    );
+    if (!response.ok) {
+      throw new AgentOpportunityError(
+        "openai_failed",
+        "OpenAI could not finish the report.",
+        502,
+      );
+    }
+
+    const payload = (await response.json()) as OpenAIResponsesPayload;
+    const status = payload.status ?? "completed";
+    if (status === "completed") return payload;
+    if (status === "failed" || status === "cancelled" || status === "incomplete") {
+      const message =
+        payload.error?.message?.trim() ||
+        `OpenAI returned status ${status}.`;
+      throw new AgentOpportunityError("openai_failed", message, 502);
+    }
+  }
+
+  throw new AgentOpportunityError(
+    "openai_failed",
+    "OpenAI took too long to generate the report.",
+    504,
+  );
+}
+
 function assertString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -588,16 +696,18 @@ function extractOpenAIText(payload: unknown): string {
 
 export async function analyzeAgentOpportunity({
   input,
-  snapshot,
+  research,
   apiKey = process.env.OPENAI_API_KEY,
   model = process.env.AGENT_OPPORTUNITY_OPENAI_MODEL || "gpt-5.4-mini",
   fetchImpl = fetch,
+  enableWebSearch = process.env.AGENT_OPPORTUNITY_WEB_SEARCH !== "false",
 }: {
   input: AgentOpportunityInput;
-  snapshot: PageSnapshot;
+  research: CompanyResearchBundle;
   apiKey?: string;
   model?: string;
   fetchImpl?: typeof fetch;
+  enableWebSearch?: boolean;
 }): Promise<AgentOpportunityReport> {
   if (!apiKey) {
     throw new AgentOpportunityError(
@@ -615,21 +725,35 @@ export async function analyzeAgentOpportunity({
     },
     body: JSON.stringify({
       model,
+      tools: enableWebSearch ? [{ type: "web_search_preview" }] : undefined,
       input: [
         {
-          role: "system",
-          content:
-            "You are an honest AI agent automation analyst for AgentClash. Decide whether a company should build an AI agent, where it would help, where it would fail, and how AgentClash should evaluate it before deployment. Do not overstate savings. If the company does not clearly need an agent, say so.",
+          role: "developer",
+          content: AGENT_OPPORTUNITY_SYSTEM_PROMPT,
         },
         {
           role: "user",
           content: JSON.stringify({
             submitted: input,
-            page: snapshot,
-            instructions: [
-              "Base your analysis only on the public page snapshot and user-provided context.",
-              "Use conservative savings ranges. Avoid fake precision.",
-              "Tie recommended evaluation cases to real workflows visible from the site.",
+            research: {
+              primaryPage: research.primary,
+              supplementaryPages: research.supplementary,
+            },
+            analysisTargets: [
+              `Company URL: ${input.url}`,
+              input.companySize
+                ? `Declared company size: ${input.companySize}`
+                : null,
+              input.currentPain
+                ? `Declared main pain: ${input.currentPain}`
+                : null,
+              input.monthlySupportVolume
+                ? `Declared support volume: ${input.monthlySupportVolume}`
+                : null,
+            ].filter(Boolean),
+            outputRequirements: [
+              "Use web search plus the page snapshots as evidence.",
+              "Prefer one strong workflow over a laundry list of agents.",
               "Return JSON matching the schema exactly.",
             ],
           }),
@@ -652,7 +776,15 @@ export async function analyzeAgentOpportunity({
     );
   }
 
-  const payload = await response.json().catch(() => null);
+  let payload = (await response.json().catch(() => null)) as OpenAIResponsesPayload | null;
+  if (
+    payload?.id &&
+    payload.status &&
+    !["completed", "failed", "cancelled", "incomplete"].includes(payload.status)
+  ) {
+    payload = await pollOpenAIResponse(payload.id, apiKey, fetchImpl);
+  }
+
   const text = extractOpenAIText(payload);
   if (!text) {
     throw new AgentOpportunityError(

--- a/web/src/lib/agent-opportunity.ts
+++ b/web/src/lib/agent-opportunity.ts
@@ -377,7 +377,8 @@ export async function fetchCompanyResearch(
   const supplementary: PageSnapshot[] = [];
 
   for (const path of SUPPLEMENTARY_PATHS) {
-    if (path === primaryPath || supplementary.length >= 2) break;
+    if (supplementary.length >= 2) break;
+    if (path === primaryPath) continue;
     try {
       const candidate = await normalizePublicUrl(`${origin}${path}`);
       supplementary.push(await fetchCompanySnapshot(candidate, fetchImpl));
@@ -454,10 +455,11 @@ async function pollOpenAIResponse(
     const status = payload.status ?? "completed";
     if (status === "completed") return payload;
     if (status === "failed" || status === "cancelled" || status === "incomplete") {
-      const message =
-        payload.error?.message?.trim() ||
-        `OpenAI returned status ${status}.`;
-      throw new AgentOpportunityError("openai_failed", message, 502);
+      throw new AgentOpportunityError(
+        "openai_failed",
+        openAIResponsesFailureMessage(payload, status),
+        502,
+      );
     }
   }
 
@@ -466,6 +468,46 @@ async function pollOpenAIResponse(
     "OpenAI took too long to generate the report.",
     504,
   );
+}
+
+function openAIResponsesFailureMessage(
+  payload: OpenAIResponsesPayload,
+  status: string,
+): string {
+  return payload.error?.message?.trim() || `OpenAI returned status ${status}.`;
+}
+
+async function resolveOpenAIResponsesPayload(
+  payload: OpenAIResponsesPayload | null,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+): Promise<OpenAIResponsesPayload> {
+  if (!payload) {
+    throw new AgentOpportunityError(
+      "openai_failed",
+      "OpenAI could not generate the report.",
+      502,
+    );
+  }
+
+  const status = payload.status ?? "completed";
+  if (status === "completed") return payload;
+  if (status === "failed" || status === "cancelled" || status === "incomplete") {
+    throw new AgentOpportunityError(
+      "openai_failed",
+      openAIResponsesFailureMessage(payload, status),
+      502,
+    );
+  }
+  if (!payload.id) {
+    throw new AgentOpportunityError(
+      "openai_failed",
+      "OpenAI could not generate the report.",
+      502,
+    );
+  }
+
+  return pollOpenAIResponse(payload.id, apiKey, fetchImpl);
 }
 
 function assertString(value: unknown): value is string {
@@ -777,13 +819,7 @@ export async function analyzeAgentOpportunity({
   }
 
   let payload = (await response.json().catch(() => null)) as OpenAIResponsesPayload | null;
-  if (
-    payload?.id &&
-    payload.status &&
-    !["completed", "failed", "cancelled", "incomplete"].includes(payload.status)
-  ) {
-    payload = await pollOpenAIResponse(payload.id, apiKey, fetchImpl);
-  }
+  payload = await resolveOpenAIResponsesPayload(payload, apiKey, fetchImpl);
 
   const text = extractOpenAIText(payload);
   if (!text) {


### PR DESCRIPTION
## Summary
- Upgrades `/agent-opportunity` with web search, supplementary page fetching, a stronger research prompt, and OpenAI response polling for longer analyses.
- Replaces the overflowing report layout with a Vercel-style scorecard dashboard: fit ring, four metric tiles, and tabbed sections for overview, opportunities, risks, and eval plan.
- Adds SEO targeting for high-intent queries (AI agent ROI calculator, build vs buy AI agent, agentic AI use cases) via metadata, FAQPage JSON-LD, on-page FAQ/content, and sitemap registration.

## Security note
OpenAI calls remain server-side via `process.env.OPENAI_API_KEY` in the API route. No client-exposed keys.

## Test plan
- [x] `pnpm exec vitest run src/lib/agent-opportunity.test.ts src/app/api/agent-opportunity/route.test.ts src/app/agent-opportunity/report-metrics.test.ts src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts`
- [ ] Visit `/agent-opportunity`, submit a public company URL, confirm scorecard + tabs render
- [ ] View page source and confirm FAQ + SoftwareApplication JSON-LD
- [ ] Confirm `/agent-opportunity` appears in `sitemap.xml`