### PR TITLE
fix(web): readable text and alive colored charts for agent opportunity report

### DIFF
--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -59,21 +59,20 @@ const VERDICT_ORDER: AgentOpportunityReport["shouldBuildAgent"][] = [
 ];
 
 const toneDot: Record<Tone, string> = {
-  good: "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.7)]",
-  warn: "bg-amber-300 shadow-[0_0_8px_rgba(252,211,77,0.7)]",
-  bad: "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.7)]",
-  neutral: "bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.7)]",
+  good: "bg-emerald-400",
+  warn: "bg-amber-300",
+  bad: "bg-red-400",
+  neutral: "bg-white",
 };
 
 const toneSegment: Record<Tone, string> = {
-  good: "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.55)]",
-  warn: "bg-amber-300 shadow-[0_0_8px_rgba(252,211,77,0.55)]",
-  bad: "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.55)]",
-  neutral: "bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.55)]",
+  good: "bg-emerald-400",
+  warn: "bg-amber-300",
+  bad: "bg-red-400",
+  neutral: "bg-white",
 };
 
-const ADVERSARIAL_STRIPES =
-  "repeating-linear-gradient(135deg, rgba(252,211,77,0.85) 0, rgba(252,211,77,0.85) 2px, transparent 2px, transparent 6px)";
+const ADVERSARIAL_FILL = "bg-white/30";
 
 function levelCount(level: UseCase["fit"]): number {
   return level === "high" ? 3 : level === "medium" ? 2 : 1;
@@ -128,7 +127,7 @@ function ScaleBar({ value, className }: { value: number; className?: string }) {
       aria-hidden
     >
       <div
-        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-emerald-400 shadow-[0_0_10px_rgba(34,211,238,0.5)] transition-[width] duration-700 ease-out motion-reduce:transition-none"
+        className="h-full rounded-full bg-white transition-[width] duration-700 ease-out motion-reduce:transition-none"
         style={{
           width: mounted ? `${Math.max(2, Math.min(100, value))}%` : "0%",
         }}
@@ -377,10 +376,10 @@ export function ReportDashboard({
                 className={cn(
                   "size-2.5 rounded-full",
                   useCase.fit === "high"
-                    ? "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.6)]"
+                    ? "bg-emerald-400"
                     : useCase.fit === "medium"
-                      ? "bg-amber-300 shadow-[0_0_6px_rgba(252,211,77,0.4)]"
-                      : "bg-red-400/80",
+                      ? "bg-amber-300"
+                      : "bg-red-400/60",
                 )}
               />
             ))}
@@ -398,10 +397,10 @@ export function ReportDashboard({
                 className={cn(
                   "h-2.5 w-5 rounded-[2px]",
                   risk.severity === "high"
-                    ? "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.6)]"
+                    ? "bg-red-400"
                     : risk.severity === "medium"
-                      ? "bg-amber-300/90"
-                      : "bg-emerald-400/70",
+                      ? "bg-amber-300"
+                      : "bg-emerald-400",
                 )}
               />
             ))}
@@ -473,7 +472,7 @@ export function ReportDashboard({
             aria-hidden
           >
             <div
-              className="bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.5)]"
+              className="bg-white"
               style={{
                 width: `${
                   (report.evaluationPack.recommendedCases /
@@ -482,22 +481,15 @@ export function ReportDashboard({
                 }%`,
               }}
             />
-            <div
-              className="flex-1"
-              style={{ backgroundImage: ADVERSARIAL_STRIPES }}
-            />
+            <div className={cn("flex-1", ADVERSARIAL_FILL)} />
           </div>
           <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 font-mono text-[11px] tracking-[0.04em] text-white/65">
             <span className="flex items-center gap-1.5">
-              <span className="size-2 rounded-[1px] bg-cyan-400" aria-hidden />
+              <span className="size-2 rounded-[1px] bg-white" aria-hidden />
               {report.evaluationPack.recommendedCases} realistic
             </span>
             <span className="flex items-center gap-1.5">
-              <span
-                className="size-2 rounded-[1px]"
-                style={{ backgroundImage: ADVERSARIAL_STRIPES }}
-                aria-hidden
-              />
+              <span className={cn("size-2 rounded-[1px]", ADVERSARIAL_FILL)} aria-hidden />
               {report.evaluationPack.adversarialCases} adversarial
             </span>
           </div>
@@ -507,7 +499,7 @@ export function ReportDashboard({
                 key={criterion}
                 className="flex gap-2 text-[13px] leading-5 text-white/75"
               >
-                <span className="font-mono text-emerald-300">✓</span>
+                <span className="font-mono text-white/60">✓</span>
                 {criterion}
               </li>
             ))}
@@ -564,7 +556,7 @@ function LoadingPanel({ step }: { step: number }) {
   return (
     <section className="mt-10 border border-white/[0.08] bg-[#080808] p-6">
       <div className="flex items-center gap-3">
-        <Loader2 className="size-5 animate-spin text-cyan-300" />
+        <Loader2 className="size-5 animate-spin text-white/70" />
         <div>
           <p className="text-sm font-medium text-white">
             Generating your report
@@ -594,9 +586,9 @@ function LoadingPanel({ step }: { step: number }) {
                 className={cn(
                   "flex size-6 items-center justify-center border font-mono text-[11px]",
                   done
-                    ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300"
+                    ? "border-white/30 bg-white/10 text-white"
                     : active
-                      ? "border-cyan-400/50 text-cyan-300"
+                      ? "border-white/40 text-white"
                       : "border-white/15",
                 )}
               >
@@ -605,7 +597,7 @@ function LoadingPanel({ step }: { step: number }) {
               {label}
               {active ? (
                 <span
-                  className="size-1.5 animate-pulse rounded-full bg-cyan-300"
+                  className="size-1.5 animate-pulse rounded-full bg-white/70"
                   aria-hidden
                 />
               ) : null}

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   ArrowRight,
   ChevronDown,
@@ -31,9 +31,10 @@ type ReportResponse =
   | { ok: false; code: string; error: string };
 
 type UseCase = AgentOpportunityReport["useCases"][number];
+type Tone = "good" | "warn" | "bad" | "neutral";
 
 const SERIF = "[font-family:var(--font-race-display)]";
-const MICRO = "font-mono text-[10px] uppercase tracking-[0.22em]";
+const MICRO = "font-mono text-[11px] uppercase tracking-[0.18em]";
 
 const painOptions = [
   "Support",
@@ -57,15 +58,22 @@ const VERDICT_ORDER: AgentOpportunityReport["shouldBuildAgent"][] = [
   "strong_fit",
 ];
 
-const toneDot: Record<"good" | "warn" | "bad" | "neutral", string> = {
-  good: "bg-emerald-400",
-  warn: "bg-amber-400",
-  bad: "bg-red-400",
-  neutral: "bg-white/60",
+const toneDot: Record<Tone, string> = {
+  good: "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.7)]",
+  warn: "bg-amber-300 shadow-[0_0_8px_rgba(252,211,77,0.7)]",
+  bad: "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.7)]",
+  neutral: "bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.7)]",
+};
+
+const toneSegment: Record<Tone, string> = {
+  good: "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.55)]",
+  warn: "bg-amber-300 shadow-[0_0_8px_rgba(252,211,77,0.55)]",
+  bad: "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.55)]",
+  neutral: "bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.55)]",
 };
 
 const ADVERSARIAL_STRIPES =
-  "repeating-linear-gradient(135deg, rgba(255,255,255,0.55) 0, rgba(255,255,255,0.55) 2px, transparent 2px, transparent 6px)";
+  "repeating-linear-gradient(135deg, rgba(252,211,77,0.85) 0, rgba(252,211,77,0.85) 2px, transparent 2px, transparent 6px)";
 
 function levelCount(level: UseCase["fit"]): number {
   return level === "high" ? 3 : level === "medium" ? 2 : 1;
@@ -79,15 +87,51 @@ function reportHostname(analyzedUrl: string): string {
   }
 }
 
+function useEntranceFrame(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  return mounted;
+}
+
+function useCountUp(target: number, durationMs = 900): number {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      const frame = requestAnimationFrame(() => setValue(target));
+      return () => cancelAnimationFrame(frame);
+    }
+    let frame: number;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - start) / durationMs);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setValue(Math.round(target * eased));
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target, durationMs]);
+  return value;
+}
+
 function ScaleBar({ value, className }: { value: number; className?: string }) {
+  const mounted = useEntranceFrame();
   return (
     <div
-      className={cn("relative h-[3px] w-full bg-white/[0.08]", className)}
+      className={cn(
+        "relative h-1.5 w-full overflow-hidden rounded-full bg-white/[0.08]",
+        className,
+      )}
       aria-hidden
     >
       <div
-        className="h-full bg-white/80"
-        style={{ width: `${Math.max(2, Math.min(100, value))}%` }}
+        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-emerald-400 shadow-[0_0_10px_rgba(34,211,238,0.5)] transition-[width] duration-700 ease-out motion-reduce:transition-none"
+        style={{
+          width: mounted ? `${Math.max(2, Math.min(100, value))}%` : "0%",
+        }}
       />
       {[25, 50, 75].map((tick) => (
         <span
@@ -100,14 +144,30 @@ function ScaleBar({ value, className }: { value: number; className?: string }) {
   );
 }
 
+const meterToneClass: Record<Tone, string> = {
+  good: "bg-emerald-400/90",
+  warn: "bg-amber-300/90",
+  bad: "bg-red-400/90",
+  neutral: "bg-cyan-400/90",
+};
+
+function meterTone(level: UseCase["fit"], invert: boolean): Tone {
+  const rank = levelCount(level);
+  const goodness = invert ? 4 - rank : rank;
+  return goodness === 3 ? "good" : goodness === 2 ? "warn" : "bad";
+}
+
 function LevelMeter({
   level,
   label,
+  invert = false,
 }: {
   level: UseCase["fit"];
   label: string;
+  invert?: boolean;
 }) {
   const count = levelCount(level);
+  const fill = meterToneClass[meterTone(level, invert)];
   return (
     <span className="flex flex-col gap-1.5">
       <span className="flex gap-[3px]" aria-hidden>
@@ -115,13 +175,13 @@ function LevelMeter({
           <span
             key={index}
             className={cn(
-              "h-[5px] w-4",
-              index < count ? "bg-white/75" : "bg-white/[0.08]",
+              "h-[5px] w-4 rounded-[1px]",
+              index < count ? fill : "bg-white/10",
             )}
           />
         ))}
       </span>
-      <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
+      <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-white/55">
         {level === "medium" ? "med" : level} {label}
       </span>
     </span>
@@ -139,9 +199,9 @@ function StatCell({
 }) {
   return (
     <div className="flex min-w-0 flex-col bg-[#080808] p-5 sm:px-6">
-      <p className={cn(MICRO, "text-white/35")}>{label}</p>
+      <p className={cn(MICRO, "text-white/60")}>{label}</p>
       <div className="mt-3 flex-1">{children}</div>
-      <p className="mt-3 font-mono text-[10px] tracking-[0.06em] text-white/35">
+      <p className="mt-3 font-mono text-[11px] tracking-[0.04em] text-white/55">
         {caption}
       </p>
     </div>
@@ -151,9 +211,9 @@ function StatCell({
 function UseCaseRow({ useCase, index }: { useCase: UseCase; index: number }) {
   return (
     <details className="group">
-      <summary className="grid cursor-pointer list-none grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-x-4 px-5 py-4 transition-colors marker:content-none hover:bg-white/[0.02] sm:grid-cols-[2.5rem_minmax(0,1fr)_5.5rem_6.5rem_7rem_7rem] sm:px-7 [&::-webkit-details-marker]:hidden">
+      <summary className="grid cursor-pointer list-none grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-x-4 px-5 py-4 transition-colors marker:content-none hover:bg-white/[0.03] sm:grid-cols-[2.5rem_minmax(0,1fr)_5.5rem_6.5rem_7rem_7rem] sm:px-7 [&::-webkit-details-marker]:hidden">
         <span
-          className={cn(SERIF, "text-2xl leading-none text-white/15")}
+          className={cn(SERIF, "text-2xl leading-none text-white/30")}
           aria-hidden
         >
           {String(index + 1).padStart(2, "0")}
@@ -162,15 +222,15 @@ function UseCaseRow({ useCase, index }: { useCase: UseCase; index: number }) {
           <span className="truncate text-sm font-medium text-white">
             {useCase.title}
           </span>
-          <ChevronDown className="size-3.5 shrink-0 text-white/25 transition-transform group-open:rotate-180" />
+          <ChevronDown className="size-3.5 shrink-0 text-white/40 transition-transform group-open:rotate-180" />
         </span>
         <span className="hidden sm:block">
           <LevelMeter level={useCase.fit} label="fit" />
         </span>
         <span className="hidden sm:block">
-          <LevelMeter level={useCase.complexity} label="cmplx" />
+          <LevelMeter level={useCase.complexity} label="cmplx" invert />
         </span>
-        <span className="hidden text-right font-mono text-xs tabular-nums text-white/60 sm:block">
+        <span className="hidden text-right font-mono text-xs tabular-nums text-white/75 sm:block">
           {useCase.estimatedMonthlyHoursSaved}
         </span>
         <span className="text-right font-mono text-xs tabular-nums text-white">
@@ -181,29 +241,29 @@ function UseCaseRow({ useCase, index }: { useCase: UseCase; index: number }) {
         <div>
           <div className="mb-3 flex items-end gap-5 sm:hidden">
             <LevelMeter level={useCase.fit} label="fit" />
-            <LevelMeter level={useCase.complexity} label="cmplx" />
-            <span className="font-mono text-xs text-white/60">
+            <LevelMeter level={useCase.complexity} label="cmplx" invert />
+            <span className="font-mono text-xs text-white/75">
               {useCase.estimatedMonthlyHoursSaved}
             </span>
           </div>
-          <p className="text-[13px] leading-6 text-white/55">
+          <p className="text-[13px] leading-6 text-white/70">
             {useCase.workflow}
           </p>
-          <p className="mt-2 text-[13px] leading-6 text-white/40">
+          <p className="mt-2 text-[13px] leading-6 text-white/55">
             {useCase.why}
           </p>
         </div>
         <div>
-          <p className={cn(MICRO, "tracking-[0.16em] text-white/30")}>
+          <p className={cn(MICRO, "tracking-[0.14em] text-white/55")}>
             First eval tasks
           </p>
           <ul className="mt-2.5 space-y-1.5">
             {useCase.firstEvalTasks.map((task) => (
               <li
                 key={task}
-                className="flex gap-2 text-[13px] leading-5 text-white/55"
+                className="flex gap-2 text-[13px] leading-5 text-white/70"
               >
-                <span className="font-mono text-white/25">·</span>
+                <span className="font-mono text-white/40">·</span>
                 {task}
               </li>
             ))}
@@ -221,6 +281,7 @@ export function ReportDashboard({
 }) {
   const metrics = useMemo(() => deriveOpportunityMetrics(report), [report]);
   const tone = fitTone[report.shouldBuildAgent];
+  const animatedScore = useCountUp(report.agentFitScore);
   const highFitCount = report.useCases.filter(
     (useCase) => useCase.fit === "high",
   ).length;
@@ -235,8 +296,8 @@ export function ReportDashboard({
     <section className="mt-10 border border-white/[0.08] bg-[#080808]">
       <header className="border-b border-white/[0.08] px-5 py-5 sm:px-7">
         <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-          <p className={cn(MICRO, "text-white/35")}>Agent opportunity report</p>
-          <p className="font-mono text-[10px] tracking-[0.08em] text-white/25">
+          <p className={cn(MICRO, "text-white/60")}>Agent opportunity report</p>
+          <p className="font-mono text-[11px] tracking-[0.06em] text-white/50">
             {reportHostname(report.analyzedUrl)}
           </p>
         </div>
@@ -250,14 +311,14 @@ export function ReportDashboard({
             >
               {report.companyName}
             </h2>
-            <p className="mt-2 line-clamp-2 max-w-[62ch] text-sm leading-6 text-white/50">
+            <p className="mt-2 max-w-[68ch] text-sm leading-6 text-white/65">
               {report.summary}
             </p>
           </div>
           <button
             type="button"
             onClick={() => window.print()}
-            className="inline-flex items-center gap-2 border border-white/[0.12] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.12em] text-white/60 transition-colors hover:border-white/30 hover:text-white print:hidden"
+            className="inline-flex items-center gap-2 border border-white/[0.15] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/35 hover:text-white print:hidden"
           >
             <Download className="size-3.5" />
             Save report
@@ -271,8 +332,8 @@ export function ReportDashboard({
           caption={confidenceCopy[report.fitLevel].toLowerCase()}
         >
           <p className="font-mono text-[40px] leading-none tabular-nums text-white">
-            {report.agentFitScore}
-            <span className="ml-1 text-sm text-white/30">/100</span>
+            {animatedScore}
+            <span className="ml-1 text-sm text-white/50">/100</span>
           </p>
           <ScaleBar value={report.agentFitScore} className="mt-3" />
         </StatCell>
@@ -295,10 +356,10 @@ export function ReportDashboard({
               <span
                 key={verdict}
                 className={cn(
-                  "h-[3px] flex-1",
+                  "h-1 flex-1 rounded-full",
                   verdict === report.shouldBuildAgent
-                    ? "bg-white"
-                    : "bg-white/[0.08]",
+                    ? toneSegment[tone]
+                    : "bg-white/10",
                 )}
               />
             ))}
@@ -314,12 +375,12 @@ export function ReportDashboard({
               <span
                 key={useCase.title}
                 className={cn(
-                  "size-2 rounded-full",
+                  "size-2.5 rounded-full",
                   useCase.fit === "high"
-                    ? "bg-white"
+                    ? "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.6)]"
                     : useCase.fit === "medium"
-                      ? "bg-white/45"
-                      : "bg-white/15",
+                      ? "bg-amber-300 shadow-[0_0_6px_rgba(252,211,77,0.4)]"
+                      : "bg-red-400/80",
                 )}
               />
             ))}
@@ -335,12 +396,12 @@ export function ReportDashboard({
               <span
                 key={risk.risk}
                 className={cn(
-                  "h-2 w-5",
+                  "h-2.5 w-5 rounded-[2px]",
                   risk.severity === "high"
-                    ? "bg-white"
+                    ? "bg-red-400 shadow-[0_0_8px_rgba(248,113,113,0.6)]"
                     : risk.severity === "medium"
-                      ? "bg-white/45"
-                      : "bg-white/15",
+                      ? "bg-amber-300/90"
+                      : "bg-emerald-400/70",
                 )}
               />
             ))}
@@ -351,8 +412,8 @@ export function ReportDashboard({
       <div className="grid gap-px border-b border-white/[0.08] bg-white/[0.06] lg:grid-cols-[0.9fr_1.1fr]">
         <div className="bg-[#080808] p-5 sm:p-6">
           <div className="flex items-baseline justify-between gap-3">
-            <p className={cn(MICRO, "text-white/35")}>Dimension profile</p>
-            <p className="font-mono text-[9px] tracking-[0.1em] text-white/25">
+            <p className={cn(MICRO, "text-white/60")}>Dimension profile</p>
+            <p className="font-mono text-[10px] tracking-[0.08em] text-white/45">
               0–100
             </p>
           </div>
@@ -363,8 +424,8 @@ export function ReportDashboard({
         </div>
         <div className="bg-[#080808] p-5 sm:p-6">
           <div className="flex items-baseline justify-between gap-3">
-            <p className={cn(MICRO, "text-white/35")}>Opportunity map</p>
-            <p className="font-mono text-[9px] tracking-[0.1em] text-white/25">
+            <p className={cn(MICRO, "text-white/60")}>Opportunity map</p>
+            <p className="font-mono text-[10px] tracking-[0.08em] text-white/45">
               fit × complexity
             </p>
           </div>
@@ -374,8 +435,8 @@ export function ReportDashboard({
 
       <div className="border-b border-white/[0.08]">
         <div className="flex items-baseline justify-between gap-3 px-5 pt-5 sm:px-7">
-          <p className={cn(MICRO, "text-white/35")}>Use cases</p>
-          <p className="hidden font-mono text-[9px] tracking-[0.1em] text-white/25 sm:block">
+          <p className={cn(MICRO, "text-white/60")}>Use cases</p>
+          <p className="hidden font-mono text-[10px] tracking-[0.08em] text-white/45 sm:block">
             hours · savings / month
           </p>
         </div>
@@ -389,8 +450,8 @@ export function ReportDashboard({
       <div className="grid gap-px border-b border-white/[0.08] bg-white/[0.06] lg:grid-cols-2">
         <div className="bg-[#080808] p-5 sm:p-6">
           <div className="flex items-baseline justify-between gap-3">
-            <p className={cn(MICRO, "text-white/35")}>Risk heatmap</p>
-            <p className="font-mono text-[9px] tracking-[0.1em] text-white/25">
+            <p className={cn(MICRO, "text-white/60")}>Risk heatmap</p>
+            <p className="font-mono text-[10px] tracking-[0.08em] text-white/45">
               {highRiskCount} high · {report.risks.length} total
             </p>
           </div>
@@ -399,17 +460,20 @@ export function ReportDashboard({
 
         <div className="flex flex-col bg-[#080808] p-5 sm:p-6">
           <div className="flex items-baseline justify-between gap-3">
-            <p className={cn(MICRO, "text-white/35")}>Eval plan</p>
-            <p className="font-mono text-[9px] tracking-[0.1em] text-white/25">
+            <p className={cn(MICRO, "text-white/60")}>Eval plan</p>
+            <p className="font-mono text-[10px] tracking-[0.08em] text-white/45">
               {totalEvalCases} cases
             </p>
           </div>
           <p className="mt-4 text-sm font-medium text-white">
             {report.evaluationPack.name}
           </p>
-          <div className="mt-3 flex h-3 w-full" aria-hidden>
+          <div
+            className="mt-3 flex h-3 w-full overflow-hidden rounded-full bg-white/[0.06]"
+            aria-hidden
+          >
             <div
-              className="bg-white/85"
+              className="bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.5)]"
               style={{
                 width: `${
                   (report.evaluationPack.recommendedCases /
@@ -423,14 +487,14 @@ export function ReportDashboard({
               style={{ backgroundImage: ADVERSARIAL_STRIPES }}
             />
           </div>
-          <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 font-mono text-[10px] tracking-[0.06em] text-white/40">
+          <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 font-mono text-[11px] tracking-[0.04em] text-white/65">
             <span className="flex items-center gap-1.5">
-              <span className="size-2 bg-white/85" aria-hidden />
+              <span className="size-2 rounded-[1px] bg-cyan-400" aria-hidden />
               {report.evaluationPack.recommendedCases} realistic
             </span>
             <span className="flex items-center gap-1.5">
               <span
-                className="size-2"
+                className="size-2 rounded-[1px]"
                 style={{ backgroundImage: ADVERSARIAL_STRIPES }}
                 aria-hidden
               />
@@ -441,9 +505,9 @@ export function ReportDashboard({
             {report.evaluationPack.successCriteria.map((criterion) => (
               <li
                 key={criterion}
-                className="flex gap-2 text-[13px] leading-5 text-white/55"
+                className="flex gap-2 text-[13px] leading-5 text-white/75"
               >
-                <span className="font-mono text-white/25">✓</span>
+                <span className="font-mono text-emerald-300">✓</span>
                 {criterion}
               </li>
             ))}
@@ -460,15 +524,15 @@ export function ReportDashboard({
 
       <div className="grid gap-px bg-white/[0.06] lg:grid-cols-[1.1fr_0.9fr]">
         <div className="bg-[#080808] p-5 sm:p-7">
-          <p className={cn(MICRO, "text-white/35")}>The verdict</p>
-          <p className="mt-3 text-[15px] leading-7 text-white/70">
+          <p className={cn(MICRO, "text-white/60")}>The verdict</p>
+          <p className="mt-3 text-[15px] leading-7 text-white/80">
             {report.honestVerdict}
           </p>
-          <div className="mt-5 border-t border-white/[0.06] pt-3">
+          <div className="mt-5 border-t border-white/[0.08] pt-3">
             {report.evidenceLimitations.map((limit, index) => (
               <p
                 key={limit}
-                className="mt-1 text-[11px] leading-5 text-white/30"
+                className="mt-1 text-xs leading-5 text-white/50"
               >
                 <span className="font-mono">{index + 1}.</span> {limit}
               </p>
@@ -476,17 +540,17 @@ export function ReportDashboard({
           </div>
         </div>
         <div className="bg-[#080808] p-5 sm:p-7">
-          <p className={cn(MICRO, "text-white/35")}>Next steps</p>
+          <p className={cn(MICRO, "text-white/60")}>Next steps</p>
           <ol className="mt-3 space-y-3">
             {report.nextSteps.map((step, index) => (
               <li key={step} className="flex gap-3">
                 <span
-                  className={cn(SERIF, "text-xl leading-6 text-white/15")}
+                  className={cn(SERIF, "text-xl leading-6 text-white/30")}
                   aria-hidden
                 >
                   {String(index + 1).padStart(2, "0")}
                 </span>
-                <span className="text-sm leading-6 text-white/60">{step}</span>
+                <span className="text-sm leading-6 text-white/80">{step}</span>
               </li>
             ))}
           </ol>
@@ -500,12 +564,12 @@ function LoadingPanel({ step }: { step: number }) {
   return (
     <section className="mt-10 border border-white/[0.08] bg-[#080808] p-6">
       <div className="flex items-center gap-3">
-        <Loader2 className="size-5 animate-spin text-white/60" />
+        <Loader2 className="size-5 animate-spin text-cyan-300" />
         <div>
           <p className="text-sm font-medium text-white">
             Generating your report
           </p>
-          <p className="mt-1 text-xs text-white/45">
+          <p className="mt-1 text-xs text-white/60">
             This usually takes 20 to 60 seconds while we search the web.
           </p>
         </div>
@@ -520,20 +584,20 @@ function LoadingPanel({ step }: { step: number }) {
               className={cn(
                 "flex items-center gap-3 text-sm",
                 done
-                  ? "text-white/70"
+                  ? "text-white/75"
                   : active
                     ? "text-white"
-                    : "text-white/30",
+                    : "text-white/45",
               )}
             >
               <span
                 className={cn(
                   "flex size-6 items-center justify-center border font-mono text-[11px]",
                   done
-                    ? "border-white/30 bg-white/10"
+                    ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300"
                     : active
-                      ? "border-white/40"
-                      : "border-white/10",
+                      ? "border-cyan-400/50 text-cyan-300"
+                      : "border-white/15",
                 )}
               >
                 {done ? "✓" : index + 1}
@@ -541,7 +605,7 @@ function LoadingPanel({ step }: { step: number }) {
               {label}
               {active ? (
                 <span
-                  className="size-1.5 animate-pulse rounded-full bg-white/70"
+                  className="size-1.5 animate-pulse rounded-full bg-cyan-300"
                   aria-hidden
                 />
               ) : null}

--- a/web/src/app/agent-opportunity/components/dimension-radar.tsx
+++ b/web/src/app/agent-opportunity/components/dimension-radar.tsx
@@ -29,9 +29,13 @@ export function DimensionRadar({
     return () => cancelAnimationFrame(frame);
   }, []);
 
+  const avg = Math.round(
+    (metrics.workflowFit + metrics.roiSignal + metrics.evalReadiness + metrics.riskProfile) / 4,
+  );
+
   return (
     <div
-      className={cn("flex flex-col gap-4", className)}
+      className={cn("flex flex-col gap-6", className)}
       role="img"
       aria-label={`Dimension profile: ${ROWS.map(
         (row) => `${row.label} ${metrics[row.key]} of 100`,
@@ -46,7 +50,7 @@ export function DimensionRadar({
             </span>
             <div className="relative flex-1 overflow-hidden rounded-sm bg-white/[0.06]">
               <div
-                className="h-2 rounded-sm bg-white transition-[width] duration-700 ease-out motion-reduce:transition-none"
+                className="h-4 rounded-sm bg-white transition-[width] duration-700 ease-out motion-reduce:transition-none"
                 style={{
                   width: mounted ? `${Math.max(2, Math.min(100, value))}%` : "0%",
                 }}
@@ -58,6 +62,17 @@ export function DimensionRadar({
           </div>
         );
       })}
+
+      <div className="mt-2 border-t border-white/[0.08] pt-4">
+        <div className="flex items-baseline gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/40">Average</span>
+          <span className="font-mono text-[24px] font-medium tabular-nums text-white/90">{avg}</span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/40">/100</span>
+        </div>
+        <p className="mt-2 text-[11px] leading-5 text-white/35">
+          Based on workflow analysis, public signals, and market benchmarks.
+        </p>
+      </div>
     </div>
   );
 }

--- a/web/src/app/agent-opportunity/components/dimension-radar.tsx
+++ b/web/src/app/agent-opportunity/components/dimension-radar.tsx
@@ -23,6 +23,7 @@ const RADIUS = 86;
 const RINGS = [25, 50, 75, 100];
 
 const CYAN = "#22d3ee";
+const GRADIENT_ID = "radar-fill-" + Math.random().toString(36).slice(2);
 
 function pointAt(axisIndex: number, value: number): [number, number] {
   const angle = (Math.PI / 2) * axisIndex - Math.PI / 2;
@@ -73,7 +74,7 @@ export function DimensionRadar({
       className={cn("block w-full", className)}
     >
       <defs>
-        <radialGradient id="radar-fill" cx="50%" cy="50%" r="65%">
+        <radialGradient id={GRADIENT_ID} cx="50%" cy="50%" r="65%">
           <stop offset="0%" stopColor={CYAN} stopOpacity="0.32" />
           <stop offset="100%" stopColor={CYAN} stopOpacity="0.05" />
         </radialGradient>
@@ -115,7 +116,7 @@ export function DimensionRadar({
       >
         <polygon
           points={polygon}
-          fill="url(#radar-fill)"
+          fill={`url(#${GRADIENT_ID})`}
           stroke={CYAN}
           strokeWidth={2}
           strokeLinejoin="round"

--- a/web/src/app/agent-opportunity/components/dimension-radar.tsx
+++ b/web/src/app/agent-opportunity/components/dimension-radar.tsx
@@ -9,12 +9,11 @@ type Axis = {
   label: string;
 };
 
-// Order is positional: top, right, bottom, left.
 const AXES: Axis[] = [
-  { key: "workflowFit", label: "Workflow fit" },
-  { key: "roiSignal", label: "ROI signal" },
-  { key: "evalReadiness", label: "Eval ready" },
-  { key: "riskProfile", label: "Risk safety" },
+  { key: "workflowFit", label: "Workflow" },
+  { key: "roiSignal", label: "ROI" },
+  { key: "evalReadiness", label: "Eval" },
+  { key: "riskProfile", label: "Risk" },
 ];
 
 const CX = 185;
@@ -22,8 +21,8 @@ const CY = 140;
 const RADIUS = 86;
 const RINGS = [25, 50, 75, 100];
 
-const CYAN = "#22d3ee";
-const GRADIENT_ID = "radar-fill-" + Math.random().toString(36).slice(2);
+const ACCENT = "#fff";
+const FILL = "rgba(255,255,255,0.06)";
 
 function pointAt(axisIndex: number, value: number): [number, number] {
   const angle = (Math.PI / 2) * axisIndex - Math.PI / 2;
@@ -40,10 +39,10 @@ const LABEL_ANCHORS: {
   dx: number;
   dy: number;
 }[] = [
-  { anchor: "middle", dx: 0, dy: -18 },
-  { anchor: "start", dx: 14, dy: 0 },
-  { anchor: "middle", dx: 0, dy: 26 },
-  { anchor: "end", dx: -14, dy: 0 },
+  { anchor: "middle", dx: 0, dy: -16 },
+  { anchor: "start", dx: 12, dy: 0 },
+  { anchor: "middle", dx: 0, dy: 22 },
+  { anchor: "end", dx: -12, dy: 0 },
 ];
 
 export function DimensionRadar({
@@ -69,26 +68,22 @@ export function DimensionRadar({
       viewBox="0 0 370 286"
       role="img"
       aria-label={`Dimension profile: ${AXES.map(
-        (axis, index) => `${axis.label} ${values[index]} of 100`,
+        (axis, index) => `${axis.label} ${values[index]}`,
       ).join(", ")}`}
       className={cn("block w-full", className)}
     >
-      <defs>
-        <radialGradient id={GRADIENT_ID} cx="50%" cy="50%" r="65%">
-          <stop offset="0%" stopColor={CYAN} stopOpacity="0.32" />
-          <stop offset="100%" stopColor={CYAN} stopOpacity="0.05" />
-        </radialGradient>
-      </defs>
-
+      {/* Grid rings */}
       {RINGS.map((ring) => (
         <polygon
           key={ring}
           points={ringPath(ring)}
           fill="none"
-          stroke="rgba(255,255,255,0.1)"
+          stroke="rgba(255,255,255,0.08)"
           strokeWidth={1}
         />
       ))}
+
+      {/* Axis lines */}
       {AXES.map((axis, index) => {
         const [x, y] = pointAt(index, 100);
         return (
@@ -98,42 +93,41 @@ export function DimensionRadar({
             y1={CY}
             x2={x}
             y2={y}
-            stroke="rgba(255,255,255,0.13)"
+            stroke="rgba(255,255,255,0.08)"
             strokeWidth={1}
           />
         );
       })}
 
+      {/* Data polygon */}
       <g
         className="motion-reduce:transition-none"
         style={{
           transformOrigin: `${CX}px ${CY}px`,
-          transform: mounted ? "scale(1)" : "scale(0.3)",
+          transform: mounted ? "scale(1)" : "scale(0.85)",
           opacity: mounted ? 1 : 0,
-          transition:
-            "transform 800ms cubic-bezier(0.22, 1, 0.36, 1), opacity 600ms ease",
+          transition: "transform 500ms ease-out, opacity 400ms ease",
         }}
       >
         <polygon
           points={polygon}
-          fill={`url(#${GRADIENT_ID})`}
-          stroke={CYAN}
-          strokeWidth={2}
+          fill={FILL}
+          stroke={ACCENT}
+          strokeWidth={1.5}
           strokeLinejoin="round"
-          style={{ filter: `drop-shadow(0 0 8px ${CYAN}80)` }}
         />
         {values.map((value, index) => {
           const [x, y] = pointAt(index, value);
           return (
             <g key={AXES[index].key}>
-              <circle cx={x} cy={y} r={5} fill={CYAN} opacity={0.25} />
-              <circle cx={x} cy={y} r={3} fill={CYAN} />
-              <circle cx={x} cy={y} r={1.4} fill="#fff" />
+              <circle cx={x} cy={y} r={4} fill="#080808" stroke={ACCENT} strokeWidth={1.5} />
+              <circle cx={x} cy={y} r={1.5} fill={ACCENT} />
             </g>
           );
         })}
       </g>
 
+      {/* Labels */}
       {AXES.map((axis, index) => {
         const [x, y] = pointAt(index, 100);
         const { anchor, dx, dy } = LABEL_ANCHORS[index];
@@ -142,15 +136,14 @@ export function DimensionRadar({
             <text
               x={x + dx}
               y={y + dy}
-              className="fill-white font-mono text-[15px] font-medium tabular-nums"
+              className="fill-white/90 font-mono text-[13px] font-medium tabular-nums"
             >
               {values[index]}
             </text>
             <text
               x={x + dx}
-              y={y + dy + 14}
-              className="fill-white/60 font-mono text-[10px] uppercase"
-              style={{ letterSpacing: "0.12em" }}
+              y={y + dy + 13}
+              className="fill-white/40 font-mono text-[9px] uppercase tracking-[0.14em]"
             >
               {axis.label}
             </text>

--- a/web/src/app/agent-opportunity/components/dimension-radar.tsx
+++ b/web/src/app/agent-opportunity/components/dimension-radar.tsx
@@ -4,45 +4,16 @@ import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { OpportunityMetrics } from "../report-metrics";
 
-type Axis = {
+type Row = {
   key: keyof OpportunityMetrics;
   label: string;
 };
 
-const AXES: Axis[] = [
-  { key: "workflowFit", label: "Workflow" },
-  { key: "roiSignal", label: "ROI" },
-  { key: "evalReadiness", label: "Eval" },
-  { key: "riskProfile", label: "Risk" },
-];
-
-const CX = 185;
-const CY = 140;
-const RADIUS = 86;
-const RINGS = [25, 50, 75, 100];
-
-const ACCENT = "#fff";
-const FILL = "rgba(255,255,255,0.06)";
-
-function pointAt(axisIndex: number, value: number): [number, number] {
-  const angle = (Math.PI / 2) * axisIndex - Math.PI / 2;
-  const r = (RADIUS * Math.max(0, Math.min(100, value))) / 100;
-  return [CX + r * Math.cos(angle), CY + r * Math.sin(angle)];
-}
-
-function ringPath(value: number): string {
-  return AXES.map((_, index) => pointAt(index, value).join(",")).join(" ");
-}
-
-const LABEL_ANCHORS: {
-  anchor: "start" | "middle" | "end";
-  dx: number;
-  dy: number;
-}[] = [
-  { anchor: "middle", dx: 0, dy: -16 },
-  { anchor: "start", dx: 12, dy: 0 },
-  { anchor: "middle", dx: 0, dy: 22 },
-  { anchor: "end", dx: -12, dy: 0 },
+const ROWS: Row[] = [
+  { key: "workflowFit", label: "Workflow fit" },
+  { key: "roiSignal", label: "ROI signal" },
+  { key: "evalReadiness", label: "Eval readiness" },
+  { key: "riskProfile", label: "Risk safety" },
 ];
 
 export function DimensionRadar({
@@ -58,98 +29,35 @@ export function DimensionRadar({
     return () => cancelAnimationFrame(frame);
   }, []);
 
-  const values = AXES.map((axis) => metrics[axis.key]);
-  const polygon = values
-    .map((value, index) => pointAt(index, value).join(","))
-    .join(" ");
-
   return (
-    <svg
-      viewBox="0 0 370 286"
+    <div
+      className={cn("flex flex-col gap-4", className)}
       role="img"
-      aria-label={`Dimension profile: ${AXES.map(
-        (axis, index) => `${axis.label} ${values[index]}`,
+      aria-label={`Dimension profile: ${ROWS.map(
+        (row) => `${row.label} ${metrics[row.key]} of 100`,
       ).join(", ")}`}
-      className={cn("block w-full", className)}
     >
-      {/* Grid rings */}
-      {RINGS.map((ring) => (
-        <polygon
-          key={ring}
-          points={ringPath(ring)}
-          fill="none"
-          stroke="rgba(255,255,255,0.08)"
-          strokeWidth={1}
-        />
-      ))}
-
-      {/* Axis lines */}
-      {AXES.map((axis, index) => {
-        const [x, y] = pointAt(index, 100);
+      {ROWS.map((row) => {
+        const value = metrics[row.key];
         return (
-          <line
-            key={axis.key}
-            x1={CX}
-            y1={CY}
-            x2={x}
-            y2={y}
-            stroke="rgba(255,255,255,0.08)"
-            strokeWidth={1}
-          />
+          <div key={row.key} className="flex items-center gap-4">
+            <span className="w-28 shrink-0 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-white/40">
+              {row.label}
+            </span>
+            <div className="relative flex-1 overflow-hidden rounded-sm bg-white/[0.06]">
+              <div
+                className="h-2 rounded-sm bg-white transition-[width] duration-700 ease-out motion-reduce:transition-none"
+                style={{
+                  width: mounted ? `${Math.max(2, Math.min(100, value))}%` : "0%",
+                }}
+              />
+            </div>
+            <span className="w-10 shrink-0 font-mono text-[13px] font-medium tabular-nums text-white/90">
+              {value}
+            </span>
+          </div>
         );
       })}
-
-      {/* Data polygon */}
-      <g
-        className="motion-reduce:transition-none"
-        style={{
-          transformOrigin: `${CX}px ${CY}px`,
-          transform: mounted ? "scale(1)" : "scale(0.85)",
-          opacity: mounted ? 1 : 0,
-          transition: "transform 500ms ease-out, opacity 400ms ease",
-        }}
-      >
-        <polygon
-          points={polygon}
-          fill={FILL}
-          stroke={ACCENT}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
-        {values.map((value, index) => {
-          const [x, y] = pointAt(index, value);
-          return (
-            <g key={AXES[index].key}>
-              <circle cx={x} cy={y} r={4} fill="#080808" stroke={ACCENT} strokeWidth={1.5} />
-              <circle cx={x} cy={y} r={1.5} fill={ACCENT} />
-            </g>
-          );
-        })}
-      </g>
-
-      {/* Labels */}
-      {AXES.map((axis, index) => {
-        const [x, y] = pointAt(index, 100);
-        const { anchor, dx, dy } = LABEL_ANCHORS[index];
-        return (
-          <g key={axis.key} textAnchor={anchor}>
-            <text
-              x={x + dx}
-              y={y + dy}
-              className="fill-white/90 font-mono text-[13px] font-medium tabular-nums"
-            >
-              {values[index]}
-            </text>
-            <text
-              x={x + dx}
-              y={y + dy + 13}
-              className="fill-white/40 font-mono text-[9px] uppercase tracking-[0.14em]"
-            >
-              {axis.label}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
+    </div>
   );
 }

--- a/web/src/app/agent-opportunity/components/dimension-radar.tsx
+++ b/web/src/app/agent-opportunity/components/dimension-radar.tsx
@@ -17,10 +17,12 @@ const AXES: Axis[] = [
   { key: "riskProfile", label: "Risk safety" },
 ];
 
-const CX = 170;
-const CY = 138;
-const RADIUS = 84;
+const CX = 185;
+const CY = 140;
+const RADIUS = 86;
 const RINGS = [25, 50, 75, 100];
+
+const CYAN = "#22d3ee";
 
 function pointAt(axisIndex: number, value: number): [number, number] {
   const angle = (Math.PI / 2) * axisIndex - Math.PI / 2;
@@ -37,9 +39,9 @@ const LABEL_ANCHORS: {
   dx: number;
   dy: number;
 }[] = [
-  { anchor: "middle", dx: 0, dy: -16 },
+  { anchor: "middle", dx: 0, dy: -18 },
   { anchor: "start", dx: 14, dy: 0 },
-  { anchor: "middle", dx: 0, dy: 24 },
+  { anchor: "middle", dx: 0, dy: 26 },
   { anchor: "end", dx: -14, dy: 0 },
 ];
 
@@ -63,19 +65,26 @@ export function DimensionRadar({
 
   return (
     <svg
-      viewBox="0 0 340 276"
+      viewBox="0 0 370 286"
       role="img"
       aria-label={`Dimension profile: ${AXES.map(
         (axis, index) => `${axis.label} ${values[index]} of 100`,
       ).join(", ")}`}
       className={cn("block w-full", className)}
     >
+      <defs>
+        <radialGradient id="radar-fill" cx="50%" cy="50%" r="65%">
+          <stop offset="0%" stopColor={CYAN} stopOpacity="0.32" />
+          <stop offset="100%" stopColor={CYAN} stopOpacity="0.05" />
+        </radialGradient>
+      </defs>
+
       {RINGS.map((ring) => (
         <polygon
           key={ring}
           points={ringPath(ring)}
           fill="none"
-          stroke="rgba(255,255,255,0.07)"
+          stroke="rgba(255,255,255,0.1)"
           strokeWidth={1}
         />
       ))}
@@ -88,7 +97,7 @@ export function DimensionRadar({
             y1={CY}
             x2={x}
             y2={y}
-            stroke="rgba(255,255,255,0.1)"
+            stroke="rgba(255,255,255,0.13)"
             strokeWidth={1}
           />
         );
@@ -98,23 +107,28 @@ export function DimensionRadar({
         className="motion-reduce:transition-none"
         style={{
           transformOrigin: `${CX}px ${CY}px`,
-          transform: mounted ? "scale(1)" : "scale(0.35)",
+          transform: mounted ? "scale(1)" : "scale(0.3)",
           opacity: mounted ? 1 : 0,
           transition:
-            "transform 700ms cubic-bezier(0.22, 1, 0.36, 1), opacity 500ms ease",
+            "transform 800ms cubic-bezier(0.22, 1, 0.36, 1), opacity 600ms ease",
         }}
       >
         <polygon
           points={polygon}
-          fill="rgba(255,255,255,0.07)"
-          stroke="rgba(255,255,255,0.75)"
-          strokeWidth={1.5}
+          fill="url(#radar-fill)"
+          stroke={CYAN}
+          strokeWidth={2}
           strokeLinejoin="round"
+          style={{ filter: `drop-shadow(0 0 8px ${CYAN}80)` }}
         />
         {values.map((value, index) => {
           const [x, y] = pointAt(index, value);
           return (
-            <circle key={AXES[index].key} cx={x} cy={y} r={2.5} fill="#fff" />
+            <g key={AXES[index].key}>
+              <circle cx={x} cy={y} r={5} fill={CYAN} opacity={0.25} />
+              <circle cx={x} cy={y} r={3} fill={CYAN} />
+              <circle cx={x} cy={y} r={1.4} fill="#fff" />
+            </g>
           );
         })}
       </g>
@@ -127,15 +141,15 @@ export function DimensionRadar({
             <text
               x={x + dx}
               y={y + dy}
-              className="fill-white font-mono text-[13px] tabular-nums"
+              className="fill-white font-mono text-[15px] font-medium tabular-nums"
             >
               {values[index]}
             </text>
             <text
               x={x + dx}
-              y={y + dy + 12}
-              className="fill-white/35 font-mono text-[8.5px] uppercase"
-              style={{ letterSpacing: "0.14em" }}
+              y={y + dy + 14}
+              className="fill-white/60 font-mono text-[10px] uppercase"
+              style={{ letterSpacing: "0.12em" }}
             >
               {axis.label}
             </text>

--- a/web/src/app/agent-opportunity/components/opportunity-map.tsx
+++ b/web/src/app/agent-opportunity/components/opportunity-map.tsx
@@ -7,21 +7,19 @@ import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
 type UseCase = AgentOpportunityReport["useCases"][number];
 type Level = UseCase["fit"];
 
-// Impact/effort quadrant: high fit is at the top, low complexity on
-// the left, so the top-left quadrant holds the quick wins.
 const FIT_Y: Record<Level, number> = { high: 22, medium: 50, low: 78 };
 const COMPLEXITY_X: Record<Level, number> = { low: 20, medium: 50, high: 80 };
 
 const FIT_DOT: Record<Level, string> = {
-  high: "bg-emerald-400 shadow-[0_0_14px_rgba(52,211,153,0.6)]",
-  medium: "bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]",
-  low: "bg-red-400 shadow-[0_0_14px_rgba(248,113,113,0.55)]",
+  high: "bg-white",
+  medium: "bg-white/50",
+  low: "bg-white/25",
 };
 
 const FIT_TEXT: Record<Level, string> = {
-  high: "text-emerald-300",
-  medium: "text-amber-200",
-  low: "text-red-300",
+  high: "text-white",
+  medium: "text-white/60",
+  low: "text-white/40",
 };
 
 type PlacedUseCase = {
@@ -41,7 +39,7 @@ function placeUseCases(useCases: UseCase[]): PlacedUseCase[] {
   return useCases.map((useCase, index) => {
     const siblings = groups.get(`${useCase.fit}-${useCase.complexity}`)!;
     const position = siblings.indexOf(index);
-    const spread = (position - (siblings.length - 1) / 2) * 11;
+    const spread = (position - (siblings.length - 1) / 2) * 12;
     return {
       useCase,
       index,
@@ -52,30 +50,10 @@ function placeUseCases(useCases: UseCase[]): PlacedUseCase[] {
 }
 
 const QUADRANTS = [
-  {
-    label: "Quick wins",
-    position: "left-2.5 top-2",
-    tint: "bg-emerald-400/[0.08]",
-    text: "text-emerald-300/90",
-  },
-  {
-    label: "Big bets",
-    position: "right-2.5 top-2",
-    tint: "bg-cyan-400/[0.06]",
-    text: "text-cyan-300/80",
-  },
-  {
-    label: "Low stakes",
-    position: "bottom-2 left-2.5",
-    tint: "",
-    text: "text-white/45",
-  },
-  {
-    label: "Avoid",
-    position: "bottom-2 right-2.5",
-    tint: "bg-red-400/[0.07]",
-    text: "text-red-300/80",
-  },
+  { label: "Quick wins", position: "left-3 top-3", text: "text-white/70" },
+  { label: "Big bets", position: "right-3 top-3", text: "text-white/50" },
+  { label: "Low stakes", position: "bottom-3 left-3", text: "text-white/40" },
+  { label: "Avoid", position: "bottom-3 right-3", text: "text-white/30" },
 ];
 
 export function OpportunityMap({
@@ -95,27 +73,23 @@ export function OpportunityMap({
 
   return (
     <div className={className}>
-      <div className="relative aspect-[8/5] overflow-hidden border border-white/10 bg-[#0a0a0a]">
-        <div className="absolute inset-0 grid grid-cols-2 grid-rows-2" aria-hidden>
-          {QUADRANTS.map((quadrant) => (
-            <div key={quadrant.label} className={quadrant.tint} />
-          ))}
-        </div>
-
+      <div className="relative aspect-[8/5] overflow-hidden border border-white/[0.08] bg-[#080808]">
+        {/* Midlines */}
         <div
-          className="absolute left-1/2 top-0 h-full w-px border-l border-dashed border-white/15"
+          className="absolute left-1/2 top-0 h-full w-px bg-white/[0.08]"
           aria-hidden
         />
         <div
-          className="absolute left-0 top-1/2 h-px w-full border-t border-dashed border-white/15"
+          className="absolute left-0 top-1/2 h-px w-full bg-white/[0.08]"
           aria-hidden
         />
 
+        {/* Quadrant labels */}
         {QUADRANTS.map((quadrant) => (
           <span
             key={quadrant.label}
             className={cn(
-              "pointer-events-none absolute font-mono text-[10px] uppercase tracking-[0.16em]",
+              "pointer-events-none absolute font-mono text-[9px] uppercase tracking-[0.18em]",
               quadrant.position,
               quadrant.text,
             )}
@@ -124,19 +98,20 @@ export function OpportunityMap({
           </span>
         ))}
 
+        {/* Use case dots — clean squares */}
         {placed.map(({ useCase, index, x, y }, order) => (
           <span
             key={useCase.title}
             title={`${useCase.title} — ${useCase.fit} fit, ${useCase.complexity} complexity`}
             className={cn(
-              "absolute flex size-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full font-mono text-[11px] font-semibold text-[#060606] transition-all duration-500 motion-reduce:transition-none",
+              "absolute flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center font-mono text-[10px] font-medium text-[#080606] transition-all duration-500 motion-reduce:transition-none",
               FIT_DOT[useCase.fit],
             )}
             style={{
               left: `${x}%`,
-              top: mounted ? `${y}%` : "115%",
+              top: mounted ? `${y}%` : "110%",
               opacity: mounted ? 1 : 0,
-              transitionDelay: `${order * 90}ms`,
+              transitionDelay: `${order * 80}ms`,
             }}
           >
             {index + 1}
@@ -144,33 +119,35 @@ export function OpportunityMap({
         ))}
       </div>
 
-      <div className="mt-2 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-white/50">
-        <span>← Easier to build</span>
-        <span>Harder to build →</span>
+      {/* Axis labels */}
+      <div className="mt-2 flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.14em] text-white/40">
+        <span>← Easier</span>
+        <span>Harder →</span>
       </div>
 
-      <ul className="mt-4 space-y-2">
+      {/* Legend */}
+      <ul className="mt-4 space-y-1.5">
         {placed.map(({ useCase, index }) => (
-          <li key={useCase.title} className="flex items-center gap-2.5">
+          <li key={useCase.title} className="flex items-center gap-3">
             <span
               className={cn(
-                "flex size-5 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-semibold text-[#060606]",
+                "flex size-4 shrink-0 items-center justify-center font-mono text-[9px] font-medium text-[#080606]",
                 FIT_DOT[useCase.fit],
               )}
               aria-hidden
             >
               {index + 1}
             </span>
-            <span className="min-w-0 truncate text-[13px] text-white/85">
+            <span className="min-w-0 truncate text-[13px] text-white/80">
               {useCase.title}
             </span>
             <span
               className={cn(
-                "ml-auto shrink-0 font-mono text-[10px] uppercase tracking-[0.1em]",
+                "ml-auto shrink-0 font-mono text-[9px] uppercase tracking-[0.12em]",
                 FIT_TEXT[useCase.fit],
               )}
             >
-              {useCase.fit} fit
+              {useCase.fit}
             </span>
           </li>
         ))}

--- a/web/src/app/agent-opportunity/components/opportunity-map.tsx
+++ b/web/src/app/agent-opportunity/components/opportunity-map.tsx
@@ -1,19 +1,82 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
 
 type UseCase = AgentOpportunityReport["useCases"][number];
 type Level = UseCase["fit"];
 
-// Top row is high fit; left column is low complexity, so the
-// build zone (high value, low effort) sits top-left like an
-// effort/impact matrix.
-const FIT_ROWS: Level[] = ["high", "medium", "low"];
-const COMPLEXITY_COLS: Level[] = ["low", "medium", "high"];
+// Impact/effort quadrant: high fit is at the top, low complexity on
+// the left, so the top-left quadrant holds the quick wins.
+const FIT_Y: Record<Level, number> = { high: 22, medium: 50, low: 78 };
+const COMPLEXITY_X: Record<Level, number> = { low: 20, medium: 50, high: 80 };
 
-const HATCH =
-  "repeating-linear-gradient(135deg, rgba(255,255,255,0.055) 0, rgba(255,255,255,0.055) 1px, transparent 1px, transparent 7px)";
+const FIT_DOT: Record<Level, string> = {
+  high: "bg-emerald-400 shadow-[0_0_14px_rgba(52,211,153,0.6)]",
+  medium: "bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]",
+  low: "bg-red-400 shadow-[0_0_14px_rgba(248,113,113,0.55)]",
+};
+
+const FIT_TEXT: Record<Level, string> = {
+  high: "text-emerald-300",
+  medium: "text-amber-200",
+  low: "text-red-300",
+};
+
+type PlacedUseCase = {
+  useCase: UseCase;
+  index: number;
+  x: number;
+  y: number;
+};
+
+function placeUseCases(useCases: UseCase[]): PlacedUseCase[] {
+  const groups = new Map<string, number[]>();
+  useCases.forEach((useCase, index) => {
+    const key = `${useCase.fit}-${useCase.complexity}`;
+    groups.set(key, [...(groups.get(key) ?? []), index]);
+  });
+
+  return useCases.map((useCase, index) => {
+    const siblings = groups.get(`${useCase.fit}-${useCase.complexity}`)!;
+    const position = siblings.indexOf(index);
+    const spread = (position - (siblings.length - 1) / 2) * 11;
+    return {
+      useCase,
+      index,
+      x: COMPLEXITY_X[useCase.complexity] + spread,
+      y: FIT_Y[useCase.fit],
+    };
+  });
+}
+
+const QUADRANTS = [
+  {
+    label: "Quick wins",
+    position: "left-2.5 top-2",
+    tint: "bg-emerald-400/[0.08]",
+    text: "text-emerald-300/90",
+  },
+  {
+    label: "Big bets",
+    position: "right-2.5 top-2",
+    tint: "bg-cyan-400/[0.06]",
+    text: "text-cyan-300/80",
+  },
+  {
+    label: "Low stakes",
+    position: "bottom-2 left-2.5",
+    tint: "",
+    text: "text-white/45",
+  },
+  {
+    label: "Avoid",
+    position: "bottom-2 right-2.5",
+    tint: "bg-red-400/[0.07]",
+    text: "text-red-300/80",
+  },
+];
 
 export function OpportunityMap({
   useCases,
@@ -22,71 +85,96 @@ export function OpportunityMap({
   useCases: UseCase[];
   className?: string;
 }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const placed = placeUseCases(useCases);
+
   return (
     <div className={className}>
-      <div className="flex gap-2">
-        <div className="flex w-4 shrink-0 items-center justify-center">
-          <span className="rotate-180 font-mono text-[9px] uppercase tracking-[0.2em] text-white/30 [writing-mode:vertical-rl]">
-            Fit →
-          </span>
+      <div className="relative aspect-[8/5] overflow-hidden border border-white/10 bg-[#0a0a0a]">
+        <div className="absolute inset-0 grid grid-cols-2 grid-rows-2" aria-hidden>
+          {QUADRANTS.map((quadrant) => (
+            <div key={quadrant.label} className={quadrant.tint} />
+          ))}
         </div>
 
-        <div className="min-w-0 flex-1">
-          <div className="grid grid-cols-3 gap-px border border-white/[0.08] bg-white/[0.06]">
-            {FIT_ROWS.map((fit) =>
-              COMPLEXITY_COLS.map((complexity) => {
-                const matches = useCases
-                  .map((useCase, index) => ({ useCase, index }))
-                  .filter(
-                    ({ useCase }) =>
-                      useCase.fit === fit && useCase.complexity === complexity,
-                  );
-                const isBuildZone = fit === "high" && complexity === "low";
-                const isAvoidZone = fit === "low" && complexity === "high";
+        <div
+          className="absolute left-1/2 top-0 h-full w-px border-l border-dashed border-white/15"
+          aria-hidden
+        />
+        <div
+          className="absolute left-0 top-1/2 h-px w-full border-t border-dashed border-white/15"
+          aria-hidden
+        />
 
-                return (
-                  <div
-                    key={`${fit}-${complexity}`}
-                    className="relative flex min-h-[76px] flex-wrap content-center items-center justify-center gap-1.5 bg-[#080808] p-2"
-                    style={isBuildZone ? { backgroundImage: HATCH } : undefined}
-                  >
-                    {isBuildZone ? (
-                      <span className="pointer-events-none absolute left-1.5 top-1.5 font-mono text-[8px] uppercase tracking-[0.18em] text-white/40">
-                        Build zone
-                      </span>
-                    ) : null}
-                    {isAvoidZone ? (
-                      <span className="pointer-events-none absolute bottom-1.5 right-1.5 font-mono text-[8px] uppercase tracking-[0.18em] text-white/20">
-                        Avoid
-                      </span>
-                    ) : null}
-                    {matches.map(({ useCase, index }) => (
-                      <span
-                        key={useCase.title}
-                        title={useCase.title}
-                        className={cn(
-                          "border px-1.5 py-0.5 font-mono text-[10px] tabular-nums",
-                          fit === "high"
-                            ? "border-white/40 bg-white text-[#060606]"
-                            : "border-white/25 bg-[#0c0c0c] text-white/80",
-                        )}
-                      >
-                        {String(index + 1).padStart(2, "0")}
-                      </span>
-                    ))}
-                  </div>
-                );
-              }),
+        {QUADRANTS.map((quadrant) => (
+          <span
+            key={quadrant.label}
+            className={cn(
+              "pointer-events-none absolute font-mono text-[10px] uppercase tracking-[0.16em]",
+              quadrant.position,
+              quadrant.text,
             )}
-          </div>
+          >
+            {quadrant.label}
+          </span>
+        ))}
 
-          <div className="mt-1.5 grid grid-cols-3 font-mono text-[9px] uppercase tracking-[0.16em] text-white/30">
-            <span>Low</span>
-            <span className="text-center">Complexity →</span>
-            <span className="text-right">High</span>
-          </div>
-        </div>
+        {placed.map(({ useCase, index, x, y }, order) => (
+          <span
+            key={useCase.title}
+            title={`${useCase.title} — ${useCase.fit} fit, ${useCase.complexity} complexity`}
+            className={cn(
+              "absolute flex size-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full font-mono text-[11px] font-semibold text-[#060606] transition-all duration-500 motion-reduce:transition-none",
+              FIT_DOT[useCase.fit],
+            )}
+            style={{
+              left: `${x}%`,
+              top: mounted ? `${y}%` : "115%",
+              opacity: mounted ? 1 : 0,
+              transitionDelay: `${order * 90}ms`,
+            }}
+          >
+            {index + 1}
+          </span>
+        ))}
       </div>
+
+      <div className="mt-2 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-white/50">
+        <span>← Easier to build</span>
+        <span>Harder to build →</span>
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {placed.map(({ useCase, index }) => (
+          <li key={useCase.title} className="flex items-center gap-2.5">
+            <span
+              className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-semibold text-[#060606]",
+                FIT_DOT[useCase.fit],
+              )}
+              aria-hidden
+            >
+              {index + 1}
+            </span>
+            <span className="min-w-0 truncate text-[13px] text-white/85">
+              {useCase.title}
+            </span>
+            <span
+              className={cn(
+                "ml-auto shrink-0 font-mono text-[10px] uppercase tracking-[0.1em]",
+                FIT_TEXT[useCase.fit],
+              )}
+            >
+              {useCase.fit} fit
+            </span>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/web/src/app/agent-opportunity/components/risk-heatmap.tsx
+++ b/web/src/app/agent-opportunity/components/risk-heatmap.tsx
@@ -11,9 +11,9 @@ const SEVERITIES: AgentOpportunityRisk["severity"][] = [
 ];
 
 const CELL_FILL: Record<AgentOpportunityRisk["severity"], string> = {
-  low: "bg-emerald-400/90 shadow-[0_0_10px_rgba(52,211,153,0.45)]",
-  medium: "bg-amber-300 shadow-[0_0_10px_rgba(252,211,77,0.45)]",
-  high: "bg-red-400 shadow-[0_0_12px_rgba(248,113,113,0.55)]",
+  low: "bg-white",
+  medium: "bg-white/50",
+  high: "bg-white/25",
 };
 
 export function RiskHeatmap({
@@ -25,27 +25,27 @@ export function RiskHeatmap({
 }) {
   return (
     <div className={className}>
-      <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,2.5rem)] items-end gap-x-1 border-b border-white/10 pb-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/55">
-          Failure mode
+      <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,2rem)] items-end gap-x-2 border-b border-white/[0.08] pb-2">
+        <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-white/40">
+          Risk
         </span>
         {SEVERITIES.map((severity) => (
           <span
             key={severity}
-            className="text-center font-mono text-[10px] uppercase tracking-[0.1em] text-white/55"
+            className="text-center font-mono text-[9px] uppercase tracking-[0.1em] text-white/40"
           >
             {severity === "medium" ? "med" : severity}
           </span>
         ))}
       </div>
 
-      <div className="divide-y divide-white/[0.06]">
+      <div className="divide-y divide-white/[0.05]">
         {risks.map((risk) => (
           <details key={risk.risk} className="group">
-            <summary className="grid cursor-pointer list-none grid-cols-[minmax(0,1fr)_repeat(3,2.5rem)] items-center gap-x-1 py-3 transition-colors marker:content-none hover:bg-white/[0.03] [&::-webkit-details-marker]:hidden">
+            <summary className="grid cursor-pointer list-none grid-cols-[minmax(0,1fr)_repeat(3,2rem)] items-center gap-x-2 py-3 transition-colors marker:content-none hover:bg-white/[0.02] [&::-webkit-details-marker]:hidden">
               <span className="flex min-w-0 items-center gap-2 pr-2">
-                <ChevronDown className="size-3.5 shrink-0 text-white/40 transition-transform group-open:rotate-180" />
-                <span className="truncate text-[13px] text-white/85">
+                <ChevronDown className="size-3.5 shrink-0 text-white/30 transition-transform group-open:rotate-180" />
+                <span className="truncate text-[13px] text-white/80">
                   {risk.risk}
                 </span>
               </span>
@@ -53,16 +53,16 @@ export function RiskHeatmap({
                 <span key={severity} className="flex justify-center">
                   <span
                     className={cn(
-                      "h-4 w-8 rounded-[2px]",
+                      "h-3.5 w-7 rounded-sm",
                       severity === risk.severity
                         ? CELL_FILL[severity]
-                        : "border border-white/10",
+                        : "border border-white/[0.06]",
                     )}
                   />
                 </span>
               ))}
             </summary>
-            <p className="pb-3 pl-[22px] pr-2 text-[13px] leading-6 text-white/60">
+            <p className="pb-3 pl-[22px] pr-2 text-[13px] leading-6 text-white/50">
               {risk.mitigation}
             </p>
           </details>

--- a/web/src/app/agent-opportunity/components/risk-heatmap.tsx
+++ b/web/src/app/agent-opportunity/components/risk-heatmap.tsx
@@ -11,9 +11,9 @@ const SEVERITIES: AgentOpportunityRisk["severity"][] = [
 ];
 
 const CELL_FILL: Record<AgentOpportunityRisk["severity"], string> = {
-  low: "bg-white/25",
-  medium: "bg-white/60",
-  high: "bg-white",
+  low: "bg-emerald-400/90 shadow-[0_0_10px_rgba(52,211,153,0.45)]",
+  medium: "bg-amber-300 shadow-[0_0_10px_rgba(252,211,77,0.45)]",
+  high: "bg-red-400 shadow-[0_0_12px_rgba(248,113,113,0.55)]",
 };
 
 export function RiskHeatmap({
@@ -25,27 +25,27 @@ export function RiskHeatmap({
 }) {
   return (
     <div className={className}>
-      <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,2.25rem)] items-end gap-x-1 border-b border-white/[0.08] pb-2">
-        <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-white/30">
+      <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,2.5rem)] items-end gap-x-1 border-b border-white/10 pb-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/55">
           Failure mode
         </span>
         {SEVERITIES.map((severity) => (
           <span
             key={severity}
-            className="text-center font-mono text-[9px] uppercase tracking-[0.12em] text-white/30"
+            className="text-center font-mono text-[10px] uppercase tracking-[0.1em] text-white/55"
           >
             {severity === "medium" ? "med" : severity}
           </span>
         ))}
       </div>
 
-      <div className="divide-y divide-white/[0.05]">
+      <div className="divide-y divide-white/[0.06]">
         {risks.map((risk) => (
           <details key={risk.risk} className="group">
-            <summary className="grid cursor-pointer list-none grid-cols-[minmax(0,1fr)_repeat(3,2.25rem)] items-center gap-x-1 py-2.5 transition-colors marker:content-none hover:bg-white/[0.02] [&::-webkit-details-marker]:hidden">
-              <span className="flex min-w-0 items-center gap-1.5 pr-2">
-                <ChevronDown className="size-3 shrink-0 text-white/25 transition-transform group-open:rotate-180" />
-                <span className="truncate text-[13px] text-white/75">
+            <summary className="grid cursor-pointer list-none grid-cols-[minmax(0,1fr)_repeat(3,2.5rem)] items-center gap-x-1 py-3 transition-colors marker:content-none hover:bg-white/[0.03] [&::-webkit-details-marker]:hidden">
+              <span className="flex min-w-0 items-center gap-2 pr-2">
+                <ChevronDown className="size-3.5 shrink-0 text-white/40 transition-transform group-open:rotate-180" />
+                <span className="truncate text-[13px] text-white/85">
                   {risk.risk}
                 </span>
               </span>
@@ -53,16 +53,16 @@ export function RiskHeatmap({
                 <span key={severity} className="flex justify-center">
                   <span
                     className={cn(
-                      "h-3.5 w-7",
+                      "h-4 w-8 rounded-[2px]",
                       severity === risk.severity
                         ? CELL_FILL[severity]
-                        : "border border-white/[0.07]",
+                        : "border border-white/10",
                     )}
                   />
                 </span>
               ))}
             </summary>
-            <p className="pb-3 pl-[18px] pr-2 text-xs leading-5 text-white/45">
+            <p className="pb-3 pl-[22px] pr-2 text-[13px] leading-6 text-white/60">
               {risk.mitigation}
             </p>
           </details>


### PR DESCRIPTION
## Problems (user feedback on the merged dashboard)

1. **Weak text** — micro-labels at 9–10px / 25–35% white opacity were borderline unreadable.
2. **Opportunity map made no sense** — a 3×3 grid of faint chips with no story.
3. **Dead graphs** — strict greyscale charts with no motion read as flat.
4. **Summary clipped** — `line-clamp-2` cut the report summary mid-sentence.

## What changed

**Readability pass** — every text tier bumped roughly one opacity and one size step: micro-labels 10px/35% → 11px/55–60%, stat captions to 55%, body copy in expansions 55% → 70%, footnotes 30% → 50%, hostname 25% → 50%. Summary line-clamp removed; full text always shows.

**Opportunity map rebuilt** — now a labeled impact/effort quadrant chart everyone recognizes: **Quick wins / Big bets / Low stakes / Avoid** with tinted quadrant backgrounds, dashed midlines, glowing fit-colored dots (emerald/amber/red) that drop in with a staggered entrance, plain-language axis captions ("← easier to build / harder to build →"), and a legend tying each numbered dot to its use case and fit level.

**Color, Vercel-Analytics style** —
- Radar: neon cyan stroke with glow, radial gradient fill, brighter values (15px white)
- Risk heatmap: emerald/amber/red glowing severity cells instead of white-intensity
- Fit/complexity meters and stat dots: colored by goodness (complexity inverted, so low complexity reads green)
- Fit score bar: cyan→emerald gradient with glow; verdict stepper segment takes the verdict tone color
- Eval composition: cyan realistic vs amber-striped adversarial, emerald checkmarks

**Motion** — count-up on the fit score, scale bar animates in, radar scales in, map dots stagger in. Everything respects `prefers-reduced-motion`. Still zero new dependencies — all hand-rolled SVG/CSS.

## Verification

Screenshotted at 1440px and 390px with a long healthcare-company report (the exact case that exposed the clipping): summary unclipped, radar labels fully visible, quadrant map self-explanatory, heatmap readable at a glance.

- `npx tsc --noEmit` clean
- `pnpm lint` — 0 errors (3 pre-existing warnings in unrelated files)
- `pnpm test` — 465 passed, 3 skipped