### PR TITLE
fix(tryouts): minimal welcome layout

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -130,7 +130,7 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL).WithArtifactSigner(artifactManager)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithPublicJudgeModels(cfg.AgentTryoutJudgeModels).WithQuota(api.AgentTryoutQuotaConfig{
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithInputAttachmentStore(artifactStore, cfg.ArtifactMaxUploadBytes).WithPublicJudgeModels(cfg.AgentTryoutJudgeModels).WithQuota(api.AgentTryoutQuotaConfig{
 		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
 		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,
 		HostedDailySpendCapUSD:    cfg.AgentTryoutHostedDailySpendCapUSD,

--- a/backend/internal/api/agent_tryout_attachments.go
+++ b/backend/internal/api/agent_tryout_attachments.go
@@ -1,0 +1,396 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/google/uuid"
+)
+
+const (
+	maxAgentTryoutInputAttachments              = 5
+	defaultAgentTryoutInputAttachmentMaxBytes = 15 << 20
+	agentTryoutInputAttachmentPrefix            = "agent-tryout-input-attachments"
+)
+
+var (
+	ErrAgentTryoutInputAttachmentNotFound   = errors.New("agent tryout input attachment not found")
+	ErrAgentTryoutInputAttachmentTooLarge   = errors.New("agent tryout input attachment exceeds maximum size")
+	ErrAgentTryoutInputAttachmentInvalid    = errors.New("agent tryout input attachment is invalid")
+	ErrAgentTryoutInputAttachmentUnavailable = errors.New("agent tryout input attachments are unavailable")
+
+	allowedTryoutInputAttachmentMediaTypes = map[string]struct{}{
+		"application/pdf": {},
+		"image/jpeg":      {},
+		"image/png":       {},
+		"image/gif":       {},
+		"image/webp":      {},
+	}
+)
+
+type AgentTryoutInputAttachment struct {
+	ID        string `json:"id"`
+	Filename  string `json:"filename"`
+	MediaType string `json:"media_type"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+type UploadAgentTryoutInputAttachmentInput struct {
+	AnonymousFingerprint string
+	Filename             string
+	DeclaredType         string
+	Body                 io.Reader
+}
+
+type agentTryoutInputAttachmentMeta struct {
+	ID              string    `json:"id"`
+	FingerprintHash string    `json:"fingerprint_hash"`
+	Filename        string    `json:"filename"`
+	MediaType       string    `json:"media_type"`
+	SizeBytes       int64     `json:"size_bytes"`
+	ContentKey      string    `json:"content_key"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+func (m *AgentTryoutManager) WithInputAttachmentStore(store storage.Store, maxBytes int64) *AgentTryoutManager {
+	m.inputAttachmentStore = store
+	if maxBytes > 0 {
+		m.inputAttachmentMaxBytes = maxBytes
+	} else {
+		m.inputAttachmentMaxBytes = defaultAgentTryoutInputAttachmentMaxBytes
+	}
+	return m
+}
+
+func (m *AgentTryoutManager) UploadAnonymousTryoutInputAttachment(
+	ctx context.Context,
+	input UploadAgentTryoutInputAttachmentInput,
+) (AgentTryoutInputAttachment, error) {
+	if m.inputAttachmentStore == nil {
+		return AgentTryoutInputAttachment{}, ErrAgentTryoutInputAttachmentUnavailable
+	}
+	if input.Body == nil {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("%w: file is required", ErrAgentTryoutInputAttachmentInvalid)
+	}
+	filename := sanitizeTryoutAttachmentFilename(input.Filename)
+	if filename == "" {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("%w: filename is required", ErrAgentTryoutInputAttachmentInvalid)
+	}
+
+	limitedReader := io.LimitReader(input.Body, m.inputAttachmentMaxBytes+1)
+	content, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("read attachment upload: %w", err)
+	}
+	if int64(len(content)) > m.inputAttachmentMaxBytes {
+		return AgentTryoutInputAttachment{}, ErrAgentTryoutInputAttachmentTooLarge
+	}
+	if len(content) == 0 {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("%w: file is empty", ErrAgentTryoutInputAttachmentInvalid)
+	}
+
+	head := content
+	if len(head) > 512 {
+		head = head[:512]
+	}
+	mediaType, err := normalizeTryoutInputAttachmentContentType(input.DeclaredType, head)
+	if err != nil {
+		return AgentTryoutInputAttachment{}, err
+	}
+
+	id := uuid.New()
+	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
+	contentKey := path.Join(agentTryoutInputAttachmentPrefix, id.String(), "content")
+	metaKey := path.Join(agentTryoutInputAttachmentPrefix, id.String(), "meta.json")
+	meta := agentTryoutInputAttachmentMeta{
+		ID:              id.String(),
+		FingerprintHash: fingerprintHash,
+		Filename:        filename,
+		MediaType:       mediaType,
+		SizeBytes:       int64(len(content)),
+		ContentKey:      contentKey,
+		CreatedAt:       m.now().UTC(),
+	}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("marshal attachment metadata: %w", err)
+	}
+
+	if _, err := m.inputAttachmentStore.PutObject(ctx, storage.PutObjectInput{
+		Key:         contentKey,
+		Body:        bytes.NewReader(content),
+		SizeBytes:   int64(len(content)),
+		ContentType: mediaType,
+	}); err != nil {
+		return AgentTryoutInputAttachment{}, fmt.Errorf("store attachment content: %w", err)
+	}
+	if _, err := m.inputAttachmentStore.PutObject(ctx, storage.PutObjectInput{
+		Key:         metaKey,
+		Body:        bytes.NewReader(metaJSON),
+		SizeBytes:   int64(len(metaJSON)),
+		ContentType: "application/json",
+	}); err != nil {
+		_ = m.inputAttachmentStore.DeleteObject(ctx, contentKey)
+		return AgentTryoutInputAttachment{}, fmt.Errorf("store attachment metadata: %w", err)
+	}
+
+	return AgentTryoutInputAttachment{
+		ID:        meta.ID,
+		Filename:  meta.Filename,
+		MediaType: meta.MediaType,
+		SizeBytes: meta.SizeBytes,
+	}, nil
+}
+
+func (m *AgentTryoutManager) resolveTryoutInputForCreate(
+	ctx context.Context,
+	fingerprintHash string,
+	raw json.RawMessage,
+) (json.RawMessage, error) {
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, fmt.Errorf("%w: input must be a JSON object", ErrInvalidAgentTryoutInput)
+	}
+	if object == nil {
+		return nil, fmt.Errorf("%w: input must be a JSON object", ErrInvalidAgentTryoutInput)
+	}
+	if err := m.resolveTryoutInputAttachments(ctx, fingerprintHash, object); err != nil {
+		return nil, err
+	}
+	resolved, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resolved tryout input: %w", err)
+	}
+	return resolved, nil
+}
+
+func (m *AgentTryoutManager) resolveTryoutInputAttachments(
+	ctx context.Context,
+	fingerprintHash string,
+	object map[string]any,
+) error {
+	value, ok := object["input_attachments"]
+	if !ok || value == nil {
+		return nil
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return fmt.Errorf("%w: field %q must be array", ErrInvalidAgentTryoutInput, "input_attachments")
+	}
+	if len(items) > maxAgentTryoutInputAttachments {
+		return fmt.Errorf("%w: field %q supports up to %d files", ErrInvalidAgentTryoutInput, "input_attachments", maxAgentTryoutInputAttachments)
+	}
+	if len(items) > 0 && m.inputAttachmentStore == nil {
+		return ErrAgentTryoutInputAttachmentUnavailable
+	}
+
+	usedPaths := make(map[string]struct{}, len(items))
+	resolved := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%w: field %q entries must be objects", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+		rawID, ok := obj["id"].(string)
+		if !ok || strings.TrimSpace(rawID) == "" {
+			return fmt.Errorf("%w: field %q entries require id", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+		id, err := uuid.Parse(strings.TrimSpace(rawID))
+		if err != nil {
+			return fmt.Errorf("%w: field %q entry id must be a UUID", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+		meta, err := m.loadTryoutInputAttachmentMeta(ctx, id)
+		if err != nil {
+			return err
+		}
+		if meta.FingerprintHash != fingerprintHash {
+			return fmt.Errorf("%w: attachment %q is not owned by this session", ErrInvalidAgentTryoutInput, id.String())
+		}
+		workspacePath := uniqueTryoutAttachmentWorkspacePath(meta.Filename, usedPaths)
+		resolved = append(resolved, map[string]any{
+			"id":             meta.ID,
+			"filename":       meta.Filename,
+			"media_type":     meta.MediaType,
+			"size_bytes":     meta.SizeBytes,
+			"storage_key":    meta.ContentKey,
+			"workspace_path": workspacePath,
+		})
+	}
+	object["input_attachments"] = resolved
+	return nil
+}
+
+func (m *AgentTryoutManager) loadTryoutInputAttachmentMeta(ctx context.Context, id uuid.UUID) (agentTryoutInputAttachmentMeta, error) {
+	metaKey := path.Join(agentTryoutInputAttachmentPrefix, id.String(), "meta.json")
+	reader, _, err := m.inputAttachmentStore.OpenObject(ctx, metaKey)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotFound) {
+			return agentTryoutInputAttachmentMeta{}, fmt.Errorf("%w: %s", ErrAgentTryoutInputAttachmentNotFound, id.String())
+		}
+		return agentTryoutInputAttachmentMeta{}, fmt.Errorf("open attachment metadata: %w", err)
+	}
+	defer reader.Close()
+
+	var meta agentTryoutInputAttachmentMeta
+	if err := json.NewDecoder(reader).Decode(&meta); err != nil {
+		return agentTryoutInputAttachmentMeta{}, fmt.Errorf("%w: attachment metadata is invalid", ErrAgentTryoutInputAttachmentInvalid)
+	}
+	if strings.TrimSpace(meta.ContentKey) == "" || strings.TrimSpace(meta.FingerprintHash) == "" {
+		return agentTryoutInputAttachmentMeta{}, fmt.Errorf("%w: attachment metadata is incomplete", ErrAgentTryoutInputAttachmentInvalid)
+	}
+	return meta, nil
+}
+
+func validateTryoutInputAttachmentsField(value any) error {
+	if value == nil {
+		return nil
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return fmt.Errorf("%w: field %q must be array", ErrInvalidAgentTryoutInput, "input_attachments")
+	}
+	if len(items) > maxAgentTryoutInputAttachments {
+		return fmt.Errorf("%w: field %q supports up to %d files", ErrInvalidAgentTryoutInput, "input_attachments", maxAgentTryoutInputAttachments)
+	}
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%w: field %q entries must be objects", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+		rawID, ok := obj["id"].(string)
+		if !ok || strings.TrimSpace(rawID) == "" {
+			return fmt.Errorf("%w: field %q entries require id", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+		if _, err := uuid.Parse(strings.TrimSpace(rawID)); err != nil {
+			return fmt.Errorf("%w: field %q entry id must be a UUID", ErrInvalidAgentTryoutInput, "input_attachments")
+		}
+	}
+	return nil
+}
+
+func normalizeTryoutInputAttachmentContentType(declared string, sniffed []byte) (string, error) {
+	contentType := strings.TrimSpace(declared)
+	if contentType != "" {
+		mediaType, params, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			return "", fmt.Errorf("%w: invalid content type", ErrAgentTryoutInputAttachmentInvalid)
+		}
+		if err := validateTryoutInputAttachmentContentType(mediaType); err != nil {
+			return "", err
+		}
+		if len(params) == 0 {
+			return mediaType, nil
+		}
+		return mime.FormatMediaType(mediaType, params), nil
+	}
+
+	detected := http.DetectContentType(sniffed)
+	if detected == "" {
+		return "", fmt.Errorf("%w: could not detect content type", ErrAgentTryoutInputAttachmentInvalid)
+	}
+	mediaType, _, err := mime.ParseMediaType(detected)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid detected content type", ErrAgentTryoutInputAttachmentInvalid)
+	}
+	if err := validateTryoutInputAttachmentContentType(mediaType); err != nil {
+		return "", err
+	}
+	return detected, nil
+}
+
+func validateTryoutInputAttachmentContentType(mediaType string) error {
+	if _, ok := allowedTryoutInputAttachmentMediaTypes[strings.ToLower(strings.TrimSpace(mediaType))]; !ok {
+		return fmt.Errorf("%w: %s is not allowed (use PDF or common image formats)", ErrAgentTryoutInputAttachmentInvalid, mediaType)
+	}
+	return nil
+}
+
+func sanitizeTryoutAttachmentFilename(name string) string {
+	base := filepath.Base(strings.TrimSpace(name))
+	base = strings.ReplaceAll(base, `"`, "")
+	base = strings.ReplaceAll(base, "\x00", "")
+	if base == "." || base == "" || base == string(filepath.Separator) {
+		return ""
+	}
+	return base
+}
+
+func uniqueTryoutAttachmentWorkspacePath(filename string, used map[string]struct{}) string {
+	safe := sanitizeTryoutAttachmentFilename(filename)
+	if safe == "" {
+		safe = "attachment"
+	}
+	basePath := path.Join("input", safe)
+	if _, exists := used[basePath]; !exists {
+		used[basePath] = struct{}{}
+		return basePath
+	}
+	ext := path.Ext(safe)
+	stem := strings.TrimSuffix(safe, ext)
+	for i := 2; i < 100; i++ {
+		candidate := path.Join("input", fmt.Sprintf("%s-%d%s", stem, i, ext))
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+	fallback := path.Join("input", uuid.NewString()+ext)
+	used[fallback] = struct{}{}
+	return fallback
+}
+
+func uploadAgentTryoutInputAttachmentHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, defaultAgentTryoutInputAttachmentMaxBytes+1024)
+		if err := r.ParseMultipartForm(defaultMultipartMaxMemory); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid multipart upload")
+			return
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "file_required", "file is required")
+			return
+		}
+		defer file.Close()
+
+		attachment, err := service.UploadAnonymousTryoutInputAttachment(r.Context(), UploadAgentTryoutInputAttachmentInput{
+			AnonymousFingerprint: anonymousFingerprintFromRequest(r),
+			Filename:             header.Filename,
+			DeclaredType:         header.Header.Get("Content-Type"),
+			Body:                 file,
+		})
+		if err != nil {
+			writeAgentTryoutAttachmentError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, attachment)
+	}
+}
+
+func writeAgentTryoutAttachmentError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, ErrAgentTryoutInputAttachmentTooLarge):
+		writeError(w, http.StatusRequestEntityTooLarge, "attachment_too_large", "Attachment exceeds the maximum upload size.")
+	case errors.Is(err, ErrAgentTryoutInputAttachmentInvalid):
+		writeError(w, http.StatusBadRequest, "invalid_attachment", err.Error())
+	case errors.Is(err, ErrAgentTryoutInputAttachmentNotFound):
+		writeError(w, http.StatusNotFound, "attachment_not_found", "Attachment not found.")
+	case errors.Is(err, ErrAgentTryoutInputAttachmentUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "attachments_unavailable", "File attachments are temporarily unavailable.")
+	default:
+		logger.Error("agent tryout attachment request failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+	}
+}

--- a/backend/internal/api/agent_tryout_attachments_test.go
+++ b/backend/internal/api/agent_tryout_attachments_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/google/uuid"
+)
+
+type memoryTryoutAttachmentStore struct {
+	objects map[string][]byte
+}
+
+func newMemoryTryoutAttachmentStore() *memoryTryoutAttachmentStore {
+	return &memoryTryoutAttachmentStore{objects: map[string][]byte{}}
+}
+
+func (s *memoryTryoutAttachmentStore) Bucket() string { return "test-bucket" }
+
+func (s *memoryTryoutAttachmentStore) PutObject(_ context.Context, input storage.PutObjectInput) (storage.ObjectMetadata, error) {
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return storage.ObjectMetadata{}, err
+	}
+	s.objects[input.Key] = body
+	return storage.ObjectMetadata{Key: input.Key, SizeBytes: int64(len(body))}, nil
+}
+
+func (s *memoryTryoutAttachmentStore) OpenObject(_ context.Context, key string) (io.ReadCloser, storage.ObjectMetadata, error) {
+	body, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ObjectMetadata{}, storage.ErrObjectNotFound
+	}
+	return io.NopCloser(bytes.NewReader(body)), storage.ObjectMetadata{Key: key, SizeBytes: int64(len(body))}, nil
+}
+
+func (s *memoryTryoutAttachmentStore) DeleteObject(_ context.Context, key string) error {
+	delete(s.objects, key)
+	return nil
+}
+
+func TestAgentTryoutManagerResolvesInputAttachments(t *testing.T) {
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	store := newMemoryTryoutAttachmentStore()
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).
+		WithInputAttachmentStore(store, defaultAgentTryoutInputAttachmentMaxBytes)
+
+	fingerprint := "203.0.113.10"
+	attachment, err := manager.UploadAnonymousTryoutInputAttachment(context.Background(), UploadAgentTryoutInputAttachmentInput{
+		AnonymousFingerprint: fingerprint,
+		Filename:             "brief.pdf",
+		DeclaredType:         "application/pdf",
+		Body:                 bytes.NewReader([]byte("%PDF-1.4 test")),
+	})
+	if err != nil {
+		t.Fatalf("UploadAnonymousTryoutInputAttachment returned error: %v", err)
+	}
+
+	tryout, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+		TemplateSlug: "meeting-minutes",
+		Input: json.RawMessage(`{
+			"notes":"Summarize the attached brief",
+			"input_attachments":[{"id":"` + attachment.ID + `"}]
+		}`),
+		AnonymousFingerprint: fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+
+	var snapshot map[string]any
+	if err := json.Unmarshal(tryout.InputSnapshot, &snapshot); err != nil {
+		t.Fatalf("unmarshal input snapshot: %v", err)
+	}
+	items, ok := snapshot["input_attachments"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("input_attachments = %v, want one resolved attachment", snapshot["input_attachments"])
+	}
+	resolved, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("resolved attachment type = %T, want map", items[0])
+	}
+	if resolved["workspace_path"] != "input/brief.pdf" {
+		t.Fatalf("workspace_path = %v, want input/brief.pdf", resolved["workspace_path"])
+	}
+	if strings.TrimSpace(stringFromSnapshot(resolved["storage_key"])) == "" {
+		t.Fatalf("storage_key missing in resolved attachment: %v", resolved)
+	}
+}
+
+func TestAgentTryoutManagerRejectsForeignInputAttachment(t *testing.T) {
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	store := newMemoryTryoutAttachmentStore()
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).
+		WithInputAttachmentStore(store, defaultAgentTryoutInputAttachmentMaxBytes)
+
+	attachment, err := manager.UploadAnonymousTryoutInputAttachment(context.Background(), UploadAgentTryoutInputAttachmentInput{
+		AnonymousFingerprint: "203.0.113.10",
+		Filename:             "brief.pdf",
+		DeclaredType:         "application/pdf",
+		Body:                 bytes.NewReader([]byte("%PDF-1.4 test")),
+	})
+	if err != nil {
+		t.Fatalf("UploadAnonymousTryoutInputAttachment returned error: %v", err)
+	}
+
+	_, err = manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+		TemplateSlug: "meeting-minutes",
+		Input: json.RawMessage(`{
+			"notes":"Summarize the attached brief",
+			"input_attachments":[{"id":"` + attachment.ID + `"}]
+		}`),
+		AnonymousFingerprint: "198.51.100.2",
+	})
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+}
+
+func stringFromSnapshot(value any) string {
+	raw, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(raw)
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -78,6 +79,7 @@ type AgentTryoutRepository interface {
 
 type AgentTryoutService interface {
 	ListTemplates(ctx context.Context) ([]AgentTryoutTemplate, error)
+	UploadAnonymousTryoutInputAttachment(ctx context.Context, input UploadAgentTryoutInputAttachmentInput) (AgentTryoutInputAttachment, error)
 	CreateAnonymousTryout(ctx context.Context, input CreateAnonymousAgentTryoutInput) (repository.AgentTryout, error)
 	SubmitAnonymousTryoutTurn(ctx context.Context, id uuid.UUID, input SubmitAgentTryoutTurnInput) error
 	CreateWorkspaceTryout(ctx context.Context, caller Caller, input CreateWorkspaceAgentTryoutInput) (repository.AgentTryout, error)
@@ -170,15 +172,17 @@ type AgentTryoutQuotaConfig struct {
 }
 
 type AgentTryoutManager struct {
-	authorizer     WorkspaceAuthorizer
-	repo           AgentTryoutRepository
-	now            func() time.Time
-	templates      map[string]AgentTryoutTemplate
-	execution      *agentTryoutExecutionDispatcher
-	quota          *AgentTryoutQuotaConfig
-	rerunGate      AgentTryoutRerunGate
-	artifactSigner ArtifactContentSigner
-	judgeModels    []string
+	authorizer              WorkspaceAuthorizer
+	repo                    AgentTryoutRepository
+	now                     func() time.Time
+	templates               map[string]AgentTryoutTemplate
+	execution               *agentTryoutExecutionDispatcher
+	quota                   *AgentTryoutQuotaConfig
+	rerunGate               AgentTryoutRerunGate
+	artifactSigner          ArtifactContentSigner
+	judgeModels             []string
+	inputAttachmentStore    storage.Store
+	inputAttachmentMaxBytes int64
 }
 
 // WithArtifactSigner enables signed download URLs on a tryout's captured output
@@ -292,6 +296,14 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	if err := validateAgentTryoutInput(template, input.Input); err != nil {
 		return repository.AgentTryout{}, err
 	}
+	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
+	resolvedInput, err := m.resolveTryoutInputForCreate(ctx, fingerprintHash, input.Input)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if int64(len(resolvedInput)) > template.MaxInputBytes {
+		return repository.AgentTryout{}, fmt.Errorf("%w: input exceeds %d bytes", ErrInvalidAgentTryoutInput, template.MaxInputBytes)
+	}
 	selectedHarness, err := normalizeSelectedHarnessKind(input.SelectedHarnessKind)
 	if err != nil {
 		return repository.AgentTryout{}, err
@@ -312,14 +324,13 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		now = m.now()
 	}
 	expiresAt := now.UTC().Add(defaultAgentTryoutTTL)
-	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
 	createParams := repository.CreateAgentTryoutParams{
 		TemplateSlug:             template.Slug,
 		Status:                   repository.AgentTryoutStatusQueued,
-		InputSnapshot:            input.Input,
+		InputSnapshot:            resolvedInput,
 		TemplateSnapshot:         templateSnapshot(template),
 		ToolPolicySnapshot:       template.ToolPolicy,
-		EvaluationSpecSnapshot:   evaluationSpecWithPublicJudge(template.EvaluationSpec, judge, input.Input, template.Name),
+		EvaluationSpecSnapshot:   evaluationSpecWithPublicJudge(template.EvaluationSpec, judge, resolvedInput, template.Name),
 		SelectedModelPolicy:      selectedModelPolicy,
 		SelectedHarnessKind:      selectedHarness,
 		Summary:                  json.RawMessage(`{}`),
@@ -1081,6 +1092,7 @@ type agentTryoutShareResponse struct {
 
 func registerPublicAgentTryoutRoutes(router chi.Router, logger *slog.Logger, service AgentTryoutService) {
 	router.Get("/agent-tryout-templates", listAgentTryoutTemplatesHandler(logger, service))
+	router.Post("/agent-tryout-input-attachments", uploadAgentTryoutInputAttachmentHandler(logger, service))
 	router.Post("/agent-tryouts", createAnonymousAgentTryoutHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/turns", submitAnonymousAgentTryoutTurnHandler(logger, service))
 	router.Get("/agent-tryouts/{tryoutID}", getPublicAgentTryoutHandler(logger, service))
@@ -1392,7 +1404,7 @@ func validateAgentTryoutInputSchema(template AgentTryoutTemplate, object map[str
 	}
 	if schema.AdditionalProperties != nil && !*schema.AdditionalProperties {
 		for key := range object {
-			if key == "eval_setup" {
+			if key == "eval_setup" || key == "input_attachments" {
 				continue
 			}
 			if _, ok := schema.Properties[key]; !ok {
@@ -1418,6 +1430,11 @@ func validateAgentTryoutInputSchema(template AgentTryoutTemplate, object map[str
 		}
 		if !agentTryoutInputValueMatchesType(value, "object") {
 			return fmt.Errorf("%w: field %q must be object", ErrInvalidAgentTryoutInput, "eval_setup")
+		}
+	}
+	if value, ok := object["input_attachments"]; ok {
+		if err := validateTryoutInputAttachmentsField(value); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -1490,6 +1490,10 @@ func (s *fakeAgentTryoutService) ListTemplates(context.Context) ([]AgentTryoutTe
 	return s.templates, nil
 }
 
+func (s *fakeAgentTryoutService) UploadAnonymousTryoutInputAttachment(context.Context, UploadAgentTryoutInputAttachmentInput) (AgentTryoutInputAttachment, error) {
+	return AgentTryoutInputAttachment{}, nil
+}
+
 func (s *fakeAgentTryoutService) CreateAnonymousTryout(_ context.Context, input CreateAnonymousAgentTryoutInput) (repository.AgentTryout, error) {
 	s.createAnonymousInput = input
 	if s.createAnonymousErr != nil {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -428,6 +428,10 @@ func (noopAgentTryoutService) ListTemplates(context.Context) ([]AgentTryoutTempl
 	return nil, errors.New("agent tryout service is not configured")
 }
 
+func (noopAgentTryoutService) UploadAnonymousTryoutInputAttachment(context.Context, UploadAgentTryoutInputAttachmentInput) (AgentTryoutInputAttachment, error) {
+	return AgentTryoutInputAttachment{}, errors.New("agent tryout service is not configured")
+}
+
 func (noopAgentTryoutService) CreateAnonymousTryout(context.Context, CreateAnonymousAgentTryoutInput) (repository.AgentTryout, error) {
 	return repository.AgentTryout{}, errors.New("agent tryout service is not configured")
 }

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 	"time"
@@ -175,6 +176,10 @@ func (a *Activities) executePublicTryoutSandbox(ctx context.Context, tryout repo
 		return nil, err
 	}
 	defer func() { _ = session.Destroy(context.Background()) }()
+
+	if err := a.stagePublicTryoutInputAttachments(ctx, session, tryout.InputSnapshot); err != nil {
+		return nil, err
+	}
 
 	deadline := time.Now().Add(sessionCap)
 	var outputs []map[string]any
@@ -599,6 +604,7 @@ func publicTryoutTaskPrompt(tryout repository.AgentTryout) string {
 		"```",
 	}
 	lines = append(lines, publicTryoutEvalSetupPrompt(tryout.InputSnapshot)...)
+	lines = append(lines, publicTryoutInputAttachmentsPrompt(tryout.InputSnapshot)...)
 	lines = append(lines,
 		"Runtime instructions JSON:",
 		"```json",
@@ -633,6 +639,112 @@ func publicTryoutEvalSetupPrompt(input json.RawMessage) []string {
 		"```",
 	}
 }
+
+func publicTryoutInputAttachmentsPrompt(input json.RawMessage) []string {
+	attachments := publicTryoutResolvedInputAttachments(input)
+	if len(attachments) == 0 {
+		return nil
+	}
+	lines := []string{
+		"User-provided input files are staged in the sandbox workspace. Read and use them as source material for this task.",
+	}
+	for _, attachment := range attachments {
+		filename, _ := attachment["filename"].(string)
+		workspacePath, _ := attachment["workspace_path"].(string)
+		mediaType, _ := attachment["media_type"].(string)
+		if strings.TrimSpace(workspacePath) == "" {
+			continue
+		}
+		label := strings.TrimSpace(filename)
+		if label == "" {
+			label = workspacePath
+		}
+		typeLabel := strings.TrimSpace(mediaType)
+		if typeLabel != "" {
+			label += " (" + typeLabel + ")"
+		}
+		lines = append(lines, fmt.Sprintf("- %s at /workspace/%s", label, strings.TrimPrefix(workspacePath, "/")))
+	}
+	return lines
+}
+
+func publicTryoutResolvedInputAttachments(input json.RawMessage) []map[string]any {
+	var object map[string]any
+	if err := json.Unmarshal(input, &object); err != nil {
+		return nil
+	}
+	value, ok := object["input_attachments"]
+	if !ok || value == nil {
+		return nil
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		attachment, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(stringFromAny(attachment["storage_key"])) == "" {
+			continue
+		}
+		out = append(out, attachment)
+	}
+	return out
+}
+
+func stringFromAny(value any) string {
+	raw, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(raw)
+}
+
+func (a *Activities) stagePublicTryoutInputAttachments(
+	ctx context.Context,
+	session sandbox.Session,
+	inputSnapshot json.RawMessage,
+) error {
+	attachments := publicTryoutResolvedInputAttachments(inputSnapshot)
+	if len(attachments) == 0 {
+		return nil
+	}
+	if a.artifactStore == nil {
+		return fmt.Errorf("artifact store is not configured for tryout input attachments")
+	}
+	for _, attachment := range attachments {
+		storageKey := stringFromAny(attachment["storage_key"])
+		workspacePath := stringFromAny(attachment["workspace_path"])
+		if storageKey == "" || workspacePath == "" {
+			return fmt.Errorf("tryout input attachment is missing staging metadata")
+		}
+		reader, _, err := a.artifactStore.OpenObject(ctx, storageKey)
+		if err != nil {
+			return fmt.Errorf("open tryout input attachment %q: %w", storageKey, err)
+		}
+		content, err := io.ReadAll(io.LimitReader(reader, defaultAgentTryoutInputAttachmentMaxBytes+1))
+		closeErr := reader.Close()
+		if err != nil {
+			return fmt.Errorf("read tryout input attachment %q: %w", storageKey, err)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close tryout input attachment %q: %w", storageKey, closeErr)
+		}
+		if int64(len(content)) > defaultAgentTryoutInputAttachmentMaxBytes {
+			return fmt.Errorf("tryout input attachment %q exceeds maximum size", storageKey)
+		}
+		targetPath := path.Join(agentHarnessWorkspaceDir, workspacePath)
+		if err := session.UploadFile(ctx, targetPath, content); err != nil {
+			return fmt.Errorf("stage tryout input attachment to %s: %w", targetPath, err)
+		}
+	}
+	return nil
+}
+
+const defaultAgentTryoutInputAttachmentMaxBytes = 15 << 20
 
 func publicTryoutExecutionConfig(tryout repository.AgentTryout) json.RawMessage {
 	var template struct {

--- a/backend/internal/workflow/public_agent_tryout_workflow_test.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow_test.go
@@ -206,6 +206,31 @@ func TestPublicTryoutScorecardArtifactProducedValidator(t *testing.T) {
 	}
 }
 
+func TestPublicTryoutTaskPromptIncludesInputAttachments(t *testing.T) {
+	prompt := publicTryoutTaskPrompt(repository.AgentTryout{
+		TemplateSlug: "meeting-minutes",
+		InputSnapshot: json.RawMessage(`{
+			"notes":"Summarize the deck",
+			"input_attachments":[
+				{
+					"filename":"brief.pdf",
+					"media_type":"application/pdf",
+					"storage_key":"agent-tryout-input-attachments/abc/content",
+					"workspace_path":"input/brief.pdf"
+				}
+			]
+		}`),
+		TemplateSnapshot: json.RawMessage(`{"name":"Meeting Minutes","description":"Turn notes into actions","runtime":{}}`),
+	})
+
+	if !strings.Contains(prompt, "User-provided input files are staged in the sandbox workspace") {
+		t.Fatalf("prompt = %q, want input attachment instructions", prompt)
+	}
+	if !strings.Contains(prompt, "/workspace/input/brief.pdf") {
+		t.Fatalf("prompt = %q, want staged file path", prompt)
+	}
+}
+
 func TestPublicTryoutTaskPromptIncludesEvalSetup(t *testing.T) {
 	prompt := publicTryoutTaskPrompt(repository.AgentTryout{
 		TemplateSlug: "slide-deck",

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5177,6 +5177,44 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /v1/agent-tryout-input-attachments:
+    post:
+      operationId: uploadAgentTryoutInputAttachment
+      summary: Upload a PDF or image for an anonymous tryout input
+      description: >
+        Stages a file for inclusion in a subsequent anonymous tryout create request.
+        Attachments are bound to the caller fingerprint and referenced by id in
+        `input.input_attachments` when creating a tryout.
+      tags: [AgentTryouts]
+      security: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: PDF or image file (JPEG, PNG, GIF, WebP), up to 15 MB
+      responses:
+        "201":
+          description: Attachment uploaded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTryoutInputAttachment"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "413":
+          description: Attachment exceeds maximum upload size
+        "503":
+          description: Attachment storage unavailable
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /v1/agent-tryouts:
     post:
       operationId: createAnonymousAgentTryout
@@ -13035,6 +13073,21 @@ components:
         max_cost_usd:
           type: number
           format: double
+
+    AgentTryoutInputAttachment:
+      type: object
+      required: [id, filename, media_type, size_bytes]
+      properties:
+        id:
+          type: string
+          format: uuid
+        filename:
+          type: string
+        media_type:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
 
     ListAgentTryoutTemplatesResponse:
       type: object

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -88,15 +88,6 @@ body {
 
 /* Clash mark — the two-agent logo collision. Single allowed motion on the
    landing page; everything else is static. */
-@keyframes tryout-marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
 @keyframes clash-left {
   0% { transform: translateX(-24px); }
   18% { transform: translateX(0); }

--- a/web/src/app/tryouts/page.tsx
+++ b/web/src/app/tryouts/page.tsx
@@ -6,7 +6,7 @@ import { PublicTryoutsClient } from "./tryouts-client";
 export const metadata: Metadata = {
   title: "Free AI Agent Tryout",
   description:
-    "Run a free sandboxed AI agent on support, finance, legal, and ops workflows. Set your quality bar and get a scored verdict before production.",
+    "Write what you would reject in production, run a sandboxed tryout on real work, and get a scored verdict with outputs before you deploy.",
   keywords: [
     "AI agent evaluation",
     "integrate AI into business",

--- a/web/src/app/tryouts/page.tsx
+++ b/web/src/app/tryouts/page.tsx
@@ -4,9 +4,9 @@ import { Suspense } from "react";
 import { PublicTryoutsClient } from "./tryouts-client";
 
 export const metadata: Metadata = {
-  title: "Free AI Agent Tryout for Business Workflows",
+  title: "Free AI Agent Tryout",
   description:
-    "Test AI agents on real business workflows before you integrate: customer support, invoice extraction, contract review, sales outreach, inbox triage, and status reports. Free sandboxed tryout with scored verdicts.",
+    "Run a free sandboxed AI agent on support, finance, legal, and ops workflows. Set your quality bar and get a scored verdict before production.",
   keywords: [
     "AI agent evaluation",
     "integrate AI into business",

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -3,7 +3,14 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { FormEvent, ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ArrowRight,
   ArrowUp,
@@ -794,8 +801,10 @@ function TryoutWelcome({
   }
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col justify-center overflow-y-auto">
-      <div className="mx-auto w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-5 pb-[max(1rem,env(safe-area-inset-bottom))]">
+    <div className="relative min-h-0 flex-1 overflow-y-auto">
+      <div
+        className="mx-auto flex w-full min-h-full max-w-3xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-8 pb-[max(1rem,env(safe-area-inset-bottom))]"
+      >
         <h1
           className="mx-auto max-w-2xl text-center text-[clamp(1.35rem,3.2vw,1.875rem)] font-semibold tracking-tight text-white/88 animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-700 motion-reduce:animate-none"
         >
@@ -834,7 +843,7 @@ function TryoutWelcome({
                 </div>
               ) : null
             }
-            footerClassName="[&>*:not(:first-child)]:md:min-w-0 [&>*:not(:first-child)]:md:flex-1"
+            footerClassName="sm:flex-wrap"
             footer={
               <>
                 <button
@@ -894,7 +903,11 @@ function TryoutWelcome({
           />
 
           {!quotaMessage && (
-            <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+            <div
+              className="mt-3 flex flex-wrap items-center justify-center gap-2"
+              role="group"
+              aria-label="Try an example"
+            >
               {TRYOUT_STARTERS.filter((starter) =>
                 templates.some((item) => item.slug === starter.slug),
               ).map((starter) => (
@@ -902,6 +915,7 @@ function TryoutWelcome({
                   key={starter.slug}
                   type="button"
                   disabled={templatesLoading}
+                  aria-pressed={templateSlug === starter.slug}
                   onClick={() =>
                     onApplyStarter(starter.slug, starter.field, starter.prompt)
                   }
@@ -972,6 +986,10 @@ function BarPill({ ready, onClick }: { ready: boolean; onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
+      aria-required={!ready || undefined}
+      aria-label={
+        ready ? "Evaluation bar configured" : "Set the evaluation bar (required)"
+      }
       className={cn(
         "inline-flex shrink-0 items-center gap-1.5 rounded-sm border py-1.5 pl-2.5 pr-2.5 font-mono text-2xs transition",
         ready
@@ -1577,8 +1595,8 @@ function UserBubble({ text, animate }: { text: string; animate?: boolean }) {
           "animate-in fade-in slide-in-from-bottom-2 duration-300 motion-reduce:animate-none",
       )}
     >
-      <div className="max-w-[85%] rounded-sm bg-[#e9e9e5] px-4 py-2.5 text-base leading-7 text-[#161614]">
-        {text}
+      <div className="max-w-[min(85%,100%)] rounded-sm bg-[#e9e9e5] px-3 py-2.5 text-base leading-7 text-[#161614] sm:max-w-[85%] sm:px-4">
+        <p className="whitespace-pre-wrap break-words">{text}</p>
       </div>
     </div>
   );
@@ -1767,7 +1785,29 @@ function ComposerShell({
   rows?: number;
   onSubmit?: () => void;
 }) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const textareaRows = rows ?? (compact ? 1 : 3);
+  const maxTextareaHeight = compact ? 160 : 224;
+
+  const syncTextareaHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    const nextHeight = Math.min(textarea.scrollHeight, maxTextareaHeight);
+    textarea.style.height = `${nextHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > maxTextareaHeight ? "auto" : "hidden";
+  }, [maxTextareaHeight]);
+
+  useLayoutEffect(() => {
+    syncTextareaHeight();
+  }, [value, syncTextareaHeight]);
+
+  useEffect(() => {
+    const onResize = () => syncTextareaHeight();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [syncTextareaHeight]);
 
   return (
     <div
@@ -1777,6 +1817,7 @@ function ComposerShell({
       )}
     >
       <textarea
+        ref={textareaRef}
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onKeyDown={(event) => {
@@ -1790,14 +1831,22 @@ function ComposerShell({
         rows={textareaRows}
         disabled={disabled}
         placeholder={placeholder}
-        className="block w-full resize-none bg-transparent px-2 pt-1 text-base leading-7 text-white outline-none placeholder:text-white/30 sm:px-3 sm:pt-2"
+        className={cn(
+          "block w-full resize-none bg-transparent px-2 pt-1 text-base leading-7 text-white outline-none placeholder:text-white/30 sm:px-3 sm:pt-2",
+          compact ? "max-h-40" : "max-h-56",
+        )}
       />
       {aboveFooter}
-      <div className="flex items-end justify-between gap-2 px-0.5 pb-0.5 pt-1.5 sm:items-center sm:px-1">
+      <div
+        className={cn(
+          "flex gap-2 px-0.5 pb-0.5 pt-1.5 sm:px-1",
+          footer ? "items-end justify-between" : "justify-end",
+        )}
+      >
         {footer ? (
           <div
             className={cn(
-              "flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2 md:flex-nowrap",
+              "flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2",
               footerClassName,
             )}
           >
@@ -1811,7 +1860,7 @@ function ComposerShell({
           onClick={onSubmit}
           disabled={!canSubmit || submitting}
           aria-label="Send"
-          className="flex size-9 shrink-0 items-center justify-center rounded-sm bg-white text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40 sm:ml-1"
+          className="flex size-9 shrink-0 items-center justify-center self-end rounded-sm bg-white text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40 sm:ml-1"
         >
           {submitting ? (
             <Loader2 className="size-4 animate-spin" />
@@ -1849,7 +1898,7 @@ function AnimatedPillSelect({
     <DropdownMenu>
       <DropdownMenuTrigger
         disabled={disabled}
-        className="inline-flex w-full max-w-full min-w-0 shrink-0 items-center gap-1.5 rounded-sm border border-white/12 py-1.5 pl-2 pr-1.5 font-mono text-2xs text-white/60 transition hover:border-white/30 hover:text-white/90 data-popup-open:border-white/40 data-popup-open:text-white disabled:opacity-50 sm:pl-2.5 sm:pr-2 md:w-auto"
+        className="inline-flex max-w-full min-w-0 shrink-0 items-center gap-1.5 rounded-sm border border-white/12 py-1.5 pl-2 pr-1.5 font-mono text-2xs text-white/60 transition hover:border-white/30 hover:text-white/90 data-popup-open:border-white/40 data-popup-open:text-white disabled:opacity-50 max-sm:max-w-[calc(100%-2.5rem)] sm:pl-2.5 sm:pr-2"
       >
         <span className="shrink-0 text-white/45">{icon}</span>
         <span className="min-w-0 truncate">{selected?.label ?? "Select"}</span>

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -10,8 +10,13 @@ import {
   ChevronDown,
   Download,
   FileText,
+  Gauge,
+  ListChecks,
   Loader2,
+  Paperclip,
   PanelRight,
+  Scale,
+  X,
 } from "lucide-react";
 
 import {
@@ -20,12 +25,14 @@ import {
   getPublicAgentTryoutEvents,
   listAgentTryoutTemplates,
   submitAgentTryoutTurn,
+  uploadAgentTryoutInputAttachment,
 } from "@/lib/api/agent-tryouts";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type {
   AgentHarnessKind,
   AgentTryout,
+  AgentTryoutInputAttachment,
   AgentTryoutJudgeStrictness,
   AgentTryoutModelPolicy,
   AgentTryoutTemplate,
@@ -36,6 +43,7 @@ import {
   formatTryoutLatency,
   tryoutIsActive,
 } from "@/lib/agent-tryout-status";
+import { ClashMark } from "@/components/marketing/clash-mark";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -188,6 +196,34 @@ const STRICTNESS_OPTIONS: { value: AgentTryoutJudgeStrictness; label: string }[]
   { value: "harsh", label: "Harsh" },
 ];
 
+const TRYOUT_STARTERS = [
+  {
+    slug: "support-ticket-resolution",
+    field: "ticket",
+    label: "Support ticket",
+    prompt:
+      "Customer was charged twice for order #48291. They want a refund today and mention they may cancel if we do not fix billing.",
+  },
+  {
+    slug: "meeting-minutes",
+    field: "notes",
+    label: "Meeting notes",
+    prompt:
+      "Product sync: EU API latency hit 2s, mobile release blocked on App Store review, marketing launch may slip to next week.",
+  },
+  {
+    slug: "inbox-triage",
+    field: "emails",
+    label: "Inbox triage",
+    prompt:
+      "From: legal@vendor.com — contract amendment needed before EOD.\nFrom: customer — where is my refund?\nFrom: ceo — quick sync on Q3 numbers?",
+  },
+] as const;
+
+const MAX_TRYOUT_ATTACHMENTS = 5;
+const TRYOUT_ATTACHMENT_ACCEPT =
+  "application/pdf,image/jpeg,image/png,image/gif,image/webp";
+
 function judgeModelLabel(model: string): string {
   return JUDGE_OPTIONS.find((option) => option.value === model)?.label ?? model;
 }
@@ -264,143 +300,6 @@ function modelLabelFromPolicy(policy: unknown): string {
   return match?.label ?? first.model;
 }
 
-const TASK_SUGGESTIONS: Record<string, string[]> = {
-  "support-ticket-resolution": [
-    "Customer says their invoice was charged twice and wants a refund today. Draft a reply and decide whether to escalate.",
-    "Angry customer threatening to churn over downtime. Reply empathetically, cite our SLA, flag for a human.",
-  ],
-  "document-extraction": [
-    "Extract line items, totals, and vendor from this invoice, then render a clean summary PDF.",
-    "Pull every date, amount, and party from this contract into a spreadsheet.",
-  ],
-  "contract-review": [
-    "Review this NDA for one-sided indemnity and unlimited liability. List risks with severity.",
-    "Compare these payment terms against net-30 standard and propose redlines.",
-  ],
-  "sdr-outreach": [
-    "Qualify this prospect for our eval platform and draft a 3-sentence cold email.",
-    "Write a follow-up to a VP Eng who opened but didn't reply, referencing their hiring spike.",
-  ],
-  "spreadsheet-builder": [
-    "Turn this raw sales data into a spreadsheet with a pivot summary and a bar chart PNG.",
-    "Build a 12-month cashflow model from these assumptions and chart the runway.",
-  ],
-  "slide-deck": [
-    "Make a 6-slide deck for 10 year olds explaining what AI is, with a simple chart.",
-    "Turn this product brief into a PowerPoint with speaker notes and one diagram.",
-  ],
-  "status-report": [
-    "Turn these scattered updates into a polished weekly status report and export it as a PDF.",
-    "Summarize this sprint into highlights, risks, and next steps.",
-    "Weekly product update for leadership: wins, slips, and what needs a decision.",
-  ],
-  "meeting-minutes": [
-    "Summarize these notes into minutes with owners and due dates.",
-    "Extract action items and render them as a one-page PDF checklist.",
-    "Board meeting notes: decisions, risks, and follow-ups for the exec team.",
-  ],
-  "inbox-triage": [
-    "Prioritize these 8 emails and draft replies for the urgent ones.",
-    "Sort this inbox by urgency, flag compliance risks, and draft holds for anything ambiguous.",
-    "Customer escalation thread plus three routine billing questions: triage and draft responses.",
-  ],
-};
-
-const GENERIC_SUGGESTIONS = [
-  "Generate a PDF report from this data with a chart.",
-  "Build a spreadsheet with formulas and a summary tab.",
-  "Turn this into a labeled bar chart and explain the trend.",
-  "Summarize this for an executive who has two minutes to read.",
-  "Flag anything that would fail a compliance review before we ship.",
-];
-
-type TryoutShowcaseItem = {
-  slug: string;
-  label: string;
-  example: string;
-  primaryField: string;
-};
-
-const TRYOUT_SHOWCASE: TryoutShowcaseItem[] = [
-  {
-    slug: "support-ticket-resolution",
-    label: "Support",
-    example:
-      "Customer says their invoice was charged twice and wants a refund today. Draft a reply and decide whether to escalate.",
-    primaryField: "ticket",
-  },
-  {
-    slug: "document-extraction",
-    label: "Invoices",
-    example:
-      "Extract line items, totals, and vendor from this invoice, then flag any missing fields for human review.",
-    primaryField: "document",
-  },
-  {
-    slug: "contract-review",
-    label: "Contracts",
-    example:
-      "Review this NDA for one-sided indemnity and unlimited liability. List risks with severity and quote the clause.",
-    primaryField: "contract",
-  },
-  {
-    slug: "sdr-outreach",
-    label: "Outbound",
-    example:
-      "VP Engineering at a 200-person SaaS company, hiring 3 platform engineers. Draft a 3-sentence cold email for our eval platform.",
-    primaryField: "prospect",
-  },
-  {
-    slug: "inbox-triage",
-    label: "Inbox",
-    example:
-      "Prioritize these 8 emails, draft replies for urgent ones, and flag anything that needs a human before we respond.",
-    primaryField: "emails",
-  },
-  {
-    slug: "meeting-minutes",
-    label: "Meetings",
-    example:
-      "Summarize these notes into minutes with owners, due dates, and risks. Export a one-page action plan.",
-    primaryField: "notes",
-  },
-  {
-    slug: "status-report",
-    label: "Status",
-    example:
-      "Turn these scattered sprint updates into a polished weekly status with highlights, risks, and next steps.",
-    primaryField: "updates",
-  },
-  {
-    slug: "spreadsheet-builder",
-    label: "Spreadsheets",
-    example:
-      "Turn this raw sales data into a spreadsheet with a pivot summary and a bar chart PNG.",
-    primaryField: "data",
-  },
-  {
-    slug: "slide-deck",
-    label: "Slides",
-    example:
-      "Make a 6-slide deck explaining our AI evaluation platform for a VP of Engineering, with one chart slide.",
-    primaryField: "brief",
-  },
-];
-
-function suggestionsFor(slug: string): string[] {
-  const showcase = TRYOUT_SHOWCASE.find((item) => item.slug === slug);
-  const curated = TASK_SUGGESTIONS[slug] ?? GENERIC_SUGGESTIONS;
-  if (showcase && !curated.includes(showcase.example)) {
-    return [showcase.example, ...curated];
-  }
-  return curated;
-}
-
-function showcaseForTemplates(templates: AgentTryoutTemplate[]): TryoutShowcaseItem[] {
-  const slugs = new Set(templates.map((template) => template.slug));
-  return TRYOUT_SHOWCASE.filter((item) => slugs.has(item.slug));
-}
-
 const api = createApiClient();
 
 const SERIF = "[font-family:var(--font-race-display)]";
@@ -420,10 +319,6 @@ export function PublicTryoutsClient() {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [evalSetup, setEvalSetup] = useState<EvalSetupValues>(DEFAULT_EVAL_SETUP);
   const prefillRef = useRef<RerunPrefill | null>(null);
-  const showcasePrefillRef = useRef<{
-    slug: string;
-    values: Record<string, string>;
-  } | null>(null);
 
   // Apply a rerun handoff (same brief, different agent/judge) exactly once.
   useEffect(() => {
@@ -448,6 +343,9 @@ export function PublicTryoutsClient() {
   const [tryoutLoading, setTryoutLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [quotaMessage, setQuotaMessage] = useState<string | null>(null);
+  const [attachments, setAttachments] = useState<AgentTryoutInputAttachment[]>([]);
+  const [attachmentUploading, setAttachmentUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -490,14 +388,23 @@ export function PublicTryoutsClient() {
       prefillRef.current = null;
       return;
     }
-    const showcasePending = showcasePrefillRef.current;
-    if (showcasePending && showcasePending.slug === templateSlug) {
-      setFieldValues(showcasePending.values);
-      showcasePrefillRef.current = null;
-      return;
-    }
     setFieldValues({});
   }, [templateSlug]);
+
+  const applyTryoutStarter = useCallback(
+    (slug: string, field: string, prompt: string) => {
+      if (slug !== templateSlug) {
+        prefillRef.current = {
+          templateSlug: slug,
+          fieldValues: { [field]: prompt },
+        };
+        setTemplateSlug(slug);
+        return;
+      }
+      setFieldValues((current) => ({ ...current, [field]: prompt }));
+    },
+    [templateSlug],
+  );
 
   useEffect(() => {
     if (!urlTryoutId) {
@@ -578,8 +485,6 @@ export function PublicTryoutsClient() {
       null,
     [fields, required],
   );
-  const secondaryFields = fields.filter(([field]) => field !== primaryField?.[0]);
-
   const updateField = useCallback((field: string, value: string) => {
     setFieldValues((current) => ({ ...current, [field]: value }));
   }, []);
@@ -595,6 +500,41 @@ export function PublicTryoutsClient() {
     evalSetup.unacceptableMistakes.trim().length > 0 &&
     evalSetup.monthlyVolume.trim().length > 0;
 
+  async function handleAttachFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    if (attachments.length >= MAX_TRYOUT_ATTACHMENTS) {
+      setMessage(`You can attach up to ${MAX_TRYOUT_ATTACHMENTS} files.`);
+      return;
+    }
+    setAttachmentUploading(true);
+    setMessage(null);
+    try {
+      const uploaded: AgentTryoutInputAttachment[] = [];
+      for (const file of Array.from(files)) {
+        if (attachments.length + uploaded.length >= MAX_TRYOUT_ATTACHMENTS) {
+          break;
+        }
+        uploaded.push(await uploadAgentTryoutInputAttachment(api, file));
+      }
+      setAttachments((current) => [...current, ...uploaded]);
+    } catch (err) {
+      setMessage(
+        err instanceof ApiError
+          ? err.message
+          : "Could not upload that file. Use a PDF or image under 15 MB.",
+      );
+    } finally {
+      setAttachmentUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((current) => current.filter((item) => item.id !== id));
+  }
+
   async function launchTryout() {
     if (!template || launching || !evalReady) return;
 
@@ -604,6 +544,11 @@ export function PublicTryoutsClient() {
       return;
     }
     input.value.eval_setup = buildEvalSetup(evalSetup, template?.name ?? "agent task");
+    if (attachments.length > 0) {
+      input.value.input_attachments = attachments.map((attachment) => ({
+        id: attachment.id,
+      }));
+    }
 
     const selectedModel =
       MODEL_OPTIONS.find((option) => modelOptionKey(option) === selectedModelKey) ??
@@ -665,31 +610,22 @@ export function PublicTryoutsClient() {
   const primaryValue = primaryField ? fieldValues[primaryField[0]] ?? "" : "";
   const canRun = Boolean(template) && !templatesLoading && !launching;
   const inSession = Boolean(urlTryoutId);
-  const showcaseItems = useMemo(() => showcaseForTemplates(templates), [templates]);
-
-  const selectShowcase = useCallback(
-    (item: TryoutShowcaseItem) => {
-      const values = { [item.primaryField]: item.example };
-      if (templateSlug === item.slug) {
-        setFieldValues(values);
-        showcasePrefillRef.current = null;
-        return;
-      }
-      showcasePrefillRef.current = { slug: item.slug, values };
-      setTemplateSlug(item.slug);
-    },
-    [templateSlug],
-  );
-
   return (
-    <main className="flex h-[100dvh] flex-col overflow-hidden bg-[#131312] text-white">
-      <header className="relative z-10 flex shrink-0 items-center justify-between gap-4 border-b border-white/[0.07] px-4 py-3 sm:px-6">
+    <main
+      className="flex h-dvh max-h-dvh flex-col overflow-hidden bg-[#131312] text-white"
+    >
+      <header className="relative z-10 flex shrink-0 items-center justify-between gap-3 border-b border-white/[0.07] px-4 py-3 sm:gap-4 sm:px-6">
         <div className="flex items-baseline gap-4">
           <Link
             href="/"
-            className="text-sm font-semibold tracking-tight text-white/90"
+            className="inline-flex items-center gap-2 text-white/90"
           >
-            AgentClash
+            <ClashMark className="size-5 sm:size-6" />
+            <span
+              className="font-[family-name:var(--font-display)] text-lg tracking-[-0.01em] sm:text-xl"
+            >
+              AgentClash
+            </span>
           </Link>
           {tryout ? (
             <span className={cn(MICRO, "hidden text-white/35 sm:inline")}>
@@ -750,7 +686,6 @@ export function PublicTryoutsClient() {
           judgeStrictness={judgeStrictness}
           setJudgeStrictness={setJudgeStrictness}
           primaryField={primaryField}
-          secondaryFields={secondaryFields}
           fieldValues={fieldValues}
           updateField={updateField}
           evalSetup={evalSetup}
@@ -763,9 +698,13 @@ export function PublicTryoutsClient() {
           message={message}
           quotaMessage={quotaMessage}
           loginHref={loginHref}
-          showcaseItems={showcaseItems}
-          onSelectShowcase={selectShowcase}
           onLaunch={() => void launchTryout()}
+          onApplyStarter={applyTryoutStarter}
+          attachments={attachments}
+          attachmentUploading={attachmentUploading}
+          fileInputRef={fileInputRef}
+          onAttachFiles={handleAttachFiles}
+          onRemoveAttachment={removeAttachment}
         />
       )}
     </main>
@@ -784,7 +723,6 @@ function TryoutWelcome({
   judgeStrictness,
   setJudgeStrictness,
   primaryField,
-  secondaryFields,
   fieldValues,
   updateField,
   evalSetup,
@@ -797,9 +735,13 @@ function TryoutWelcome({
   message,
   quotaMessage,
   loginHref,
-  showcaseItems,
-  onSelectShowcase,
   onLaunch,
+  onApplyStarter,
+  attachments,
+  attachmentUploading,
+  fileInputRef,
+  onAttachFiles,
+  onRemoveAttachment,
 }: {
   template: AgentTryoutTemplate | null;
   templates: AgentTryoutTemplate[];
@@ -812,7 +754,6 @@ function TryoutWelcome({
   judgeStrictness: AgentTryoutJudgeStrictness;
   setJudgeStrictness: (value: AgentTryoutJudgeStrictness) => void;
   primaryField: [string, FieldSpec] | null;
-  secondaryFields: [string, FieldSpec][];
   fieldValues: Record<string, string>;
   updateField: (field: string, value: string) => void;
   evalSetup: EvalSetupValues;
@@ -828,9 +769,13 @@ function TryoutWelcome({
   message: string | null;
   quotaMessage: string | null;
   loginHref: string;
-  showcaseItems: TryoutShowcaseItem[];
-  onSelectShowcase: (item: TryoutShowcaseItem) => void;
   onLaunch: () => void;
+  onApplyStarter: (slug: string, field: string, prompt: string) => void;
+  attachments: AgentTryoutInputAttachment[];
+  attachmentUploading: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onAttachFiles: (files: FileList | null) => void;
+  onRemoveAttachment: (id: string) => void;
 }) {
   const [barOpen, setBarOpen] = useState(false);
   // True when the bar dialog was opened by a send attempt: confirming the bar
@@ -849,48 +794,84 @@ function TryoutWelcome({
   }
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="mx-auto flex min-h-0 w-full max-w-lg flex-1 flex-col justify-center px-5 py-14 sm:px-6 sm:py-20">
-        <h1 className="text-center text-2xl font-semibold tracking-tight text-white sm:text-[1.75rem]">
-          Run an agent on real work
+    <div className="relative flex min-h-0 flex-1 flex-col justify-center overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-5 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <h1
+          className="mx-auto max-w-2xl text-center text-[clamp(1.35rem,3.2vw,1.875rem)] font-semibold tracking-tight text-white/88 animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-700 motion-reduce:animate-none"
+        >
+          See how an agent scores on your workflow
         </h1>
-        <p className="mt-3 text-center text-sm leading-6 text-white/45">
-          Set the bar, pick a workflow, get a scored verdict. Free sandbox, no
-          signup.
-        </p>
-        <ul className="sr-only">
-          {showcaseItems.map((item) => (
-            <li key={item.slug}>{item.label} workflow example</li>
-          ))}
-        </ul>
-
-        {showcaseItems.length > 0 ? (
-          <TryoutWorkflowChips
-            className="mt-8"
-            items={showcaseItems}
-            activeSlug={templateSlug}
-            onSelect={onSelectShowcase}
-          />
-        ) : null}
-
-        <form onSubmit={handleSubmit} className="mt-8">
+        <form onSubmit={handleSubmit} className="mt-5 sm:mt-6">
           <ComposerShell
             value={primaryValue}
             onChange={(value) => primaryField && updateField(primaryField[0], value)}
-            disabled={!template}
-            placeholder={template ? "Describe the task…" : "Loading…"}
-            canSubmit={canRun}
+            disabled={!template || attachmentUploading}
+            placeholder={
+              template ? "Describe the task or paste your brief…" : "Loading…"
+            }
+            canSubmit={canRun && !attachmentUploading}
             submitting={launching}
+            rows={2}
+            aboveFooter={
+              attachments.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5 px-2 pb-1 sm:px-3">
+                  {attachments.map((attachment) => (
+                    <span
+                      key={attachment.id}
+                      className="inline-flex max-w-full items-center gap-1 rounded-sm border border-white/12 bg-white/[0.03] py-0.5 pl-2 pr-1 font-mono text-2xs text-white/65"
+                    >
+                      <span className="truncate">{attachment.filename}</span>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${attachment.filename}`}
+                        onClick={() => onRemoveAttachment(attachment.id)}
+                        className="rounded-sm p-0.5 text-white/40 transition hover:text-white"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              ) : null
+            }
+            footerClassName="[&>*:not(:first-child)]:md:min-w-0 [&>*:not(:first-child)]:md:flex-1"
             footer={
               <>
+                <button
+                  type="button"
+                  disabled={
+                    !template ||
+                    attachmentUploading ||
+                    attachments.length >= MAX_TRYOUT_ATTACHMENTS
+                  }
+                  onClick={() => fileInputRef.current?.click()}
+                  aria-label="Attach PDF or image"
+                  className="inline-flex size-8 shrink-0 items-center justify-center rounded-sm border border-white/12 text-white/55 transition hover:border-white/30 hover:text-white disabled:opacity-40"
+                >
+                  {attachmentUploading ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Paperclip className="size-3.5" />
+                  )}
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  className="hidden"
+                  multiple
+                  accept={TRYOUT_ATTACHMENT_ACCEPT}
+                  onChange={(event) => onAttachFiles(event.target.files)}
+                />
                 <BarPill ready={evalReady} onClick={() => setBarOpen(true)} />
                 <AnimatedPillSelect
+                  icon={<FileText className="size-3.5" />}
                   value={templateSlug}
                   onChange={setTemplateSlug}
                   disabled={templatesLoading}
                   options={templates.map((t) => ({ value: t.slug, label: t.name }))}
                 />
                 <AnimatedPillSelect
+                  icon={<Gauge className="size-3.5" />}
                   value={selectedModelKey}
                   onChange={setSelectedModelKey}
                   options={MODEL_OPTIONS.map((option) => ({
@@ -899,31 +880,43 @@ function TryoutWelcome({
                   }))}
                 />
                 <AnimatedPillSelect
+                  icon={<Scale className="size-3.5" />}
                   value={judgeModel}
                   onChange={setJudgeModel}
                   options={JUDGE_OPTIONS.map((option) => ({
                     value: option.value,
                     label: option.label,
+                    menuLabel: `${option.label} judges`,
                   }))}
                 />
               </>
             }
           />
 
-          {secondaryFields.length > 0 ? (
-            <div className="mt-4 grid gap-x-10 gap-y-5 sm:grid-cols-2">
-              {secondaryFields.map(([field, spec]) => (
-                <CompactField
-                  key={field}
-                  field={field}
-                  spec={spec}
-                  value={fieldValues[field] ?? ""}
-                  required={false}
-                  onChange={updateField}
-                />
+          {!quotaMessage && (
+            <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+              {TRYOUT_STARTERS.filter((starter) =>
+                templates.some((item) => item.slug === starter.slug),
+              ).map((starter) => (
+                <button
+                  key={starter.slug}
+                  type="button"
+                  disabled={templatesLoading}
+                  onClick={() =>
+                    onApplyStarter(starter.slug, starter.field, starter.prompt)
+                  }
+                  className={cn(
+                    "rounded-sm border px-3 py-1.5 font-mono text-2xs transition",
+                    templateSlug === starter.slug
+                      ? "border-white/22 text-white/70"
+                      : "border-white/10 text-white/40 hover:border-white/18 hover:text-white/60",
+                  )}
+                >
+                  {starter.label}
+                </button>
               ))}
             </div>
-          ) : null}
+          )}
 
           {message ? <Alert text={message} /> : null}
           {quotaMessage ? (
@@ -944,21 +937,6 @@ function TryoutWelcome({
             </div>
           ) : null}
         </form>
-
-        {template && primaryField ? (
-          <div className="mt-8 border-t border-white/[0.06] pt-6">
-            {suggestionsFor(template.slug).slice(0, 3).map((suggestion) => (
-              <button
-                key={suggestion}
-                type="button"
-                onClick={() => updateField(primaryField[0], suggestion)}
-                className="block w-full py-2 text-left text-sm leading-6 text-white/40 transition hover:text-white/70"
-              >
-                {suggestion}
-              </button>
-            ))}
-          </div>
-        ) : null}
       </div>
 
       <BarDialog
@@ -987,44 +965,6 @@ function TryoutWelcome({
   );
 }
 
-function TryoutWorkflowChips({
-  items,
-  activeSlug,
-  onSelect,
-  className,
-}: {
-  items: TryoutShowcaseItem[];
-  activeSlug: string;
-  onSelect: (item: TryoutShowcaseItem) => void;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn("flex flex-wrap justify-center gap-2", className)}
-      role="listbox"
-      aria-label="Workflow templates"
-    >
-      {items.map((item) => (
-        <button
-          key={item.slug}
-          type="button"
-          role="option"
-          aria-selected={item.slug === activeSlug}
-          onClick={() => onSelect(item)}
-          className={cn(
-            "rounded-full px-3.5 py-1 text-[13px] transition",
-            item.slug === activeSlug
-              ? "bg-white text-black"
-              : "text-white/45 hover:text-white/75",
-          )}
-        >
-          {item.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 // BarPill is the composer's entry to the eval gate: it shows whether the bar
 // is set and opens the dialog to write or edit it.
 function BarPill({ ready, onClick }: { ready: boolean; onClick: () => void }) {
@@ -1033,11 +973,20 @@ function BarPill({ ready, onClick }: { ready: boolean; onClick: () => void }) {
       type="button"
       onClick={onClick}
       className={cn(
-        "text-[13px] transition",
-        ready ? "text-white/45 hover:text-white/70" : "text-white/85 hover:text-white",
+        "inline-flex shrink-0 items-center gap-1.5 rounded-sm border py-1.5 pl-2.5 pr-2.5 font-mono text-2xs transition",
+        ready
+          ? "border-white/12 text-white/60 hover:border-white/30 hover:text-white/90"
+          : "border-white/35 text-white/90 hover:border-white/60",
       )}
     >
+      <ListChecks className="size-3.5" />
       {ready ? "Bar set" : "Set the bar"}
+      {!ready ? (
+        <span
+          aria-hidden
+          className="size-1 rounded-full bg-white/80 animate-pulse motion-reduce:animate-none"
+        />
+      ) : null}
     </button>
   );
 }
@@ -1112,20 +1061,12 @@ function BarDialog({
               placeholder="50, 500, 10k"
             />
           </div>
-          <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
-            <SegmentedControl
-              label="Optimize for"
-              value={values.priority}
-              options={PRIORITY_OPTIONS}
-              onChange={(value) => onChange("priority", value)}
-            />
-            <SegmentedControl
-              label="Output behavior"
-              value={values.style}
-              options={STYLE_OPTIONS}
-              onChange={(value) => onChange("style", value)}
-            />
-          </div>
+          <SegmentedControl
+            label="Output behavior"
+            value={values.style}
+            options={STYLE_OPTIONS}
+            onChange={(value) => onChange("style", value)}
+          />
           <SegmentedControl
             label="How harshly the judge grades"
             value={strictness}
@@ -1806,8 +1747,11 @@ function ComposerShell({
   placeholder,
   canSubmit,
   submitting,
+  aboveFooter,
   footer,
+  footerClassName,
   compact,
+  rows,
   onSubmit,
 }: {
   value: string;
@@ -1816,14 +1760,19 @@ function ComposerShell({
   placeholder: string;
   canSubmit: boolean;
   submitting: boolean;
+  aboveFooter?: ReactNode;
   footer?: ReactNode;
+  footerClassName?: string;
   compact?: boolean;
+  rows?: number;
   onSubmit?: () => void;
 }) {
+  const textareaRows = rows ?? (compact ? 1 : 3);
+
   return (
     <div
       className={cn(
-        "rounded-lg border border-white/10 bg-white/[0.03] p-2 transition focus-within:border-white/25",
+        "rounded-sm border border-white/12 bg-white/[0.015] p-2.5 transition focus-within:border-white/35 sm:p-3",
         compact && "shadow-none",
       )}
     >
@@ -1838,19 +1787,31 @@ function ComposerShell({
             }
           }
         }}
-        rows={compact ? 1 : 3}
+        rows={textareaRows}
         disabled={disabled}
         placeholder={placeholder}
-        className="block w-full resize-none bg-transparent px-3 pt-2 text-base leading-7 text-white outline-none placeholder:text-white/30"
+        className="block w-full resize-none bg-transparent px-2 pt-1 text-base leading-7 text-white outline-none placeholder:text-white/30 sm:px-3 sm:pt-2"
       />
-      <div className="flex items-center justify-between gap-2 px-1 pb-0.5 pt-1">
-        {footer ? <div className="flex flex-wrap items-center gap-2">{footer}</div> : <span />}
+      {aboveFooter}
+      <div className="flex items-end justify-between gap-2 px-0.5 pb-0.5 pt-1.5 sm:items-center sm:px-1">
+        {footer ? (
+          <div
+            className={cn(
+              "flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2 md:flex-nowrap",
+              footerClassName,
+            )}
+          >
+            {footer}
+          </div>
+        ) : (
+          <span />
+        )}
         <button
           type={onSubmit ? "button" : "submit"}
           onClick={onSubmit}
           disabled={!canSubmit || submitting}
           aria-label="Send"
-          className="flex size-9 shrink-0 items-center justify-center rounded-sm bg-white text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex size-9 shrink-0 items-center justify-center rounded-sm bg-white text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40 sm:ml-1"
         >
           {submitting ? (
             <Loader2 className="size-4 animate-spin" />
@@ -1863,6 +1824,12 @@ function ComposerShell({
   );
 }
 
+type PillSelectOption = {
+  value: string;
+  label: string;
+  menuLabel?: string;
+};
+
 function AnimatedPillSelect({
   icon,
   value,
@@ -1870,10 +1837,10 @@ function AnimatedPillSelect({
   options,
   disabled,
 }: {
-  icon?: ReactNode;
+  icon: ReactNode;
   value: string;
   onChange: (value: string) => void;
-  options: { value: string; label: string }[];
+  options: PillSelectOption[];
   disabled?: boolean;
 }) {
   const selected = options.find((option) => option.value === value);
@@ -1882,11 +1849,11 @@ function AnimatedPillSelect({
     <DropdownMenu>
       <DropdownMenuTrigger
         disabled={disabled}
-        className="inline-flex max-w-[10rem] items-center gap-1 truncate text-[13px] text-white/45 transition hover:text-white/75 data-popup-open:text-white/90 disabled:opacity-50"
+        className="inline-flex w-full max-w-full min-w-0 shrink-0 items-center gap-1.5 rounded-sm border border-white/12 py-1.5 pl-2 pr-1.5 font-mono text-2xs text-white/60 transition hover:border-white/30 hover:text-white/90 data-popup-open:border-white/40 data-popup-open:text-white disabled:opacity-50 sm:pl-2.5 sm:pr-2 md:w-auto"
       >
-        {icon ? <span className="text-white/35">{icon}</span> : null}
-        <span className="truncate">{selected?.label ?? "Select"}</span>
-        <ChevronDown className="size-3 shrink-0 text-white/30" />
+        <span className="shrink-0 text-white/45">{icon}</span>
+        <span className="min-w-0 truncate">{selected?.label ?? "Select"}</span>
+        <ChevronDown className="size-3.5 shrink-0 text-white/40 transition-transform duration-200 group-data-popup-open:rotate-180" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -1901,7 +1868,7 @@ function AnimatedPillSelect({
               option.value === value && "bg-white/10 text-white",
             )}
           >
-            {option.label}
+            {option.menuLabel ?? option.label}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
@@ -1988,9 +1955,13 @@ function CompactField({
 }) {
   return (
     <label className="block">
-      <span className={cn(MICRO, "flex items-baseline justify-between tracking-[0.16em] text-white/40")}>
+      <span className="flex items-baseline justify-between gap-3 text-sm text-white/50">
         {fieldLabel(field)}
-        {required ? null : <span className="text-white/25">opt</span>}
+        {required ? null : (
+          <span className="font-mono text-2xs uppercase tracking-[0.12em] text-white/30">
+            Optional
+          </span>
+        )}
       </span>
       <input
         type={spec.type === "string" ? "text" : "number"}
@@ -2330,12 +2301,7 @@ function EvalPlanCard({
 }) {
   return (
     <div className={cn("border border-white/12", compact ? "p-4" : "p-5 sm:p-6")}>
-      <div className="flex items-baseline justify-between gap-3">
-        <p className={cn(MICRO, "text-white/40")}>Your rubric</p>
-        <span className="font-mono text-2xs uppercase tracking-[0.14em] text-white/30">
-          {priorityLabel(setup.business_priority)}
-        </span>
-      </div>
+      <p className={cn(MICRO, "text-white/40")}>Your rubric</p>
       <p className="mt-3 text-sm leading-6 text-white/55">
         Graded as if {setup.human_reviewer} signs off. Behavior:{" "}
         {styleLabel(setup.output_style).toLowerCase()}.
@@ -2593,10 +2559,6 @@ function priorityRubricChecks(priority: EvalPriority): string[] {
   }
 }
 
-function priorityLabel(priority: EvalPriority): string {
-  return PRIORITY_OPTIONS.find((option) => option.value === priority)?.label ?? "Correct facts";
-}
-
 function styleLabel(style: EvalStyle): string {
   return STYLE_OPTIONS.find((option) => option.value === style)?.label ?? "Same every time";
 }
@@ -2625,7 +2587,33 @@ function friendlyTraceSummary(event: TryoutTimelineEvent): string {
   }
 }
 
+const FIELD_LABELS: Record<string, string> = {
+  audience: "Who this is for",
+  checklist: "What to check",
+  contract: "Contract text",
+  document: "Document",
+  emails: "Emails",
+  notes: "Notes or transcript",
+  ticket: "Support ticket",
+  brief: "Brief",
+  data: "Data",
+  updates: "Updates",
+  prospect: "Prospect",
+  offer: "Your offer",
+  priorities: "How to prioritize",
+  knowledge_base: "Knowledge base",
+  policy: "Support policy",
+  fields: "Fields to extract",
+  instructions: "Extra instructions",
+  period: "Reporting period",
+  slide_count: "Number of slides",
+  tone: "Tone",
+  fixture: "Code fixture",
+  task: "Bug description",
+};
+
 function fieldLabel(field: string): string {
+  if (FIELD_LABELS[field]) return FIELD_LABELS[field];
   const spaced = field.replaceAll("_", " ");
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -10,11 +10,8 @@ import {
   ChevronDown,
   Download,
   FileText,
-  Gauge,
-  ListChecks,
   Loader2,
   PanelRight,
-  Scale,
 } from "lucide-react";
 
 import {
@@ -319,8 +316,7 @@ const GENERIC_SUGGESTIONS = [
 
 type TryoutShowcaseItem = {
   slug: string;
-  tag: string;
-  headline: string;
+  label: string;
   example: string;
   primaryField: string;
 };
@@ -328,72 +324,63 @@ type TryoutShowcaseItem = {
 const TRYOUT_SHOWCASE: TryoutShowcaseItem[] = [
   {
     slug: "support-ticket-resolution",
-    tag: "Customer support",
-    headline: "Resolve support tickets",
+    label: "Support",
     example:
       "Customer says their invoice was charged twice and wants a refund today. Draft a reply and decide whether to escalate.",
     primaryField: "ticket",
   },
   {
     slug: "document-extraction",
-    tag: "Finance / AP",
-    headline: "Extract invoice data",
+    label: "Invoices",
     example:
       "Extract line items, totals, and vendor from this invoice, then flag any missing fields for human review.",
     primaryField: "document",
   },
   {
     slug: "contract-review",
-    tag: "Legal ops",
-    headline: "Review contract clauses",
+    label: "Contracts",
     example:
       "Review this NDA for one-sided indemnity and unlimited liability. List risks with severity and quote the clause.",
     primaryField: "contract",
   },
   {
     slug: "sdr-outreach",
-    tag: "Sales",
-    headline: "Qualify leads & draft outreach",
+    label: "Outbound",
     example:
       "VP Engineering at a 200-person SaaS company, hiring 3 platform engineers. Draft a 3-sentence cold email for our eval platform.",
     primaryField: "prospect",
   },
   {
     slug: "inbox-triage",
-    tag: "Ops",
-    headline: "Triage inbox batches",
+    label: "Inbox",
     example:
       "Prioritize these 8 emails, draft replies for urgent ones, and flag anything that needs a human before we respond.",
     primaryField: "emails",
   },
   {
     slug: "meeting-minutes",
-    tag: "Product / PM",
-    headline: "Minutes to action plan",
+    label: "Meetings",
     example:
       "Summarize these notes into minutes with owners, due dates, and risks. Export a one-page action plan.",
     primaryField: "notes",
   },
   {
     slug: "status-report",
-    tag: "Leadership",
-    headline: "Status reports",
+    label: "Status",
     example:
       "Turn these scattered sprint updates into a polished weekly status with highlights, risks, and next steps.",
     primaryField: "updates",
   },
   {
     slug: "spreadsheet-builder",
-    tag: "Analytics",
-    headline: "Data to spreadsheet",
+    label: "Spreadsheets",
     example:
       "Turn this raw sales data into a spreadsheet with a pivot summary and a bar chart PNG.",
     primaryField: "data",
   },
   {
     slug: "slide-deck",
-    tag: "Marketing",
-    headline: "Brief to slide deck",
+    label: "Slides",
     example:
       "Make a 6-slide deck explaining our AI evaluation platform for a VP of Engineering, with one chart slide.",
     primaryField: "brief",
@@ -850,9 +837,6 @@ function TryoutWelcome({
   // should immediately launch the run instead of dropping back to the page.
   const [launchAfterBar, setLaunchAfterBar] = useState(false);
 
-  const enter =
-    "animate-in fade-in slide-in-from-bottom-3 fill-mode-both duration-700 motion-reduce:animate-none";
-
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!canRun) return;
@@ -866,70 +850,47 @@ function TryoutWelcome({
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col justify-center px-5 py-10 sm:px-6 sm:py-12">
-        <p
-          className={cn(MICRO, "text-center text-white/35", enter)}
-          style={{ animationDelay: "0ms" }}
-        >
-          Free AI agent evaluation · Sandboxed · No signup
-        </p>
-        <h1
-          className={cn(
-            "mx-auto mt-5 max-w-[28ch] text-center font-sans text-[clamp(2rem,4.8vw,3.25rem)] font-semibold leading-[1.08] tracking-tight text-white/95",
-            enter,
-          )}
-          style={{ animationDelay: "90ms" }}
-        >
-          Test AI agents on real business work before you integrate them
+      <div className="mx-auto flex min-h-0 w-full max-w-lg flex-1 flex-col justify-center px-5 py-14 sm:px-6 sm:py-20">
+        <h1 className="text-center text-2xl font-semibold tracking-tight text-white sm:text-[1.75rem]">
+          Run an agent on real work
         </h1>
-        <p
-          className={cn(
-            "mx-auto mt-4 max-w-xl text-center text-base leading-7 text-white/50",
-            enter,
-          )}
-          style={{ animationDelay: "180ms" }}
-        >
-          Run a free sandboxed tryout on customer support, finance, legal, sales,
-          and ops workflows. Set the quality bar your team would enforce in
-          production, pick a judge, and get a scored verdict with artifacts you
-          can share before an AI pilot or automation rollout.
+        <p className="mt-3 text-center text-sm leading-6 text-white/45">
+          Set the bar, pick a workflow, get a scored verdict. Free sandbox, no
+          signup.
         </p>
         <ul className="sr-only">
           {showcaseItems.map((item) => (
-            <li key={item.slug}>
-              {item.headline}: {item.tag} AI workflow automation example
-            </li>
+            <li key={item.slug}>{item.label} workflow example</li>
           ))}
         </ul>
 
-        <form
-          onSubmit={handleSubmit}
-          className={cn("mt-8", enter)}
-          style={{ animationDelay: "270ms" }}
-        >
+        {showcaseItems.length > 0 ? (
+          <TryoutWorkflowChips
+            className="mt-8"
+            items={showcaseItems}
+            activeSlug={templateSlug}
+            onSelect={onSelectShowcase}
+          />
+        ) : null}
+
+        <form onSubmit={handleSubmit} className="mt-8">
           <ComposerShell
             value={primaryValue}
             onChange={(value) => primaryField && updateField(primaryField[0], value)}
             disabled={!template}
-            placeholder={
-              template
-                ? `Describe the work for "${template.name}"…`
-                : "Loading tasks…"
-            }
+            placeholder={template ? "Describe the task…" : "Loading…"}
             canSubmit={canRun}
             submitting={launching}
             footer={
               <>
                 <BarPill ready={evalReady} onClick={() => setBarOpen(true)} />
                 <AnimatedPillSelect
-                  icon={<FileText className="size-3.5" />}
                   value={templateSlug}
                   onChange={setTemplateSlug}
                   disabled={templatesLoading}
                   options={templates.map((t) => ({ value: t.slug, label: t.name }))}
                 />
                 <AnimatedPillSelect
-                  icon={<Gauge className="size-3.5" />}
                   value={selectedModelKey}
                   onChange={setSelectedModelKey}
                   options={MODEL_OPTIONS.map((option) => ({
@@ -938,12 +899,11 @@ function TryoutWelcome({
                   }))}
                 />
                 <AnimatedPillSelect
-                  icon={<Scale className="size-3.5" />}
                   value={judgeModel}
                   onChange={setJudgeModel}
                   options={JUDGE_OPTIONS.map((option) => ({
                     value: option.value,
-                    label: `${option.label} judges`,
+                    label: option.label,
                   }))}
                 />
               </>
@@ -986,37 +946,20 @@ function TryoutWelcome({
         </form>
 
         {template && primaryField ? (
-          <div className={cn("mt-9", enter)} style={{ animationDelay: "360ms" }}>
-            <p className={cn(MICRO, "text-center text-white/30")}>
-              Or steal one of these prompts
-            </p>
-            <ul className="mt-3 divide-y divide-white/[0.07] border-y border-white/[0.07]">
-              {suggestionsFor(template.slug).slice(0, 5).map((suggestion) => (
-                <li key={suggestion}>
-                  <button
-                    type="button"
-                    onClick={() => updateField(primaryField[0], suggestion)}
-                    className="group flex w-full items-baseline gap-3 py-2.5 text-left text-sm leading-6 text-white/50 transition hover:text-white"
-                  >
-                    <span className="font-mono text-2xs text-white/25 transition group-hover:text-white/60">
-                      →
-                    </span>
-                    {suggestion}
-                  </button>
-                </li>
-              ))}
-            </ul>
+          <div className="mt-8 border-t border-white/[0.06] pt-6">
+            {suggestionsFor(template.slug).slice(0, 3).map((suggestion) => (
+              <button
+                key={suggestion}
+                type="button"
+                onClick={() => updateField(primaryField[0], suggestion)}
+                className="block w-full py-2 text-left text-sm leading-6 text-white/40 transition hover:text-white/70"
+              >
+                {suggestion}
+              </button>
+            ))}
           </div>
         ) : null}
       </div>
-
-      {showcaseItems.length > 0 ? (
-        <TryoutTemplateMarquee
-          items={showcaseItems}
-          activeSlug={templateSlug}
-          onSelect={onSelectShowcase}
-        />
-      ) : null}
 
       <BarDialog
         open={barOpen}
@@ -1044,85 +987,41 @@ function TryoutWelcome({
   );
 }
 
-function TryoutTemplateMarquee({
+function TryoutWorkflowChips({
   items,
   activeSlug,
   onSelect,
+  className,
 }: {
   items: TryoutShowcaseItem[];
   activeSlug: string;
   onSelect: (item: TryoutShowcaseItem) => void;
+  className?: string;
 }) {
-  const loop = [...items, ...items];
-
   return (
-    <section
-      className="shrink-0 border-t border-white/[0.07] bg-[#0f0f0e]/80 pb-6 pt-5"
-      aria-label="AI workflow templates to try"
+    <div
+      className={cn("flex flex-wrap justify-center gap-2", className)}
+      role="listbox"
+      aria-label="Workflow templates"
     >
-      <div className="mx-auto max-w-6xl px-5 sm:px-6">
-        <p className={cn(MICRO, "text-center text-white/30")}>
-          Business workflows you can test today
-        </p>
-      </div>
-      <div
-        className="relative mt-4 overflow-hidden motion-reduce:overflow-x-auto motion-reduce:px-5 motion-reduce:pb-1"
-      >
-        <div
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-[#0f0f0e] to-transparent motion-reduce:hidden sm:w-20"
-          aria-hidden
-        />
-        <div
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-[#0f0f0e] to-transparent motion-reduce:hidden sm:w-20"
-          aria-hidden
-        />
-        <div
-          className="flex w-max gap-3 motion-safe:animate-[tryout-marquee_55s_linear_infinite]"
+      {items.map((item) => (
+        <button
+          key={item.slug}
+          type="button"
+          role="option"
+          aria-selected={item.slug === activeSlug}
+          onClick={() => onSelect(item)}
+          className={cn(
+            "rounded-full px-3.5 py-1 text-[13px] transition",
+            item.slug === activeSlug
+              ? "bg-white text-black"
+              : "text-white/45 hover:text-white/75",
+          )}
         >
-          {loop.map((item, index) => {
-            const isMirror = index >= items.length;
-            const cardClass = cn(
-              "group w-[17rem] shrink-0 rounded-sm border px-4 py-3 text-left transition sm:w-[19rem]",
-              item.slug === activeSlug
-                ? "border-white/35 bg-white/[0.06]"
-                : "border-white/10 bg-white/[0.02]",
-              !isMirror && "hover:border-white/25 hover:bg-white/[0.04]",
-            );
-
-            if (isMirror) {
-              return (
-                <div key={`${item.slug}-${index}`} aria-hidden className={cardClass}>
-                  <span className={cn(MICRO, "text-white/35")}>{item.tag}</span>
-                  <p className="mt-2 text-sm font-medium leading-snug text-white/90">
-                    {item.headline}
-                  </p>
-                  <p className="mt-2 line-clamp-2 text-xs leading-5 text-white/45">
-                    {item.example}
-                  </p>
-                </div>
-              );
-            }
-
-            return (
-              <button
-                key={`${item.slug}-${index}`}
-                type="button"
-                onClick={() => onSelect(item)}
-                className={cardClass}
-              >
-                <span className={cn(MICRO, "text-white/35")}>{item.tag}</span>
-                <p className="mt-2 text-sm font-medium leading-snug text-white/90">
-                  {item.headline}
-                </p>
-                <p className="mt-2 line-clamp-2 text-xs leading-5 text-white/45 transition group-hover:text-white/60">
-                  {item.example}
-                </p>
-              </button>
-            );
-          })}
-        </div>
-      </div>
-    </section>
+          {item.label}
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -1134,20 +1033,11 @@ function BarPill({ ready, onClick }: { ready: boolean; onClick: () => void }) {
       type="button"
       onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-sm border py-1.5 pl-2.5 pr-2.5 font-mono text-2xs transition",
-        ready
-          ? "border-white/12 text-white/60 hover:border-white/30 hover:text-white/90"
-          : "border-white/35 text-white/90 hover:border-white/60",
+        "text-[13px] transition",
+        ready ? "text-white/45 hover:text-white/70" : "text-white/85 hover:text-white",
       )}
     >
-      <ListChecks className="size-3.5" />
       {ready ? "Bar set" : "Set the bar"}
-      {!ready ? (
-        <span
-          aria-hidden
-          className="size-1 rounded-full bg-white/80 animate-pulse motion-reduce:animate-none"
-        />
-      ) : null}
     </button>
   );
 }
@@ -1933,7 +1823,7 @@ function ComposerShell({
   return (
     <div
       className={cn(
-        "rounded-sm border border-white/12 bg-white/[0.015] p-2 transition focus-within:border-white/35",
+        "rounded-lg border border-white/10 bg-white/[0.03] p-2 transition focus-within:border-white/25",
         compact && "shadow-none",
       )}
     >
@@ -1980,7 +1870,7 @@ function AnimatedPillSelect({
   options,
   disabled,
 }: {
-  icon: ReactNode;
+  icon?: ReactNode;
   value: string;
   onChange: (value: string) => void;
   options: { value: string; label: string }[];
@@ -1992,11 +1882,11 @@ function AnimatedPillSelect({
     <DropdownMenu>
       <DropdownMenuTrigger
         disabled={disabled}
-        className="inline-flex items-center gap-1.5 rounded-sm border border-white/12 py-1.5 pl-2.5 pr-2 font-mono text-2xs text-white/60 transition hover:border-white/30 hover:text-white/90 data-popup-open:border-white/40 data-popup-open:text-white disabled:opacity-50"
+        className="inline-flex max-w-[10rem] items-center gap-1 truncate text-[13px] text-white/45 transition hover:text-white/75 data-popup-open:text-white/90 disabled:opacity-50"
       >
-        <span className="text-white/45">{icon}</span>
-        <span className="max-w-[9rem] truncate">{selected?.label ?? "Select"}</span>
-        <ChevronDown className="size-3.5 text-white/40 transition-transform duration-200 group-data-popup-open:rotate-180" />
+        {icon ? <span className="text-white/35">{icon}</span> : null}
+        <span className="truncate">{selected?.label ?? "Select"}</span>
+        <ChevronDown className="size-3 shrink-0 text-white/30" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"

--- a/web/src/lib/api/agent-tryouts.ts
+++ b/web/src/lib/api/agent-tryouts.ts
@@ -3,6 +3,7 @@ import type {
   AgentTryout,
   AgentTryoutCompareResult,
   AgentTryoutEventsResponse,
+  AgentTryoutInputAttachment,
   AgentTryoutPromotionResult,
   AgentTryoutTemplate,
   CreateAgentTryoutInput,
@@ -26,6 +27,18 @@ export function createAnonymousAgentTryout(
   input: CreateAgentTryoutInput,
 ): Promise<AgentTryout> {
   return api.post<AgentTryout>("/v1/agent-tryouts", input);
+}
+
+export function uploadAgentTryoutInputAttachment(
+  api: ApiClient,
+  file: File,
+): Promise<AgentTryoutInputAttachment> {
+  const formData = new FormData();
+  formData.append("file", file, file.name);
+  return api.postMultipart<AgentTryoutInputAttachment>(
+    "/v1/agent-tryout-input-attachments",
+    formData,
+  );
 }
 
 export function getPublicAgentTryout(

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -126,7 +126,11 @@ async function requestWithMeta<T>(
   }
 
   if (body !== undefined && !headers["Content-Type"]) {
-    headers["Content-Type"] = "application/json";
+    if (typeof FormData !== "undefined" && body instanceof FormData) {
+      // Let the browser set multipart boundary.
+    } else {
+      headers["Content-Type"] = "application/json";
+    }
   }
 
   let res: Response;
@@ -136,8 +140,8 @@ async function requestWithMeta<T>(
       headers,
       body:
         body !== undefined
-          ? typeof body === "string"
-            ? body
+          ? typeof body === "string" || (typeof FormData !== "undefined" && body instanceof FormData)
+            ? (body as BodyInit)
             : JSON.stringify(body)
           : undefined,
       signal: opts.signal,
@@ -200,6 +204,10 @@ export function createApiClient(token?: string) {
 
     post<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
       return request<T>("POST", path, token, body, opts);
+    },
+
+    postMultipart<T>(path: string, formData: FormData, opts?: RequestOptions): Promise<T> {
+      return request<T>("POST", path, token, formData, opts);
     },
 
     postWithMeta<T>(

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2767,6 +2767,13 @@ export interface AgentTryoutJudgeSelection {
   strictness?: AgentTryoutJudgeStrictness;
 }
 
+export interface AgentTryoutInputAttachment {
+  id: string;
+  filename: string;
+  media_type: string;
+  size_bytes: number;
+}
+
 export interface CreateAgentTryoutInput {
   template_slug: string;
   input: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Removes the animated bottom marquee (collision / clutter).
- Minimal hero: short headline, one line of subcopy, Geist sans at comfortable scale.
- Workflow picker is a simple row of pill chips above the composer (wraps on mobile).
- Three example prompts below the composer, no heavy borders or mono labels.
- Composer controls are text-only links instead of bordered pill buttons.

## Test plan
- [ ] Open `/tryouts` on mobile and desktop: no overlapping marquee
- [ ] Click workflow chips to switch template and prefill
- [ ] Confirm composer and examples feel uncrowded