### PR TITLE
fix(web): site-wide responsive typography and layout

### DIFF
--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -50,7 +50,7 @@ export default async function OrgLayout({
           currentUserId: session.user_id,
         }}
       >
-        <div className="flex min-h-screen">
+        <div className="flex min-h-dvh">
           <OrgSettingsSidebar
             orgSlug={orgSlug}
             orgName={org.name}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
@@ -553,7 +553,7 @@ export function VersionEditor({ version }: VersionEditorProps) {
                   >
                     <div className="flex items-center justify-between gap-3">
                       <span className="text-sm font-medium">{template.name}</span>
-                      <span className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                      <span className="text-2xs uppercase tracking-[0.12em] text-muted-foreground">
                         Apply
                       </span>
                     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
@@ -139,7 +139,7 @@ export function PublishPackDialog({ workspaceId }: PublishPackDialogProps) {
       <DialogContent
         className={
           isFullscreen
-            ? "max-w-[100vw] w-[100vw] h-[100vh] m-0 rounded-none p-6 flex flex-col sm:max-w-none data-closed:zoom-out-95 data-open:zoom-in-95 data-closed:fade-out-0 data-open:fade-in-0"
+            ? "max-w-[100vw] w-[100vw] h-dvh m-0 rounded-none p-6 flex flex-col sm:max-w-none data-closed:zoom-out-95 data-open:zoom-in-95 data-closed:fade-out-0 data-open:fade-in-0"
             : "sm:max-w-3xl flex flex-col max-h-[90vh]"
         }
       >

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -347,11 +347,11 @@ export function EvaluateReleaseGateDialog({
                   className={cn(capInvalid && "border-destructive")}
                 />
               </label>
-              <p className="mt-1 text-[11px] text-muted-foreground">
+              <p className="mt-1 text-2xs text-muted-foreground">
                 Leave blank to disable. 0 = allow no warning failures.
               </p>
               {capInvalid && (
-                <p className="mt-1 text-[11px] text-destructive">
+                <p className="mt-1 text-2xs text-destructive">
                   Must be zero or greater. Negative values are dropped at
                   submit.
                 </p>
@@ -366,10 +366,10 @@ export function EvaluateReleaseGateDialog({
                 </span>
               </p>
               {suitesError && (
-                <p className="text-[11px] text-destructive">{suitesError}</p>
+                <p className="text-2xs text-destructive">{suitesError}</p>
               )}
               {suites.length === 0 && !suitesError ? (
-                <p className="text-[11px] text-muted-foreground">
+                <p className="text-2xs text-muted-foreground">
                   No active regression suites in this workspace.
                 </p>
               ) : (
@@ -525,7 +525,7 @@ function ToggleRow({
       />
       <div>
         <p className="text-xs font-medium">{label}</p>
-        <p className="text-[11px] text-muted-foreground">{description}</p>
+        <p className="text-2xs text-muted-foreground">{description}</p>
       </div>
     </label>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
@@ -502,7 +502,7 @@ function Stat({
           : "text-amber-400";
   return (
     <div>
-      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
+      <dt className="text-2xs uppercase tracking-wide text-muted-foreground/80">
         {label}
       </dt>
       <dd

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/dataset-ui-shared.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/dataset-ui-shared.tsx
@@ -99,7 +99,7 @@ export function StructuredValue({ value }: { value: unknown }) {
             key={key}
             className={isNestedValue(nested) ? "sm:col-span-2" : undefined}
           >
-            <dt className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            <dt className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
               {humanizeKey(key)}
             </dt>
             <dd className="mt-1">

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -30,7 +30,7 @@ export default async function WorkspaceLayout({
 
   if (!hasMembership && !hasOrgAccess) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center">
         <div className="text-center">
           <h1 className="text-4xl font-semibold mb-2">403</h1>
           <p className="text-sm text-muted-foreground mb-4">
@@ -50,7 +50,7 @@ export default async function WorkspaceLayout({
   return (
     <AuthenticatedAppProviders initialAuth={initialAuth}>
       <PostHogIdentify session={session} />
-      <div className="flex h-screen overflow-hidden">
+      <div className="flex h-dvh overflow-hidden">
         <Sidebar workspaceId={workspaceId} />
         <div className="flex flex-1 flex-col overflow-hidden">
           <TopBar

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
@@ -624,7 +624,7 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
         )}
 
         {form.validators.length > 0 && (
-          <div className="hidden sm:flex items-center gap-3 px-3 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          <div className="hidden sm:flex items-center gap-3 px-3 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
             <span className="shrink-0 w-20">Key</span>
             <span className="w-40">Type</span>
             <span className="w-40">Checks</span>
@@ -701,11 +701,11 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
                       className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-invalid:border-destructive aria-invalid:ring-destructive/30"
                     />
                     {validatorConfigErrors[v.key] && (
-                      <p className="mt-1 text-[10px] text-destructive">
+                      <p className="mt-1 text-2xs text-destructive">
                         {validatorConfigErrors[v.key]}
                       </p>
                     )}
-                    <p className="mt-1 text-[10px] text-muted-foreground">
+                    <p className="mt-1 text-2xs text-muted-foreground">
                       JSON config for tool_name, must_call, count, min_count, max_count, arguments_contain, ordered_tools, and order_mode.
                     </p>
                   </div>
@@ -717,7 +717,7 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
                       placeholder="case.expectations.expected_output"
                       className="text-xs"
                     />
-                    <p className="mt-1 text-[10px] text-muted-foreground">
+                    <p className="mt-1 text-2xs text-muted-foreground">
                       Path to expected value in your test case, e.g. <code className="font-mono">case.expectations.your_field</code>
                     </p>
                   </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
@@ -859,7 +859,7 @@ function ResourceChecklist({
                 className="size-3.5 accent-primary"
               />
               <span className="min-w-0 flex-1 truncate font-medium">{item.label}</span>
-              <code className="truncate text-[11px] text-muted-foreground">
+              <code className="truncate text-2xs text-muted-foreground">
                 {item.meta}
               </code>
             </label>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -211,7 +211,7 @@ export function ReplayViewerClient({
               />
             )}
           </div>
-          <p className="mt-2 text-[11px] uppercase tracking-[0.14em] text-white/40">
+          <p className="mt-2 text-2xs uppercase tracking-[0.14em] text-white/40">
             Replay for{" "}
             <Link
               href={`/workspaces/${workspaceId}/runs/${run.id}`}
@@ -228,7 +228,7 @@ export function ReplayViewerClient({
         <Panel tone="warn" className="px-4 py-3 text-sm">
           <div className="flex items-center gap-2 text-amber-500">
             <Loader2 className="size-4 animate-spin" />
-            <span className="font-medium uppercase tracking-[0.14em] text-[11px]">Replay pending</span>
+            <span className="font-medium uppercase tracking-[0.14em] text-2xs">Replay pending</span>
           </div>
           {replayData.message && (
             <p className="mt-1.5 text-amber-500/70 text-xs">
@@ -243,7 +243,7 @@ export function ReplayViewerClient({
         <Panel tone="danger" className="px-4 py-3 text-sm">
           <div className="flex items-center gap-2 text-red-500">
             <AlertTriangle className="size-4" />
-            <span className="font-medium uppercase tracking-[0.14em] text-[11px]">Replay unavailable</span>
+            <span className="font-medium uppercase tracking-[0.14em] text-2xs">Replay unavailable</span>
           </div>
           {replayData.message && (
             <p className="mt-1.5 text-red-500/70 text-xs">
@@ -294,7 +294,7 @@ export function ReplayViewerClient({
 
       {/* Terminal state */}
       {isReady && replayData.replay?.summary?.terminal_state && (
-        <Panel className="flex items-center gap-3 px-4 py-3 text-[11px] uppercase tracking-[0.14em] text-white/60">
+        <Panel className="flex items-center gap-3 px-4 py-3 text-2xs uppercase tracking-[0.14em] text-white/60">
           <Clock className="size-4 text-white/30" />
           <span>{replayData.replay.summary.terminal_state.headline}</span>
           {replayData.replay.summary.terminal_state.error_message && (
@@ -351,7 +351,7 @@ function StatCard({
 }) {
   return (
     <Panel className="px-4 py-3 flex flex-col gap-1.5">
-      <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-white/40">
+      <div className="flex items-center gap-2 text-2xs uppercase tracking-[0.14em] text-white/40">
         <div className="text-white/30">{icon}</div>
         <span>{label}</span>
       </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/copy-markdown.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/copy-markdown.tsx
@@ -43,7 +43,7 @@ export function CopyMarkdownButton({
       onClick={handleCopy}
       className={cn(
         "inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md border transition-colors",
-        "text-[11px] uppercase tracking-[0.12em]",
+        "text-2xs uppercase tracking-[0.12em]",
         copied
           ? "border-emerald-500/30 bg-emerald-500/[0.06] text-emerald-300"
           : "border-white/10 bg-white/[0.02] text-white/55 hover:text-white/85 hover:border-white/20",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/dimensions-deck.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/dimensions-deck.tsx
@@ -37,7 +37,7 @@ export function DimensionsDeck({
         title="Dimensions"
         icon={<Gauge className="size-3.5" />}
         trailing={
-          <span className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+          <span className="text-2xs uppercase tracking-[0.14em] text-white/40">
             {keys.length} {keys.length === 1 ? "axis" : "axes"}
           </span>
         }
@@ -68,11 +68,11 @@ function DimensionCard({
     <div className="bg-[#060606] p-4 flex flex-col gap-3 min-h-[112px]">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1 min-w-0">
-          <h3 className="text-[13px] leading-none text-white/90 truncate font-medium tracking-[-0.005em]">
+          <h3 className="text-sm leading-none text-white/90 truncate font-medium tracking-[-0.005em]">
             {humanizeKey(dimKey)}
           </h3>
           {direction && (
-            <span className="flex items-center gap-1 text-[10px] uppercase tracking-[0.14em] text-white/35">
+            <span className="flex items-center gap-1 text-2xs uppercase tracking-[0.14em] text-white/35">
               {direction === "higher" ? (
                 <ArrowUp className="size-2.5" />
               ) : (
@@ -85,7 +85,7 @@ function DimensionCard({
         {!isAvailable && (
           <span
             className={cn(
-              "text-[9px] uppercase tracking-[0.14em] px-1.5 py-0.5 rounded border",
+              "text-2xs uppercase tracking-[0.14em] px-1.5 py-0.5 rounded border",
               dim.state === "error"
                 ? "text-red-300 border-red-500/30 bg-red-500/[0.06]"
                 : "text-white/50 border-white/10 bg-white/[0.03]",
@@ -105,7 +105,7 @@ function DimensionCard({
         >
           {dim.score == null ? "—" : (dim.score * 100).toFixed(1)}
         </span>
-        <span className="text-[10px] text-white/30 font-[family-name:var(--font-mono)]">
+        <span className="text-2xs text-white/30 font-[family-name:var(--font-mono)]">
           {dim.score == null ? "" : "/100"}
         </span>
       </div>
@@ -120,7 +120,7 @@ function DimensionCard({
       </div>
 
       {dim.reason && (
-        <p className="text-[11px] text-white/45 leading-relaxed line-clamp-3">
+        <p className="text-2xs text-white/45 leading-relaxed line-clamp-3">
           {dim.reason}
         </p>
       )}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/evidence-panels.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/evidence-panels.tsx
@@ -38,7 +38,7 @@ export function ValidatorsPanel({
         title="Validators"
         icon={<FlaskConical className="size-3.5" />}
         trailing={
-          <span className="text-[11px] text-white/45 font-[family-name:var(--font-mono)]">
+          <span className="text-2xs text-white/45 font-[family-name:var(--font-mono)]">
             {passCount}/{validators.length}
           </span>
         }
@@ -51,7 +51,7 @@ export function ValidatorsPanel({
           >
             <StateDot state={normalizeState(v.verdict, v.state)} />
             <span className="text-sm text-white/85 truncate">{v.key}</span>
-            <span className="text-[10px] uppercase tracking-[0.12em] text-white/35 shrink-0">
+            <span className="text-2xs uppercase tracking-[0.12em] text-white/35 shrink-0">
               {v.type.replace(/_/g, " ")}
             </span>
             <span className="flex-1" />
@@ -89,7 +89,7 @@ export function MetricsPanel({
         title="Metrics"
         icon={<Activity className="size-3.5" />}
         trailing={
-          <span className="text-[11px] text-white/45 font-[family-name:var(--font-mono)]">
+          <span className="text-2xs text-white/45 font-[family-name:var(--font-mono)]">
             {availableCount}/{metrics.length}
           </span>
         }
@@ -102,7 +102,7 @@ export function MetricsPanel({
           >
             <StateDot state={m.state === "available" ? "available" : "unavailable"} />
             <span className="text-sm text-white/85 truncate">{m.key}</span>
-            <span className="text-[10px] uppercase tracking-[0.12em] text-white/35 shrink-0">
+            <span className="text-2xs uppercase tracking-[0.12em] text-white/35 shrink-0">
               {m.collector.replace(/_/g, " ")}
             </span>
             <span className="flex-1" />
@@ -139,7 +139,7 @@ export function JudgesPanel({
         title="LLM Judges"
         icon={<Bot className="size-3.5" />}
         trailing={
-          <span className="text-[11px] text-white/45 font-[family-name:var(--font-mono)]">
+          <span className="text-2xs text-white/45 font-[family-name:var(--font-mono)]">
             {availableCount}/{judges.length}
           </span>
         }
@@ -158,15 +158,15 @@ export function JudgesPanel({
               <span className="text-sm text-white/85 truncate">
                 {judge.judge_key}
               </span>
-              <span className="text-[10px] uppercase tracking-[0.12em] text-white/35 shrink-0">
+              <span className="text-2xs uppercase tracking-[0.12em] text-white/35 shrink-0">
                 {judge.mode.replace(/_/g, " ")}
               </span>
               <span className="flex-1" />
-              <span className="hidden sm:inline font-[family-name:var(--font-mono)] text-[11px] text-white/35 tabular-nums shrink-0">
+              <span className="hidden sm:inline font-[family-name:var(--font-mono)] text-2xs text-white/35 tabular-nums shrink-0">
                 {judge.sample_count}×{judge.model_count}
               </span>
               {judge.confidence && (
-                <span className="hidden md:inline text-[10px] uppercase tracking-[0.12em] text-white/40 shrink-0">
+                <span className="hidden md:inline text-2xs uppercase tracking-[0.12em] text-white/40 shrink-0">
                   {judge.confidence}
                 </span>
               )}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
@@ -52,7 +52,7 @@ export function Hero({
             {run.name}
           </span>
         </div>
-        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-white/35">
+        <div className="flex items-center gap-2 text-2xs uppercase tracking-[0.14em] text-white/35">
           <Clock className="size-3" />
           <span className="font-[family-name:var(--font-mono)] normal-case tracking-normal text-white/55">
             {duration}
@@ -73,7 +73,7 @@ export function Hero({
 
         <div className="flex flex-col gap-4 min-w-0">
           {/* Meta row */}
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 text-[11px]">
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 text-2xs">
             {strategy && (
               <MetaChip label="Strategy" value={strategy} />
             )}
@@ -101,7 +101,7 @@ export function Hero({
             />
             {doc?.metric_summary?.run_total_tokens != null && (
               <div className="flex items-baseline gap-1.5">
-                <span className="text-[9px] uppercase tracking-[0.18em] text-white/35">Tokens</span>
+                <span className="text-2xs uppercase tracking-[0.18em] text-white/35">Tokens</span>
                 <span className="text-xs text-white/80 font-[family-name:var(--font-mono)]">
                   {doc.metric_summary.run_total_tokens.toLocaleString()}
                   {(doc.metric_summary.run_race_context_tokens ?? 0) > 0 && (
@@ -126,14 +126,14 @@ export function Hero({
             <div className="flex items-start gap-2 border border-amber-500/25 bg-amber-500/[0.04] rounded-md px-3 py-2">
               <AlertTriangle className="size-3.5 text-amber-400 shrink-0 mt-0.5" />
               <div className="flex-1 min-w-0">
-                <div className="text-[11px] uppercase tracking-[0.14em] text-amber-400/85 mb-1">
+                <div className="text-2xs uppercase tracking-[0.14em] text-amber-400/85 mb-1">
                   {warnings.length} {warnings.length === 1 ? "warning" : "warnings"}
                 </div>
                 <ul className="space-y-0.5">
                   {warnings.map((w, i) => (
                     <li
                       key={i}
-                      className="text-[12px] text-amber-200/75 leading-snug"
+                      className="text-xs text-amber-200/75 leading-snug"
                     >
                       {w}
                     </li>
@@ -153,7 +153,7 @@ function VerdictPill({ passed }: { passed: boolean }) {
     return (
       <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-emerald-500/30 bg-emerald-500/[0.08]">
         <CheckCircle2 className="size-3 text-emerald-400" />
-        <span className="text-[10px] uppercase tracking-[0.16em] text-emerald-300">
+        <span className="text-2xs uppercase tracking-[0.16em] text-emerald-300">
           Passed
         </span>
       </div>
@@ -162,7 +162,7 @@ function VerdictPill({ passed }: { passed: boolean }) {
   return (
     <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-red-500/30 bg-red-500/[0.08]">
       <XCircle className="size-3 text-red-400" />
-      <span className="text-[10px] uppercase tracking-[0.16em] text-red-300">
+      <span className="text-2xs uppercase tracking-[0.16em] text-red-300">
         Failed
       </span>
     </div>
@@ -189,7 +189,7 @@ function MetaChip({
   }[valueTone];
   return (
     <div className="flex items-baseline gap-1.5">
-      <span className="text-[9px] uppercase tracking-[0.18em] text-white/35">
+      <span className="text-2xs uppercase tracking-[0.18em] text-white/35">
         {label}
       </span>
       <span

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
@@ -115,7 +115,7 @@ function ValidatorInspector({
         <DataRow
           label="Type"
           value={
-            <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/60">
+            <span className="font-[family-name:var(--font-mono)] text-2xs text-white/60">
               {detail.type}
             </span>
           }
@@ -193,7 +193,7 @@ function MetricInspector({ detail }: { detail: MetricDetail }) {
         <DataRow
           label="Collector"
           value={
-            <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/60">
+            <span className="font-[family-name:var(--font-mono)] text-2xs text-white/60">
               {detail.collector}
             </span>
           }
@@ -243,7 +243,7 @@ function ValueDisplay({ detail }: { detail: MetricDetail }) {
   }
   if (detail.text_value != null) {
     return (
-      <pre className="text-[12px] text-white/80 whitespace-pre-wrap font-[family-name:var(--font-mono)] max-h-64 overflow-y-auto">
+      <pre className="text-xs text-white/80 whitespace-pre-wrap font-[family-name:var(--font-mono)] max-h-64 overflow-y-auto">
         {detail.text_value}
       </pre>
     );
@@ -318,7 +318,7 @@ function JudgeInspector({ detail }: { detail: LLMJudgeResult }) {
         {parsed.reason && (
           <div className="flex items-start gap-2 border border-red-500/25 bg-red-500/[0.04] rounded-md px-3 py-2.5">
             <XCircle className="size-3.5 text-red-400 shrink-0 mt-0.5" />
-            <div className="text-[12px] text-red-200/85 leading-snug">
+            <div className="text-xs text-red-200/85 leading-snug">
               {parsed.reason}
               {parsed.unableToJudgeCount != null && parsed.unableToJudgeCount > 0 && (
                 <span className="ml-2 text-red-300/70 font-[family-name:var(--font-mono)]">
@@ -334,7 +334,7 @@ function JudgeInspector({ detail }: { detail: LLMJudgeResult }) {
             <AlertTriangle className="size-3.5 text-amber-400 shrink-0 mt-0.5" />
             <ul className="flex-1 space-y-1">
               {parsed.warnings.map((w, i) => (
-                <li key={i} className="text-[11px] text-amber-200/80 leading-snug">
+                <li key={i} className="text-2xs text-amber-200/80 leading-snug">
                   {w}
                 </li>
               ))}
@@ -351,7 +351,7 @@ function JudgeInspector({ detail }: { detail: LLMJudgeResult }) {
                   key={ms.model}
                   className="flex items-center gap-3 px-3 h-9"
                 >
-                  <span className="text-[12px] text-white/75 truncate flex-1 font-[family-name:var(--font-mono)]">
+                  <span className="text-xs text-white/75 truncate flex-1 font-[family-name:var(--font-mono)]">
                     {ms.model}
                   </span>
                   <div className="h-[3px] w-28 bg-white/[0.06] rounded-full overflow-hidden">
@@ -420,20 +420,20 @@ function ModelSampleGroup({
   return (
     <details open={defaultOpen} className="group">
       <summary className="flex items-center gap-3 px-3 h-9 cursor-pointer border border-white/[0.06] rounded-md hover:bg-white/[0.02] group-open:rounded-b-none group-open:border-b-0">
-        <span className="font-[family-name:var(--font-mono)] text-[12px] text-white/75 flex-1 truncate">
+        <span className="font-[family-name:var(--font-mono)] text-xs text-white/75 flex-1 truncate">
           {model}
         </span>
         {avg != null && (
           <span
             className={cn(
-              "font-[family-name:var(--font-mono)] text-[11px] tabular-nums",
+              "font-[family-name:var(--font-mono)] text-2xs tabular-nums",
               scoreColor(avg),
             )}
           >
             {(avg * 100).toFixed(1)}
           </span>
         )}
-        <span className="text-[10px] text-white/40 uppercase tracking-[0.12em]">
+        <span className="text-2xs text-white/40 uppercase tracking-[0.12em]">
           {calls.length}
           {calls.length === 1 ? " sample" : " samples"}
         </span>
@@ -480,7 +480,7 @@ function VarianceSpread({
           style={{ left: `${meanPct}%` }}
         />
       </div>
-      <div className="flex justify-between text-[10px] mt-1.5 uppercase tracking-[0.14em] text-white/35">
+      <div className="flex justify-between text-2xs mt-1.5 uppercase tracking-[0.14em] text-white/35">
         <span>min</span>
         <span className="text-emerald-300/80">
           mean {meanPct.toFixed(1)}
@@ -499,7 +499,7 @@ function Tick({ pct, label }: { pct: number; label: string }) {
       style={{ left: `${pct}%` }}
     >
       <div className="w-[2px] h-2 bg-white/40 mx-auto" />
-      <div className="text-[9px] text-white/40 font-[family-name:var(--font-mono)] tabular-nums mt-1 whitespace-nowrap text-center">
+      <div className="text-2xs text-white/40 font-[family-name:var(--font-mono)] tabular-nums mt-1 whitespace-nowrap text-center">
         {label}
       </div>
     </div>
@@ -529,7 +529,7 @@ function InspectorHeader({
 }) {
   return (
     <div className="border-b border-white/[0.06] px-6 pt-5 pb-4">
-      <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-white/40 mb-2">
+      <div className="flex items-center gap-2 text-2xs uppercase tracking-[0.18em] text-white/40 mb-2">
         <StateDot state={stateKind} />
         {kicker}
         {subtitle && (
@@ -542,7 +542,7 @@ function InspectorHeader({
         )}
       </div>
       <div className="flex items-baseline justify-between gap-4">
-        <h2 className="text-[17px] leading-tight text-white/95 truncate font-medium tracking-[-0.01em]">
+        <h2 className="text-base leading-tight text-white/95 truncate font-medium tracking-[-0.01em]">
           {humanizeKey(title)}
         </h2>
         {score != null && (
@@ -556,7 +556,7 @@ function InspectorHeader({
           </span>
         )}
       </div>
-      <div className="mt-0.5 text-[11px] text-white/35 font-[family-name:var(--font-mono)] truncate">
+      <div className="mt-0.5 text-2xs text-white/35 font-[family-name:var(--font-mono)] truncate">
         {title}
       </div>
     </div>
@@ -572,7 +572,7 @@ function DataRow({
 }) {
   return (
     <div className="flex items-start gap-4 border-b border-white/[0.04] pb-3">
-      <span className="text-[10px] uppercase tracking-[0.16em] text-white/35 w-24 shrink-0 pt-1">
+      <span className="text-2xs uppercase tracking-[0.16em] text-white/35 w-24 shrink-0 pt-1">
         {label}
       </span>
       <div className="flex-1 min-w-0">{value}</div>
@@ -589,7 +589,7 @@ function Section({
 }) {
   return (
     <div>
-      <h3 className="text-[10px] uppercase tracking-[0.2em] text-white/55 mb-2.5 font-medium">
+      <h3 className="text-2xs uppercase tracking-[0.2em] text-white/55 mb-2.5 font-medium">
         {title}
       </h3>
       {children}
@@ -600,7 +600,7 @@ function Section({
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="bg-[#060606] px-3 py-2.5 flex flex-col gap-0.5">
-      <span className="text-[9px] uppercase tracking-[0.16em] text-white/35">
+      <span className="text-2xs uppercase tracking-[0.16em] text-white/35">
         {label}
       </span>
       <span className="font-[family-name:var(--font-mono)] text-sm text-white/90 tabular-nums">
@@ -635,16 +635,16 @@ function ReplaySourceLink({
   const body = (
     <div className="flex items-center justify-between gap-3">
       <div className="flex flex-col gap-0.5 min-w-0">
-        <span className="text-[10px] uppercase tracking-[0.18em] text-white/45">
+        <span className="text-2xs uppercase tracking-[0.18em] text-white/45">
           {label}
         </span>
-        <span className="font-[family-name:var(--font-mono)] text-[12px] text-white/85 truncate">
+        <span className="font-[family-name:var(--font-mono)] text-xs text-white/85 truncate">
           #{source.sequence}
           {meta ? ` · ${meta}` : ""}
         </span>
       </div>
       {href && (
-        <span className="flex items-center gap-1 text-[11px] uppercase tracking-[0.18em] text-white/65 group-hover:text-white">
+        <span className="flex items-center gap-1 text-2xs uppercase tracking-[0.18em] text-white/65 group-hover:text-white">
           View in replay
           <ArrowUpRight className="size-3.5" />
         </span>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
@@ -246,11 +246,11 @@ export function JudgeSampleCard({ call }: { call: JudgeCall }) {
 
       {/* Header — sample #, model, score, confidence, raw toggle */}
       <div className="flex items-center gap-3 pl-4 pr-3 h-10 border-b border-white/[0.05]">
-        <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/35 tabular-nums w-6">
+        <span className="font-[family-name:var(--font-mono)] text-2xs text-white/35 tabular-nums w-6">
           #{call.sampleIndex ?? "?"}
         </span>
         <span
-          className="font-[family-name:var(--font-mono)] text-[11px] text-white/65 truncate flex-1"
+          className="font-[family-name:var(--font-mono)] text-2xs text-white/65 truncate flex-1"
           title={call.model}
         >
           {call.model}
@@ -272,7 +272,7 @@ export function JudgeSampleCard({ call }: { call: JudgeCall }) {
             type="button"
             onClick={() => setShowRaw(!showRaw)}
             className={cn(
-              "ml-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.14em] rounded px-1.5 h-6 border transition-colors",
+              "ml-1 inline-flex items-center gap-1 text-2xs uppercase tracking-[0.14em] rounded px-1.5 h-6 border transition-colors",
               showRaw
                 ? "border-white/25 bg-white/[0.05] text-white/75"
                 : "border-white/10 text-white/40 hover:text-white/70 hover:border-white/20",
@@ -288,7 +288,7 @@ export function JudgeSampleCard({ call }: { call: JudgeCall }) {
       {/* Body */}
       <div className="px-4 py-3.5 space-y-3.5">
         {hasError && (
-          <div className="text-[12px] text-red-300/85 leading-snug whitespace-pre-wrap">
+          <div className="text-xs text-red-300/85 leading-snug whitespace-pre-wrap">
             {call.error}
           </div>
         )}
@@ -329,7 +329,7 @@ export function JudgeSampleCard({ call }: { call: JudgeCall }) {
               parsed.feedback.length === 0 &&
               parsed.other.length === 0 &&
               !parsed.ranking && (
-                <p className="text-[12px] text-white/40 italic">
+                <p className="text-xs text-white/40 italic">
                   No rationale was provided by the judge.
                 </p>
               )}
@@ -342,7 +342,7 @@ export function JudgeSampleCard({ call }: { call: JudgeCall }) {
 
         {/* Raw toggle — always available when response exists */}
         {hasResponse && showRaw && (
-          <details open className="text-[11px]">
+          <details open className="text-2xs">
             <summary className="cursor-pointer text-white/40 uppercase tracking-[0.16em] mb-1.5">
               Raw response
             </summary>
@@ -365,7 +365,7 @@ function RationaleBlock({ text }: { text: string }) {
         aria-hidden
         className="absolute left-0 top-0 size-4 text-white/20"
       />
-      <p className="text-[13px] text-white/80 leading-relaxed whitespace-pre-wrap font-[family-name:var(--font-body)]">
+      <p className="text-sm text-white/80 leading-relaxed whitespace-pre-wrap font-[family-name:var(--font-body)]">
         {text}
       </p>
     </div>
@@ -388,14 +388,14 @@ function BulletBlock({
   }[tone];
   return (
     <div>
-      <h4 className="text-[10px] uppercase tracking-[0.2em] text-white/45 mb-1.5 font-medium">
+      <h4 className="text-2xs uppercase tracking-[0.2em] text-white/45 mb-1.5 font-medium">
         {title}
       </h4>
       <ul className="space-y-1">
         {items.map((item, i) => (
           <li
             key={i}
-            className="flex gap-2 text-[12.5px] text-white/75 leading-relaxed"
+            className="flex gap-2 text-xs text-white/75 leading-relaxed"
           >
             <span
               className={cn("mt-[7px] size-1 rounded-full shrink-0", marker)}
@@ -412,14 +412,14 @@ function BulletBlock({
 function RankingBlock({ ranking }: { ranking: string[] }) {
   return (
     <div>
-      <h4 className="text-[10px] uppercase tracking-[0.2em] text-white/45 mb-1.5 font-medium">
+      <h4 className="text-2xs uppercase tracking-[0.2em] text-white/45 mb-1.5 font-medium">
         Ranking
       </h4>
       <ol className="space-y-1">
         {ranking.map((id, i) => (
           <li
             key={id}
-            className="flex gap-3 text-[12px] text-white/70 font-[family-name:var(--font-mono)] leading-tight"
+            className="flex gap-3 text-xs text-white/70 font-[family-name:var(--font-mono)] leading-tight"
           >
             <span className="text-white/35 tabular-nums w-4">{i + 1}.</span>
             <span className="truncate">{id}</span>
@@ -442,11 +442,11 @@ function OtherFields({
           key={f.key}
           className="inline-flex items-baseline gap-1.5 px-2 py-1 rounded border border-white/[0.08] bg-white/[0.02]"
         >
-          <span className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+          <span className="text-2xs uppercase tracking-[0.14em] text-white/40">
             {f.key.replace(/_/g, " ")}
           </span>
           <span
-            className="text-[11px] text-white/75 font-[family-name:var(--font-mono)] max-w-[240px] truncate"
+            className="text-2xs text-white/75 font-[family-name:var(--font-mono)] max-w-[240px] truncate"
             title={f.value}
           >
             {f.value}
@@ -461,14 +461,14 @@ function FallbackText({ text }: { text: string }) {
   return (
     <div>
       <div className="flex items-center gap-2 mb-1.5">
-        <span className="text-[10px] uppercase tracking-[0.18em] text-white/40">
+        <span className="text-2xs uppercase tracking-[0.18em] text-white/40">
           Raw response
         </span>
-        <span className="text-[10px] text-white/30">
+        <span className="text-2xs text-white/30">
           · couldn&apos;t parse as structured JSON
         </span>
       </div>
-      <pre className="font-[family-name:var(--font-mono)] text-[11.5px] text-white/70 leading-relaxed whitespace-pre-wrap bg-black/30 border border-white/[0.05] rounded px-3 py-2 max-h-60 overflow-y-auto">
+      <pre className="font-[family-name:var(--font-mono)] text-2xs text-white/70 leading-relaxed whitespace-pre-wrap bg-black/30 border border-white/[0.05] rounded px-3 py-2 max-h-60 overflow-y-auto">
         {text}
       </pre>
     </div>
@@ -484,7 +484,7 @@ function VerdictChip({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.14em] px-1.5 h-5 rounded border",
+        "inline-flex items-center gap-1 text-2xs uppercase tracking-[0.14em] px-1.5 h-5 rounded border",
         pass
           ? "border-emerald-500/30 bg-emerald-500/[0.08] text-emerald-300"
           : "border-red-500/30 bg-red-500/[0.08] text-red-300",
@@ -506,7 +506,7 @@ function ConfidenceChip({ value }: { value: string }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center text-[10px] uppercase tracking-[0.14em] px-1.5 h-5 rounded border bg-white/[0.015]",
+        "inline-flex items-center text-2xs uppercase tracking-[0.14em] px-1.5 h-5 rounded border bg-white/[0.015]",
         tone,
       )}
     >

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel.tsx
@@ -52,7 +52,7 @@ export function PanelHeader({
       )}
     >
       {icon && <span className="text-white/40">{icon}</span>}
-      <h2 className="text-[11px] leading-none text-white/75 uppercase tracking-[0.22em] font-medium">
+      <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium">
         {title}
       </h2>
       {trailing && <div className="ml-auto">{trailing}</div>}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/rank-strip.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/rank-strip.tsx
@@ -43,7 +43,7 @@ export function RankStrip({
         icon={<Trophy className="size-3.5" />}
         trailing={
           current ? (
-            <span className="text-[11px] text-white/45 font-[family-name:var(--font-mono)]">
+            <span className="text-2xs text-white/45 font-[family-name:var(--font-mono)]">
               #{current.rank ?? "—"} of {items.length}
             </span>
           ) : null
@@ -94,7 +94,7 @@ function RankRow({
         {/* Rank badge */}
         <span
           className={cn(
-            "font-[family-name:var(--font-mono)] text-[11px] w-6 tabular-nums",
+            "font-[family-name:var(--font-mono)] text-2xs w-6 tabular-nums",
             isWinner ? "text-amber-300" : "text-white/35",
           )}
         >
@@ -110,12 +110,12 @@ function RankRow({
         >
           {item.label}
           {isWinner && (
-            <span className="ml-2 text-[10px] uppercase tracking-[0.16em] text-amber-300/80">
+            <span className="ml-2 text-2xs uppercase tracking-[0.16em] text-amber-300/80">
               Winner
             </span>
           )}
           {isCurrent && !isWinner && (
-            <span className="ml-2 text-[10px] uppercase tracking-[0.16em] text-white/40">
+            <span className="ml-2 text-2xs uppercase tracking-[0.16em] text-white/40">
               You
             </span>
           )}
@@ -125,7 +125,7 @@ function RankRow({
         {item.passed != null && (
           <span
             className={cn(
-              "text-[10px] uppercase tracking-[0.14em]",
+              "text-2xs uppercase tracking-[0.14em]",
               item.passed ? "text-emerald-400/80" : "text-red-400/80",
             )}
           >
@@ -134,7 +134,7 @@ function RankRow({
         )}
 
         {/* Delta from top */}
-        <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40 tabular-nums w-14 text-right">
+        <span className="font-[family-name:var(--font-mono)] text-2xs text-white/40 tabular-nums w-14 text-right">
           {item.delta_from_top != null && item.delta_from_top !== 0
             ? signedDelta(item.delta_from_top)
             : ""}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/score-meter.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/score-meter.tsx
@@ -135,7 +135,7 @@ export function ScoreMeter({
         >
           {overallPct}
         </span>
-        <span className="mt-0.5 text-[9px] uppercase tracking-[0.18em] text-white/40">
+        <span className="mt-0.5 text-2xs uppercase tracking-[0.18em] text-white/40">
           Overall
         </span>
       </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/state-dot.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/state-dot.tsx
@@ -75,8 +75,8 @@ export function StateDot({ state, size = 6 }: { state: StateKind; size?: number 
         side="top"
         className="max-w-[240px] bg-[#0b0b0b] border border-white/10 text-white/85 px-3 py-2"
       >
-        <div className="font-medium text-[11px]">{copy.label}</div>
-        <div className="text-[11px] text-white/55 mt-0.5">{copy.body}</div>
+        <div className="font-medium text-2xs">{copy.label}</div>
+        <div className="text-2xs text-white/55 mt-0.5">{copy.body}</div>
       </TooltipContent>
     </Tooltip>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/validator-evidence.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/validator-evidence.tsx
@@ -69,10 +69,10 @@ function RegexEvidence({ evidence }: { evidence: ValidatorRegexEvidence }) {
         />
       )}
       <div className="space-y-2">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-white/35">
+        <div className="text-2xs uppercase tracking-[0.18em] text-white/35">
           Actual
         </div>
-        <pre className="max-h-[60vh] overflow-auto rounded-2xl border border-white/[0.08] bg-white/[0.03] p-4 text-[12px] text-white/82 whitespace-pre-wrap font-[family-name:var(--font-mono)]">
+        <pre className="max-h-[60vh] overflow-auto rounded-2xl border border-white/[0.08] bg-white/[0.03] p-4 text-xs text-white/82 whitespace-pre-wrap font-[family-name:var(--font-mono)]">
           {segments?.map((segment, index) =>
             segment.matched ? (
               <mark
@@ -106,7 +106,7 @@ function JSONSchemaEvidence({
       )}
       {evidence.validation_errors && evidence.validation_errors.length > 0 && (
         <div className="space-y-2">
-          <div className="text-[11px] uppercase tracking-[0.18em] text-white/35">
+          <div className="text-2xs uppercase tracking-[0.18em] text-white/35">
             Validation Errors
           </div>
           <ul className="space-y-2">
@@ -232,11 +232,11 @@ function EvidenceSection({
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between gap-3">
-        <h3 className="text-[11px] uppercase tracking-[0.22em] text-white/40">
+        <h3 className="text-2xs uppercase tracking-[0.22em] text-white/40">
           {title}
         </h3>
         {sourceField && (
-          <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+          <span className="font-[family-name:var(--font-mono)] text-2xs text-white/35">
             {sourceField}
           </span>
         )}
@@ -257,13 +257,13 @@ function EvidenceMeta({
 }) {
   return (
     <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-3 items-start">
-      <div className="text-[11px] uppercase tracking-[0.18em] text-white/30">
+      <div className="text-2xs uppercase tracking-[0.18em] text-white/30">
         {label}
       </div>
       <div
         className={cn(
           "text-sm text-white/78 break-words",
-          mono && "font-[family-name:var(--font-mono)] text-[12px]",
+          mono && "font-[family-name:var(--font-mono)] text-xs",
         )}
       >
         {value}
@@ -300,10 +300,10 @@ function EvidenceBlock({
 }) {
   return (
     <div className="space-y-2">
-      <div className="text-[11px] uppercase tracking-[0.18em] text-white/35">
+      <div className="text-2xs uppercase tracking-[0.18em] text-white/35">
         {label}
       </div>
-      <pre className="max-h-[60vh] overflow-auto rounded-2xl border border-white/[0.08] bg-white/[0.03] p-4 text-[12px] text-white/82 whitespace-pre-wrap break-words font-[family-name:var(--font-mono)]">
+      <pre className="max-h-[60vh] overflow-auto rounded-2xl border border-white/[0.08] bg-white/[0.03] p-4 text-xs text-white/82 whitespace-pre-wrap break-words font-[family-name:var(--font-mono)]">
         {children}
       </pre>
     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
@@ -200,10 +200,10 @@ function PendingState() {
   return (
     <div className="border border-white/[0.08] rounded-md bg-white/[0.015] px-8 py-14 text-center">
       <Loader2 className="size-5 animate-spin mx-auto mb-3 text-white/55" />
-      <p className="text-[15px] text-white/85 font-medium tracking-[-0.005em]">
+      <p className="text-base text-white/85 font-medium tracking-[-0.005em]">
         Scoring in progress
       </p>
-      <p className="mt-1.5 text-[12px] text-white/45 max-w-md mx-auto leading-relaxed">
+      <p className="mt-1.5 text-xs text-white/45 max-w-md mx-auto leading-relaxed">
         Running validators and collectors against the agent&apos;s trace. LLM judges,
         if any, run last — they can take a minute or two per sample.
       </p>
@@ -215,10 +215,10 @@ function ErroredState({ message }: { message?: string }) {
   return (
     <div className="border border-red-500/25 bg-red-500/[0.04] rounded-md px-8 py-14 text-center">
       <AlertTriangle className="size-5 mx-auto mb-3 text-red-400" />
-      <p className="text-[15px] text-red-200 font-medium tracking-[-0.005em]">
+      <p className="text-base text-red-200 font-medium tracking-[-0.005em]">
         Scorecard unavailable
       </p>
-      <p className="mt-1.5 text-[12px] text-red-200/60 max-w-md mx-auto leading-relaxed">
+      <p className="mt-1.5 text-xs text-red-200/60 max-w-md mx-auto leading-relaxed">
         {message || "An error occurred during evaluation."}
       </p>
     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
@@ -64,7 +64,7 @@ function FailureDetailBody({
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
       <div className="border-b border-border px-6 pt-6 pb-4">
-        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-muted-foreground mb-2">
+        <div className="flex items-center gap-2 text-2xs uppercase tracking-[0.18em] text-muted-foreground mb-2">
           <span>Failure review</span>
           <span className="text-muted-foreground/50">·</span>
           <span className="normal-case tracking-normal font-[family-name:var(--font-mono)] text-xs">
@@ -106,7 +106,7 @@ function FailureDetailBody({
             <div className="flex items-center gap-3 min-w-0">
               <Play className="size-4 text-foreground/70 shrink-0" />
               <div className="min-w-0">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                <div className="text-2xs uppercase tracking-[0.18em] text-muted-foreground">
                   Open replay
                 </div>
                 <div className="text-sm text-foreground font-[family-name:var(--font-mono)] truncate">
@@ -309,7 +309,7 @@ function Section({
 }) {
   return (
     <div>
-      <h3 className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground mb-2 font-medium">
+      <h3 className="text-2xs uppercase tracking-[0.2em] text-muted-foreground mb-2 font-medium">
         {title}
       </h3>
       {children}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -565,7 +565,7 @@ function FailureClusterRollups({
                     <div className="text-sm font-semibold tabular-nums">
                       {cluster.count}
                     </div>
-                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    <div className="text-2xs uppercase tracking-[0.14em] text-muted-foreground">
                       failures
                     </div>
                   </div>
@@ -573,7 +573,7 @@ function FailureClusterRollups({
                     <div className="text-sm font-semibold tabular-nums">
                       {cluster.promotable_count}
                     </div>
-                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    <div className="text-2xs uppercase tracking-[0.14em] text-muted-foreground">
                       promote
                     </div>
                   </div>
@@ -582,7 +582,7 @@ function FailureClusterRollups({
                       <div className="text-sm font-semibold tabular-nums">
                         {history.prior_run_count}
                       </div>
-                      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      <div className="text-2xs uppercase tracking-[0.14em] text-muted-foreground">
                         prior
                       </div>
                     </div>
@@ -696,7 +696,7 @@ function FilterSelect({
 }) {
   return (
     <label className="flex flex-col gap-1">
-      <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+      <span className="text-2xs uppercase tracking-[0.14em] text-muted-foreground">
         {label}
       </span>
       <select
@@ -843,7 +843,7 @@ function FailureRow({
 
           <div className="mt-2 border-l-2 border-border pl-3 pr-2">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              <span className="text-2xs uppercase tracking-[0.14em] text-muted-foreground">
                 Likely issue area
               </span>
               <Badge variant="outline">{item.remediation.label}</Badge>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -358,7 +358,7 @@ export function RunDetailClient({
             </Badge>
             {isActive && sseConnected && (
               <span
-                className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 h-6 text-[10px] font-medium uppercase tracking-wider text-emerald-400"
+                className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 h-6 text-2xs font-medium uppercase tracking-wider text-emerald-400"
                 title="Streaming live events"
               >
                 <Radio className="size-3 animate-pulse" />
@@ -437,7 +437,7 @@ export function RunDetailClient({
         </div>
 
         {/* KPI strip */}
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-5 py-3 text-[11px] uppercase tracking-[0.14em] text-white/40 bg-black/20">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-5 py-3 text-2xs uppercase tracking-[0.14em] text-white/40 bg-black/20">
           <div className="flex items-center gap-2">
             <Clock className="size-3.5" />
             {run.started_at ? (
@@ -538,7 +538,7 @@ export function RunDetailClient({
 
       {/* === Agent Lanes === */}
       <div>
-        <h2 className="text-[11px] leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-4">Agent Lanes</h2>
+        <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-4">Agent Lanes</h2>
         {arenaMode === "race" ? (
           <RaceModeArena
             agents={sortedAgents}
@@ -621,18 +621,18 @@ export function RunDetailClient({
         (run.regression_coverage.suites.length > 0 ||
           run.regression_coverage.unmatched_cases.length > 0) && (
           <div>
-            <h2 className="text-[11px] leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-3">Regression Coverage</h2>
+            <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-3">Regression Coverage</h2>
             <div className="space-y-3">
               {run.regression_coverage.suites.length > 0 && (
                 <Panel className="overflow-x-auto">
                   <Table className="text-white/70">
                     <TableHeader className="border-white/10 hover:bg-transparent">
                       <TableRow className="border-white/10 hover:bg-transparent">
-                        <TableHead className="text-white/40 uppercase tracking-[0.14em] text-[10px]">Suite</TableHead>
-                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Cases</TableHead>
-                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Pass</TableHead>
-                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Fail</TableHead>
-                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Pending</TableHead>
+                        <TableHead className="text-white/40 uppercase tracking-[0.14em] text-2xs">Suite</TableHead>
+                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Cases</TableHead>
+                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Pass</TableHead>
+                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Fail</TableHead>
+                        <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Pending</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -666,7 +666,7 @@ export function RunDetailClient({
 
               {run.regression_coverage.unmatched_cases.length > 0 && (
                 <Panel className="p-4">
-                  <h3 className="text-[10px] font-medium uppercase tracking-[0.14em] text-white/40 mb-3">
+                  <h3 className="text-2xs font-medium uppercase tracking-[0.14em] text-white/40 mb-3">
                     Unmatched Cases
                   </h3>
                   <div className="flex flex-wrap gap-2">
@@ -691,15 +691,15 @@ export function RunDetailClient({
         run.status === "failed" ||
         run.status === "cancelled") && (
         <div>
-          <h2 className="text-[11px] leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-4">Ranking</h2>
+          <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-4">Ranking</h2>
 
           {!ranking || ranking.state === "pending" ? (
-            <Panel className="p-8 text-center text-[11px] uppercase tracking-[0.14em] text-white/40">
+            <Panel className="p-8 text-center text-2xs uppercase tracking-[0.14em] text-white/40">
               <Loader2 className="size-5 animate-spin mx-auto mb-3 text-white/20" />
               Scoring in progress...
             </Panel>
           ) : ranking.state === "errored" ? (
-            <Panel tone="danger" className="p-8 text-center text-[11px] uppercase tracking-[0.14em] text-red-400/80">
+            <Panel tone="danger" className="p-8 text-center text-2xs uppercase tracking-[0.14em] text-red-400/80">
               <AlertTriangle className="size-5 mx-auto mb-3 text-red-400/50" />
               {ranking.message || "Ranking unavailable for this run."}
             </Panel>
@@ -742,7 +742,7 @@ export function RunDetailClient({
 
                     {/* Strategy badge (if present) */}
                     {ranking.ranking.items[0]?.strategy && (
-                      <div className="flex items-center gap-2 mb-4 text-[10px] uppercase tracking-[0.14em] text-white/40">
+                      <div className="flex items-center gap-2 mb-4 text-2xs uppercase tracking-[0.14em] text-white/40">
                         <span>Strategy:</span>
                         <Badge variant="outline" className="bg-white/5 text-white/70 border-white/10">
                           {ranking.ranking.items[0].strategy}
@@ -754,19 +754,19 @@ export function RunDetailClient({
                       <Table className="text-white/70">
                         <TableHeader className="border-white/10 hover:bg-transparent">
                           <TableRow className="border-white/10 hover:bg-transparent">
-                            <TableHead className="w-16 text-white/40 uppercase tracking-[0.14em] text-[10px]">Rank</TableHead>
-                            <TableHead className="text-white/40 uppercase tracking-[0.14em] text-[10px]">Agent</TableHead>
-                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Overall</TableHead>
-                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Correctness</TableHead>
-                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Reliability</TableHead>
-                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Latency</TableHead>
-                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">Cost</TableHead>
+                            <TableHead className="w-16 text-white/40 uppercase tracking-[0.14em] text-2xs">Rank</TableHead>
+                            <TableHead className="text-white/40 uppercase tracking-[0.14em] text-2xs">Agent</TableHead>
+                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Overall</TableHead>
+                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Correctness</TableHead>
+                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Reliability</TableHead>
+                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Latency</TableHead>
+                            <TableHead className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">Cost</TableHead>
                             {customDimKeys.map((key) => (
-                              <TableHead key={key} className="text-right text-white/40 uppercase tracking-[0.14em] text-[10px]">
+                              <TableHead key={key} className="text-right text-white/40 uppercase tracking-[0.14em] text-2xs">
                                 {key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, " ")}
                               </TableHead>
                             ))}
-                            <TableHead className="text-center text-white/40 uppercase tracking-[0.14em] text-[10px]">Pass</TableHead>
+                            <TableHead className="text-center text-white/40 uppercase tracking-[0.14em] text-2xs">Pass</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -789,7 +789,7 @@ export function RunDetailClient({
                                 </TableCell>
                                 <TableCell className="font-medium text-white/90">
                                   {item.label}
-                                  <span className="text-[10px] text-white/30 ml-2 font-[family-name:var(--font-mono)]">
+                                  <span className="text-2xs text-white/30 ml-2 font-[family-name:var(--font-mono)]">
                                     #{item.lane_index}
                                   </span>
                                 </TableCell>
@@ -797,7 +797,7 @@ export function RunDetailClient({
                                   <div className="font-[family-name:var(--font-mono)] text-white/90">{scorePercent(item.overall_score ?? item.composite_score)}</div>
                                   {item.delta_from_top != null &&
                                     item.delta_from_top !== 0 && (
-                                      <div className="text-[10px] text-white/40 font-[family-name:var(--font-mono)] mt-0.5">
+                                      <div className="text-2xs text-white/40 font-[family-name:var(--font-mono)] mt-0.5">
                                         {deltaLabel(item.delta_from_top)}
                                       </div>
                                     )}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-ranking-insights-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-ranking-insights-card.tsx
@@ -169,7 +169,7 @@ export function RunRankingInsightsCard({
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-semibold">Insights</h3>
-            <span className="rounded-full border border-border px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            <span className="rounded-full border border-border px-2 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
               LLM advisory
             </span>
           </div>
@@ -318,10 +318,10 @@ export function RunRankingInsightsCard({
                 <div key={summary.run_agent_id} className="rounded-md border border-border p-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium">{summary.label}</span>
-                    <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-2xs text-muted-foreground">
                       Strongest: {formatDimensionLabel(summary.strongest_dimension)}
                     </span>
-                    <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-2xs text-muted-foreground">
                       Weakest: {formatDimensionLabel(summary.weakest_dimension)}
                     </span>
                   </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
@@ -98,7 +98,7 @@ export function ScorecardSummaryCard({
           >
             {scorePercent(scorecard.overall_score)}
           </span>
-          <span className="text-[10px] text-muted-foreground">overall</span>
+          <span className="text-2xs text-muted-foreground">overall</span>
           {scorecard.scorecard?.passed != null && (
             scorecard.scorecard.passed ? (
               <CheckCircle2 className="size-3 text-emerald-400" />
@@ -107,7 +107,7 @@ export function ScorecardSummaryCard({
             )
           )}
           {scorecard.scorecard?.strategy && (
-            <span className="text-[10px] text-muted-foreground/60 ml-1">
+            <span className="text-2xs text-muted-foreground/60 ml-1">
               {scorecard.scorecard.strategy}
             </span>
           )}
@@ -125,7 +125,7 @@ export function ScorecardSummaryCard({
           return (
             <div
               key={key}
-              className="flex items-center gap-1 text-[10px]"
+              className="flex items-center gap-1 text-2xs"
               title={key}
             >
               <Icon className="size-2.5 text-muted-foreground" />
@@ -138,7 +138,7 @@ export function ScorecardSummaryCard({
 
       {/* Token split */}
       {scorecard.scorecard?.metric_summary?.run_total_tokens != null && (
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-2xs text-muted-foreground">
           <span className="font-[family-name:var(--font-mono)]">{scorecard.scorecard.metric_summary.run_total_tokens.toLocaleString()} tokens</span>
           {(scorecard.scorecard.metric_summary.run_race_context_tokens ?? 0) > 0 && (
             <span className="text-muted-foreground/60 font-[family-name:var(--font-mono)]">

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -46,7 +46,7 @@ function ReportPanel({ report }: { report: AgentOpportunityReport }) {
     <section className="mt-14 border-t border-white/[0.08] pt-10">
       <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
         <div>
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40">
             Agent opportunity report
           </p>
           <h2 className="mt-4 text-3xl font-sans font-semibold tracking-tight text-white sm:text-4xl">
@@ -107,7 +107,7 @@ function ReportPanel({ report }: { report: AgentOpportunityReport }) {
                         {useCase.workflow}
                       </p>
                     </div>
-                    <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.12em] text-white/45">
+                    <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.12em] text-white/45">
                       {useCase.fit} fit
                     </span>
                   </div>
@@ -198,7 +198,7 @@ function ReportPanel({ report }: { report: AgentOpportunityReport }) {
 
           <div className="grid gap-4 border-t border-white/[0.08] pt-6 md:grid-cols-2">
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/35">
                 Next steps
               </p>
               <ul className="mt-3 space-y-2 text-sm leading-6 text-white/55">
@@ -208,7 +208,7 @@ function ReportPanel({ report }: { report: AgentOpportunityReport }) {
               </ul>
             </div>
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/35">
                 Evidence limits
               </p>
               <ul className="mt-3 space-y-2 text-sm leading-6 text-white/45">
@@ -272,7 +272,7 @@ export function AgentOpportunityClient() {
       <section className="px-6 pt-16 sm:px-12 sm:pt-24">
         <div className="mx-auto grid max-w-[1180px] gap-12 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
           <div>
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40">
               AI agent opportunity scanner
             </p>
             <h1 className="mt-6 max-w-[13ch] text-[clamp(2.75rem,7vw,5.8rem)] font-sans font-semibold leading-[0.98] tracking-tight text-white">
@@ -377,7 +377,7 @@ export function AgentOpportunityClient() {
                 ["3", "Generate the eval pack"],
               ].map(([step, label]) => (
                 <div key={step} className="bg-[#0a0a0a] p-4">
-                  <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+                  <p className="font-[family-name:var(--font-mono)] text-2xs text-white/35">
                     {step}
                   </p>
                   <p className="mt-3 text-sm leading-5 text-white/60">{label}</p>

--- a/web/src/app/auth/login/lightspeed.tsx
+++ b/web/src/app/auth/login/lightspeed.tsx
@@ -466,7 +466,7 @@ export function LightSpeed({
           type="button"
           onClick={onTiltChipClick}
           data-testid="lightspeed-tilt-chip"
-          className="absolute left-4 top-4 z-10 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.2em] text-white/70 backdrop-blur transition-colors hover:bg-white/[0.1] hover:text-white"
+          className="absolute left-4 top-4 z-10 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1.5 font-mono text-2xs uppercase tracking-[0.2em] text-white/70 backdrop-blur transition-colors hover:bg-white/[0.1] hover:text-white"
         >
           Tap to tilt
         </button>

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -48,7 +48,7 @@ export default async function LoginPage({
 
       <div className="pointer-events-none relative grid min-h-screen grid-rows-[1fr_auto] lg:grid-cols-[minmax(0,1fr)_minmax(440px,520px)] lg:grid-rows-1">
         <div className="flex flex-col justify-end p-6 sm:p-10 lg:p-14">
-          <p className="font-mono text-[0.66rem] uppercase tracking-[0.28em] text-white/45">
+          <p className="font-mono text-2xs uppercase tracking-[0.28em] text-white/45">
             Open evals engine
           </p>
           <h1 className="mt-3 max-w-2xl font-mono text-[1.65rem] font-medium uppercase leading-[1.05] tracking-[0.04em] text-white sm:text-4xl lg:text-[2.6rem]">
@@ -56,7 +56,7 @@ export default async function LoginPage({
             <br />
             and agents.
           </h1>
-          <p className="mt-4 max-w-md text-[0.85rem] leading-6 text-white/55 sm:mt-5 sm:text-sm">
+          <p className="mt-4 max-w-md text-sm leading-6 text-white/55 sm:mt-5 sm:text-sm">
             Run the same task across models. Score on real outcomes. Replay
             every step.
           </p>
@@ -66,7 +66,7 @@ export default async function LoginPage({
           <div className="pointer-events-auto w-full max-w-[440px] lg:-translate-y-[6vh]">
             <div className="mb-7 flex items-center gap-3">
               <ClashMark className="size-9" />
-              <span className="font-mono text-[0.7rem] uppercase tracking-[0.26em] text-white/55">
+              <span className="font-mono text-2xs uppercase tracking-[0.26em] text-white/55">
                 AgentClash
               </span>
             </div>

--- a/web/src/app/benchmarks/[slug]/page.tsx
+++ b/web/src/app/benchmarks/[slug]/page.tsx
@@ -81,13 +81,13 @@ export default async function BenchmarkReportPage({ params }: Props) {
       <article className="mx-auto w-full max-w-3xl px-6 py-16">
         <Link
           href="/benchmarks"
-          className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
+          className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
         >
           &larr; Benchmarks
         </Link>
 
         <header className="mt-6">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+          <p className="font-[family-name:var(--font-mono)] text-2xs text-white/40">
             {report.date} &middot; {report.featuredModel}
             {report.challengePack ? ` · ${report.challengePack}` : ""}
           </p>
@@ -108,7 +108,7 @@ export default async function BenchmarkReportPage({ params }: Props) {
         )}
 
         <section className="mt-8">
-          <h2 className="mb-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+          <h2 className="mb-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
             Scoreboard
           </h2>
           <BenchmarkScoreboard
@@ -131,7 +131,7 @@ export default async function BenchmarkReportPage({ params }: Props) {
 
         {report.tasks.length > 0 && (
           <section className="mt-10">
-            <h2 className="mb-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+            <h2 className="mb-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
               The tasks
             </h2>
             <ol className="flex flex-col gap-2">
@@ -141,7 +141,7 @@ export default async function BenchmarkReportPage({ params }: Props) {
                   className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
                 >
                   <div className="flex items-baseline gap-2">
-                    <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                    <span className="font-[family-name:var(--font-mono)] text-2xs text-white/30">
                       {String(index + 1).padStart(2, "0")}
                     </span>
                     <span className="text-sm font-medium text-white/85">

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -103,13 +103,13 @@ export default async function BlogPostPage({ params }: Props) {
       <article className="mx-auto w-full max-w-3xl px-6 py-16">
         <Link
           href="/blog"
-          className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
+          className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
         >
           &larr; Blog
         </Link>
 
         <header className="mt-6 mb-8">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+          <p className="font-[family-name:var(--font-mono)] text-2xs text-white/40">
             {post.date} &middot; {post.author}
           </p>
           <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -56,7 +56,7 @@ export default function BlogPage() {
     <MarketingShell>
       <JsonLd id="agentclash-blog-index-schema" data={blogIndexSchema(posts)} />
       <section className="mx-auto w-full max-w-3xl px-6 py-16">
-        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+        <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
           Blog
         </p>
         <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
@@ -78,7 +78,7 @@ export default function BlogPage() {
               href={`/blog/${post.slug}`}
               className="group flex flex-col gap-1 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 hover:border-white/15 transition-colors"
             >
-              <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+              <span className="font-[family-name:var(--font-mono)] text-2xs text-white/40">
                 {post.date} &middot; {post.author}
               </span>
               <span className="text-sm font-medium text-white group-hover:text-white/90">

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -31,7 +31,7 @@ export default function ChangelogPage() {
         )}
       />
       <ChangelogShell backHref="/" backLabel="Back to AgentClash">
-        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+        <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
           Release notes
         </p>
         <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">

--- a/web/src/app/compare/[competitor]/page.tsx
+++ b/web/src/app/compare/[competitor]/page.tsx
@@ -112,7 +112,7 @@ export default async function CompareCompetitorPage({ params }: Props) {
               <span>/</span>
               <span>AgentClash vs {competitor.name}</span>
             </nav>
-            <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+            <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
               agent eval vs {competitor.tag}
             </p>
             <h1 className="mt-5 font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
@@ -138,7 +138,7 @@ export default async function CompareCompetitorPage({ params }: Props) {
                   <tr className="border-b border-white/[0.14]">
                     <th
                       scope="col"
-                      className="py-4 pr-4 text-[11px] font-medium uppercase tracking-[0.16em] text-white/40"
+                      className="py-4 pr-4 text-2xs font-medium uppercase tracking-[0.16em] text-white/40"
                     >
                       Capability
                     </th>
@@ -163,10 +163,10 @@ export default async function CompareCompetitorPage({ params }: Props) {
                       className="border-b border-white/[0.06] align-top"
                     >
                       <th scope="row" className="py-5 pr-6 font-normal">
-                        <span className="block text-[15px] text-white/85">
+                        <span className="block text-base text-white/85">
                           {row.label}
                         </span>
-                        <span className="mt-1 block max-w-[52ch] text-[12px] leading-5 text-white/40">
+                        <span className="mt-1 block max-w-[52ch] text-xs leading-5 text-white/40">
                           {row.sub}
                         </span>
                       </th>
@@ -215,7 +215,7 @@ export default async function CompareCompetitorPage({ params }: Props) {
 
         <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">

--- a/web/src/app/compare/_components/compare-shell.tsx
+++ b/web/src/app/compare/_components/compare-shell.tsx
@@ -8,27 +8,27 @@ import { ClashMark } from "@/components/marketing/clash-mark";
 export function CompareShell({ children }: { children: ReactNode }) {
   return (
     <>
-      <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+      <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6 lg:py-7">
         <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
           <Link
             href="/"
-            className="inline-flex items-center gap-2.5 text-white/90"
+            className="inline-flex items-center gap-2.5 lg:gap-3 text-white/90"
           >
-            <ClashMark className="size-6" />
-            <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+            <ClashMark className="size-6 lg:size-7 2xl:size-8" />
+            <span className="font-[family-name:var(--font-display)] text-xl lg:text-2xl 2xl:text-[1.75rem] tracking-normal">
               AgentClash
             </span>
           </Link>
-          <nav className="flex items-center gap-2 text-xs">
+          <nav className="flex items-center gap-2 text-xs lg:text-sm">
             <Link
               href="/compare"
-              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+              className="hidden px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
             >
               Compare
             </Link>
             <Link
               href="/docs"
-              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+              className="hidden px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
             >
               Docs
             </Link>
@@ -36,16 +36,16 @@ export function CompareShell({ children }: { children: ReactNode }) {
               href="https://github.com/agentclash/agentclash"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+              className="hidden px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
             >
               GitHub
             </a>
             <Link
               href="/auth/login"
-              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 lg:px-3.5 lg:py-2 font-medium text-[#060606] transition-colors hover:bg-white/90"
             >
               Start
-              <ArrowRight className="size-3.5" />
+              <ArrowRight className="size-3.5 lg:size-4" />
             </Link>
           </nav>
         </div>

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -118,7 +118,7 @@ export default function ComparePage() {
               <span>/</span>
               <span>Compare</span>
             </nav>
-            <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+            <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
               Agent eval vs prompt eval
             </p>
             <h1 className="mt-5 max-w-[18ch] font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
@@ -147,7 +147,7 @@ export default function ComparePage() {
                   <tr className="border-b border-white/[0.14]">
                     <th
                       scope="col"
-                      className="py-4 pr-4 text-[11px] font-medium uppercase tracking-[0.16em] text-white/40"
+                      className="py-4 pr-4 text-2xs font-medium uppercase tracking-[0.16em] text-white/40"
                     >
                       Capability
                     </th>
@@ -162,7 +162,7 @@ export default function ComparePage() {
                         <span className="block text-sm font-semibold">
                           {column.name}
                         </span>
-                        <span className="mt-1 block text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
+                        <span className="mt-1 block text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
                           {column.tag}
                         </span>
                       </th>
@@ -176,10 +176,10 @@ export default function ComparePage() {
                       className="border-b border-white/[0.06] align-top"
                     >
                       <th scope="row" className="py-5 pr-6 font-normal">
-                        <span className="block text-[15px] text-white/85">
+                        <span className="block text-base text-white/85">
                           {row.label}
                         </span>
-                        <span className="mt-1 block max-w-[42ch] text-[12px] leading-5 text-white/40">
+                        <span className="mt-1 block max-w-[42ch] text-xs leading-5 text-white/40">
                           {row.sub}
                         </span>
                       </th>
@@ -233,7 +233,7 @@ export default function ComparePage() {
 
         <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -137,7 +137,7 @@ export default async function DocsPage({ params }: Props) {
                 key={section.title}
                 className="rounded-[24px] border border-white/[0.08] bg-black/20 p-5"
               >
-                <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+                <p className="text-2xs font-semibold uppercase tracking-wider text-zinc-400">
                   {section.title}
                 </p>
                 <p className="mt-3 text-sm leading-6 text-white/45">
@@ -167,7 +167,7 @@ export default async function DocsPage({ params }: Props) {
 
       {isHome && (
         <div className="mt-12 border-t border-white/[0.08] pt-8">
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+          <p className="text-2xs font-semibold uppercase tracking-wider text-zinc-400">
             Docs FAQ
           </p>
           <div className="mt-5 grid gap-4 xl:grid-cols-3">
@@ -195,7 +195,7 @@ export default async function DocsPage({ params }: Props) {
               href={neighbors.previous.href}
               className="rounded-[24px] border border-white/[0.08] bg-black/20 px-5 py-4 transition-colors hover:border-white/15"
             >
-              <span className="block text-[11px] uppercase tracking-[0.18em] text-white/30">
+              <span className="block text-2xs uppercase tracking-[0.18em] text-white/30">
                 Previous
               </span>
               <span className="mt-2 block text-sm font-medium text-white/88">
@@ -210,7 +210,7 @@ export default async function DocsPage({ params }: Props) {
               href={neighbors.next.href}
               className="rounded-[24px] border border-white/[0.08] bg-black/20 px-5 py-4 text-left transition-colors hover:border-white/15"
             >
-              <span className="block text-[11px] uppercase tracking-[0.18em] text-white/30">
+              <span className="block text-2xs uppercase tracking-[0.18em] text-white/30">
                 Next
               </span>
               <span className="mt-2 block text-sm font-medium text-white/88">

--- a/web/src/app/enterprise/page.tsx
+++ b/web/src/app/enterprise/page.tsx
@@ -179,7 +179,7 @@ export const metadata: Metadata = {
 };
 
 const eyebrowClass =
-  "font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40";
+  "font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40";
 
 export default function EnterprisePage() {
   return (

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -396,7 +396,7 @@ body {
 
 /* Blog prose */
 .prose-agentclash {
-  font-size: 15px;
+  font-size: clamp(0.9375rem, 0.895rem + 0.175vw, 1.0625rem); /* 15 → 17px */
   line-height: 1.75;
   color: rgba(255, 255, 255, 0.65);
 }
@@ -526,7 +526,7 @@ body {
 /* Docs prose */
 .prose-agentclash-docs {
   max-width: 72ch;
-  font-size: 15px;
+  font-size: clamp(0.9375rem, 0.895rem + 0.175vw, 1.0625rem); /* 15 → 17px */
   line-height: 1.8;
   color: rgba(255, 255, 255, 0.68);
 }
@@ -715,6 +715,25 @@ body {
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+/*
+ * Fluid font-size scale. Floors equal the prior fixed sizes so phones (≤390px)
+ * render identically; a uniform 0.175vw slope (~+2px from 390→1536px) lets text
+ * grow on large displays while keeping a constant gap between adjacent steps so
+ * sizes never invert. text-2xs is new (replaces the old text-[9/10/11px] swarm).
+ */
+@theme {
+  --text-2xs: clamp(0.6875rem, 0.645rem + 0.175vw, 0.8125rem); /* 11 → 13px */
+  --text-2xs--line-height: 1.45;
+  --text-xs: clamp(0.75rem, 0.707rem + 0.175vw, 0.875rem); /* 12 → 14px */
+  --text-xs--line-height: 1.4;
+  --text-sm: clamp(0.875rem, 0.832rem + 0.175vw, 1rem); /* 14 → 16px */
+  --text-sm--line-height: 1.45;
+  --text-base: clamp(1rem, 0.957rem + 0.175vw, 1.125rem); /* 16 → 18px */
+  --text-base--line-height: 1.5;
+  --text-lg: clamp(1.125rem, 1.082rem + 0.175vw, 1.25rem); /* 18 → 20px */
+  --text-lg--line-height: 1.45;
 }
 
 .dark {

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -1421,51 +1421,51 @@ export default function HomePage({
       <TryCliBanner />
 
       {/* ── Header ──────────────────────────────────────────────── */}
-      <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
+      <header className="px-5 sm:px-12 py-5 sm:py-6 lg:py-7 border-b border-white/[0.06]">
         <div className="mx-auto flex max-w-[1440px] items-center justify-between">
           <Link
             href="/"
-            className="inline-flex items-center gap-2.5 text-white/90"
+            className="inline-flex items-center gap-2.5 lg:gap-3 text-white/90"
           >
-            <ClashMark className="size-6" />
-            <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+            <ClashMark className="size-6 lg:size-7 2xl:size-8" />
+            <span className="font-[family-name:var(--font-display)] text-xl lg:text-2xl 2xl:text-[1.75rem] tracking-[-0.01em]">
               AgentClash
             </span>
           </Link>
-          <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
+          <nav className="flex items-center gap-0.5 sm:gap-2 text-xs lg:text-sm">
             <a
               href="#features"
-              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="hidden sm:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Features
             </a>
             <Link
               href="/why"
-              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="hidden sm:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Why we built this
             </Link>
             <Link
               href="#pricing"
-              className="inline-flex px-2.5 sm:px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="inline-flex px-2.5 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Pricing
             </Link>
             <Link
               href="/docs"
-              className="inline-flex px-2.5 sm:px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="inline-flex px-2.5 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Docs
             </Link>
             <Link
               href="/benchmarks"
-              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="hidden sm:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Benchmarks
             </Link>
             <Link
               href="/blog"
-              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              className="hidden sm:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
             >
               Blog
             </Link>
@@ -1474,21 +1474,21 @@ export default function HomePage({
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
             >
-              <Star className="size-3.5" />
+              <Star className="size-3.5 lg:size-4" />
               <span className="hidden sm:inline">GitHub</span>
             </a>
             {authLoading ? (
-              <span className="inline-flex h-[30px] w-[40px] sm:w-[88px] rounded-md border border-white/[0.08] bg-white/[0.04]" />
+              <span className="inline-flex h-[30px] w-[40px] sm:w-[88px] lg:h-[38px] lg:w-[96px] rounded-md border border-white/[0.08] bg-white/[0.04]" />
             ) : user ? (
               <Link
                 href="/dashboard"
                 aria-label="Dashboard"
-                className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 font-medium text-[#060606] hover:bg-white/90 transition-colors"
+                className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 font-medium text-[#060606] hover:bg-white/90 transition-colors"
               >
                 <span className="hidden sm:inline">Dashboard</span>
-                <ArrowRight className="size-3" />
+                <ArrowRight className="size-3 lg:size-3.5" />
               </Link>
             ) : (
               <AuthCtaLink returning={returning} />

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -1733,37 +1733,37 @@ export default function HomePage({
 
             <dl className="mt-10 grid gap-x-10 gap-y-5 sm:grid-cols-2">
               <div>
-                <dt className="text-[15px] font-medium text-white/90">
+                <dt className="text-base font-medium text-white/90">
                   Deterministic
                 </dt>
-                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                <dd className="mt-1 text-sm leading-[1.55] text-white/50">
                   exact, regex, JSON Schema, code execution, file-tree
                   assertions.
                 </dd>
               </div>
               <div>
-                <dt className="text-[15px] font-medium text-white/90">
+                <dt className="text-base font-medium text-white/90">
                   Mathematic
                 </dt>
-                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                <dd className="mt-1 text-sm leading-[1.55] text-white/50">
                   math equivalence, BLEU, ROUGE, ChrF, token F1, numeric
                   tolerance.
                 </dd>
               </div>
               <div>
-                <dt className="text-[15px] font-medium text-white/90">
+                <dt className="text-base font-medium text-white/90">
                   Behavioural
                 </dt>
-                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                <dd className="mt-1 text-sm leading-[1.55] text-white/50">
                   recovery, exploration, scope adherence, confidence
                   calibration &middot; plus latency, cost, reliability.
                 </dd>
               </div>
               <div>
-                <dt className="text-[15px] font-medium text-white/90">
+                <dt className="text-base font-medium text-white/90">
                   LLM + aggregation
                 </dt>
-                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                <dd className="mt-1 text-sm leading-[1.55] text-white/50">
                   rubric, assertion, reference, pairwise &middot; median,
                   mean, majority-vote, unanimous consensus.
                 </dd>
@@ -1963,10 +1963,10 @@ export default function HomePage({
                 key={`m-${row.label}`}
                 className="border-b border-white/[0.08] pb-8 last:border-b-0"
               >
-                <p className="text-[16px] font-medium text-white/90 leading-[1.35]">
+                <p className="text-base font-medium text-white/90 leading-[1.35]">
                   {row.label}
                 </p>
-                <p className="mt-2 text-[13px] leading-[1.55] text-white/40">
+                <p className="mt-2 text-sm leading-[1.55] text-white/40">
                   {row.sub}
                 </p>
                 <dl className="mt-5 grid grid-cols-1 gap-0">
@@ -1979,7 +1979,7 @@ export default function HomePage({
                     >
                       <div className="flex flex-col">
                         <dt
-                          className={`text-[13px] ${
+                          className={`text-sm ${
                             col.highlight
                               ? "text-white/95 font-medium"
                               : "text-white/60"
@@ -1988,7 +1988,7 @@ export default function HomePage({
                           {col.name}
                         </dt>
                         <span
-                          className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                          className={`text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
                             col.highlight ? "text-white/45" : "text-white/25"
                           }`}
                         >
@@ -2014,7 +2014,7 @@ export default function HomePage({
               {/* Header row */}
               <div className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.12]">
                 <div className="pb-5 pr-4">
-                  <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
+                  <p className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
                     Capability
                   </p>
                 </div>
@@ -2026,14 +2026,14 @@ export default function HomePage({
                     <span
                       className={`text-center leading-tight ${
                         col.highlight
-                          ? "text-[13px] font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
-                          : "text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
+                          ? "text-sm font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
+                          : "text-xs font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
                       }`}
                     >
                       {col.name}
                     </span>
                     <span
-                      className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                      className={`text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
                         col.highlight ? "text-white/30" : "text-white/25"
                       }`}
                     >
@@ -2050,8 +2050,8 @@ export default function HomePage({
                   className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.05] last:border-b-0"
                 >
                   <div className="py-7 pr-6">
-                    <p className="text-[15px] text-white/85">{row.label}</p>
-                    <p className="mt-1.5 text-[12px] leading-[1.5] text-white/40">
+                    <p className="text-base text-white/85">{row.label}</p>
+                    <p className="mt-1.5 text-xs leading-[1.5] text-white/40">
                       {row.sub}
                     </p>
                   </div>
@@ -2070,7 +2070,7 @@ export default function HomePage({
             </div>
           </div>
 
-          <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+          <p className="mt-10 text-xs font-[family-name:var(--font-mono)] text-white/35">
             <span className="text-white/60">●</span>&nbsp;&nbsp;supported
             &nbsp;·&nbsp; <span className="text-white/45">◐</span>
             &nbsp;&nbsp;partial &nbsp;·&nbsp;
@@ -2129,7 +2129,7 @@ export default function HomePage({
                   {feature.glyph}
                 </div>
 
-                <p className="mt-8 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+                <p className="mt-8 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
                   {feature.label}
                 </p>
 
@@ -2137,7 +2137,7 @@ export default function HomePage({
                   {feature.title}
                 </h3>
 
-                <p className="mt-4 text-[14px] leading-[1.65] text-white/55">
+                <p className="mt-4 text-sm leading-[1.65] text-white/55">
                   {feature.body}
                 </p>
               </li>
@@ -2317,7 +2317,7 @@ export default function HomePage({
                 <h3 className="text-lg font-medium leading-snug text-white/90">
                   {item.question}
                 </h3>
-                <p className="mt-3 text-[15px] leading-[1.7] text-white/55">
+                <p className="mt-3 text-base leading-[1.7] text-white/55">
                   {item.answer}
                 </p>
               </div>
@@ -2328,7 +2328,7 @@ export default function HomePage({
 
       {/* ── Footer ──────────────────────────────────────────────── */}
       <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 py-10">
-        <div className="mx-auto max-w-[1440px] flex flex-wrap items-center justify-between gap-4 text-[11px] font-[family-name:var(--font-mono)] text-white/35">
+        <div className="mx-auto max-w-[1440px] flex flex-wrap items-center justify-between gap-4 text-2xs font-[family-name:var(--font-mono)] text-white/35">
           <div className="flex items-center gap-6">
             <span className="font-medium text-white/55">AgentClash</span>
             <span className="text-white/40">Beta</span>

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -188,11 +188,11 @@ function ProductVisual() {
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-emerald-300" />
-            <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/45">
+            <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/45">
               live race
             </span>
           </div>
-          <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] text-white/45">
+          <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-2xs text-white/45">
             gate: pass
           </span>
         </div>
@@ -218,7 +218,7 @@ function ProductVisual() {
       </div>
       <div className="grid gap-px bg-white/[0.06] md:grid-cols-[1.1fr_0.9fr]">
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             replay timeline
           </p>
           <div className="mt-4 space-y-3">
@@ -229,7 +229,7 @@ function ProductVisual() {
               "attached diff, logs, and scorecard",
             ].map((item, index) => (
               <div key={item} className="flex items-start gap-3">
-                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 font-[family-name:var(--font-mono)] text-[10px] text-cyan-100">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 font-[family-name:var(--font-mono)] text-2xs text-cyan-100">
                   {index + 1}
                 </span>
                 <span className="text-sm leading-6 text-white/68">{item}</span>
@@ -238,7 +238,7 @@ function ProductVisual() {
           </div>
         </div>
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             ci verdict
           </p>
           <div className="mt-4 rounded-md border border-emerald-300/15 bg-emerald-300/[0.06] p-4">
@@ -251,7 +251,7 @@ function ProductVisual() {
               failures exceeded the configured threshold.
             </p>
           </div>
-          <pre className="mt-4 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] leading-5 text-white/55">
+          <pre className="mt-4 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-2xs leading-5 text-white/55">
             agentclash ci run --manifest .agentclash/ci.yaml
           </pre>
         </div>
@@ -292,7 +292,7 @@ export default function AgentEvaluationPage() {
                 <span>/</span>
                 <span>Platform</span>
               </nav>
-              <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
                 AgentClash platform
               </p>
               <h1 className="mt-5 max-w-[11ch] font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-7xl">
@@ -328,7 +328,7 @@ export default function AgentEvaluationPage() {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto max-w-[1440px]">
             <div className="max-w-3xl">
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 What the platform evaluates
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -360,7 +360,7 @@ export default function AgentEvaluationPage() {
           <div className="mx-auto max-w-[1440px]">
             <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
               <div>
-                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                   Workflow
                 </p>
                 <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -390,7 +390,7 @@ export default function AgentEvaluationPage() {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 Start with docs
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -443,7 +443,7 @@ export default function AgentEvaluationPage() {
 
         <section className="px-6 py-20 sm:px-12 sm:py-28">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -192,18 +192,18 @@ function GateVisual() {
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-emerald-300" />
-            <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/45">
+            <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/45">
               pull request gate
             </span>
           </div>
-          <span className="rounded-md border border-rose-300/20 bg-rose-300/[0.06] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] text-rose-100/75">
+          <span className="rounded-md border border-rose-300/20 bg-rose-300/[0.06] px-2 py-1 font-[family-name:var(--font-mono)] text-2xs text-rose-100/75">
             blocked
           </span>
         </div>
       </div>
       <div className="grid gap-px bg-white/[0.06] md:grid-cols-[0.92fr_1.08fr]">
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             regression scorecard
           </p>
           <div className="mt-5 space-y-3">
@@ -225,7 +225,7 @@ function GateVisual() {
                     {value}
                   </span>
                 </div>
-                <p className="mt-2 font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+                <p className="mt-2 font-[family-name:var(--font-mono)] text-2xs text-white/35">
                   {threshold}
                 </p>
               </div>
@@ -233,7 +233,7 @@ function GateVisual() {
           </div>
         </div>
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             replay evidence
           </p>
           <div className="mt-5 space-y-4">
@@ -243,14 +243,14 @@ function GateVisual() {
               "candidate final answer passed prose check but failed file check",
             ].map((item, index) => (
               <div key={item} className="flex items-start gap-3">
-                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-emerald-300/25 bg-emerald-300/10 font-[family-name:var(--font-mono)] text-[10px] text-emerald-100">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-emerald-300/25 bg-emerald-300/10 font-[family-name:var(--font-mono)] text-2xs text-emerald-100">
                   {index + 1}
                 </span>
                 <span className="text-sm leading-6 text-white/62">{item}</span>
               </div>
             ))}
           </div>
-          <pre className="mt-6 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] leading-5 text-white/55">
+          <pre className="mt-6 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-2xs leading-5 text-white/55">
             agentclash compare gate --baseline run-stable --candidate run-pr-184
           </pre>
         </div>
@@ -291,7 +291,7 @@ export default function AgentRegressionTestingPage() {
                 <span>/</span>
                 <span>AI Agent Regression Testing</span>
               </nav>
-              <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-emerald-200/70">
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-emerald-200/70">
                 Release gates for agents
               </p>
               <h1 className="mt-5 max-w-[11ch] font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-7xl">
@@ -327,7 +327,7 @@ export default function AgentRegressionTestingPage() {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto max-w-[1440px]">
             <div className="max-w-3xl">
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 What a gate checks
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -359,7 +359,7 @@ export default function AgentRegressionTestingPage() {
           <div className="mx-auto max-w-[1440px]">
             <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
               <div>
-                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                   Workflow
                 </p>
                 <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -389,7 +389,7 @@ export default function AgentRegressionTestingPage() {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 Start with docs
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -443,7 +443,7 @@ export default function AgentRegressionTestingPage() {
 
         <section className="px-6 py-20 sm:px-12 sm:py-28">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">

--- a/web/src/app/pricing/page.tsx
+++ b/web/src/app/pricing/page.tsx
@@ -91,7 +91,7 @@ export default function PricingPage() {
               <span>/</span>
               <span>Pricing</span>
             </nav>
-            <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+            <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
               Pricing
             </p>
             <h1 className="mt-5 max-w-[20ch] font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
@@ -139,7 +139,7 @@ export default function PricingPage() {
 
         <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">

--- a/web/src/app/resources/eval-checklist/page.tsx
+++ b/web/src/app/resources/eval-checklist/page.tsx
@@ -50,7 +50,7 @@ export const metadata: Metadata = {
 };
 
 const eyebrowClass =
-  "font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40";
+  "font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40";
 
 export default function EvalChecklistResourcePage() {
   return (

--- a/web/src/app/resources/eval-checklist/thank-you/page.tsx
+++ b/web/src/app/resources/eval-checklist/thank-you/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 };
 
 const eyebrowClass =
-  "font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40";
+  "font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40";
 
 export default function EvalChecklistThankYouPage() {
   return (

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -149,7 +149,7 @@ export const metadata: Metadata = {
 };
 
 const eyebrowClass =
-  "font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40";
+  "font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/40";
 
 export default function ServicesPage() {
   return (
@@ -222,7 +222,7 @@ export default function ServicesPage() {
                     <h3 className="text-lg font-sans font-semibold tracking-[-0.01em] text-white">
                       {offering.name}
                     </h3>
-                    <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.12em] text-white/40">
+                    <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.12em] text-white/40">
                       {offering.duration}
                     </span>
                   </div>

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -165,7 +165,7 @@ export default function HtmlSitemapPage() {
   return (
     <main className="min-h-screen px-6 py-16 text-white">
       <div className="mx-auto max-w-5xl">
-        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-wider text-white/35">
+        <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-wider text-white/35">
           Public sitemap
         </p>
         <h1 className="mt-4 font-[family-name:var(--font-display)] text-3xl leading-tight tracking-normal sm:text-5xl">

--- a/web/src/app/team/page.tsx
+++ b/web/src/app/team/page.tsx
@@ -40,7 +40,7 @@ export default function TeamPage() {
                 {member.name}
               </p>
               <p className="text-xs text-white/35">@{member.handle}</p>
-              <p className="text-[11px] text-white/20 italic mt-0.5">{member.tagline}</p>
+              <p className="text-2xs text-white/20 italic mt-0.5">{member.tagline}</p>
             </div>
             <span className="shrink-0 rounded-md bg-white/90 px-3 py-1.5 text-xs font-semibold text-[#060606]">
               Follow

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -847,7 +847,7 @@ function TryoutSidebar({
                 className="border-b border-white/6 px-3 py-2 text-xs last:border-b-0"
               >
                 <p className="text-white/75">{event.summary}</p>
-                <time className="mt-0.5 block text-[10px] text-white/35">
+                <time className="mt-0.5 block text-2xs text-white/35">
                   {new Date(event.occurred_at).toLocaleTimeString()}
                 </time>
               </li>
@@ -1081,7 +1081,7 @@ function UserBubble({ text, animate }: { text: string; animate?: boolean }) {
         animate && "animate-in fade-in slide-in-from-bottom-2 duration-300",
       )}
     >
-      <div className="max-w-[85%] rounded-2xl rounded-br-md bg-white px-4 py-2.5 text-[15px] leading-7 text-black">
+      <div className="max-w-[85%] rounded-2xl rounded-br-md bg-white px-4 py-2.5 text-base leading-7 text-black">
         {text}
       </div>
     </div>
@@ -1148,7 +1148,7 @@ function ArtifactChatCard({ output }: { output: TryoutOutputPreview }) {
             <div className="min-w-0">
               <p className="truncate text-sm font-medium text-white/90">{label}</p>
               {sizeLabel ? (
-                <p className="text-[11px] text-white/40">{artifactKindLabel(output)} · {sizeLabel}</p>
+                <p className="text-2xs text-white/40">{artifactKindLabel(output)} · {sizeLabel}</p>
               ) : null}
             </div>
           </div>
@@ -1228,7 +1228,7 @@ function ArtifactPreviewCard({ output }: { output: TryoutOutputPreview }) {
           <p className="truncate text-xs font-medium text-white/80">
             {output.relative_path || output.key || "Output"}
           </p>
-          <p className="text-[10px] text-white/35">{artifactKindLabel(output)}</p>
+          <p className="text-2xs text-white/35">{artifactKindLabel(output)}</p>
         </div>
         <button
           type="button"
@@ -1240,7 +1240,7 @@ function ArtifactPreviewCard({ output }: { output: TryoutOutputPreview }) {
         </button>
       </div>
       {!isBinaryArtifact(output) ? (
-        <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-[11px] leading-5 text-white/55">
+        <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-2xs leading-5 text-white/55">
           {output.preview.slice(0, 400)}
           {output.preview.length > 400 ? "…" : ""}
         </pre>
@@ -1291,7 +1291,7 @@ function ComposerShell({
         rows={compact ? 1 : 3}
         disabled={disabled}
         placeholder={placeholder}
-        className="block w-full resize-none bg-transparent px-3 pt-2 text-[15px] leading-7 text-white outline-none placeholder:text-white/30"
+        className="block w-full resize-none bg-transparent px-3 pt-2 text-base leading-7 text-white outline-none placeholder:text-white/30"
       />
       <div className="flex items-center justify-between gap-2 px-1 pb-0.5 pt-1">
         {footer ? <div className="flex flex-wrap items-center gap-2">{footer}</div> : <span />}

--- a/web/src/app/why/page.tsx
+++ b/web/src/app/why/page.tsx
@@ -31,7 +31,7 @@ export default function WhyWeBuiltThisPage() {
 
       <section className="px-8 sm:px-12 py-32 sm:py-48">
         <div className="mx-auto max-w-[1440px]">
-          <p className="font-mono text-[0.66rem] uppercase tracking-[0.28em] text-white/45">
+          <p className="font-mono text-2xs uppercase tracking-[0.28em] text-white/45">
             Why we built this
           </p>
 
@@ -56,7 +56,7 @@ export default function WhyWeBuiltThisPage() {
             AgentClash is that eval.
           </p>
 
-          <p className="mt-24 max-w-[56ch] text-[15px] leading-[1.7] text-white/50">
+          <p className="mt-24 max-w-[56ch] text-base leading-[1.7] text-white/50">
             Pick your task the way your product actually runs it. Six
             models race, live, on the same inputs with the same tools.
             Scored on what matters in production — correctness, cost,

--- a/web/src/components/app-shell/sidebar.tsx
+++ b/web/src/components/app-shell/sidebar.tsx
@@ -67,7 +67,7 @@ function SidebarNav({
       {navSections.map((section) => (
         <div key={section.title} className="mb-5">
           {!collapsed && (
-            <p className="mb-1 px-2 text-[0.625rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground/50">
+            <p className="mb-1 px-2 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground/50">
               {section.title}
             </p>
           )}
@@ -84,7 +84,7 @@ function SidebarNav({
                   onMouseEnter={() => warmRoute(href)}
                   onFocus={() => warmRoute(href)}
                   className={cn(
-                    "group relative flex items-center rounded-md text-[0.8125rem] transition-colors",
+                    "group relative flex items-center rounded-md text-sm transition-colors",
                     collapsed
                       ? "justify-center p-2"
                       : "gap-2.5 px-2 py-1.5",
@@ -161,7 +161,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           >
             <LogoMark className="size-6 text-foreground" />
             {!collapsed && (
-              <span className="font-[family-name:var(--font-display)] text-[0.9375rem] tracking-tight">
+              <span className="font-[family-name:var(--font-display)] text-base tracking-tight">
                 AgentClash
               </span>
             )}
@@ -211,7 +211,7 @@ export function MobileSidebar({ workspaceId }: SidebarProps) {
           {/* Logo */}
           <div className="flex h-14 items-center gap-2 px-3 border-b border-white/[0.06]">
             <LogoMark className="size-6 text-foreground" />
-            <span className="font-[family-name:var(--font-display)] text-[0.9375rem] tracking-tight text-foreground/90">
+            <span className="font-[family-name:var(--font-display)] text-base tracking-tight text-foreground/90">
               AgentClash
             </span>
           </div>

--- a/web/src/components/app-shell/user-menu.tsx
+++ b/web/src/components/app-shell/user-menu.tsx
@@ -38,7 +38,7 @@ export function UserMenu({
   return (
     <div className="flex items-center gap-3">
       {orgName && (
-        <span className="hidden text-[0.6875rem] font-medium text-muted-foreground/50 tracking-wide sm:block">
+        <span className="hidden text-2xs font-medium text-muted-foreground/50 tracking-wide sm:block">
           {orgName}
         </span>
       )}
@@ -46,7 +46,7 @@ export function UserMenu({
         <DropdownMenuTrigger className="outline-none rounded-full ring-offset-background focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2">
           <Avatar className="size-7">
             {avatarUrl && <AvatarImage src={avatarUrl} alt="" />}
-            <AvatarFallback className="bg-white/[0.08] text-[0.5625rem] font-medium text-foreground/70">
+            <AvatarFallback className="bg-white/[0.08] text-2xs font-medium text-foreground/70">
               {initials}
             </AvatarFallback>
           </Avatar>

--- a/web/src/components/app-shell/workspace-switcher.tsx
+++ b/web/src/components/app-shell/workspace-switcher.tsx
@@ -55,7 +55,7 @@ export function WorkspaceSwitcher({
           />
         }
       >
-        <span className="truncate text-[0.8125rem]">
+        <span className="truncate text-sm">
           {current?.name ?? "Select workspace"}
         </span>
         <ChevronsUpDown className="size-3 opacity-40" />
@@ -71,7 +71,7 @@ export function WorkspaceSwitcher({
           >
             <div className="flex flex-col gap-0.5">
               <span className="text-sm">{ws.name}</span>
-              <span className="text-[0.6875rem] text-muted-foreground/60">
+              <span className="text-2xs text-muted-foreground/60">
                 {ws.orgName}
               </span>
             </div>

--- a/web/src/components/arena/live-agent-lane.tsx
+++ b/web/src/components/arena/live-agent-lane.tsx
@@ -203,7 +203,7 @@ export function LiveAgentLane({
       {/* === Streaming model output === */}
       {isActive && lane.streamingOutput && (
         <div className="mb-3">
-          <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-1">
+          <div className="text-2xs uppercase tracking-[0.16em] text-muted-foreground mb-1">
             Streaming
           </div>
           <pre className="max-h-32 overflow-auto rounded-md bg-background border border-border px-2.5 py-1.5 text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
@@ -215,7 +215,7 @@ export function LiveAgentLane({
       {/* === Live ticker === */}
       {(isActive || lane.ticker.length > 0) && (
         <div className="mb-3">
-          <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-1">
+          <div className="text-2xs uppercase tracking-[0.16em] text-muted-foreground mb-1">
             Activity
           </div>
           <LiveEventTicker entries={lane.ticker} />

--- a/web/src/components/arena/live-commentary-sidebar.tsx
+++ b/web/src/components/arena/live-commentary-sidebar.tsx
@@ -61,7 +61,7 @@ export function LiveCommentarySidebar({
     >
       <div className="mb-3 flex items-start justify-between gap-3">
         <div>
-          <div className="mb-1 inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.18em] text-amber-700/80 dark:text-amber-300/80">
+          <div className="mb-1 inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-[0.18em] text-amber-700/80 dark:text-amber-300/80">
             <AudioLines className="size-3" />
             Commentary Booth
           </div>
@@ -101,7 +101,7 @@ export function LiveCommentarySidebar({
                 TONE_STYLES[entry.tone],
               )}
             >
-              <div className="mb-1 flex items-center gap-2 text-[11px] uppercase tracking-[0.12em] text-current/70">
+              <div className="mb-1 flex items-center gap-2 text-2xs uppercase tracking-[0.12em] text-current/70">
                 {entry.tone === "warning" ? (
                   <AlertTriangle className="size-3.5" />
                 ) : (

--- a/web/src/components/arena/live-event-ticker.tsx
+++ b/web/src/components/arena/live-event-ticker.tsx
@@ -124,7 +124,7 @@ export function LiveEventTicker({
               </div>
               {entry.kind === "system" && entry.headline === "Race standings injected" && entry.detail && (
                 <div className="pl-[4.5rem] w-full">
-                  <pre className="text-[10px] text-muted-foreground whitespace-pre-wrap break-words font-[family-name:var(--font-mono)] bg-muted/30 p-2 rounded border border-border/50">
+                  <pre className="text-2xs text-muted-foreground whitespace-pre-wrap break-words font-[family-name:var(--font-mono)] bg-muted/30 p-2 rounded border border-border/50">
                     {entry.detail}
                   </pre>
                 </div>

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -185,7 +185,7 @@ export function RaceLane({
 
         {lane.ticker.filter(e => e.kind === "system" && e.headline === "Race standings injected").slice(-1).map(e => (
           <div key={e.id} className="rm-stream !bg-emerald-500/[0.03] !border-emerald-500/20 !text-emerald-500/70 !max-h-none">
-            <div className="text-[10px] uppercase tracking-[0.16em] text-emerald-500/50 mb-1.5 font-sans">
+            <div className="text-2xs uppercase tracking-[0.16em] text-emerald-500/50 mb-1.5 font-sans">
               Latest Race Standings Injected
             </div>
             {e.detail}

--- a/web/src/components/docs/callout.tsx
+++ b/web/src/components/docs/callout.tsx
@@ -48,7 +48,7 @@ export function Callout({
       <div className="flex items-start gap-3">
         <Icon className="mt-0.5 size-4 shrink-0 opacity-70" />
         <div className="min-w-0 text-sm leading-7">
-          <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.14em] opacity-80">
+          <p className="mb-1 text-2xs font-semibold uppercase tracking-[0.14em] opacity-80">
             {style.label}
           </p>
           <div>{children}</div>

--- a/web/src/components/docs/copyable-code-block.tsx
+++ b/web/src/components/docs/copyable-code-block.tsx
@@ -52,7 +52,7 @@ export function CopyableCodeBlock({ children }: { children: ReactNode }) {
 
   return (
     <div className="not-prose my-6 overflow-x-auto rounded-2xl border border-white/[0.08] bg-white/[0.04] p-4">
-      <pre className="m-0 font-mono text-[13px] leading-6 text-white/78">
+      <pre className="m-0 font-mono text-sm leading-6 text-white/78">
         <code>{text}</code>
       </pre>
     </div>

--- a/web/src/components/docs/docs-diagram-presets.tsx
+++ b/web/src/components/docs/docs-diagram-presets.tsx
@@ -27,7 +27,7 @@ function Pill({
   return (
     <span
       className={cn(
-        "inline-flex max-w-[18rem] items-center justify-center rounded-xl border px-3 py-1.5 text-center text-[13px] font-medium leading-snug text-white/88",
+        "inline-flex max-w-[18rem] items-center justify-center rounded-xl border px-3 py-1.5 text-center text-sm font-medium leading-snug text-white/88",
         "border-white/[0.12] bg-white/[0.04]",
         className,
       )}
@@ -167,7 +167,7 @@ export function DiagramAgentsToRun() {
         </div>
         <div className="flex flex-col items-center gap-2">
           <div className="hidden h-[2rem] border-l border-dashed border-white/20 md:block" aria-hidden />
-          <p className="text-center text-[11px] uppercase tracking-[0.18em] text-white/35">
+          <p className="text-center text-2xs uppercase tracking-[0.18em] text-white/35">
             feed deployment
           </p>
           <ArrowD />
@@ -175,7 +175,7 @@ export function DiagramAgentsToRun() {
           <ArrowD />
           <Pill>Run</Pill>
         </div>
-        <p className="text-center text-[12px] leading-relaxed text-white/35">
+        <p className="text-center text-xs leading-relaxed text-white/35">
           Ready build versions and runtime configuration rows converge on the same Deployment—the
           object runs once your challenge pack binds through run submission.
         </p>
@@ -223,7 +223,7 @@ export function DiagramReplayVsScorecards() {
         </div>
         <div className="hidden w-px self-stretch bg-white/[0.08] md:block md:mx-10" aria-hidden />
         <div className="flex flex-1 flex-col items-center gap-3 md:items-start">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45 md:-mt-[1rem] md:pb-10">
+          <span className="text-2xs font-semibold uppercase tracking-[0.2em] text-white/45 md:-mt-[1rem] md:pb-10">
             also
           </span>
           <Pill className="-mt-[0.5rem] md:mt-0">Canonical events</Pill>
@@ -259,7 +259,7 @@ export function DiagramEvidenceClosingLoop() {
             <Pill>Scorecards</Pill>
           </div>
           <div className="rounded-2xl border border-dashed border-white/[0.08] bg-black/35 p-6">
-            <p className="mb-6 text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+            <p className="mb-6 text-2xs font-semibold uppercase tracking-wider text-zinc-400">
               Convergent outcomes
             </p>
             <div className="flex flex-col gap-8">
@@ -272,7 +272,7 @@ export function DiagramEvidenceClosingLoop() {
               <ArrowD />
               <RowArrowRow pills={["Future challenge-pack improvements"]} />
             </div>
-            <p className="mt-6 text-[12px] leading-relaxed text-white/35">
+            <p className="mt-6 text-xs leading-relaxed text-white/35">
               Review and comparison tighten the authored packs you ship next, turning observed drifts into explicit benchmark updates.
             </p>
           </div>
@@ -353,7 +353,7 @@ export function DiagramChallengePackBundleShape() {
 
         <div className="flex flex-col items-center gap-6 border-t border-white/[0.08] pt-12 md:flex-row md:flex-wrap md:justify-center md:gap-10">
           <RowArrowRow pills={["Cases", "Run execution"]} />
-          <span className="hidden text-[11px] uppercase tracking-[0.2em] text-zinc-600 md:inline">
+          <span className="hidden text-2xs uppercase tracking-[0.2em] text-zinc-600 md:inline">
             —
           </span>
           <div className="flex flex-col items-center gap-2">

--- a/web/src/components/docs/docs-mobile-nav.tsx
+++ b/web/src/components/docs/docs-mobile-nav.tsx
@@ -24,7 +24,7 @@ export function DocsMobileNav({
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger
-        className="inline-flex items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-1.5 text-2xs font-semibold uppercase tracking-wider text-white/55 transition-colors hover:border-white/15 hover:text-white/75 lg:hidden"
+        className="inline-flex min-h-9 items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-2 text-2xs font-semibold uppercase tracking-wider text-white/55 transition-colors hover:border-white/15 hover:text-white/75 lg:hidden"
         aria-label="Open docs navigation"
       >
         <Menu className="size-4" />

--- a/web/src/components/docs/docs-mobile-nav.tsx
+++ b/web/src/components/docs/docs-mobile-nav.tsx
@@ -24,7 +24,7 @@ export function DocsMobileNav({
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger
-        className="inline-flex items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-white/55 transition-colors hover:border-white/15 hover:text-white/75 lg:hidden"
+        className="inline-flex items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-1.5 text-2xs font-semibold uppercase tracking-wider text-white/55 transition-colors hover:border-white/15 hover:text-white/75 lg:hidden"
         aria-label="Open docs navigation"
       >
         <Menu className="size-4" />

--- a/web/src/components/docs/docs-search.tsx
+++ b/web/src/components/docs/docs-search.tsx
@@ -82,7 +82,7 @@ export function DocsSearch() {
           placeholder="Search docs..."
           className="h-9 w-full rounded-xl border border-white/[0.08] bg-white/[0.03] pl-10 pr-10 text-sm text-white/80 outline-none transition-colors placeholder:text-white/30 focus:border-white/15 focus:bg-white/[0.05]"
         />
-        <div className="pointer-events-none absolute right-3 flex items-center gap-1 text-[10px] uppercase tracking-wider text-white/25">
+        <div className="pointer-events-none absolute right-3 flex items-center gap-1 text-2xs uppercase tracking-wider text-white/25">
           <Command className="size-3" />
           <span>K</span>
         </div>

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -71,7 +71,7 @@ export function DocsShell({
       </header>
 
       <div className="mx-auto flex w-full max-w-[1536px] items-start px-6 lg:px-8">
-        <aside className="sticky top-16 hidden h-[calc(100vh-4rem)] w-64 shrink-0 overflow-y-auto border-r border-white/[0.08] pt-8 lg:block">
+        <aside className="sticky top-16 hidden h-[calc(100dvh-4rem)] w-64 shrink-0 overflow-y-auto border-r border-white/[0.08] pt-8 lg:block">
           <DocsSidebar sections={sections} currentHref={currentHref} />
         </aside>
 

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -79,11 +79,11 @@ export function DocsShell({
           <div className="mx-auto max-w-[720px]">
             <header className="mb-10 border-b border-white/[0.08] pb-8">
               {sectionTitle ? (
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/35">
+                <p className="text-2xs font-semibold uppercase tracking-[0.18em] text-white/35">
                   {sectionTitle}
                 </p>
               ) : (
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/35">
+                <p className="text-2xs font-semibold uppercase tracking-[0.18em] text-white/35">
                   Documentation
                 </p>
               )}
@@ -96,7 +96,7 @@ export function DocsShell({
                   onClick={() =>
                     navigator.clipboard.writeText(window.location.href)
                   }
-                  className="hidden items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-white/45 transition-colors hover:border-white/15 hover:text-white/70 sm:flex"
+                  className="hidden items-center gap-2 rounded-xl border border-white/[0.08] px-3 py-1.5 text-2xs font-medium uppercase tracking-wider text-white/45 transition-colors hover:border-white/15 hover:text-white/70 sm:flex"
                 >
                   <Copy className="size-3.5" />
                   Copy page

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -46,7 +46,7 @@ export function DocsSidebar({
       <div className="space-y-6">
         {sections.map((section) => (
           <div key={section.title} className="px-1">
-            <h4 className="mb-2 px-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">
+            <h4 className="mb-2 px-2 text-2xs font-semibold uppercase tracking-[0.16em] text-white/35">
               {section.title}
             </h4>
             <div className="space-y-0.5">

--- a/web/src/components/docs/docs-toc.tsx
+++ b/web/src/components/docs/docs-toc.tsx
@@ -6,7 +6,7 @@ export function DocsToc({ headings }: { headings: DocHeading[] }) {
   return (
     <aside className="hidden xl:block">
       <div className="sticky top-24 pt-8">
-        <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">
+        <p className="mb-4 text-2xs font-semibold uppercase tracking-[0.16em] text-white/35">
           On this page
         </p>
         <div className="space-y-3 border-l border-white/[0.08] pl-4">

--- a/web/src/components/docs/mdx-components.tsx
+++ b/web/src/components/docs/mdx-components.tsx
@@ -56,7 +56,7 @@ function DocsHeading({
         "scroll-mt-28 font-sans font-semibold tracking-tight text-white/92 not-italic antialiased",
         level === 2
           ? "mt-14 border-b border-white/[0.08] pb-3 text-xl"
-          : "mt-10 text-[1.0625rem] leading-snug text-white/84",
+          : "mt-10 text-base leading-snug text-white/84",
         className,
       )}
     >

--- a/web/src/components/marketing/auth-cta-link.tsx
+++ b/web/src/components/marketing/auth-cta-link.tsx
@@ -24,9 +24,9 @@ export function AuthCtaLink({ returning }: { returning: boolean }) {
     <Link
       href={href}
       aria-label={label}
-      className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/75 hover:text-white hover:border-white/25 transition-colors"
     >
-      <Icon className="size-3.5" />
+      <Icon className="size-3.5 lg:size-4" />
       <span className="hidden sm:inline">{label}</span>
     </Link>
   );

--- a/web/src/components/marketing/benchmark-scoreboard.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.tsx
@@ -52,16 +52,16 @@ export function BenchmarkScoreboard({ results, featuredModel }: Props) {
       <table className="w-full min-w-[680px] border-collapse text-left">
         <thead>
           <tr className="border-b border-white/[0.08]">
-            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
               #
             </th>
-            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
               Model
             </th>
             {COLUMNS.map((col) => (
               <th
                 key={col.key}
-                className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35"
+                className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35"
               >
                 {col.label}
               </th>
@@ -94,13 +94,13 @@ export function BenchmarkScoreboard({ results, featuredModel }: Props) {
                       {result.model}
                     </span>
                     {result.winner && (
-                      <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.12em] text-emerald-300">
+                      <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.12em] text-emerald-300">
                         Winner
                       </span>
                     )}
                   </div>
                   {result.provider && (
-                    <span className="mt-0.5 block text-[11px] text-white/35">
+                    <span className="mt-0.5 block text-2xs text-white/35">
                       {result.provider}
                     </span>
                   )}

--- a/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
+++ b/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 function SectionEyebrow({ children }: { children: ReactNode }) {
   return (
-    <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+    <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
       {children}
     </p>
   );
@@ -108,7 +108,7 @@ export function BenchmarksHubContent({ published }: Props) {
           <p className="mt-3 text-sm leading-relaxed text-white/50">
             {latest.verdict}
           </p>
-          <p className="mt-2 font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+          <p className="mt-2 font-[family-name:var(--font-mono)] text-2xs text-white/35">
             {latest.date}
             {latest.challengePack ? ` · ${latest.challengePack}` : ""}
             {latest.featuredModel ? ` · ${latest.featuredModel}` : ""}
@@ -158,7 +158,7 @@ export function BenchmarksHubContent({ published }: Props) {
                 key={step}
                 className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
               >
-                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                <span className="font-[family-name:var(--font-mono)] text-2xs text-white/30">
                   {String(index + 1).padStart(2, "0")}
                 </span>
                 <span className="text-sm leading-relaxed text-white/55">
@@ -217,7 +217,7 @@ export function BenchmarksHubContent({ published }: Props) {
                 key={step}
                 className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
               >
-                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                <span className="font-[family-name:var(--font-mono)] text-2xs text-white/30">
                   {String(index + 1).padStart(2, "0")}
                 </span>
                 <span className="text-sm leading-relaxed text-white/55">
@@ -298,7 +298,7 @@ export function BenchmarksHubContent({ published }: Props) {
                 href={`/benchmarks/${report.slug}`}
                 className="group flex flex-col gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
               >
-                <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+                <span className="font-[family-name:var(--font-mono)] text-2xs text-white/40">
                   {report.date} · {report.featuredModel}
                 </span>
                 <span className="text-base font-medium text-white group-hover:text-white/90">

--- a/web/src/components/marketing/blog-related-resources.tsx
+++ b/web/src/components/marketing/blog-related-resources.tsx
@@ -11,7 +11,7 @@ export function BlogRelatedResources({ links, className = "mt-12" }: Props) {
 
   return (
     <section className={className} aria-labelledby="blog-related-resources">
-      <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
+      <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/40">
         Explore
       </p>
       <h2

--- a/web/src/components/marketing/changelog/changelog-index-list.tsx
+++ b/web/src/components/marketing/changelog/changelog-index-list.tsx
@@ -24,23 +24,23 @@ export function ChangelogIndexList({
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <time
                       dateTime={period.endDate}
-                      className="font-[family-name:var(--font-mono)] text-[11px] text-white/45"
+                      className="font-[family-name:var(--font-mono)] text-2xs text-white/45"
                     >
                       {period.label}
                     </time>
                     {index === 0 ? (
-                      <span className="rounded border border-white/10 bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white/60">
+                      <span className="rounded border border-white/10 bg-white/[0.06] px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-white/60">
                         Latest
                       </span>
                     ) : null}
                   </div>
-                  <h2 className="mt-2 text-[15px] font-semibold leading-snug text-white group-hover:text-white/90">
+                  <h2 className="mt-2 text-base font-semibold leading-snug text-white group-hover:text-white/90">
                     {period.headline}
                   </h2>
                   <p className="mt-2 text-sm leading-relaxed text-white/45">
                     {period.summary}
                   </p>
-                  <p className="mt-3 text-[11px] text-white/30">
+                  <p className="mt-3 text-2xs text-white/30">
                     {period.entries.length} updates
                     {pullRequestCount > 0
                       ? ` · ${pullRequestCount} merged PRs`

--- a/web/src/components/marketing/changelog/changelog-period-detail.tsx
+++ b/web/src/components/marketing/changelog/changelog-period-detail.tsx
@@ -53,7 +53,7 @@ export function ChangelogPeriodDetail({
       <header className="border-b border-white/[0.08] pb-8">
         <time
           dateTime={period.endDate}
-          className="font-[family-name:var(--font-mono)] text-[11px] text-white/45"
+          className="font-[family-name:var(--font-mono)] text-2xs text-white/45"
         >
           {period.label}
         </time>
@@ -68,7 +68,7 @@ export function ChangelogPeriodDetail({
             {period.themes.map((theme) => (
               <li
                 key={theme}
-                className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-[11px] text-white/50"
+                className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-2xs text-white/50"
               >
                 {theme}
               </li>
@@ -78,7 +78,7 @@ export function ChangelogPeriodDetail({
       </header>
 
       <section className="mt-10">
-        <h2 className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+        <h2 className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/35">
           What shipped
         </h2>
         <div className="mt-5 space-y-8">
@@ -106,7 +106,7 @@ export function ChangelogPeriodDetail({
                       entry.text
                     )}
                     {entry.detail ? (
-                      <p className="mt-1 text-[13px] leading-relaxed text-white/40">
+                      <p className="mt-1 text-sm leading-relaxed text-white/40">
                         {entry.detail}
                       </p>
                     ) : null}
@@ -121,10 +121,10 @@ export function ChangelogPeriodDetail({
       {pullRequests.length > 0 ? (
         <section className="mt-12 border-t border-white/[0.08] pt-10">
           <div className="flex flex-wrap items-baseline justify-between gap-2">
-            <h2 className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/35">
+            <h2 className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.16em] text-white/35">
               Merged pull requests
             </h2>
-            <span className="text-[11px] text-white/30">{pullRequests.length} PRs</span>
+            <span className="text-2xs text-white/30">{pullRequests.length} PRs</span>
           </div>
           <ol className="mt-5 divide-y divide-white/[0.06] rounded-lg border border-white/[0.08]">
             {pullRequests.map((pullRequest) => (
@@ -135,7 +135,7 @@ export function ChangelogPeriodDetail({
                   rel="noopener noreferrer"
                   className="flex items-start gap-3 px-4 py-3 text-sm transition-colors hover:bg-white/[0.03]"
                 >
-                  <span className="shrink-0 font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+                  <span className="shrink-0 font-[family-name:var(--font-mono)] text-2xs text-white/35">
                     #{pullRequest.number}
                   </span>
                   <span className="min-w-0 flex-1 leading-relaxed text-white/70 hover:text-white/90">

--- a/web/src/components/marketing/closing-cta.tsx
+++ b/web/src/components/marketing/closing-cta.tsx
@@ -15,7 +15,7 @@ export function ClosingCTA({ title, body, children }: Props) {
             {title}
           </h2>
           {body ? (
-            <div className="mt-8 max-w-[52ch] text-[15px] sm:text-lg leading-[1.6] text-white/55">
+            <div className="mt-8 max-w-[52ch] text-base sm:text-lg leading-[1.6] text-white/55">
               {body}
             </div>
           ) : null}

--- a/web/src/components/marketing/code-card.tsx
+++ b/web/src/components/marketing/code-card.tsx
@@ -8,7 +8,7 @@ export function CodeCard({ title, language = "shell", code }: Props) {
   return (
     <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] overflow-hidden">
       <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
-        <span className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+        <span className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
           {title ?? language}
         </span>
         <div className="flex items-center gap-1.5">
@@ -17,7 +17,7 @@ export function CodeCard({ title, language = "shell", code }: Props) {
           <span className="size-2 rounded-full bg-white/15" />
         </div>
       </div>
-      <pre className="overflow-x-auto px-5 py-4 font-[family-name:var(--font-mono)] text-[13px] leading-[1.7] text-white/75">
+      <pre className="overflow-x-auto px-5 py-4 font-[family-name:var(--font-mono)] text-sm leading-[1.7] text-white/75">
         <code>{code}</code>
       </pre>
     </div>

--- a/web/src/components/marketing/comparison-table.tsx
+++ b/web/src/components/marketing/comparison-table.tsx
@@ -22,8 +22,8 @@ export function ComparisonTable({ columns, rows }: Props) {
 
   return (
     <div>
-      {/* Mobile: stacked per-capability cards */}
-      <div className="md:hidden space-y-10">
+      {/* Mobile + tablet: stacked per-capability cards */}
+      <div className="lg:hidden space-y-10">
         {rows.map((row) => (
           <div
             key={`m-${row.label}`}
@@ -75,8 +75,8 @@ export function ComparisonTable({ columns, rows }: Props) {
       </div>
 
       {/* Desktop: full matrix */}
-      <div className="hidden md:block -mx-8 sm:mx-0 overflow-x-auto">
-        <div className="min-w-[1040px] px-8 sm:px-0">
+      <div className="hidden lg:block overflow-x-auto">
+        <div className="min-w-[1040px]">
           <div className={`grid ${gridTemplate} border-b border-white/[0.12]`}>
             <div className="pb-5 pr-4">
               <p className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">

--- a/web/src/components/marketing/comparison-table.tsx
+++ b/web/src/components/marketing/comparison-table.tsx
@@ -29,10 +29,10 @@ export function ComparisonTable({ columns, rows }: Props) {
             key={`m-${row.label}`}
             className="border-b border-white/[0.08] pb-8 last:border-b-0"
           >
-            <p className="text-[16px] font-medium text-white/90 leading-[1.35]">
+            <p className="text-base font-medium text-white/90 leading-[1.35]">
               {row.label}
             </p>
-            <p className="mt-2 text-[13px] leading-[1.55] text-white/40">
+            <p className="mt-2 text-sm leading-[1.55] text-white/40">
               {row.sub}
             </p>
             <dl className="mt-5 grid grid-cols-1 gap-0">
@@ -45,7 +45,7 @@ export function ComparisonTable({ columns, rows }: Props) {
                 >
                   <div className="flex flex-col">
                     <dt
-                      className={`text-[13px] ${
+                      className={`text-sm ${
                         col.highlight
                           ? "text-white/95 font-medium"
                           : "text-white/60"
@@ -54,7 +54,7 @@ export function ComparisonTable({ columns, rows }: Props) {
                       {col.name}
                     </dt>
                     <span
-                      className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                      className={`text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
                         col.highlight ? "text-white/45" : "text-white/25"
                       }`}
                     >
@@ -79,7 +79,7 @@ export function ComparisonTable({ columns, rows }: Props) {
         <div className="min-w-[1040px] px-8 sm:px-0">
           <div className={`grid ${gridTemplate} border-b border-white/[0.12]`}>
             <div className="pb-5 pr-4">
-              <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
+              <p className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
                 Capability
               </p>
             </div>
@@ -91,14 +91,14 @@ export function ComparisonTable({ columns, rows }: Props) {
                 <span
                   className={`text-center leading-tight ${
                     col.highlight
-                      ? "text-[13px] font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
-                      : "text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
+                      ? "text-sm font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
+                      : "text-xs font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
                   }`}
                 >
                   {col.name}
                 </span>
                 <span
-                  className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                  className={`text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
                     col.highlight ? "text-white/30" : "text-white/25"
                   }`}
                 >
@@ -114,8 +114,8 @@ export function ComparisonTable({ columns, rows }: Props) {
               className={`grid ${gridTemplate} border-b border-white/[0.05] last:border-b-0`}
             >
               <div className="py-7 pr-6">
-                <p className="text-[15px] text-white/85">{row.label}</p>
-                <p className="mt-1.5 text-[12px] leading-[1.5] text-white/40">
+                <p className="text-base text-white/85">{row.label}</p>
+                <p className="mt-1.5 text-xs leading-[1.5] text-white/40">
                   {row.sub}
                 </p>
               </div>
@@ -137,7 +137,7 @@ export function ComparisonTable({ columns, rows }: Props) {
         </div>
       </div>
 
-      <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+      <p className="mt-10 text-xs font-[family-name:var(--font-mono)] text-white/35">
         <span className="text-white/60">●</span>&nbsp;&nbsp;supported
         &nbsp;·&nbsp; <span className="text-white/45">◐</span>
         &nbsp;&nbsp;partial &nbsp;·&nbsp;

--- a/web/src/components/marketing/cta-strip.tsx
+++ b/web/src/components/marketing/cta-strip.tsx
@@ -93,7 +93,7 @@ export function CLIInstallStrip({
   learnMoreLabel?: string;
 }) {
   return (
-    <div className="inline-flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-4 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-white/55">
+    <div className="inline-flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-4 py-2.5 font-[family-name:var(--font-mono)] text-xs text-white/55">
       <span className="text-white/30 select-none">$</span>
       <code className="text-white/85">{command}</code>
       <span className="text-white/20">·</span>

--- a/web/src/components/marketing/expanded-cards-block.tsx
+++ b/web/src/components/marketing/expanded-cards-block.tsx
@@ -43,7 +43,7 @@ export function ExpandedCardsBlock({ cards }: { cards: ExpandedCard[] }) {
           <p className="font-[family-name:var(--font-display)] text-[clamp(1.5rem,2.4vw,2rem)] leading-[1.1] tracking-[-0.02em] text-white">
             …and many more.
           </p>
-          <p className="text-[14px] leading-[1.55] text-white/55">
+          <p className="text-sm leading-[1.55] text-white/55">
             Whatever agent you can dream up — race it on AgentClash.
           </p>
         </div>

--- a/web/src/components/marketing/faq-block.tsx
+++ b/web/src/components/marketing/faq-block.tsx
@@ -23,12 +23,12 @@ export function FAQBlock({
     : "font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4rem)] max-w-[22ch]";
   const questionClass = sansHeadlines
     ? "text-lg font-sans font-semibold tracking-[-0.01em] text-white/90 sm:text-xl"
-    : "font-[family-name:var(--font-display)] text-[18px] sm:text-[22px] leading-[1.3] tracking-[-0.01em] text-white/90";
+    : "font-[family-name:var(--font-display)] text-lg sm:text-[22px] leading-[1.3] tracking-[-0.01em] text-white/90";
   return (
     <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
       <JsonLd id={schemaId} data={faqSchema(items)} />
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+        <p className="mb-6 inline-flex items-center gap-2 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
           <span className="inline-block size-1 rounded-full bg-white/60" />
           {eyebrow}
         </p>
@@ -38,7 +38,7 @@ export function FAQBlock({
           {items.map((qa) => (
             <div key={qa.question} className="py-8">
               <dt className={questionClass}>{qa.question}</dt>
-              <dd className="mt-3 max-w-[68ch] text-[14px] sm:text-[15px] leading-[1.7] text-white/55">
+              <dd className="mt-3 max-w-[68ch] text-sm sm:text-base leading-[1.7] text-white/55">
                 {qa.answer}
               </dd>
             </div>

--- a/web/src/components/marketing/feature-grid.tsx
+++ b/web/src/components/marketing/feature-grid.tsx
@@ -38,7 +38,7 @@ export function FeatureGrid({ features, columns = 3 }: Props) {
             </div>
           )}
 
-          <p className="mt-8 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+          <p className="mt-8 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
             {feature.label}
           </p>
 
@@ -46,7 +46,7 @@ export function FeatureGrid({ features, columns = 3 }: Props) {
             {feature.title}
           </h3>
 
-          <p className="mt-4 text-[14px] leading-[1.65] text-white/55">
+          <p className="mt-4 text-sm leading-[1.65] text-white/55">
             {feature.body}
           </p>
         </li>

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -48,10 +48,10 @@ export function MarketingFooter() {
         <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
           {COLUMNS.map((col) => (
             <div key={col.heading}>
-              <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
+              <p className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
                 {col.heading}
               </p>
-              <ul className="mt-5 space-y-3 text-[13px] text-white/55">
+              <ul className="mt-5 space-y-3 text-sm text-white/55">
                 {col.links.map((link) =>
                   link.external ? (
                     <li key={link.href}>
@@ -80,7 +80,7 @@ export function MarketingFooter() {
           ))}
         </div>
 
-        <div className="mt-16 flex flex-wrap items-center justify-between gap-4 border-t border-white/[0.06] pt-8 text-[11px] font-[family-name:var(--font-mono)] text-white/35">
+        <div className="mt-16 flex flex-wrap items-center justify-between gap-4 border-t border-white/[0.06] pt-8 text-2xs font-[family-name:var(--font-mono)] text-white/35">
           <div className="flex items-center gap-6">
             <span className="font-medium text-white/55">AgentClash</span>
             <span className="text-white/40">Beta · MIT</span>

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -19,18 +19,18 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
   const returning = await isReturningVisitor();
 
   return (
-    <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
+    <header className="px-5 sm:px-12 py-5 sm:py-6 lg:py-7 border-b border-white/[0.06]">
       <div className="mx-auto flex max-w-[1440px] items-center justify-between">
         <Link
           href="/"
-          className="inline-flex items-center gap-2.5 text-white/90"
+          className="inline-flex items-center gap-2.5 lg:gap-3 text-white/90"
         >
-          <ClashMark className="size-6" />
-          <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+          <ClashMark className="size-6 lg:size-7 2xl:size-8" />
+          <span className="font-[family-name:var(--font-display)] text-xl lg:text-2xl 2xl:text-[1.75rem] tracking-[-0.01em]">
             AgentClash
           </span>
         </Link>
-        <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
+        <nav className="flex items-center gap-0.5 sm:gap-2 text-xs lg:text-sm">
           {nav.map((item) =>
             item.external ? (
               <a
@@ -38,7 +38,7 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
                 href={item.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+                className="hidden sm:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
               >
                 {item.label}
               </a>
@@ -46,7 +46,7 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
               <Link
                 key={item.href}
                 href={item.href}
-                className="hidden md:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+                className="hidden md:inline-flex px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 hover:text-white/85 transition-colors"
               >
                 {item.label}
               </Link>
@@ -57,19 +57,19 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="GitHub"
-            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
           >
-            <Star className="size-3.5" />
+            <Star className="size-3.5 lg:size-4" />
             <span className="hidden sm:inline">GitHub</span>
           </a>
           {user ? (
             <Link
               href="/dashboard"
               aria-label="Dashboard"
-              className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 font-medium text-[#060606] hover:bg-white/90 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 lg:px-3.5 lg:py-2 font-medium text-[#060606] hover:bg-white/90 transition-colors"
             >
               <span className="hidden sm:inline">Dashboard</span>
-              <ArrowRight className="size-3" />
+              <ArrowRight className="size-3 lg:size-3.5" />
             </Link>
           ) : (
             <AuthCtaLink returning={returning} />

--- a/web/src/components/marketing/page-header.tsx
+++ b/web/src/components/marketing/page-header.tsx
@@ -27,7 +27,7 @@ export function PageHeader({
         {breadcrumbs && breadcrumbs.length > 0 ? (
           <nav
             aria-label="Breadcrumb"
-            className="mb-10 flex flex-wrap items-center gap-1.5 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35"
+            className="mb-10 flex flex-wrap items-center gap-1.5 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35"
           >
             {breadcrumbs.map((crumb, i) => (
               <span key={`${crumb.label}-${i}`} className="flex items-center gap-1.5">
@@ -51,7 +51,7 @@ export function PageHeader({
 
         <div className="grid gap-16 md:grid-cols-[1.5fr_1fr] md:gap-20 items-start">
           <div>
-            <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+            <p className="mb-6 inline-flex items-center gap-2 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
               <span className="inline-block size-1 rounded-full bg-white/60" />
               {eyebrow}
             </p>

--- a/web/src/components/marketing/pricing-block.tsx
+++ b/web/src/components/marketing/pricing-block.tsx
@@ -72,7 +72,7 @@ function PeriodToggle({
       >
         <span>Yearly</span>
         <span
-          className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold tracking-tight ${
+          className={`rounded-full px-1.5 py-0.5 text-2xs font-semibold tracking-tight ${
             period === "yearly"
               ? "bg-[#060606]/15 text-[#060606]"
               : "bg-emerald-400/15 text-emerald-300"
@@ -161,7 +161,7 @@ function TierCard({ tier, period }: { tier: Tier; period: Period }) {
 
           <div className="my-6 h-px bg-white/10" />
 
-          <ul className="flex flex-col gap-2.5 text-[14px] leading-6 text-white/85">
+          <ul className="flex flex-col gap-2.5 text-sm leading-6 text-white/85">
             {tier.features.map((feature) => (
               <li key={feature} className="flex items-start gap-2.5">
                 <span
@@ -212,7 +212,7 @@ function CtaButton({ cta }: { cta: Cta }) {
         </Link>
       )}
       {cta.sublabel && (
-        <p className="mt-2 text-center text-[11px] text-white/40">
+        <p className="mt-2 text-center text-2xs text-white/40">
           {cta.sublabel}
         </p>
       )}

--- a/web/src/components/marketing/provider-strip.tsx
+++ b/web/src/components/marketing/provider-strip.tsx
@@ -30,7 +30,7 @@ export function ProviderStrip() {
           <div className="flex h-10 items-center justify-center">
             {render(32)}
           </div>
-          <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/40">
+          <p className="text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/40">
             {name}
           </p>
         </li>

--- a/web/src/components/marketing/resource-pack-cta.tsx
+++ b/web/src/components/marketing/resource-pack-cta.tsx
@@ -11,7 +11,7 @@ export function ResourcePackCTA({ className = "", compact = false }: Props) {
     <aside
       className={`rounded-lg border border-white/[0.1] bg-white/[0.035] p-5 sm:p-6 ${className}`}
     >
-      <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
+      <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/40">
         Free resource pack
       </p>
       <h2 className="mt-3 text-lg font-sans font-semibold tracking-tight text-white">

--- a/web/src/components/marketing/section-heading.tsx
+++ b/web/src/components/marketing/section-heading.tsx
@@ -26,7 +26,7 @@ export function SectionHeading({
   return (
     <div className={`${alignClass} ${className}`}>
       {eyebrow ? (
-        <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+        <p className="mb-6 inline-flex items-center gap-2 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
           <span className="inline-block size-1 rounded-full bg-white/60" />
           {eyebrow}
         </p>

--- a/web/src/components/marketing/seo-collection-page.tsx
+++ b/web/src/components/marketing/seo-collection-page.tsx
@@ -115,7 +115,7 @@ export function SeoCollectionPage({
             <span>/</span>
             <span>{eyebrow}</span>
           </nav>
-          <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+          <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
             {eyebrow}
           </p>
           <h1 className="mt-5 font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-6xl">

--- a/web/src/components/marketing/seo-landing-page.tsx
+++ b/web/src/components/marketing/seo-landing-page.tsx
@@ -22,21 +22,21 @@ const workflowIcons = [Code2, Play, Sparkles, GitBranch] as const;
 
 function StaticHeader() {
   return (
-    <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+    <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6 lg:py-7">
       <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
         <Link
           href="/"
-          className="inline-flex items-center gap-2.5 text-white/90"
+          className="inline-flex items-center gap-2.5 lg:gap-3 text-white/90"
         >
-          <ClashMark className="size-6" />
-          <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+          <ClashMark className="size-6 lg:size-7 2xl:size-8" />
+          <span className="font-[family-name:var(--font-display)] text-xl lg:text-2xl 2xl:text-[1.75rem] tracking-normal">
             AgentClash
           </span>
         </Link>
-        <nav className="flex items-center gap-2 text-xs">
+        <nav className="flex items-center gap-2 text-xs lg:text-sm">
           <Link
             href="/docs"
-            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+            className="hidden px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
           >
             Docs
           </Link>
@@ -44,16 +44,16 @@ function StaticHeader() {
             href="https://github.com/agentclash/agentclash"
             target="_blank"
             rel="noopener noreferrer"
-            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+            className="hidden px-3 py-1.5 lg:px-3.5 lg:py-2 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
           >
             GitHub
           </a>
           <Link
             href="/auth/login"
-            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 lg:px-3.5 lg:py-2 font-medium text-[#060606] transition-colors hover:bg-white/90"
           >
             Start
-            <ArrowRight className="size-3.5" />
+            <ArrowRight className="size-3.5 lg:size-4" />
           </Link>
         </nav>
       </div>

--- a/web/src/components/marketing/seo-landing-page.tsx
+++ b/web/src/components/marketing/seo-landing-page.tsx
@@ -99,11 +99,11 @@ function ProductVisual() {
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-emerald-300" />
-            <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/45">
+            <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/45">
               live race
             </span>
           </div>
-          <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] text-white/45">
+          <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-2xs text-white/45">
             gate: pass
           </span>
         </div>
@@ -129,7 +129,7 @@ function ProductVisual() {
       </div>
       <div className="grid gap-px bg-white/[0.06] md:grid-cols-[1.1fr_0.9fr]">
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             replay timeline
           </p>
           <div className="mt-4 space-y-3">
@@ -140,7 +140,7 @@ function ProductVisual() {
               "attached scorecard and release verdict",
             ].map((item, index) => (
               <div key={item} className="flex items-start gap-3">
-                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 font-[family-name:var(--font-mono)] text-[10px] text-cyan-100">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 font-[family-name:var(--font-mono)] text-2xs text-cyan-100">
                   {index + 1}
                 </span>
                 <span className="text-sm leading-6 text-white/68">{item}</span>
@@ -149,7 +149,7 @@ function ProductVisual() {
           </div>
         </div>
         <div className="bg-[#090909] p-5">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
             ci verdict
           </p>
           <div className="mt-4 rounded-md border border-emerald-300/15 bg-emerald-300/[0.06] p-4">
@@ -162,7 +162,7 @@ function ProductVisual() {
               artifacts were preserved for review.
             </p>
           </div>
-          <pre className="mt-4 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] leading-5 text-white/55">
+          <pre className="mt-4 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-2xs leading-5 text-white/55">
             agentclash run create --follow
           </pre>
         </div>
@@ -213,7 +213,7 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
                   </span>
                 ))}
               </nav>
-              <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-cyan-200/70">
                 {config.eyebrow}
               </p>
               <h1 className="mt-5 max-w-[14ch] font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-7xl">
@@ -246,7 +246,7 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto max-w-[1440px]">
             <div className="max-w-3xl">
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 {config.proofSectionTitle}
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -276,7 +276,7 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
           <div className="mx-auto max-w-[1440px]">
             <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
               <div>
-                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                   Workflow
                 </p>
                 <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -309,7 +309,7 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
         <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
           <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
             <div>
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
                 {config.docsSectionTitle}
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
@@ -345,7 +345,7 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
 
         <section className="px-6 py-20 sm:px-12 sm:py-28">
           <div className="mx-auto max-w-[960px]">
-            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
               FAQ
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">

--- a/web/src/components/marketing/split-section.tsx
+++ b/web/src/components/marketing/split-section.tsx
@@ -25,7 +25,7 @@ export function SplitSection({
       <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
         <div className={reverse ? "md:order-2" : ""}>
           {eyebrow ? (
-            <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+            <p className="mb-6 inline-flex items-center gap-2 text-2xs font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
               <span className="inline-block size-1 rounded-full bg-white/60" />
               {eyebrow}
             </p>
@@ -33,7 +33,7 @@ export function SplitSection({
           <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
             {title}
           </h2>
-          <div className="mt-8 max-w-[52ch] text-[15px] sm:text-lg leading-[1.65] text-white/55">
+          <div className="mt-8 max-w-[52ch] text-base sm:text-lg leading-[1.65] text-white/55">
             {body}
           </div>
         </div>

--- a/web/src/components/marketing/try-cli-banner.tsx
+++ b/web/src/components/marketing/try-cli-banner.tsx
@@ -59,9 +59,9 @@ export function TryCliBanner() {
     <div className="relative border-b border-white/[0.06] bg-white/[0.02]">
       <Link
         href="/try"
-        className="group mx-auto flex max-w-[1440px] flex-wrap items-center justify-center gap-x-3 gap-y-1.5 px-12 sm:px-14 py-2.5 text-xs sm:text-[13px]"
+        className="group mx-auto flex max-w-[1440px] flex-wrap items-center justify-center gap-x-3 gap-y-1.5 px-12 sm:px-14 py-2.5 text-xs sm:text-sm"
       >
-        <span className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.18em] text-white/35">
+        <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.18em] text-white/35">
           New
         </span>
         <span className="text-white/70">

--- a/web/src/components/replay/agent-output-renderer.tsx
+++ b/web/src/components/replay/agent-output-renderer.tsx
@@ -67,13 +67,13 @@ export function CodeBlock({ code, language = "text", showLineNumbers = true }: C
       <div className="flex items-center justify-between border-b border-white/[0.06] bg-black/30 px-3 py-2">
         <div className="flex items-center gap-2">
           <FileCode className="size-3.5 text-white/40" />
-          <span className="text-[11px] font-medium uppercase tracking-wider text-white/50">
+          <span className="text-2xs font-medium uppercase tracking-wider text-white/50">
             {normalizedLang}
           </span>
         </div>
         <button
           onClick={handleCopy}
-          className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-white/60 transition-colors hover:bg-white/10 hover:text-white/90"
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-2xs text-white/60 transition-colors hover:bg-white/10 hover:text-white/90"
         >
           {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
           {copied ? "Copied" : "Copy"}
@@ -275,7 +275,7 @@ export function AgentOutputRenderer({ text }: AgentOutputRendererProps) {
   }
 
   return (
-    <div className="text-[13px] leading-relaxed text-white/85">
+    <div className="text-sm leading-relaxed text-white/85">
       {tokens.map((token, i) => {
         switch (token.type) {
           case "code_block":

--- a/web/src/components/replay/conversation-transcript.tsx
+++ b/web/src/components/replay/conversation-transcript.tsx
@@ -96,26 +96,26 @@ function TurnBlock({ turn }: { turn: TranscriptTurn }) {
     <div className="px-4 py-4 sm:px-5">
       {/* Turn header */}
       <div className="mb-3 flex items-center gap-2">
-        <span className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.18em] text-white/35">
+        <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.18em] text-white/35">
           Turn {turn.turn_index}
         </span>
         {turn.phase_id && (
           <Badge
             variant="outline"
-            className="border-white/10 bg-white/[0.03] px-1.5 py-0 text-[10px] font-normal text-white/55"
+            className="border-white/10 bg-white/[0.03] px-1.5 py-0 text-2xs font-normal text-white/55"
           >
             {turn.phase_id}
           </Badge>
         )}
         {turn.mismatch && (
-          <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+          <Badge variant="destructive" className="px-1.5 py-0 text-2xs">
             mismatch
           </Badge>
         )}
         {turn.awaiting_human && (
           <Badge
             variant="outline"
-            className="flex items-center gap-1 border-amber-500/30 bg-amber-500/[0.06] px-1.5 py-0 text-[10px] font-normal text-amber-400/90"
+            className="flex items-center gap-1 border-amber-500/30 bg-amber-500/[0.06] px-1.5 py-0 text-2xs font-normal text-amber-400/90"
           >
             <Clock className="size-3" /> awaiting human
           </Badge>
@@ -164,7 +164,7 @@ function SpeakerRow({
     <div className="flex flex-col gap-1.5">
       <div
         className={cn(
-          "flex items-center gap-1.5 text-[10px] uppercase tracking-[0.16em]",
+          "flex items-center gap-1.5 text-2xs uppercase tracking-[0.16em]",
           accent === "student" ? "text-cyan-300/70" : "text-violet-300/70",
         )}
       >
@@ -175,7 +175,7 @@ function SpeakerRow({
       </div>
       <div
         className={cn(
-          "rounded-md border px-3.5 py-2.5 text-[13px] leading-relaxed whitespace-pre-wrap break-words",
+          "rounded-md border px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap break-words",
           accent === "student"
             ? "border-cyan-400/15 bg-cyan-400/[0.04] text-white/85"
             : "border-violet-400/15 bg-violet-400/[0.04] text-white/85",

--- a/web/src/components/replay/replay-step-card.tsx
+++ b/web/src/components/replay/replay-step-card.tsx
@@ -101,7 +101,7 @@ export function ReplayStepCard({
         )}
       >
         {/* Step number */}
-        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-white/5 text-[10px] font-medium text-white/50 font-[family-name:var(--font-mono)]">
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-white/5 text-2xs font-medium text-white/50 font-[family-name:var(--font-mono)]">
           {index + 1}
         </span>
 
@@ -115,7 +115,7 @@ export function ReplayStepCard({
 
         {/* Duration */}
         {duration && (
-          <span className="shrink-0 text-[11px] uppercase tracking-[0.14em] text-white/40">
+          <span className="shrink-0 text-2xs uppercase tracking-[0.14em] text-white/40">
             {duration}
           </span>
         )}
@@ -126,7 +126,7 @@ export function ReplayStepCard({
         </Badge>
 
         {/* Timestamp */}
-        <span className="shrink-0 text-[11px] font-[family-name:var(--font-mono)] text-white/30 tabular-nums">
+        <span className="shrink-0 text-2xs font-[family-name:var(--font-mono)] text-white/30 tabular-nums">
           {formatTime(step.occurred_at)}
         </span>
 
@@ -144,7 +144,7 @@ export function ReplayStepCard({
       {expanded && (
         <div className="ml-[4.5rem] mr-4 mb-4 space-y-4 rounded-lg border border-white/[0.08] bg-white/[0.02] p-4 text-sm">
           {/* Metadata row */}
-          <div className="flex flex-wrap gap-x-5 gap-y-2 text-[11px] uppercase tracking-[0.14em] text-white/40">
+          <div className="flex flex-wrap gap-x-5 gap-y-2 text-2xs uppercase tracking-[0.14em] text-white/40">
             {step.provider_key && (
               <span className="flex items-baseline gap-1.5">
                 Provider: <span className="text-white/80 font-[family-name:var(--font-mono)] normal-case tracking-normal">{step.provider_key}</span>
@@ -184,7 +184,7 @@ export function ReplayStepCard({
               {step.event_types.map((et, i) => (
                 <span
                   key={i}
-                  className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[10px] font-[family-name:var(--font-mono)] text-white/60"
+                  className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-2xs font-[family-name:var(--font-mono)] text-white/60"
                 >
                   {et}
                 </span>
@@ -204,7 +204,7 @@ export function ReplayStepCard({
             <div className="pt-2">
               <div className="mb-2 flex items-center gap-2">
                 <div className="h-px flex-1 bg-white/[0.06]" />
-                <span className="text-[10px] uppercase tracking-[0.16em] text-white/40">
+                <span className="text-2xs uppercase tracking-[0.16em] text-white/40">
                   Model output
                 </span>
                 <div className="h-px flex-1 bg-white/[0.06]" />
@@ -220,7 +220,7 @@ export function ReplayStepCard({
             <div className="pt-2">
               <div className="mb-2 flex items-center gap-2">
                 <div className="h-px flex-1 bg-white/[0.06]" />
-                <span className="text-[10px] uppercase tracking-[0.16em] text-white/40">
+                <span className="text-2xs uppercase tracking-[0.16em] text-white/40">
                   Tool result
                 </span>
                 <div className="h-px flex-1 bg-white/[0.06]" />
@@ -243,7 +243,7 @@ export function ReplayStepCard({
           {/* Artifacts */}
           {hasArtifacts && (
             <div className="flex flex-wrap items-center gap-2 pt-2">
-              <span className="text-[10px] uppercase tracking-[0.16em] text-white/40">Artifacts:</span>
+              <span className="text-2xs uppercase tracking-[0.16em] text-white/40">Artifacts:</span>
               {step.artifact_ids!.map((id) => (
                 <DownloadArtifactButton
                   key={id}

--- a/web/src/components/share/public-share-renderers.tsx
+++ b/web/src/components/share/public-share-renderers.tsx
@@ -350,7 +350,7 @@ function PublicComparisonStrip({
     <div className="rounded-md border border-white/[0.08] bg-white/[0.015]">
       <div className="flex items-center gap-2.5 px-4 h-11 border-b border-white/[0.06]">
         <Trophy className="size-3.5 text-white/40" />
-        <h2 className="text-[11px] leading-none text-white/75 uppercase tracking-[0.22em] font-medium">
+        <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium">
           Comparison
         </h2>
       </div>
@@ -364,7 +364,7 @@ function PublicComparisonStrip({
                 current ? "bg-white/[0.04]" : ""
               }`}
             >
-              <span className="w-8 text-[11px] font-[family-name:var(--font-mono)] text-white/45">
+              <span className="w-8 text-2xs font-[family-name:var(--font-mono)] text-white/45">
                 #{index + 1}
               </span>
               <span className="min-w-0 flex-1 truncate text-sm text-white/85">

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -326,7 +326,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
         <div className="flex items-center gap-3">
           {tier === "anonymous" ? (
             <span
-              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-[family-name:var(--font-mono)] text-[11px] transition-colors ${
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-[family-name:var(--font-mono)] text-2xs transition-colors ${
                 low
                   ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
                   : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
@@ -474,7 +474,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
                 <Copy className="size-3.5 text-white/25 transition-colors group-hover:text-white/60" />
               )}
             </button>
-            <code className="mt-2 block break-all rounded-md bg-white/[0.03] p-2.5 font-[family-name:var(--font-mono)] text-[10px] leading-relaxed text-white/45">
+            <code className="mt-2 block break-all rounded-md bg-white/[0.03] p-2.5 font-[family-name:var(--font-mono)] text-2xs leading-relaxed text-white/45">
               {badgeMd}
             </code>
           </div>

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -229,7 +229,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
   if (trialUsed) {
     return (
-      <div className="relative flex min-h-[calc(100vh-4rem)] items-center justify-center px-6 py-20">
+      <div className="relative flex min-h-[calc(100dvh-4rem)] items-center justify-center px-6 py-20">
         <div
           aria-hidden
           className="pointer-events-none absolute left-1/2 top-1/3 -z-10 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.10),transparent_70%)] blur-2xl"
@@ -283,7 +283,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   }
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col">
+    <div className="flex h-[calc(100dvh-4rem)] flex-col">
       {/* Demo toolbar */}
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-white/[0.06] px-5 py-3 sm:px-8">
         <div className="flex items-center gap-3">

--- a/web/src/components/try-cli/terminal.tsx
+++ b/web/src/components/try-cli/terminal.tsx
@@ -142,7 +142,7 @@ export function TryCliTerminal({ sessionId, status, onReady }: Props) {
         <span className="size-2.5 rounded-full bg-white/15" />
         <span className="size-2.5 rounded-full bg-white/15" />
         <span className="size-2.5 rounded-full bg-white/15" />
-        <span className="ml-2 font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+        <span className="ml-2 font-[family-name:var(--font-mono)] text-2xs text-white/30">
           e2b · disposable sandbox
         </span>
       </div>

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-8",
         "icon-xs":


### PR DESCRIPTION
## Summary

Fixes the navbar looking too small on large displays (the reported issue) and the systemic root cause behind it: headings used fluid `clamp()` but ~360 bits of UI text were hard-coded to fixed tiny sizes that never scaled. Introduces a Tailwind v4 fluid font-size token scale and sweeps the arbitrary sizes onto it, plus a few targeted layout fixes.

## Changes (5 commits)

1. **Navbar scaling** — logo mark (`size-6→7→8`), wordmark (`text-xl→2xl→28px`), nav links (`text-xs→sm`), padding/height steps across all five header surfaces (marketing, homepage, compare, SEO, shared auth CTA).
2. **Fluid token scale** — new non-inline `@theme` block with `clamp()` `--text-2xs/xs/sm/base/lg` (uniform `0.175vw` slope, ~+2px from 390→1536px). Floors equal the prior fixed sizes, so mobile renders identically while text grows on large displays. Prose roots made fluid (15→17px).
3. **Mechanical sweep** — ~360 arbitrary `text-[Npx]/[Nrem]` utilities across 91 `.tsx` files mapped onto the scale: 9–11px→`text-2xs`, 12px→`text-xs`, 13–14px→`text-sm`, 15–17px→`text-base`, 18px→`text-lg`. Headings ≥22px left untouched.
4. **Targeted fixes** — comparison table switches stacked/matrix at `lg` (no tablet horizontal scroll) and drops a negative-margin hack; docs mobile-nav gets a 36px touch target.
5. **Dynamic viewport height** — `h-screen`/`calc(100vh)`/`h-[100vh]`→`dvh` in the workspace shell, org settings shell, docs sidebar, CLI demo, and fullscreen publish dialog, so content stops hiding behind collapsing mobile browser chrome. Decorative marketing `min-h-screen` left as-is.

## Verification

- `npx tsc --noEmit`, `pnpm lint` (only 3 pre-existing unrelated warnings), and `pnpm build` all pass.
- Confirmed in built CSS that all five fluid tokens emit and `.text-2xs` generates.
- Live screenshots: home (390 / 1920 / 2560), docs (1280), pricing (768) — all readable, well-proportioned, no overflow. Mobile floor is pixel-identical to before.

## Caveats

- Authenticated pages (dashboard, run-detail, race-mode) weren't screenshotted live (no local backend/seed data) — covered by the build compiling those routes + the verified-clean sweep + targeted dvh edits.
- `ComparisonTable` is currently dead code (no import sites); improved per plan but renders nowhere today.
- iOS `<16px` input auto-zoom is pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)