### PR TITLE
Eval playground: selectable LLM judge, verdict funnel, rerun loop

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -130,7 +130,7 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL).WithArtifactSigner(artifactManager)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithQuota(api.AgentTryoutQuotaConfig{
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithPublicJudgeModels(cfg.AgentTryoutJudgeModels).WithQuota(api.AgentTryoutQuotaConfig{
 		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
 		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,
 		HostedDailySpendCapUSD:    cfg.AgentTryoutHostedDailySpendCapUSD,

--- a/backend/internal/api/agent_tryout_events.go
+++ b/backend/internal/api/agent_tryout_events.go
@@ -187,10 +187,16 @@ func tryoutEventSummary(t runevents.Type, facts map[string]any) string {
 		runevents.EventTypeGraderVerificationCodeExecuted:
 		return "Validation"
 	case runevents.EventTypeScoringStarted:
+		if model := factString(facts, "provider_model_id"); model != "" {
+			return fmt.Sprintf("Judge (%s) is grading against your bar", model)
+		}
 		return "Scoring started"
 	case runevents.EventTypeScoringMetricRecorded:
 		return joinSummary("Scored", factString(facts, "metric_key"))
 	case runevents.EventTypeScoringCompleted:
+		if verdict := factString(facts, "verdict"); verdict != "" {
+			return fmt.Sprintf("Judge verdict: %s", strings.ReplaceAll(verdict, "_", " "))
+		}
 		return "Scoring completed"
 	case runevents.EventTypeScoringFailed:
 		return "Scoring failed"

--- a/backend/internal/api/agent_tryout_judge.go
+++ b/backend/internal/api/agent_tryout_judge.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Public-tryout LLM-as-judge selection. Anonymous visitors pick a judge model
+// from a small hosted allowlist (platform keys only — never user keys) and a
+// strictness level. The selection is baked into the tryout's
+// evaluation_spec_snapshot at create time as standard llm_judges declarations,
+// so the worker can reuse the existing judge machinery unchanged.
+
+const (
+	defaultPublicJudgeModel      = "gpt-5-mini"
+	defaultPublicJudgeStrictness = "standard"
+	publicJudgeTimeoutMS         = 45_000
+
+	publicJudgeKeyOverall     = "overall_quality"
+	publicJudgeKeyInstantFail = "instant_fail"
+	publicJudgeKeyReviewer    = "reviewer_bar"
+)
+
+// defaultPublicJudgeModels is the hosted judge allowlist. Models must be cheap
+// (they run on platform keys for anonymous visitors) and their names must be
+// inferable to a provider by the worker's judge credential resolution
+// (claude-* -> anthropic, gpt-* -> openai, gemini-* -> gemini).
+func defaultPublicJudgeModels() []string {
+	return []string{"gpt-5-mini", "claude-haiku-4-5", "gemini-2.5-flash"}
+}
+
+type AgentTryoutJudgeSelection struct {
+	Model      string `json:"model"`
+	Strictness string `json:"strictness,omitempty"`
+}
+
+// normalizePublicTryoutJudge validates a judge selection against the hosted
+// allowlist. A nil selection enables the default judge, so every public tryout
+// ends with a verdict. Returns ErrInvalidAgentTryoutInput on unknown models or
+// strictness values.
+func normalizePublicTryoutJudge(selection *AgentTryoutJudgeSelection, allowedModels []string) (AgentTryoutJudgeSelection, error) {
+	normalized := AgentTryoutJudgeSelection{
+		Model:      defaultPublicJudgeModel,
+		Strictness: defaultPublicJudgeStrictness,
+	}
+	if len(allowedModels) > 0 {
+		normalized.Model = allowedModels[0]
+	}
+	if selection == nil {
+		return normalized, nil
+	}
+
+	if model := strings.TrimSpace(selection.Model); model != "" {
+		allowed := false
+		for _, candidate := range allowedModels {
+			if strings.EqualFold(candidate, model) {
+				normalized.Model = candidate
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return AgentTryoutJudgeSelection{}, fmt.Errorf(
+				"%w: judge model %q is not available; choose one of %s",
+				ErrInvalidAgentTryoutInput, model, strings.Join(allowedModels, ", "),
+			)
+		}
+	}
+
+	switch strictness := strings.ToLower(strings.TrimSpace(selection.Strictness)); strictness {
+	case "":
+		// keep default
+	case "lenient", "standard", "harsh":
+		normalized.Strictness = strictness
+	default:
+		return AgentTryoutJudgeSelection{}, fmt.Errorf(
+			"%w: judge strictness %q is not supported; use lenient, standard, or harsh",
+			ErrInvalidAgentTryoutInput, selection.Strictness,
+		)
+	}
+	return normalized, nil
+}
+
+// publicTryoutEvalSetup is the non-engineer questionnaire the playground embeds
+// in the tryout input. Every field is optional; the judge rubric degrades to a
+// sensible generic bar when answers are missing.
+type publicTryoutEvalSetup struct {
+	UnacceptableMistakes string `json:"unacceptable_mistakes"`
+	HumanReviewer        string `json:"human_reviewer"`
+	BusinessPriority     string `json:"business_priority"`
+	OutputStyle          string `json:"output_style"`
+	MonthlyVolume        string `json:"monthly_volume"`
+}
+
+func decodePublicTryoutEvalSetup(input json.RawMessage) publicTryoutEvalSetup {
+	var wrapper struct {
+		EvalSetup publicTryoutEvalSetup `json:"eval_setup"`
+	}
+	_ = json.Unmarshal(input, &wrapper)
+	return wrapper.EvalSetup
+}
+
+func publicJudgeStrictnessClause(strictness string) string {
+	switch strictness {
+	case "lenient":
+		return "Grade generously: only clear violations of the operator's bar should fail the work; do not penalize minor stylistic issues."
+	case "harsh":
+		return "Grade ruthlessly: any violation of the operator's bar, sloppiness, placeholder content, or unsupported claim fails the work."
+	default:
+		return "Grade like a careful professional reviewer: real violations of the operator's bar fail the work, nitpicks do not."
+	}
+}
+
+func publicJudgePriorityClause(priority string) string {
+	switch strings.ToLower(strings.TrimSpace(priority)) {
+	case "polish":
+		return "Top priority: the result must look client-ready with clear structure and an appropriate tone."
+	case "speed":
+		return "Top priority: the result must be complete and immediately usable without extra back-and-forth."
+	case "cost":
+		return "Top priority: the result must justify automation, with no wasteful filler or padding."
+	case "compliance":
+		return "Top priority: the result must stay inside stated policies and flag risky or missing information."
+	default:
+		return "Top priority: the facts must be correct, grounded in the provided input, with nothing fabricated."
+	}
+}
+
+func publicJudgeStyleClause(style string) string {
+	switch strings.ToLower(strings.TrimSpace(style)) {
+	case "creative":
+		return "Creative variation is welcome as long as the core requirements are met."
+	case "balanced":
+		return "A balance of consistency and judgment is expected."
+	default:
+		return "Output is expected to be consistent and repeatable, in a form that could be produced the same way every time."
+	}
+}
+
+// publicTryoutJudgeDeclarations derives the llm_judges declarations from the
+// operator's own answers: one overall rubric judge plus assertion judges for
+// the named instant-fail mistake and the sign-off reviewer when provided. The
+// declarations use the exact JSON shape scoring.LLMJudgeDeclaration decodes.
+func publicTryoutJudgeDeclarations(judge AgentTryoutJudgeSelection, setup publicTryoutEvalSetup, taskName string) ([]map[string]any, map[string]string) {
+	mistake := strings.TrimSpace(setup.UnacceptableMistakes)
+	reviewer := strings.TrimSpace(setup.HumanReviewer)
+	task := strings.TrimSpace(taskName)
+	if task == "" {
+		task = "an office-work task"
+	}
+
+	base := func(key string) map[string]any {
+		return map[string]any{
+			"key":          key,
+			"model":        judge.Model,
+			"context_from": []string{"final_output"},
+			"samples":      1,
+			"timeout_ms":   publicJudgeTimeoutMS,
+		}
+	}
+
+	rubricLines := []string{
+		"You are grading the output of an AI agent that completed office work for a non-technical operator.",
+		fmt.Sprintf("Task: %s.", task),
+		publicJudgeStrictnessClause(judge.Strictness),
+		"The operator's bar:",
+	}
+	if mistake != "" {
+		rubricLines = append(rubricLines, fmt.Sprintf("- Unforgivable mistake (instant fail): %s.", mistake))
+	} else {
+		rubricLines = append(rubricLines, "- Unforgivable mistake (instant fail): fabricated facts presented as real.")
+	}
+	if reviewer != "" {
+		rubricLines = append(rubricLines, fmt.Sprintf("- The person who must be able to sign off without embarrassment: %s.", reviewer))
+	}
+	rubricLines = append(rubricLines,
+		fmt.Sprintf("- %s", publicJudgePriorityClause(setup.BusinessPriority)),
+		fmt.Sprintf("- %s", publicJudgeStyleClause(setup.OutputStyle)),
+		"Score 1-5: 5 = approvable without edits; 3 = usable after minor edits; 1 = commits the unforgivable mistake or misses the task.",
+	)
+
+	overall := base(publicJudgeKeyOverall)
+	overall["mode"] = "rubric"
+	overall["rubric"] = strings.Join(rubricLines, "\n")
+	overall["score_scale"] = map[string]float64{"min": 1, "max": 5}
+
+	declarations := []map[string]any{overall}
+	labels := map[string]string{publicJudgeKeyOverall: "Overall, against your bar"}
+
+	if mistake != "" {
+		instantFail := base(publicJudgeKeyInstantFail)
+		instantFail["mode"] = "assertion"
+		instantFail["assertion"] = fmt.Sprintf(
+			"%s The output does not commit the operator's unforgivable mistake: %s.",
+			publicJudgeStrictnessClause(judge.Strictness), mistake,
+		)
+		declarations = append(declarations, instantFail)
+		labels[publicJudgeKeyInstantFail] = fmt.Sprintf("Avoids your instant fail: %s", truncatePublicJudgeLabel(mistake, 60))
+	}
+	if reviewer != "" {
+		reviewerBar := base(publicJudgeKeyReviewer)
+		reviewerBar["mode"] = "assertion"
+		reviewerBar["assertion"] = fmt.Sprintf(
+			"%s A reviewer in the role of %q would accept this output for the task %q with at most minor edits.",
+			publicJudgeStrictnessClause(judge.Strictness), reviewer, task,
+		)
+		declarations = append(declarations, reviewerBar)
+		labels[publicJudgeKeyReviewer] = fmt.Sprintf("%s would sign off", reviewer)
+	}
+	return declarations, labels
+}
+
+func truncatePublicJudgeLabel(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit]) + "…"
+}
+
+// evaluationSpecWithPublicJudge merges the judge declarations into the
+// template's evaluation spec snapshot. The result keeps the deterministic
+// validators untouched and adds llm_judges + judge_meta, which the public
+// tryout workflow decodes with the same helpers as harness runs.
+func evaluationSpecWithPublicJudge(spec json.RawMessage, judge AgentTryoutJudgeSelection, input json.RawMessage, taskName string) json.RawMessage {
+	merged := map[string]any{}
+	if len(spec) > 0 {
+		if err := json.Unmarshal(spec, &merged); err != nil {
+			merged = map[string]any{}
+		}
+	}
+
+	declarations, labels := publicTryoutJudgeDeclarations(judge, decodePublicTryoutEvalSetup(input), taskName)
+	merged["judge_mode"] = "hybrid"
+	merged["llm_judges"] = declarations
+	merged["judge_meta"] = map[string]any{
+		"model":      judge.Model,
+		"strictness": judge.Strictness,
+		"labels":     labels,
+	}
+
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return spec
+	}
+	return encoded
+}

--- a/backend/internal/api/agent_tryout_judge_test.go
+++ b/backend/internal/api/agent_tryout_judge_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalizePublicTryoutJudgeDefaults(t *testing.T) {
+	judge, err := normalizePublicTryoutJudge(nil, defaultPublicJudgeModels())
+	if err != nil {
+		t.Fatalf("normalizePublicTryoutJudge() error = %v", err)
+	}
+	if judge.Model != defaultPublicJudgeModels()[0] {
+		t.Fatalf("model = %q, want default %q", judge.Model, defaultPublicJudgeModels()[0])
+	}
+	if judge.Strictness != "standard" {
+		t.Fatalf("strictness = %q, want standard", judge.Strictness)
+	}
+}
+
+func TestNormalizePublicTryoutJudgeAcceptsAllowlistedModel(t *testing.T) {
+	judge, err := normalizePublicTryoutJudge(&AgentTryoutJudgeSelection{
+		Model:      "Claude-Haiku-4-5",
+		Strictness: "harsh",
+	}, defaultPublicJudgeModels())
+	if err != nil {
+		t.Fatalf("normalizePublicTryoutJudge() error = %v", err)
+	}
+	if judge.Model != "claude-haiku-4-5" {
+		t.Fatalf("model = %q, want canonical claude-haiku-4-5", judge.Model)
+	}
+	if judge.Strictness != "harsh" {
+		t.Fatalf("strictness = %q, want harsh", judge.Strictness)
+	}
+}
+
+func TestNormalizePublicTryoutJudgeRejectsUnknownModel(t *testing.T) {
+	_, err := normalizePublicTryoutJudge(&AgentTryoutJudgeSelection{Model: "gpt-5-pro-max"}, defaultPublicJudgeModels())
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+}
+
+func TestNormalizePublicTryoutJudgeRejectsUnknownStrictness(t *testing.T) {
+	_, err := normalizePublicTryoutJudge(&AgentTryoutJudgeSelection{Strictness: "brutal"}, defaultPublicJudgeModels())
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+}
+
+func TestEvaluationSpecWithPublicJudgeDerivesJudgesFromEvalSetup(t *testing.T) {
+	templateSpec := json.RawMessage(`{"validators":[{"key":"has_summary","type":"json_field","field":"summary"}],"scorecard":{"dimensions":["correctness"]}}`)
+	input := json.RawMessage(`{"notes":"hello","eval_setup":{"unacceptable_mistakes":"Invented numbers","human_reviewer":"CFO","business_priority":"accuracy","output_style":"consistent"}}`)
+
+	merged := evaluationSpecWithPublicJudge(templateSpec, AgentTryoutJudgeSelection{
+		Model:      "gpt-5-mini",
+		Strictness: "standard",
+	}, input, "Meeting Minutes to Action Plan")
+
+	var decoded struct {
+		Validators []map[string]any `json:"validators"`
+		JudgeMode  string           `json:"judge_mode"`
+		LLMJudges  []struct {
+			Key       string   `json:"key"`
+			Mode      string   `json:"mode"`
+			Model     string   `json:"model"`
+			Rubric    string   `json:"rubric"`
+			Assertion string   `json:"assertion"`
+			Samples   int      `json:"samples"`
+			Context   []string `json:"context_from"`
+		} `json:"llm_judges"`
+		JudgeMeta struct {
+			Model      string            `json:"model"`
+			Strictness string            `json:"strictness"`
+			Labels     map[string]string `json:"labels"`
+		} `json:"judge_meta"`
+	}
+	if err := json.Unmarshal(merged, &decoded); err != nil {
+		t.Fatalf("unmarshal merged spec: %v", err)
+	}
+
+	if len(decoded.Validators) != 1 {
+		t.Fatalf("validators = %d, want untouched template validators", len(decoded.Validators))
+	}
+	if decoded.JudgeMode != "hybrid" {
+		t.Fatalf("judge_mode = %q, want hybrid", decoded.JudgeMode)
+	}
+	if len(decoded.LLMJudges) != 3 {
+		t.Fatalf("llm_judges = %d, want overall + instant_fail + reviewer_bar", len(decoded.LLMJudges))
+	}
+	for _, judge := range decoded.LLMJudges {
+		if judge.Model != "gpt-5-mini" {
+			t.Fatalf("judge %q model = %q, want gpt-5-mini", judge.Key, judge.Model)
+		}
+		if judge.Samples != 1 {
+			t.Fatalf("judge %q samples = %d, want 1", judge.Key, judge.Samples)
+		}
+		if len(judge.Context) != 1 || judge.Context[0] != "final_output" {
+			t.Fatalf("judge %q context_from = %v, want [final_output]", judge.Key, judge.Context)
+		}
+	}
+	overall := decoded.LLMJudges[0]
+	if overall.Key != publicJudgeKeyOverall || overall.Mode != "rubric" {
+		t.Fatalf("first judge = %q/%q, want overall_quality rubric", overall.Key, overall.Mode)
+	}
+	if !strings.Contains(overall.Rubric, "Invented numbers") || !strings.Contains(overall.Rubric, "CFO") {
+		t.Fatalf("overall rubric does not quote the operator's answers: %q", overall.Rubric)
+	}
+	if decoded.JudgeMeta.Model != "gpt-5-mini" || decoded.JudgeMeta.Strictness != "standard" {
+		t.Fatalf("judge_meta = %+v, want model/strictness echoed", decoded.JudgeMeta)
+	}
+	if decoded.JudgeMeta.Labels[publicJudgeKeyReviewer] != "CFO would sign off" {
+		t.Fatalf("reviewer label = %q", decoded.JudgeMeta.Labels[publicJudgeKeyReviewer])
+	}
+}
+
+func TestEvaluationSpecWithPublicJudgeWithoutEvalSetupKeepsOverallJudgeOnly(t *testing.T) {
+	merged := evaluationSpecWithPublicJudge(json.RawMessage(`{}`), AgentTryoutJudgeSelection{
+		Model:      "gemini-2.5-flash",
+		Strictness: "lenient",
+	}, json.RawMessage(`{"notes":"hi"}`), "Status Report")
+
+	var decoded struct {
+		LLMJudges []struct {
+			Key string `json:"key"`
+		} `json:"llm_judges"`
+	}
+	if err := json.Unmarshal(merged, &decoded); err != nil {
+		t.Fatalf("unmarshal merged spec: %v", err)
+	}
+	if len(decoded.LLMJudges) != 1 || decoded.LLMJudges[0].Key != publicJudgeKeyOverall {
+		t.Fatalf("llm_judges = %+v, want only the overall rubric judge", decoded.LLMJudges)
+	}
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -117,6 +117,7 @@ type CreateAnonymousAgentTryoutInput struct {
 	Input                json.RawMessage
 	SelectedHarnessKind  string
 	SelectedModelPolicy  json.RawMessage
+	Judge                *AgentTryoutJudgeSelection
 	AnonymousFingerprint string
 	Now                  time.Time
 }
@@ -177,6 +178,7 @@ type AgentTryoutManager struct {
 	quota          *AgentTryoutQuotaConfig
 	rerunGate      AgentTryoutRerunGate
 	artifactSigner ArtifactContentSigner
+	judgeModels    []string
 }
 
 // WithArtifactSigner enables signed download URLs on a tryout's captured output
@@ -193,11 +195,27 @@ func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepos
 		bySlug[template.Slug] = template
 	}
 	return &AgentTryoutManager{
-		authorizer: authorizer,
-		repo:       repo,
-		now:        time.Now,
-		templates:  bySlug,
+		authorizer:  authorizer,
+		repo:        repo,
+		now:         time.Now,
+		templates:   bySlug,
+		judgeModels: defaultPublicJudgeModels(),
 	}
+}
+
+// WithPublicJudgeModels overrides the hosted LLM-judge allowlist for anonymous
+// tryouts. An empty list keeps the built-in default.
+func (m *AgentTryoutManager) WithPublicJudgeModels(models []string) *AgentTryoutManager {
+	cleaned := make([]string, 0, len(models))
+	for _, model := range models {
+		if trimmed := strings.TrimSpace(model); trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	if len(cleaned) > 0 {
+		m.judgeModels = cleaned
+	}
+	return m
 }
 
 func (m *AgentTryoutManager) WithExecution(starter AgentHarnessExecutionWorkflowStarter, config AgentTryoutExecutionConfig) *AgentTryoutManager {
@@ -285,6 +303,10 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	if err := validatePublicTryoutModelSelection(selectedHarness, selectedModelPolicy); err != nil {
 		return repository.AgentTryout{}, err
 	}
+	judge, err := normalizePublicTryoutJudge(input.Judge, m.judgeModels)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
 	now := input.Now
 	if now.IsZero() {
 		now = m.now()
@@ -297,7 +319,7 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		InputSnapshot:            input.Input,
 		TemplateSnapshot:         templateSnapshot(template),
 		ToolPolicySnapshot:       template.ToolPolicy,
-		EvaluationSpecSnapshot:   template.EvaluationSpec,
+		EvaluationSpecSnapshot:   evaluationSpecWithPublicJudge(template.EvaluationSpec, judge, input.Input, template.Name),
 		SelectedModelPolicy:      selectedModelPolicy,
 		SelectedHarnessKind:      selectedHarness,
 		Summary:                  json.RawMessage(`{}`),
@@ -984,10 +1006,11 @@ func (m *AgentTryoutManager) lookupTemplate(slug string) (AgentTryoutTemplate, e
 }
 
 type createAgentTryoutRequest struct {
-	TemplateSlug        string          `json:"template_slug"`
-	Input               json.RawMessage `json:"input"`
-	SelectedHarnessKind string          `json:"selected_harness_kind,omitempty"`
-	SelectedModelPolicy json.RawMessage `json:"selected_model_policy,omitempty"`
+	TemplateSlug        string                     `json:"template_slug"`
+	Input               json.RawMessage            `json:"input"`
+	SelectedHarnessKind string                     `json:"selected_harness_kind,omitempty"`
+	SelectedModelPolicy json.RawMessage            `json:"selected_model_policy,omitempty"`
+	Judge               *AgentTryoutJudgeSelection `json:"judge,omitempty"`
 }
 
 type claimAgentTryoutRequest struct {
@@ -1102,6 +1125,7 @@ func createAnonymousAgentTryoutHandler(logger *slog.Logger, service AgentTryoutS
 			Input:                req.Input,
 			SelectedHarnessKind:  req.SelectedHarnessKind,
 			SelectedModelPolicy:  req.SelectedModelPolicy,
+			Judge:                req.Judge,
 			AnonymousFingerprint: anonymousFingerprintFromRequest(r),
 		})
 		if err != nil {

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	AgentTryoutAnonymousWindow           time.Duration
 	AgentTryoutHostedDailySpendCapUSD    float64
 	AgentTryoutAnonymousPerRunCostCapUSD float64
+	AgentTryoutJudgeModels               []string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -300,6 +301,7 @@ func LoadConfigFromEnv() (Config, error) {
 		AgentTryoutAnonymousWindow:           agentTryoutAnonymousWindow,
 		AgentTryoutHostedDailySpendCapUSD:    agentTryoutHostedDailySpendCapUSD,
 		AgentTryoutAnonymousPerRunCostCapUSD: agentTryoutAnonymousPerRunCostCapUSD,
+		AgentTryoutJudgeModels:               commaSeparatedEnv("AGENT_TRYOUT_JUDGE_MODELS"),
 	}
 
 	if err := validateArtifactConfig(cfg); err != nil {
@@ -393,6 +395,27 @@ func int64EnvOrDefault(key string, fallback int64) (int64, error) {
 	}
 
 	return parsed, nil
+}
+
+// commaSeparatedEnv parses an optional comma-separated env var into a slice of
+// trimmed, non-empty values. Unset or empty returns nil so callers keep their
+// built-in defaults.
+func commaSeparatedEnv(key string) []string {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
 }
 
 func nonNegativeIntEnvOrDefault(key string, fallback int) (int, error) {

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -958,7 +958,10 @@ func publicTryoutJudgeDigest(outputs []map[string]any) string {
 			continue
 		}
 		if len(preview) > publicJudgeMaxBytesPerOutput {
-			preview = preview[:publicJudgeMaxBytesPerOutput] + "\n…(truncated)"
+			runes := []rune(preview)
+			if len(runes) > publicJudgeMaxBytesPerOutput {
+				preview = string(runes[:publicJudgeMaxBytesPerOutput]) + "\n…(truncated)"
+			}
 		}
 		section := fmt.Sprintf("=== %s ===\n%s", name, preview)
 		if total+len(section) > publicJudgeMaxDigestBytes {

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 	sdkworkflow "go.temporal.io/sdk/workflow"
 )
@@ -76,11 +77,23 @@ func (a *Activities) ExecutePublicAgentTryout(ctx context.Context, input Execute
 
 	latencyMS := time.Since(started).Milliseconds()
 	scorecard := publicTryoutScorecard(tryout.EvaluationSpecSnapshot, outputs, latencyMS)
-	if err := a.recordPublicTryoutEvent(ctx, tryout.ID, runevents.EventTypeScoringCompleted, map[string]any{
+	if judgeSection := a.runPublicTryoutJudges(ctx, tryout, outputs); judgeSection != nil {
+		scorecard["judge"] = judgeSection
+	}
+	scoringPayload := map[string]any{
 		"passed": scorecard["passed_validators"],
 		"total":  scorecard["total_validators"],
 		"score":  scorecard["score"],
-	}); err != nil {
+	}
+	if judgeSection, ok := scorecard["judge"].(map[string]any); ok {
+		if verdict, ok := judgeSection["verdict"].(string); ok {
+			scoringPayload["verdict"] = verdict
+		}
+		if model, ok := judgeSection["model"].(string); ok {
+			scoringPayload["provider_model_id"] = model
+		}
+	}
+	if err := a.recordPublicTryoutEvent(ctx, tryout.ID, runevents.EventTypeScoringCompleted, scoringPayload); err != nil {
 		return wrapActivityError(err)
 	}
 
@@ -789,6 +802,212 @@ func publicTryoutScorecard(evaluationSpec json.RawMessage, outputs []map[string]
 		"latency_ms":        latencyMS,
 		"outputs_count":     len(outputs),
 	}
+}
+
+// Judge-output digest bounds. Output previews are truncated before they are
+// handed to the LLM judge so anonymous tryouts cannot run up platform-key
+// spend with giant artifacts.
+const (
+	publicJudgeMaxBytesPerOutput = 6_000
+	publicJudgeMaxDigestBytes    = 18_000
+)
+
+// runPublicTryoutJudges executes the llm_judges baked into the tryout's
+// evaluation spec snapshot against the produced outputs, reusing the same
+// judge machinery as harness runs (evaluateLLMJudges). Anonymous tryouts carry
+// no deployment context, so credential resolution always lands on platform env
+// keys. Returns nil when no judges are configured; judge failures degrade to a
+// section with skipped criteria instead of failing the tryout.
+func (a *Activities) runPublicTryoutJudges(ctx context.Context, tryout repository.AgentTryout, outputs []map[string]any) map[string]any {
+	var spec struct {
+		LLMJudges []json.RawMessage `json:"llm_judges"`
+		JudgeMeta struct {
+			Model      string            `json:"model"`
+			Strictness string            `json:"strictness"`
+			Labels     map[string]string `json:"labels"`
+		} `json:"judge_meta"`
+	}
+	if err := json.Unmarshal(tryout.EvaluationSpecSnapshot, &spec); err != nil || len(spec.LLMJudges) == 0 {
+		return nil
+	}
+	judges, err := agentHarnessLLMJudges(spec.LLMJudges)
+	if err != nil || len(judges) == 0 {
+		return nil
+	}
+
+	judgeModel := strings.TrimSpace(spec.JudgeMeta.Model)
+	if judgeModel == "" {
+		judgeModel = judges[0].Model
+	}
+	_ = a.recordPublicTryoutEvent(ctx, tryout.ID, runevents.EventTypeScoringStarted, map[string]any{
+		"status":            "judging",
+		"provider_model_id": judgeModel,
+	})
+
+	digest := publicTryoutJudgeDigest(outputs)
+	if digest == "" {
+		_ = a.recordPublicTryoutEvent(ctx, tryout.ID, runevents.EventTypeScoringFailed, map[string]any{
+			"status": "no_output_to_judge",
+		})
+		return map[string]any{
+			"model":      judgeModel,
+			"strictness": spec.JudgeMeta.Strictness,
+			"verdict":    "not_judged",
+			"reason":     "the run produced no output the judge could grade",
+		}
+	}
+
+	input := scoring.EvaluationInput{
+		Events: []scoring.Event{{
+			Type:       string(runevents.EventTypeSystemOutputFinalized),
+			Source:     "worker",
+			OccurredAt: time.Now().UTC(),
+			Payload:    mustMarshalJSON(map[string]any{"final_output": digest}),
+		}},
+	}
+	results, warnings := evaluateLLMJudges(ctx, a.judgeClient, a.repo, repository.RunAgentExecutionContext{}, input, scoring.EvaluationSpec{LLMJudges: judges})
+
+	criteria := make([]map[string]any, 0, len(results))
+	var overallScore *float64
+	anyScored := false
+	instantFailHit := false
+	for _, result := range results {
+		entry := map[string]any{
+			"key":   result.JudgeKey,
+			"label": publicJudgeLabel(spec.JudgeMeta.Labels, result.JudgeKey),
+			"mode":  result.Mode,
+		}
+		if result.NormalizedScore == nil {
+			entry["status"] = "skipped"
+			if result.Reason != "" {
+				entry["reason"] = result.Reason
+			}
+		} else {
+			anyScored = true
+			score := *result.NormalizedScore
+			entry["score"] = score
+			if score >= 0.5 {
+				entry["status"] = "passed"
+			} else {
+				entry["status"] = "failed"
+			}
+			if result.JudgeKey == "overall_quality" {
+				overallScore = result.NormalizedScore
+			} else if score < 0.5 && result.JudgeKey == "instant_fail" {
+				instantFailHit = true
+			}
+		}
+		if result.Confidence != nil {
+			entry["confidence"] = *result.Confidence
+		}
+		if reasoning := publicJudgeReasoning(result.Payload); reasoning != "" {
+			entry["reasoning"] = reasoning
+		}
+		criteria = append(criteria, entry)
+	}
+
+	section := map[string]any{
+		"model":      judgeModel,
+		"strictness": spec.JudgeMeta.Strictness,
+		"criteria":   criteria,
+	}
+	if len(warnings) > 0 {
+		section["warnings"] = warnings
+	}
+	if !anyScored {
+		section["verdict"] = "not_judged"
+		section["reason"] = "the judge could not grade this run"
+		return section
+	}
+	if overallScore != nil {
+		section["score"] = *overallScore
+	}
+	switch {
+	case instantFailHit:
+		section["verdict"] = "rejected"
+	case overallScore != nil && *overallScore >= 0.75:
+		section["verdict"] = "approved"
+	case overallScore != nil && *overallScore >= 0.4:
+		section["verdict"] = "needs_edits"
+	case overallScore != nil:
+		section["verdict"] = "rejected"
+	default:
+		section["verdict"] = "needs_edits"
+	}
+	return section
+}
+
+// publicTryoutJudgeDigest flattens output previews into one bounded text block
+// the judge can grade. Binary previews (base64) are summarized, not inlined.
+func publicTryoutJudgeDigest(outputs []map[string]any) string {
+	sections := make([]string, 0, len(outputs))
+	total := 0
+	for _, output := range outputs {
+		preview, _ := output["preview"].(string)
+		name, _ := output["relative_path"].(string)
+		if name == "" {
+			name, _ = output["key"].(string)
+		}
+		encoding, _ := output["encoding"].(string)
+		if strings.TrimSpace(preview) == "" {
+			continue
+		}
+		if encoding == "base64" {
+			kind, _ := output["type"].(string)
+			sections = append(sections, fmt.Sprintf("=== %s ===\n(binary %s artifact was produced; grade based on the other outputs)", name, kind))
+			continue
+		}
+		if len(preview) > publicJudgeMaxBytesPerOutput {
+			preview = preview[:publicJudgeMaxBytesPerOutput] + "\n…(truncated)"
+		}
+		section := fmt.Sprintf("=== %s ===\n%s", name, preview)
+		if total+len(section) > publicJudgeMaxDigestBytes {
+			break
+		}
+		total += len(section)
+		sections = append(sections, section)
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func publicJudgeLabel(labels map[string]string, key string) string {
+	if label, ok := labels[key]; ok && strings.TrimSpace(label) != "" {
+		return label
+	}
+	spaced := strings.ReplaceAll(key, "_", " ")
+	if spaced == "" {
+		return "Check"
+	}
+	return strings.ToUpper(spaced[:1]) + spaced[1:]
+}
+
+// publicJudgeReasoning extracts the judge's own "reasoning" text from the
+// first successful call recorded in an LLMJudgeResult payload.
+func publicJudgeReasoning(payload json.RawMessage) string {
+	var decoded struct {
+		Calls []struct {
+			Error        string `json:"error"`
+			ResponseText string `json:"response_text"`
+		} `json:"calls"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return ""
+	}
+	for _, call := range decoded.Calls {
+		if call.Error != "" || strings.TrimSpace(call.ResponseText) == "" {
+			continue
+		}
+		var response struct {
+			Reasoning string `json:"reasoning"`
+		}
+		if err := json.Unmarshal([]byte(sanitizeJudgeJSON(call.ResponseText)), &response); err != nil {
+			continue
+		}
+		if reasoning := strings.TrimSpace(response.Reasoning); reasoning != "" {
+			return reasoning
+		}
+	}
+	return ""
 }
 
 func isEmptyScorecardValue(value any) bool {

--- a/backend/internal/workflow/public_agent_tryout_workflow_test.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow_test.go
@@ -1,7 +1,9 @@
 package workflow
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -9,7 +11,145 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/google/uuid"
 )
+
+// fakePublicTryoutRepo is a minimal PublicAgentTryoutRepository capturing
+// recorded timeline events for assertions.
+type fakePublicTryoutRepo struct {
+	events []repository.RecordAgentTryoutEventParams
+}
+
+func (f *fakePublicTryoutRepo) GetAgentTryoutByID(context.Context, uuid.UUID) (repository.AgentTryout, error) {
+	return repository.AgentTryout{}, nil
+}
+
+func (f *fakePublicTryoutRepo) UpdateAgentTryoutStatus(_ context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error) {
+	return repository.AgentTryout{ID: params.ID}, nil
+}
+
+func (f *fakePublicTryoutRepo) RecordAgentTryoutEvent(_ context.Context, params repository.RecordAgentTryoutEventParams) (repository.AgentTryoutEvent, error) {
+	f.events = append(f.events, params)
+	return repository.AgentTryoutEvent{}, nil
+}
+
+func (f *fakePublicTryoutRepo) ClaimNextPendingAgentTryoutTurn(context.Context, uuid.UUID) (repository.AgentTryoutTurn, bool, error) {
+	return repository.AgentTryoutTurn{}, false, nil
+}
+
+func (f *fakePublicTryoutRepo) MarkAgentTryoutTurnProcessed(context.Context, int64) error {
+	return nil
+}
+
+func publicJudgeSpecSnapshot() json.RawMessage {
+	return json.RawMessage(`{
+		"validators":[{"key":"has_summary","type":"json_field","field":"summary"}],
+		"judge_mode":"hybrid",
+		"llm_judges":[
+			{"mode":"rubric","key":"overall_quality","model":"gpt-5-mini","rubric":"Score the work 1-5 against the operator's bar.","context_from":["final_output"],"samples":1,"score_scale":{"min":1,"max":5}},
+			{"mode":"assertion","key":"instant_fail","model":"gpt-5-mini","assertion":"The output does not invent numbers.","context_from":["final_output"],"samples":1}
+		],
+		"judge_meta":{"model":"gpt-5-mini","strictness":"standard","labels":{"overall_quality":"Overall, against your bar","instant_fail":"Avoids your instant fail"}}
+	}`)
+}
+
+func TestRunPublicTryoutJudgesMergesVerdictAndReasoning(t *testing.T) {
+	repo := &fakePublicTryoutRepo{}
+	client := &provider.FakeClient{
+		Response: provider.Response{
+			ProviderKey:     "openai",
+			ProviderModelID: "gpt-5-mini",
+			OutputText:      `{"score":5,"pass":true,"confidence":"high","reasoning":"Grounded in the supplied notes; nothing fabricated."}`,
+		},
+	}
+	activities := &Activities{publicTryoutRepo: repo, judgeClient: client}
+
+	section := activities.runPublicTryoutJudges(context.Background(), repository.AgentTryout{
+		ID:                     uuid.New(),
+		EvaluationSpecSnapshot: publicJudgeSpecSnapshot(),
+	}, []map[string]any{
+		{"key": "structured_minutes", "type": "json", "relative_path": "minutes.json", "preview": `{"summary":"Weekly sync","action_items":[{"owner":"Dana"}]}`},
+	})
+
+	if section == nil {
+		t.Fatal("runPublicTryoutJudges() = nil, want judge section")
+	}
+	if section["verdict"] != "approved" {
+		t.Fatalf("verdict = %v, want approved", section["verdict"])
+	}
+	if section["model"] != "gpt-5-mini" {
+		t.Fatalf("model = %v, want gpt-5-mini", section["model"])
+	}
+	criteria, ok := section["criteria"].([]map[string]any)
+	if !ok || len(criteria) != 2 {
+		t.Fatalf("criteria = %#v, want 2 entries", section["criteria"])
+	}
+	for _, criterion := range criteria {
+		if criterion["status"] != "passed" {
+			t.Fatalf("criterion %v status = %v, want passed", criterion["key"], criterion["status"])
+		}
+		if reasoning, _ := criterion["reasoning"].(string); !strings.Contains(reasoning, "Grounded") {
+			t.Fatalf("criterion %v reasoning = %v, want judge reasoning", criterion["key"], criterion["reasoning"])
+		}
+	}
+	if len(client.Requests) != 2 {
+		t.Fatalf("judge calls = %d, want one per declaration", len(client.Requests))
+	}
+	for _, request := range client.Requests {
+		if request.CredentialReference != "env://OPENAI_API_KEY" {
+			t.Fatalf("credential = %q, want platform env key", request.CredentialReference)
+		}
+	}
+	if len(repo.events) == 0 || repo.events[0].EventType != string(runevents.EventTypeScoringStarted) {
+		t.Fatalf("events = %#v, want scoring.started first", repo.events)
+	}
+}
+
+func TestRunPublicTryoutJudgesWithoutJudgesReturnsNil(t *testing.T) {
+	activities := &Activities{publicTryoutRepo: &fakePublicTryoutRepo{}, judgeClient: &provider.FakeClient{}}
+	section := activities.runPublicTryoutJudges(context.Background(), repository.AgentTryout{
+		ID:                     uuid.New(),
+		EvaluationSpecSnapshot: json.RawMessage(`{"validators":[]}`),
+	}, nil)
+	if section != nil {
+		t.Fatalf("section = %#v, want nil when no judges configured", section)
+	}
+}
+
+func TestRunPublicTryoutJudgesDegradesWhenJudgeFails(t *testing.T) {
+	repo := &fakePublicTryoutRepo{}
+	client := &provider.FakeClient{Err: fmt.Errorf("provider unavailable")}
+	activities := &Activities{publicTryoutRepo: repo, judgeClient: client}
+
+	section := activities.runPublicTryoutJudges(context.Background(), repository.AgentTryout{
+		ID:                     uuid.New(),
+		EvaluationSpecSnapshot: publicJudgeSpecSnapshot(),
+	}, []map[string]any{
+		{"key": "structured_minutes", "type": "json", "relative_path": "minutes.json", "preview": `{"summary":"Weekly sync"}`},
+	})
+
+	if section == nil {
+		t.Fatal("runPublicTryoutJudges() = nil, want degraded section")
+	}
+	if section["verdict"] != "not_judged" {
+		t.Fatalf("verdict = %v, want not_judged when every call fails", section["verdict"])
+	}
+}
+
+func TestRunPublicTryoutJudgesNoOutputsIsNotJudged(t *testing.T) {
+	repo := &fakePublicTryoutRepo{}
+	activities := &Activities{publicTryoutRepo: repo, judgeClient: &provider.FakeClient{}}
+
+	section := activities.runPublicTryoutJudges(context.Background(), repository.AgentTryout{
+		ID:                     uuid.New(),
+		EvaluationSpecSnapshot: publicJudgeSpecSnapshot(),
+	}, nil)
+
+	if section == nil || section["verdict"] != "not_judged" {
+		t.Fatalf("section = %#v, want not_judged verdict", section)
+	}
+}
 
 func TestNormalizePublicAgentTryoutConfigDefaultsToEnvCredential(t *testing.T) {
 	config := NormalizePublicAgentTryoutConfig(PublicAgentTryoutConfig{})

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -13060,6 +13060,33 @@ components:
             Optional agent harness to run the tryout. One of codex_e2b,
             claude_e2b, openclaw_e2b, hermes_e2b. Empty uses the hosted default.
           enum: [codex_e2b, claude_e2b, openclaw_e2b, hermes_e2b]
+        selected_model_policy:
+          type: object
+          additionalProperties: true
+          description: Optional explicit model policy for the selected harness.
+        judge:
+          $ref: "#/components/schemas/AgentTryoutJudgeSelection"
+
+    AgentTryoutJudgeSelection:
+      type: object
+      description: >-
+        LLM-as-judge selection for anonymous tryouts. The judge always runs on
+        hosted platform keys; the model must come from the hosted allowlist
+        (default gpt-5-mini, claude-haiku-4-5, gemini-2.5-flash). Omitting the
+        object enables the default judge. The selection is baked into the
+        tryout's evaluation_spec_snapshot as llm_judges declarations, and the
+        verdict appears in the completed summary under scorecard.judge with
+        model, strictness, verdict (approved | needs_edits | rejected |
+        not_judged), score, and per-criterion entries carrying status and the
+        judge's reasoning.
+      properties:
+        model:
+          type: string
+          description: Judge model from the hosted allowlist. Empty uses the default.
+        strictness:
+          type: string
+          enum: [lenient, standard, harsh]
+          description: How harshly the judge grades. Defaults to standard.
 
     ClaimAgentTryoutRequest:
       type: object

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -13,6 +13,8 @@ import {
   Gauge,
   Loader2,
   PanelRight,
+  Scale,
+  SlidersHorizontal,
 } from "lucide-react";
 
 import {
@@ -27,6 +29,7 @@ import { ApiError } from "@/lib/api/errors";
 import type {
   AgentHarnessKind,
   AgentTryout,
+  AgentTryoutJudgeStrictness,
   AgentTryoutModelPolicy,
   AgentTryoutTemplate,
   TryoutTimelineEvent,
@@ -168,6 +171,58 @@ const MODEL_OPTIONS: ModelOption[] = [
   },
 ];
 
+// Judge models must match the backend's hosted allowlist
+// (defaultPublicJudgeModels). Judges always run on platform keys.
+const JUDGE_OPTIONS = [
+  { value: "gpt-5-mini", label: "GPT-5 mini" },
+  { value: "claude-haiku-4-5", label: "Claude Haiku" },
+  { value: "gemini-2.5-flash", label: "Gemini Flash" },
+];
+
+const STRICTNESS_OPTIONS: { value: AgentTryoutJudgeStrictness; label: string }[] = [
+  { value: "lenient", label: "Lenient" },
+  { value: "standard", label: "Standard" },
+  { value: "harsh", label: "Harsh" },
+];
+
+function judgeModelLabel(model: string): string {
+  return JUDGE_OPTIONS.find((option) => option.value === model)?.label ?? model;
+}
+
+// Cross-page handoff for the "run it again" funnel loop: the verdict screen
+// stashes the brief + eval answers here, and the welcome screen prefills from
+// it so a rerun takes one click instead of re-typing everything.
+const RERUN_STORAGE_KEY = "agentclash.tryout.rerun";
+
+type RerunPrefill = {
+  templateSlug?: string;
+  fieldValues?: Record<string, string>;
+  evalSetup?: Partial<EvalSetupValues>;
+  judgeModel?: string;
+  judgeStrictness?: AgentTryoutJudgeStrictness;
+  selectedModelKey?: string;
+};
+
+function readRerunPrefill(): RerunPrefill | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(RERUN_STORAGE_KEY);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(RERUN_STORAGE_KEY);
+    return JSON.parse(raw) as RerunPrefill;
+  } catch {
+    return null;
+  }
+}
+
+function writeRerunPrefill(prefill: RerunPrefill) {
+  try {
+    window.sessionStorage.setItem(RERUN_STORAGE_KEY, JSON.stringify(prefill));
+  } catch {
+    // best-effort
+  }
+}
+
 function agentLabel(value: string): string {
   switch (value) {
     case "codex_e2b":
@@ -267,8 +322,29 @@ export function PublicTryoutsClient() {
   const [templates, setTemplates] = useState<AgentTryoutTemplate[]>([]);
   const [templateSlug, setTemplateSlug] = useState("");
   const [selectedModelKey, setSelectedModelKey] = useState("auto");
+  const [judgeModel, setJudgeModel] = useState(JUDGE_OPTIONS[0].value);
+  const [judgeStrictness, setJudgeStrictness] =
+    useState<AgentTryoutJudgeStrictness>("standard");
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [evalSetup, setEvalSetup] = useState<EvalSetupValues>(DEFAULT_EVAL_SETUP);
+  const prefillRef = useRef<RerunPrefill | null>(null);
+
+  // Apply a rerun handoff (same brief, different agent/judge) exactly once.
+  useEffect(() => {
+    if (urlTryoutId) return;
+    const prefill = readRerunPrefill();
+    if (!prefill) return;
+    prefillRef.current = prefill;
+    if (prefill.templateSlug) setTemplateSlug(prefill.templateSlug);
+    if (prefill.evalSetup) {
+      setEvalSetup((current) => ({ ...current, ...prefill.evalSetup }));
+    }
+    if (prefill.judgeModel) setJudgeModel(prefill.judgeModel);
+    if (prefill.judgeStrictness) setJudgeStrictness(prefill.judgeStrictness);
+    if (prefill.selectedModelKey) setSelectedModelKey(prefill.selectedModelKey);
+    if (prefill.fieldValues) setFieldValues(prefill.fieldValues);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [templatesLoading, setTemplatesLoading] = useState(true);
   const [launching, setLaunching] = useState(false);
   const [tryout, setTryout] = useState<AgentTryout | null>(null);
@@ -309,6 +385,15 @@ export function PublicTryoutsClient() {
   }, []);
 
   useEffect(() => {
+    const pending = prefillRef.current;
+    if (
+      pending?.fieldValues &&
+      (!pending.templateSlug || pending.templateSlug === templateSlug)
+    ) {
+      setFieldValues(pending.fieldValues);
+      prefillRef.current = null;
+      return;
+    }
     setFieldValues({});
   }, [templateSlug]);
 
@@ -439,6 +524,7 @@ export function PublicTryoutsClient() {
         input: input.value,
         ...(selectedModel.value ? { selected_harness_kind: selectedModel.value } : {}),
         ...(selectedPolicy ? { selected_model_policy: selectedPolicy } : {}),
+        judge: { model: judgeModel, strictness: judgeStrictness },
       });
       setTryout(nextTryout);
       setEvents([]);
@@ -532,6 +618,10 @@ export function PublicTryoutsClient() {
           setTemplateSlug={setTemplateSlug}
           selectedModelKey={selectedModelKey}
           setSelectedModelKey={setSelectedModelKey}
+          judgeModel={judgeModel}
+          setJudgeModel={setJudgeModel}
+          judgeStrictness={judgeStrictness}
+          setJudgeStrictness={setJudgeStrictness}
           primaryField={primaryField}
           secondaryFields={secondaryFields}
           fieldValues={fieldValues}
@@ -560,6 +650,10 @@ function TryoutWelcome({
   setTemplateSlug,
   selectedModelKey,
   setSelectedModelKey,
+  judgeModel,
+  setJudgeModel,
+  judgeStrictness,
+  setJudgeStrictness,
   primaryField,
   secondaryFields,
   fieldValues,
@@ -582,6 +676,10 @@ function TryoutWelcome({
   setTemplateSlug: (value: string) => void;
   selectedModelKey: string;
   setSelectedModelKey: (value: string) => void;
+  judgeModel: string;
+  setJudgeModel: (value: string) => void;
+  judgeStrictness: AgentTryoutJudgeStrictness;
+  setJudgeStrictness: (value: AgentTryoutJudgeStrictness) => void;
   primaryField: [string, FieldSpec] | null;
   secondaryFields: [string, FieldSpec][];
   fieldValues: Record<string, string>;
@@ -632,8 +730,8 @@ function TryoutWelcome({
           style={{ animationDelay: "200ms" }}
         >
           Answer that and you have written your first eval. Then brief a
-          sandboxed agent, watch every step it takes, and see it graded against
-          your own bar.
+          sandboxed agent, pick the judge, and watch the work get graded
+          against your own bar.
         </p>
 
         <form onSubmit={onSubmit}>
@@ -700,6 +798,23 @@ function TryoutWelcome({
                           label: option.label,
                         }))}
                       />
+                      <AnimatedPillSelect
+                        icon={<Scale className="size-3.5" />}
+                        value={judgeModel}
+                        onChange={setJudgeModel}
+                        options={JUDGE_OPTIONS.map((option) => ({
+                          value: option.value,
+                          label: `${option.label} judges`,
+                        }))}
+                      />
+                      <AnimatedPillSelect
+                        icon={<SlidersHorizontal className="size-3.5" />}
+                        value={judgeStrictness}
+                        onChange={(value) =>
+                          setJudgeStrictness(value as AgentTryoutJudgeStrictness)
+                        }
+                        options={STRICTNESS_OPTIONS}
+                      />
                     </>
                   }
                 />
@@ -750,14 +865,19 @@ function TryoutWelcome({
 
           {message ? <Alert text={message} /> : null}
           {quotaMessage ? (
-            <div className="mt-5 border border-white/15 p-4 text-sm text-white/70">
-              <p>{quotaMessage}</p>
+            <div className="mt-6 border border-white/25 p-5">
+              <p className={cn(MICRO, "text-white/45")}>Free runs used</p>
+              <p className="mt-2 text-sm leading-6 text-white/55">{quotaMessage}</p>
+              <p className="mt-2 text-sm leading-6 text-white/70">
+                Your bar is already written. Sign up free to keep grading agents
+                against it, and to save every verdict.
+              </p>
               <Link
                 href={loginHref}
-                className="mt-2 inline-flex items-center gap-1 font-medium text-white hover:underline"
+                className="mt-4 inline-flex h-9 items-center gap-1.5 rounded-sm bg-white px-4 text-sm font-medium text-black transition hover:bg-white/90"
               >
-                Save this tryout in a workspace
-                <ArrowRight className="size-3.5" />
+                Keep grading
+                <ArrowRight className="size-4" />
               </Link>
             </div>
           ) : null}
@@ -767,7 +887,8 @@ function TryoutWelcome({
               {template.description} ·{" "}
               {MODEL_OPTIONS.find((option) => modelOptionKey(option) === selectedModelKey)?.hint ??
                 "Hosted default agent and model"}{" "}
-              · cost cap {`$${template.max_cost_usd.toFixed(2)}`}
+              · judged by {judgeModelLabel(judgeModel)} ({judgeStrictness}) on our
+              keys · cost cap {`$${template.max_cost_usd.toFixed(2)}`}
             </p>
           ) : null}
         </form>
@@ -955,7 +1076,7 @@ function TryoutSidebar({
 
       {scorecard ? (
         <div className="mt-4 px-1">
-          <ScorecardCard scorecard={scorecard} compact />
+          <VerdictCard scorecard={scorecard} compact />
         </div>
       ) : null}
 
@@ -1101,14 +1222,20 @@ function TryoutChatThread({
     return out;
   }, [timeline]);
 
-  const thinkingLabel =
-    !active || outputs.length > 0
-      ? null
-      : events.length === 0
-        ? "Starting"
-        : timeline[timeline.length - 1]?.kind === "agent"
-          ? "Working"
-          : null;
+  const lastEvent = events[events.length - 1];
+  const judging =
+    active && lastEvent?.type === "scoring" && /grading/i.test(lastEvent.summary);
+  const thinkingLabel = !active
+    ? null
+    : judging
+      ? "The judge is reading"
+      : outputs.length > 0
+        ? null
+        : events.length === 0
+          ? "Starting"
+          : timeline[timeline.length - 1]?.kind === "agent"
+            ? "Working"
+            : null;
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -1185,13 +1312,23 @@ function TryoutChatThread({
 
           {scorecard && finished ? (
             <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
-              <ScorecardCard scorecard={scorecard} />
+              <VerdictCard scorecard={scorecard} />
+            </div>
+          ) : null}
+
+          {scorecard?.judge && finished ? (
+            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
+              <RerunStrip tryout={tryout} judge={scorecard.judge} loginHref={loginHref} />
             </div>
           ) : null}
 
           {finished ? (
             <div className="animate-in fade-in slide-in-from-bottom-3 duration-700">
-              <EvalRoiCalculator tryout={tryout} loginHref={loginHref} />
+              <EvalRoiCalculator
+                tryout={tryout}
+                loginHref={loginHref}
+                initialVolume={evalPlan?.monthly_volume}
+              />
             </div>
           ) : null}
 
@@ -1592,8 +1729,9 @@ function EvalSetupPanel({
       </div>
 
       <p className="max-w-md text-[13px] leading-6 text-white/35">
-        These answers become the rubric the agent is graded against. That is the
-        whole trick: an eval is just your standards, written down.
+        These answers become the judge&apos;s instructions, word for word. That
+        is the whole trick: an eval is just your standards, written down and
+        enforced by a model you pick.
       </p>
     </div>
   );
@@ -1698,6 +1836,252 @@ function Alert({ text }: { text: string }) {
   return (
     <div className="mt-5 border-l-2 border-white/40 pl-4 text-sm leading-6 text-white/70">
       {text}
+    </div>
+  );
+}
+
+// modelKeyFromPolicy maps a tryout's stored model policy back to the
+// MODEL_OPTIONS key so reruns can rotate to a different agent.
+function modelKeyFromPolicy(policy: unknown): string {
+  if (!policy || typeof policy !== "object") return "auto";
+  const models = (policy as { models?: unknown }).models;
+  if (!Array.isArray(models) || models.length === 0) return "auto";
+  const first = models[0] as { provider?: unknown; model?: unknown };
+  const match = MODEL_OPTIONS.find(
+    (option) => option.provider === first.provider && option.model === first.model,
+  );
+  return match ? modelOptionKey(match) : "auto";
+}
+
+// RerunStrip drives the comparison loop: one click reruns the same brief and
+// the same bar with a different agent, a harsher judge, or a different judge.
+function RerunStrip({
+  tryout,
+  judge,
+  loginHref,
+}: {
+  tryout: AgentTryout;
+  judge: TryoutJudgeSection;
+  loginHref: string;
+}) {
+  const router = useRouter();
+
+  function basePrefill(): RerunPrefill {
+    const fieldValues: Record<string, string> = {};
+    for (const [key, value] of Object.entries(tryout.input_snapshot ?? {})) {
+      if (key === "eval_setup") continue;
+      if (typeof value === "string") fieldValues[key] = value;
+      else if (typeof value === "number") fieldValues[key] = String(value);
+    }
+    const setup = evalSetupFromInput(tryout.input_snapshot);
+    return {
+      templateSlug: tryout.template_slug,
+      fieldValues,
+      evalSetup: setup
+        ? {
+            unacceptableMistakes: setup.unacceptable_mistakes,
+            reviewer: setup.human_reviewer,
+            priority: setup.business_priority,
+            style: setup.output_style,
+            monthlyVolume: setup.monthly_volume,
+          }
+        : undefined,
+      selectedModelKey: modelKeyFromPolicy(tryout.selected_model_policy),
+      judgeModel: judge.model,
+      judgeStrictness:
+        judge.strictness === "lenient" || judge.strictness === "harsh"
+          ? judge.strictness
+          : "standard",
+    };
+  }
+
+  function rerun(overrides: Partial<RerunPrefill>) {
+    writeRerunPrefill({ ...basePrefill(), ...overrides });
+    router.push("/tryouts");
+  }
+
+  const currentModelKey = modelKeyFromPolicy(tryout.selected_model_policy);
+  const currentOption = MODEL_OPTIONS.find(
+    (option) => modelOptionKey(option) === currentModelKey,
+  );
+  const nextAgent =
+    MODEL_OPTIONS.find(
+      (option) =>
+        option.model &&
+        option.provider !== currentOption?.provider &&
+        modelOptionKey(option) !== currentModelKey,
+    ) ?? MODEL_OPTIONS.find((option) => option.model && modelOptionKey(option) !== currentModelKey);
+  const nextJudge =
+    JUDGE_OPTIONS.find((option) => option.value !== judge.model) ?? JUDGE_OPTIONS[0];
+
+  return (
+    <div className="border border-white/12 p-5 sm:p-6">
+      <p className={cn(MICRO, "text-white/40")}>Do not take one run&apos;s word for it</p>
+      <p className="mt-2 max-w-lg text-sm leading-6 text-white/50">
+        This is the whole point of an eval: the bar stays fixed, everything else
+        can change, and the verdicts stay comparable.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {nextAgent ? (
+          <RerunButton
+            onClick={() =>
+              rerun({ selectedModelKey: modelOptionKey(nextAgent) })
+            }
+          >
+            Same brief, run {nextAgent.label} instead
+          </RerunButton>
+        ) : null}
+        {judge.strictness !== "harsh" ? (
+          <RerunButton onClick={() => rerun({ judgeStrictness: "harsh" })}>
+            Same brief, harsher judge
+          </RerunButton>
+        ) : null}
+        <RerunButton onClick={() => rerun({ judgeModel: nextJudge.value })}>
+          Let {nextJudge.label} judge instead
+        </RerunButton>
+      </div>
+      <p className="mt-4 border-t border-white/[0.07] pt-3 text-xs leading-5 text-white/35">
+        The bar you wrote is reusable.{" "}
+        <Link href={loginHref} className="text-white/60 underline-offset-4 hover:text-white hover:underline">
+          Save this eval
+        </Link>{" "}
+        and it grades every future run, automatically.
+      </p>
+    </div>
+  );
+}
+
+function RerunButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="border border-white/15 px-3 py-1.5 text-left font-mono text-[11px] text-white/65 transition hover:border-white/40 hover:text-white"
+    >
+      {children}
+    </button>
+  );
+}
+
+const VERDICT_WORDS: Record<TryoutJudgeSection["verdict"], string> = {
+  approved: "Approved",
+  needs_edits: "Needs edits",
+  rejected: "Rejected",
+  not_judged: "Not judged",
+};
+
+// VerdictCard is the centerpiece of the funnel: the judge the visitor chose,
+// grading the work against the visitor's own words, with its reasoning quoted.
+function VerdictCard({
+  scorecard,
+  compact,
+}: {
+  scorecard: TryoutScorecard;
+  compact?: boolean;
+}) {
+  const judge = scorecard.judge;
+  if (!judge) return <ScorecardCard scorecard={scorecard} compact={compact} />;
+  const grade = judge.score != null ? 1 + judge.score * 4 : null;
+
+  return (
+    <div
+      className={cn(
+        "border",
+        judge.verdict === "approved" ? "border-white/30" : "border-white/12",
+        compact ? "p-4" : "p-5 sm:p-6",
+      )}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <p className={cn(MICRO, "text-white/40")}>The verdict</p>
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/30">
+          {judgeModelLabel(judge.model)}
+          {judge.strictness ? ` · ${judge.strictness}` : ""}
+        </p>
+      </div>
+
+      <div className="mt-4 flex items-end justify-between gap-4">
+        <p
+          className={cn(
+            SERIF,
+            "font-light leading-none",
+            compact ? "text-3xl" : "text-4xl sm:text-5xl",
+            judge.verdict === "rejected" ? "text-white/55" : "text-white/95",
+          )}
+        >
+          {VERDICT_WORDS[judge.verdict]}
+        </p>
+        {grade != null ? (
+          <p className={cn(SERIF, "font-light leading-none text-white/85", compact ? "text-2xl" : "text-3xl sm:text-4xl")}>
+            {grade.toFixed(1)}
+            <span className="text-lg text-white/35"> / 5</span>
+          </p>
+        ) : null}
+      </div>
+      <p className="mt-3 text-xs leading-5 text-white/40">
+        Graded by the judge you chose, against the bar you wrote in step 01.
+      </p>
+      {judge.reason ? (
+        <p className="mt-2 text-sm leading-6 text-white/55">{judge.reason}</p>
+      ) : null}
+
+      {!compact && judge.criteria.length > 0 ? (
+        <ul className="mt-5 divide-y divide-white/[0.07] border-t border-white/[0.07]">
+          {judge.criteria.map((criterion) => (
+            <li key={criterion.key} className="py-3">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-sm leading-6 text-white/75">{criterion.label}</span>
+                <span
+                  className={cn(
+                    "font-mono text-[10px] uppercase tracking-[0.14em]",
+                    criterion.status === "passed"
+                      ? "text-white/80"
+                      : criterion.status === "failed"
+                        ? "text-white/35 line-through"
+                        : "text-white/25",
+                  )}
+                >
+                  {criterion.status === "skipped" ? "not graded" : criterion.status}
+                </span>
+              </div>
+              {criterion.reasoning ? (
+                <p className="mt-1 max-w-xl text-xs leading-5 text-white/40">
+                  “{criterion.reasoning}”
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {!compact && scorecard.checks.length > 0 ? (
+        <div className="mt-5">
+          <p className={cn(MICRO, "text-white/30")}>Automatic checks</p>
+          <ul className="mt-2 divide-y divide-white/[0.06]">
+            {scorecard.checks.map((check) => (
+              <li
+                key={check.key}
+                className="flex items-baseline justify-between gap-3 py-1.5 text-xs"
+              >
+                <span className="text-white/50">{fieldLabel(check.key)}</span>
+                <span
+                  className={cn(
+                    "font-mono text-[9px] uppercase tracking-[0.14em]",
+                    check.status === "passed" ? "text-white/60" : "text-white/25",
+                  )}
+                >
+                  {check.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -2063,7 +2447,7 @@ function friendlyTraceSummary(event: TryoutTimelineEvent): string {
     case "validation":
       return "Checked the output against validators";
     case "scoring":
-      return "Updated the eval scorecard";
+      return summary.startsWith("Judge") ? summary : "Updated the eval scorecard";
     default:
       return summary || "Working";
   }
@@ -2283,6 +2667,26 @@ type TryoutScorecardCheck = {
   status: "passed" | "failed" | "skipped";
 };
 
+type TryoutJudgeCriterion = {
+  key: string;
+  label: string;
+  mode: string;
+  status: "passed" | "failed" | "skipped";
+  score?: number;
+  reasoning?: string;
+  confidence?: string;
+  reason?: string;
+};
+
+type TryoutJudgeSection = {
+  model: string;
+  strictness?: string;
+  verdict: "approved" | "needs_edits" | "rejected" | "not_judged";
+  score?: number;
+  reason?: string;
+  criteria: TryoutJudgeCriterion[];
+};
+
 type TryoutScorecard = {
   passed_validators: number;
   total_validators: number;
@@ -2290,7 +2694,58 @@ type TryoutScorecard = {
   passed: boolean;
   dimensions: string[];
   checks: TryoutScorecardCheck[];
+  judge: TryoutJudgeSection | null;
 };
+
+function tryoutJudgeSection(raw: unknown): TryoutJudgeSection | null {
+  if (!raw || typeof raw !== "object") return null;
+  const section = raw as Record<string, unknown>;
+  if (typeof section.model !== "string" || section.model.trim() === "") return null;
+  const verdict =
+    section.verdict === "approved" ||
+    section.verdict === "needs_edits" ||
+    section.verdict === "rejected" ||
+    section.verdict === "not_judged"
+      ? section.verdict
+      : "not_judged";
+  const criteria: TryoutJudgeCriterion[] = Array.isArray(section.criteria)
+    ? section.criteria
+        .map((item): TryoutJudgeCriterion | null => {
+          if (!item || typeof item !== "object") return null;
+          const criterion = item as Record<string, unknown>;
+          const status =
+            criterion.status === "passed" || criterion.status === "failed"
+              ? criterion.status
+              : "skipped";
+          const key = typeof criterion.key === "string" ? criterion.key : "criterion";
+          return {
+            key,
+            label:
+              typeof criterion.label === "string" && criterion.label.trim()
+                ? criterion.label
+                : fieldLabel(key),
+            mode: typeof criterion.mode === "string" ? criterion.mode : "",
+            status,
+            score: typeof criterion.score === "number" ? criterion.score : undefined,
+            reasoning:
+              typeof criterion.reasoning === "string" ? criterion.reasoning : undefined,
+            confidence:
+              typeof criterion.confidence === "string" ? criterion.confidence : undefined,
+            reason: typeof criterion.reason === "string" ? criterion.reason : undefined,
+          };
+        })
+        .filter((item): item is TryoutJudgeCriterion => item !== null)
+    : [];
+  return {
+    model: section.model,
+    strictness:
+      typeof section.strictness === "string" ? section.strictness : undefined,
+    verdict,
+    score: typeof section.score === "number" ? section.score : undefined,
+    reason: typeof section.reason === "string" ? section.reason : undefined,
+    criteria,
+  };
+}
 
 function tryoutScorecard(summary: unknown): TryoutScorecard | null {
   if (!summary || typeof summary !== "object") return null;
@@ -2326,6 +2781,7 @@ function tryoutScorecard(summary: unknown): TryoutScorecard | null {
       ? card.dimensions.filter((d): d is string => typeof d === "string")
       : [],
     checks,
+    judge: tryoutJudgeSection(card.judge),
   };
 }
 
@@ -2369,17 +2825,36 @@ function usd(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
+// parseMonthlyVolume turns freeform answers like "500", "10k", or "2,000 runs"
+// into a number for the ROI inputs.
+function parseMonthlyVolume(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const match = raw.replaceAll(",", "").match(/(\d+(?:\.\d+)?)\s*(k|m)?/i);
+  if (!match) return null;
+  let value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const unit = (match[2] ?? "").toLowerCase();
+  if (unit === "k") value *= 1_000;
+  if (unit === "m") value *= 1_000_000;
+  return Math.round(value);
+}
+
 function EvalRoiCalculator({
   tryout,
   loginHref,
+  initialVolume,
 }: {
   tryout: AgentTryout;
   loginHref: string;
+  initialVolume?: string;
 }) {
   const anchor = ROI_ANCHORS[tryout.template_slug] ?? DEFAULT_ANCHOR;
   const [company, setCompany] = useState("");
   const [email, setEmail] = useState("");
-  const [volume, setVolume] = useState("5000");
+  const [volume, setVolume] = useState(() => {
+    const parsed = parseMonthlyVolume(initialVolume);
+    return parsed != null ? String(parsed) : "5000";
+  });
   const [humanCost, setHumanCost] = useState(String(anchor.humanCostPerTask));
 
   const monthlyVolume = Math.max(0, Number(volume) || 0);

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -519,13 +519,30 @@ export function PublicTryoutsClient() {
     setMessage(null);
     setQuotaMessage(null);
     try {
-      const nextTryout = await createAnonymousAgentTryout(api, {
+      const payload = {
         template_slug: template.slug,
         input: input.value,
         ...(selectedModel.value ? { selected_harness_kind: selectedModel.value } : {}),
         ...(selectedPolicy ? { selected_model_policy: selectedPolicy } : {}),
         judge: { model: judgeModel, strictness: judgeStrictness },
-      });
+      };
+      let nextTryout: AgentTryout;
+      try {
+        nextTryout = await createAnonymousAgentTryout(api, payload);
+      } catch (err) {
+        // Backends that predate judge selection reject unknown fields; fall
+        // back to a judgeless run instead of breaking the page.
+        if (
+          err instanceof ApiError &&
+          err.status === 400 &&
+          err.message.toLowerCase().includes("judge")
+        ) {
+          const withoutJudge = { ...payload, judge: undefined };
+          nextTryout = await createAnonymousAgentTryout(api, withoutJudge);
+        } else {
+          throw err;
+        }
+      }
       setTryout(nextTryout);
       setEvents([]);
       router.replace(`/tryouts?tryout=${encodeURIComponent(nextTryout.id)}`, {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2760,11 +2760,19 @@ export type AgentHarnessKind =
   | "openclaw_e2b"
   | "hermes_e2b";
 
+export type AgentTryoutJudgeStrictness = "lenient" | "standard" | "harsh";
+
+export interface AgentTryoutJudgeSelection {
+  model?: string;
+  strictness?: AgentTryoutJudgeStrictness;
+}
+
 export interface CreateAgentTryoutInput {
   template_slug: string;
   input: Record<string, unknown>;
   selected_harness_kind?: AgentHarnessKind;
   selected_model_policy?: AgentTryoutModelPolicy;
+  judge?: AgentTryoutJudgeSelection;
 }
 
 export interface RerunAgentTryoutInput {


### PR DESCRIPTION
Stacked on #1023 (greyscale redesign). Merge that first; this PR then retargets to main automatically.

## Summary

Turns /tryouts into a self-serve eval playground for non-engineers, built as a conversion funnel: write your bar, brief the agent, watch a judge you chose grade the work against your own words, rerun to compare, hit the quota gate, sign up.

### Backend (reuses existing judge machinery end to end)
- `POST /v1/agent-tryouts` accepts `judge: { model, strictness }`. Models are validated against a hosted allowlist (`gpt-5-mini`, `claude-haiku-4-5`, `gemini-2.5-flash`; override via `AGENT_TRYOUT_JUDGE_MODELS`). Judges always run on platform env keys — anonymous users never supply keys.
- At create time the operator's eval answers (`input.eval_setup`) plus strictness are derived server-side into standard `llm_judges` declarations (one overall rubric judge scored 1-5, plus assertion judges for the named instant-fail mistake and sign-off reviewer) and baked into `evaluation_spec_snapshot`. No migration needed.
- The public tryout workflow now calls the existing `evaluateLLMJudges` with the worker's existing `judgeClient` after outputs finalize, with output previews truncated to a fixed byte budget. It emits `scoring.started` ("Judge (model) is grading against your bar") and a verdict-bearing `scoring.completed`, and merges `scorecard.judge` (model, strictness, verdict, 0-1 score, per-criterion status + the judge's quoted reasoning) into the summary. Judge failures degrade to the deterministic scorecard instead of failing the run.
- Tests: judge normalization/allowlist, spec derivation, workflow verdict merge, platform-key resolution, graceful degradation. `go vet` + full `-short -race` suite green. OpenAPI spec updated (pre-existing lint errors on main unchanged).

### Frontend
- Composer pills now include Judge ("GPT-5 mini judges", …) and Strictness (Lenient / Standard / Harsh) next to Task and Agent; caption shows "judged by X (standard) on our keys".
- Verdict card replaces the plain scorecard when judge data exists: Approved / Needs edits / Rejected in serif with a /5 grade, per-criterion pass/fail with the judge's reasoning quoted, automatic checks listed below. Trace thread shows a pulsating "the judge is reading" node during grading.
- Rerun strip under the verdict relaunches the same brief + bar with a different agent, a harsher judge, or a different judge (sessionStorage handoff prefills the whole form). Quota exhaustion is now a sign-up gate framed around the eval the visitor wrote; the ROI calculator prefills their stated monthly volume.
- Deploy-order safety: old backends reject the unknown `judge` field (DisallowUnknownFields), so the client transparently retries judgeless — verified live against production.

## Deploy notes
- Worker env needs `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` for the judge allowlist (xAI unused by defaults).
- Deploy backend before (or with) web; until then the web fallback keeps tryouts working without judges.

## Test plan
- [x] Backend unit tests (API + workflow), vet, race suite
- [x] OpenAPI lint parity with main
- [x] Frontend tsc + ESLint + vitest
- [x] Live browser check against prod API: pills render, judgeless fallback launches, degraded scorecard + prefilled ROI render
- [ ] After backend deploy: run one tryout end to end and confirm the verdict card + judging trace event