### PR TITLE
feat(analytics): close PostHog coverage gaps — attribution, dead events, tryouts funnel

### DIFF
--- a/backend/internal/api/middleware.go
+++ b/backend/internal/api/middleware.go
@@ -119,6 +119,14 @@ var trackingSkipPrefixes = []string{
 // trackingSkipExact lists exact paths to skip in addition to prefix matches.
 var trackingSkipExact = map[string]struct{}{
 	"/v1/model-catalog": {},
+	// Device-token polling: `agentclash auth login` polls this endpoint every
+	// ~5s for up to 10 minutes (~120 hits per login). It currently sits outside
+	// the trackUsage middleware (registered on the top-level router in
+	// server.go, not the authenticated /v1 group), so no events are emitted for
+	// it today — but skip it explicitly so that if the route is ever moved under
+	// tracking, polling can never flood analytics. The one-shot initiation
+	// endpoint (/v1/cli-auth/device) is intentionally NOT skipped.
+	"/v1/cli-auth/device/token": {},
 }
 
 func shouldSkipTracking(path string) bool {
@@ -215,13 +223,25 @@ func trackUsage(logger *slog.Logger, hog posthog.Client) func(http.Handler) http
 			if caller, err := CallerFromContext(r.Context()); err == nil {
 				authenticated = true
 				distinctID = caller.UserID.String()
+
+				// workspace_id: prefer the value set by authorizeWorkspaceAccess;
+				// fall back to the {workspaceID} URL param for workspace-scoped
+				// routes that resolve access in the handler rather than in
+				// middleware (so the property is set consistently across both).
 				if wsID, wsErr := WorkspaceIDFromContext(r.Context()); wsErr == nil {
 					props["workspace_id"] = wsID.String()
+				} else if urlWS, ok := uuidURLParam(r, "workspaceID"); ok {
+					props["workspace_id"] = urlWS.String()
 				}
-				// Best-effort org attribution: pick the first membership.
-				for orgID := range caller.OrganizationMemberships {
-					props["org_id"] = orgID.String()
-					break
+
+				// org_id: prefer an explicit {organizationID} from the route;
+				// otherwise attribute only when unambiguous (exactly one
+				// membership). Never guess among multiple orgs — a stable but
+				// possibly-wrong org_id pollutes per-org rollups, so omit it.
+				if urlOrg, ok := uuidURLParam(r, "organizationID"); ok {
+					props["org_id"] = urlOrg.String()
+				} else if len(caller.OrganizationMemberships) == 1 {
+					props["org_id"] = SortedOrganizationMemberships(caller.OrganizationMemberships)[0].OrganizationID.String()
 				}
 			}
 			if !authenticated {
@@ -244,6 +264,22 @@ func trackUsage(logger *slog.Logger, hog posthog.Client) func(http.Handler) http
 			})
 		})
 	}
+}
+
+// uuidURLParam reads a chi URL param and parses it as a UUID. It is safe to
+// call post-serve: the RouteContext (and the params populated during routing)
+// persists in the request context, which is exactly how RoutePattern() is read
+// above. Returns ok=false when the param is absent or not a valid UUID.
+func uuidURLParam(r *http.Request, name string) (uuid.UUID, bool) {
+	raw := chi.URLParam(r, name)
+	if raw == "" {
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, false
+	}
+	return id, true
 }
 
 // isLikelyWebOrigin returns true if the request carries an Origin or Referer

--- a/backend/internal/api/middleware_test.go
+++ b/backend/internal/api/middleware_test.go
@@ -1,0 +1,222 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/posthog"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// recordingPostHog is a posthog.Client spy that captures every emitted event so
+// tests can assert exactly which requests produce analytics events and what
+// properties they carry.
+type recordingPostHog struct {
+	mu     sync.Mutex
+	events []posthog.Event
+}
+
+func (s *recordingPostHog) Capture(event posthog.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+}
+
+func (s *recordingPostHog) Identify(string, map[string]any) {}
+func (s *recordingPostHog) Close() error                    { return nil }
+
+func (s *recordingPostHog) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.events)
+}
+
+func (s *recordingPostHog) last() *posthog.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.events) == 0 {
+		return nil
+	}
+	event := s.events[len(s.events)-1]
+	return &event
+}
+
+func TestShouldSkipTracking(t *testing.T) {
+	cases := []struct {
+		path string
+		skip bool
+	}{
+		{"/healthz", true},
+		{"/healthz/ready", true},
+		{"/v1/model-catalog", true},
+		{"/v1/cli-auth/device/token", true}, // noisy login polling — skipped
+		{"/v1/cli-auth/device", false},       // one-shot initiation — kept
+		{"/v1/runs", false},
+		{"/v1/workspaces/abc/runs", false},
+		{"/v1/auth/session", false},
+	}
+	for _, tc := range cases {
+		if got := shouldSkipTracking(tc.path); got != tc.skip {
+			t.Errorf("shouldSkipTracking(%q) = %v, want %v", tc.path, got, tc.skip)
+		}
+	}
+}
+
+// captureFor builds a minimal chi router that injects the given caller (and
+// optional workspace-id context) ahead of trackUsage, serves a GET to
+// requestPath matched by routePattern, and returns the single captured event
+// (or nil if none was emitted). This exercises trackUsage's real attribution
+// logic — including post-serve chi URLParam reads — without standing up the
+// full application router.
+func captureFor(t *testing.T, caller *Caller, wsCtx *uuid.UUID, routePattern, requestPath string) *posthog.Event {
+	t.Helper()
+	spy := &recordingPostHog{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			if caller != nil {
+				ctx = context.WithValue(ctx, callerContextKey{}, *caller)
+			}
+			if wsCtx != nil {
+				ctx = context.WithValue(ctx, workspaceIDContextKey{}, *wsCtx)
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	router.Use(trackUsage(logger, spy))
+	router.Get(routePattern, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, requestPath, nil))
+	return spy.last()
+}
+
+func singleOrgCaller(userID, orgID uuid.UUID) *Caller {
+	return &Caller{
+		UserID: userID,
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgID: {OrganizationID: orgID, Role: "org_admin"},
+		},
+	}
+}
+
+func TestTrackUsageAttribution(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	wsURL := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	wsCtx := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	orgA := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000000")
+	orgB := uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000000")
+
+	t.Run("workspace_id falls back to URL param when context is absent", func(t *testing.T) {
+		event := captureFor(t, singleOrgCaller(userID, orgA), nil,
+			"/v1/workspaces/{workspaceID}/runs", "/v1/workspaces/"+wsURL.String()+"/runs")
+		if event == nil {
+			t.Fatal("expected an event")
+		}
+		if got := event.Properties["workspace_id"]; got != wsURL.String() {
+			t.Errorf("workspace_id = %v, want %v", got, wsURL)
+		}
+		if got := event.Properties["org_id"]; got != orgA.String() {
+			t.Errorf("org_id = %v, want %v (single membership)", got, orgA)
+		}
+	})
+
+	t.Run("workspace_id context wins over URL param", func(t *testing.T) {
+		event := captureFor(t, singleOrgCaller(userID, orgA), &wsCtx,
+			"/v1/workspaces/{workspaceID}/runs", "/v1/workspaces/"+wsURL.String()+"/runs")
+		if got := event.Properties["workspace_id"]; got != wsCtx.String() {
+			t.Errorf("workspace_id = %v, want context value %v", got, wsCtx)
+		}
+	})
+
+	t.Run("org_id comes from the organizationID route param", func(t *testing.T) {
+		caller := &Caller{UserID: userID, OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgA: {OrganizationID: orgA}, orgB: {OrganizationID: orgB},
+		}}
+		event := captureFor(t, caller, nil,
+			"/v1/organizations/{organizationID}/workspaces", "/v1/organizations/"+orgB.String()+"/workspaces")
+		if got := event.Properties["org_id"]; got != orgB.String() {
+			t.Errorf("org_id = %v, want route param %v", got, orgB)
+		}
+	})
+
+	t.Run("org_id is omitted for multi-org callers without a route param", func(t *testing.T) {
+		caller := &Caller{UserID: userID, OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgA: {OrganizationID: orgA}, orgB: {OrganizationID: orgB},
+		}}
+		event := captureFor(t, caller, nil,
+			"/v1/workspaces/{workspaceID}/runs", "/v1/workspaces/"+wsURL.String()+"/runs")
+		if _, ok := event.Properties["org_id"]; ok {
+			t.Errorf("org_id should be omitted for ambiguous multi-org caller, got %v", event.Properties["org_id"])
+		}
+	})
+
+	t.Run("anonymous request is not profiled", func(t *testing.T) {
+		event := captureFor(t, nil, nil, "/v1/runs", "/v1/runs")
+		if event == nil {
+			t.Fatal("expected an event")
+		}
+		if event.DistinctID != posthog.AnonymousDistinctID() {
+			t.Errorf("distinct_id = %v, want anonymous", event.DistinctID)
+		}
+		if event.Properties["$process_person_profile"] != false {
+			t.Errorf("$process_person_profile = %v, want false", event.Properties["$process_person_profile"])
+		}
+		if _, ok := event.Properties["workspace_id"]; ok {
+			t.Error("anonymous event should not carry workspace_id")
+		}
+	})
+}
+
+// TestTrackUsageDeviceFlowEmitsNoEvents proves against the real application
+// router that the unauthenticated CLI device-login endpoints (init + poll) do
+// not emit analytics events — they are registered on the top-level router,
+// outside the authenticated /v1 group that carries trackUsage — while a
+// protected route does emit exactly one event.
+func TestTrackUsageDeviceFlowEmitsNoEvents(t *testing.T) {
+	spy := &recordingPostHog{}
+	handler := buildRouter(routerOptions{
+		authMode:                   "dev",
+		logger:                     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		authenticator:              NewDevelopmentAuthenticator(),
+		authorizer:                 NewCallerWorkspaceAuthorizer(),
+		posthogClient:              spy,
+		runCreationService:         stubRunCreationService{},
+		runReadService:             stubRunReadService{},
+		replayReadService:          stubReplayReadService{},
+		hostedRunIngestionService:  stubHostedRunIngestionService{},
+		agentDeploymentReadService: stubAgentDeploymentReadService{},
+		challengePackReadService:   stubChallengePackReadService{},
+		agentBuildService:          stubAgentBuildService{},
+		releaseGateService:         noopReleaseGateService{},
+		challengePackAuthoringSvc:  stubChallengePackAuthoringService{},
+		cliAuthServices:            []CLIAuthService{stubCLIAuthService{}},
+	})
+
+	for _, path := range []string{"/v1/cli-auth/device", "/v1/cli-auth/device/token"} {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+	if n := spy.count(); n != 0 {
+		t.Fatalf("device-flow endpoints emitted %d analytics events, want 0", n)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set(headerUserID, "11111111-1111-1111-1111-111111111111")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if n := spy.count(); n != 1 {
+		t.Fatalf("protected route produced %d events, want 1", n)
+	}
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -34,15 +34,53 @@ they don't create junk person profiles (and don't inflate MAU billing).
 - `api.request` — non-CLI authenticated request (no browser origin).
 - `web.api.request` — request carrying a browser Origin/Referer.
 
-`/healthz` and `/v1/model-catalog` are skipped.
+**Attribution:** `workspace_id` comes from the `authorizeWorkspaceAccess`
+context, falling back to the `{workspaceID}` route param. `org_id` comes from a
+`{organizationID}` route param, else the caller's single org membership — it is
+**omitted** for multi-org callers rather than guessed (a stable-but-wrong org
+would pollute per-org rollups).
+
+**Skipped:** `/healthz*`, `/v1/model-catalog`, and `/v1/cli-auth/device/token`
+(the login-poll endpoint — `agentclash auth login` polls it ~120×/login). The
+one-shot `/v1/cli-auth/device` initiation is intentionally *not* skipped. Note:
+both device endpoints currently sit outside `trackUsage` (registered on the
+top-level router, not the authenticated `/v1` group), so they emit nothing
+today regardless; the skip is defensive in case they are ever moved under
+tracking.
 
 ### Web (`web/src/lib/analytics/events.ts`)
 - `$pageview` — auto-captured on every App Router navigation
   (`web/src/components/posthog-provider.tsx`).
 - `web.auth.login.success` — once per fresh tab session after login.
-- `web.workspace.created`, `web.provider_account.added`, `web.run.created`,
-  and (defined, wire as needed) `web.org.created`, `web.pack.uploaded`,
-  `web.regression.case_promoted`.
+- `web.org.created` + `web.workspace.created` — onboarding wizard
+  (`web/src/app/onboard/onboarding-wizard.tsx`). `web.workspace.created` also
+  fires from the standalone create-workspace dialog, so the onboarding funnel
+  counts both paths.
+- `web.provider_account.added`, `web.run.created`.
+- `web.pack.uploaded` — challenge-pack publish dialog (`publish-pack-dialog.tsx`).
+- `web.regression.case_promoted` — run-failure → regression case promotion
+  (`promote-failure-dialog.tsx`).
+
+**Public agent-tryouts funnel** (anonymous visitors; stitched per-browser by
+posthog-js — `web/src/app/tryouts/tryouts-client.tsx`):
+- `web.tryout.session_started` — `tryout_id`, `template_slug`, `model_key`.
+- `web.tryout.launch_failed` — `template_slug`, `status_code`.
+- `web.tryout.message_sent` — `tryout_id`, `message_length`.
+- `web.tryout.session_ended` — `tryout_id`.
+- `web.tryout.signup_cta_clicked` — `location`
+  (`header`/`quota`/`save_rerun`/`end_session`), `tryout_id?`.
+- `web.tryout.roi_cta_clicked` — `template_slug`, `email_domain?`.
+
+**Lead-capture surfaces:**
+- `web.resource.lead_submitted` — marketing resource form
+  (`resource-lead-form.tsx`): `source`, `resource`, `intent`, `email_domain?`.
+- `web.agent_opportunity.report_generated` — opportunity report
+  (`agent-opportunity-client.tsx`): `verdict`, `use_case_count`,
+  `company_size?`, `current_pain?`.
+
+**Privacy — no raw PII in properties.** Lead/ROI surfaces collect an email, but
+events only ever carry the derived **`email_domain`** (e.g. `acme.com`), never
+the raw address, and never the company name. Keep it that way when adding events.
 
 ### Worker run lifecycle (`backend/internal/worker/posthog_recorder.go`)
 - `run.started`, `run.completed`, `run.failed`. Props: `run_id`,
@@ -92,6 +130,7 @@ Creates the "AgentClash — Usage" dashboard with the insights below. Idempotent
 | Top CLI commands | Trends on `cli.command.invoked`, breakdown by `command` (or the provisioned HogQL insight) |
 | Top pages / routes | Trends on `$pageview` breakdown by `$pathname`; API routes via `api.request` breakdown by `route` |
 | Onboarding drop-off | **Funnels** — the two provisioned funnels (`Onboarding funnel — web` / `— CLI`) |
+| Tryouts drop-off | **Funnels** — the provisioned `Tryouts funnel` (`/tryouts` view → session → message → signup) |
 | User journeys | **Paths** |
 | DAU / WAU / MAU | Trends with "Active users" math at day/week/month interval |
 | Signups over time | **Lifecycle** insight ("new" series) — no dedicated signup event needed |

--- a/scripts/posthog/provision-dashboard.mjs
+++ b/scripts/posthog/provision-dashboard.mjs
@@ -76,8 +76,10 @@ function hogqlInsight(name, description, sql) {
   };
 }
 
-// Native funnel insight. steps: [{ event, command? }] — command adds an
-// event-property filter so multiple steps can share the same event name.
+// Native funnel insight. steps: [{ event, command?, properties?, label? }].
+// `command` is shorthand for an exact event-property filter (so multiple steps
+// can share one event name); `properties` is an escape hatch for arbitrary
+// PostHog property filters (e.g. matching $current_url on $pageview).
 function funnelInsight(name, description, steps) {
   return {
     name,
@@ -95,7 +97,9 @@ function funnelInsight(name, description, steps) {
                 { key: "command", value: s.command, operator: "exact", type: "event" },
               ],
             }
-          : {}),
+          : s.properties
+            ? { properties: s.properties }
+            : {}),
       })),
     },
   };
@@ -153,11 +157,12 @@ const INSIGHTS = [
   ),
   hogqlInsight(
     "Daily active users (30d)",
-    "Distinct authenticated users per day across CLI + web.",
+    "Distinct identified users per day across CLI + web. Excludes the shared server-side 'anonymous' distinct_id so unauthenticated traffic doesn't collapse into one fake DAU.",
     `
     SELECT toDate(timestamp) AS day, count(DISTINCT person_id) AS dau
     FROM events
     WHERE timestamp > now() - INTERVAL 30 day
+      AND distinct_id != 'anonymous'
     GROUP BY day
     ORDER BY day
   `,
@@ -210,6 +215,22 @@ const INSIGHTS = [
       { event: "cli.command.invoked", command: "challenge-pack.publish", label: "pack publish" },
       { event: "cli.command.invoked", command: "deployment.create", label: "deployment create" },
       { event: "cli.command.invoked", command: "run.create", label: "run create" },
+    ],
+  ),
+  funnelInsight(
+    "Tryouts funnel",
+    "Public agent tryout drop-off: visited /tryouts → started a session → sent a message → clicked a signup CTA. Anonymous visitors stitch per-browser via posthog-js.",
+    [
+      {
+        event: "$pageview",
+        label: "Visited /tryouts",
+        properties: [
+          { key: "$current_url", value: "/tryouts", operator: "icontains", type: "event" },
+        ],
+      },
+      { event: "web.tryout.session_started", label: "Started session" },
+      { event: "web.tryout.message_sent", label: "Sent a message" },
+      { event: "web.tryout.signup_cta_clicked", label: "Clicked signup" },
     ],
   ),
   lifecycleInsight(

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
@@ -7,6 +7,8 @@ import { useApiMutator } from "@/lib/api/swr";
 import { ApiError } from "@/lib/api/errors";
 import { billingGateToastMessage } from "@/lib/billing";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 import type {
   ValidateChallengePackResponse,
   PublishChallengePackResponse,
@@ -101,6 +103,10 @@ export function PublishPackDialog({ workspaceId }: PublishPackDialogProps) {
         yaml,
         "application/yaml",
       );
+      captureWebEvent(WEB_EVENTS.PACK_UPLOADED, {
+        workspace_id: workspaceId,
+        pack_id: result.challenge_pack_id,
+      });
       toast.success("Challenge pack published");
       setOpen(false);
       reset();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.tsx
@@ -9,6 +9,8 @@ import { toast } from "sonner";
 
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 import {
   buildPromotionOverrides,
   defaultPromotionSeverityForFailure,
@@ -231,6 +233,11 @@ export function PromoteFailureDialog({
           }),
         },
       );
+
+      captureWebEvent(WEB_EVENTS.REGRESSION_CASE_PROMOTED, {
+        workspace_id: workspaceId,
+        case_id: result.case.id,
+      });
 
       const caseHref = `/workspaces/${workspaceId}/regression-suites/${result.case.suite_id}/cases/${result.case.id}`;
       if (result.created) {

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 import { DimensionRadar } from "./components/dimension-radar";
 import { OpportunityMap } from "./components/opportunity-map";
 import { RiskHeatmap } from "./components/risk-heatmap";
@@ -721,6 +723,12 @@ export function AgentOpportunityClient() {
         return;
       }
       setReport(payload.report);
+      captureWebEvent(WEB_EVENTS.AGENT_OPPORTUNITY_REPORT_GENERATED, {
+        verdict: payload.report.shouldBuildAgent,
+        use_case_count: payload.report.useCases.length,
+        ...(companySize ? { company_size: companySize } : {}),
+        ...(currentPain ? { current_pain: currentPain } : {}),
+      });
     } catch {
       setError("The report request failed. Please try again.");
     } finally {

--- a/web/src/app/onboard/onboarding-wizard.tsx
+++ b/web/src/app/onboard/onboarding-wizard.tsx
@@ -6,6 +6,8 @@ import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { OnboardResult } from "@/lib/api/types";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Loader2, ArrowRight, Sparkles } from "lucide-react";
@@ -31,6 +33,17 @@ export function OnboardingWizard() {
       const result = await api.post<OnboardResult>("/v1/onboarding", {
         organization_name: orgName.trim(),
         workspace_name: workspaceName.trim(),
+      });
+
+      captureWebEvent(WEB_EVENTS.ORG_CREATED, {
+        organization_id: result.organization.id,
+      });
+      // Wizard path creates org + workspace together; fire workspace.created
+      // here too so the onboarding funnel counts these users (the standalone
+      // create-workspace dialog is the only other emitter).
+      captureWebEvent(WEB_EVENTS.WORKSPACE_CREATED, {
+        workspace_id: result.workspace.id,
+        organization_id: result.organization.id,
       });
 
       toast.success("You're all set!");

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -36,6 +36,8 @@ import {
 } from "@/lib/api/agent-tryouts";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 import type {
   AgentHarnessKind,
   AgentTryout,
@@ -72,6 +74,21 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+
+// Analytics helpers for the public tryouts funnel. Privacy: derive email_domain
+// only — never send raw email or company name to PostHog.
+function tryoutEmailDomain(email: string): string | undefined {
+  const at = email.lastIndexOf("@");
+  if (at < 0 || at === email.length - 1) return undefined;
+  return email.slice(at + 1).trim().toLowerCase() || undefined;
+}
+
+function trackTryoutSignup(location: string, tryoutId?: string): void {
+  captureWebEvent(WEB_EVENTS.TRYOUT_SIGNUP_CTA_CLICKED, {
+    location,
+    ...(tryoutId ? { tryout_id: tryoutId } : {}),
+  });
+}
 
 type FieldSpec = {
   type: string;
@@ -592,10 +609,19 @@ export function PublicTryoutsClient() {
       }
       setTryout(nextTryout);
       setEvents([]);
+      captureWebEvent(WEB_EVENTS.TRYOUT_SESSION_STARTED, {
+        tryout_id: nextTryout.id,
+        template_slug: template.slug,
+        model_key: selectedModelKey,
+      });
       router.replace(`/tryouts?tryout=${encodeURIComponent(nextTryout.id)}`, {
         scroll: false,
       });
     } catch (err) {
+      captureWebEvent(WEB_EVENTS.TRYOUT_LAUNCH_FAILED, {
+        template_slug: template.slug,
+        ...(err instanceof ApiError ? { status_code: err.status } : {}),
+      });
       if (err instanceof ApiError) {
         if (err.status === 402 || err.status === 429) {
           setQuotaMessage(err.message);
@@ -665,6 +691,7 @@ export function PublicTryoutsClient() {
           )}
           <Link
             href={loginHref}
+            onClick={() => trackTryoutSignup("header")}
             className="rounded-sm border border-white/15 px-3 py-1.5 text-sm text-white/80 transition hover:border-white/40 hover:text-white"
           >
             Sign in
@@ -943,6 +970,7 @@ function TryoutWelcome({
               </p>
               <Link
                 href={loginHref}
+                onClick={() => trackTryoutSignup("quota")}
                 className="mt-4 inline-flex h-9 items-center gap-1.5 rounded-sm bg-white px-4 text-sm font-medium text-black transition hover:bg-white/90"
               >
                 Keep grading
@@ -1318,6 +1346,7 @@ function TryoutSidebar({
 
       <Link
         href={loginHref}
+        onClick={() => trackTryoutSignup("save_rerun", tryout.id)}
         className="mt-5 inline-flex h-9 items-center justify-center gap-1.5 rounded-sm bg-white px-4 text-sm font-medium text-black transition hover:bg-white/90"
       >
         Save and rerun
@@ -1441,6 +1470,10 @@ function TryoutChatThread({
     setError(null);
     try {
       await submitAgentTryoutTurn(api, tryout.id, { message: text });
+      captureWebEvent(WEB_EVENTS.TRYOUT_MESSAGE_SENT, {
+        tryout_id: tryout.id,
+        message_length: text.length,
+      });
       setFollowUps((current) => [
         ...current,
         { id: `u${Date.now()}`, text, at: Date.now() },
@@ -1460,6 +1493,7 @@ function TryoutChatThread({
     setEnding(true);
     try {
       await submitAgentTryoutTurn(api, tryout.id, { end: true });
+      captureWebEvent(WEB_EVENTS.TRYOUT_SESSION_ENDED, { tryout_id: tryout.id });
     } catch {
       // best-effort
     } finally {
@@ -1562,7 +1596,11 @@ function TryoutChatThread({
           ) : (
             <p className="text-center text-sm text-white/45">
               Session complete.{" "}
-              <Link href={loginHref} className="text-white underline-offset-4 hover:underline">
+              <Link
+                href={loginHref}
+                onClick={() => trackTryoutSignup("end_session", tryout.id)}
+                className="text-white underline-offset-4 hover:underline"
+              >
                 Sign in
               </Link>{" "}
               to save this run and wire it into evals.
@@ -3118,6 +3156,12 @@ function EvalRoiCalculator({
         </p>
         <Link
           href={`/enterprise?from=tryout&task=${encodeURIComponent(tryout.template_slug)}${email.trim() ? `&email=${encodeURIComponent(email.trim())}` : ""}`}
+          onClick={() =>
+            captureWebEvent(WEB_EVENTS.TRYOUT_ROI_CTA_CLICKED, {
+              template_slug: tryout.template_slug,
+              ...(tryoutEmailDomain(email) ? { email_domain: tryoutEmailDomain(email) } : {}),
+            })
+          }
           className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-sm bg-white px-4 text-sm font-medium text-black transition hover:bg-white/90"
         >
           Talk to us about integrating

--- a/web/src/components/marketing/resource-lead-form.tsx
+++ b/web/src/components/marketing/resource-lead-form.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
 import { useState } from "react";
+import { captureWebEvent } from "@/lib/analytics/posthog-client";
+import { WEB_EVENTS } from "@/lib/analytics/events";
 
 type Props = {
   source: string;
@@ -46,6 +48,17 @@ export function ResourceLeadForm({
         setError(payload?.error ?? "Something went wrong. Try again.");
         return;
       }
+
+      // Privacy: email_domain only — never send the raw email to PostHog.
+      const emailDomain = email.includes("@")
+        ? email.split("@").pop()?.trim().toLowerCase() || undefined
+        : undefined;
+      captureWebEvent(WEB_EVENTS.RESOURCE_LEAD_SUBMITTED, {
+        source,
+        resource,
+        intent: "resource-download",
+        ...(emailDomain ? { email_domain: emailDomain } : {}),
+      });
 
       const params = new URLSearchParams({
         email: email.trim().toLowerCase(),

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -27,6 +27,26 @@ export const WEB_EVENTS = {
   RUN_CREATED: "web.run.created",
   /** User promoted a run failure to a regression case. */
   REGRESSION_CASE_PROMOTED: "web.regression.case_promoted",
+
+  // Public agent-tryouts funnel (anonymous visitors trying an agent).
+  /** Anonymous tryout session successfully launched. */
+  TRYOUT_SESSION_STARTED: "web.tryout.session_started",
+  /** Tryout launch failed (quota, rate limit, or other error). */
+  TRYOUT_LAUNCH_FAILED: "web.tryout.launch_failed",
+  /** User sent a follow-up message in a tryout session. */
+  TRYOUT_MESSAGE_SENT: "web.tryout.message_sent",
+  /** User ended a tryout session. */
+  TRYOUT_SESSION_ENDED: "web.tryout.session_ended",
+  /** User clicked a sign-in / save CTA from the tryout surface. */
+  TRYOUT_SIGNUP_CTA_CLICKED: "web.tryout.signup_cta_clicked",
+  /** User clicked the "talk to us" CTA in the tryout ROI calculator. */
+  TRYOUT_ROI_CTA_CLICKED: "web.tryout.roi_cta_clicked",
+
+  // Adjacent lead-capture surfaces.
+  /** Visitor submitted a marketing resource lead form. */
+  RESOURCE_LEAD_SUBMITTED: "web.resource.lead_submitted",
+  /** Agent-opportunity report generated for a visitor. */
+  AGENT_OPPORTUNITY_REPORT_GENERATED: "web.agent_opportunity.report_generated",
 } as const;
 
 export type WebEventName = (typeof WEB_EVENTS)[keyof typeof WEB_EVENTS];
@@ -39,4 +59,26 @@ export interface WebEventPayloads {
   [WEB_EVENTS.PACK_UPLOADED]: { workspace_id: string; pack_id?: string };
   [WEB_EVENTS.RUN_CREATED]: { workspace_id: string; run_id?: string };
   [WEB_EVENTS.REGRESSION_CASE_PROMOTED]: { workspace_id: string; case_id?: string };
+  [WEB_EVENTS.TRYOUT_SESSION_STARTED]: {
+    tryout_id: string;
+    template_slug: string;
+    model_key: string;
+  };
+  [WEB_EVENTS.TRYOUT_LAUNCH_FAILED]: { template_slug: string; status_code?: number };
+  [WEB_EVENTS.TRYOUT_MESSAGE_SENT]: { tryout_id: string; message_length: number };
+  [WEB_EVENTS.TRYOUT_SESSION_ENDED]: { tryout_id: string };
+  [WEB_EVENTS.TRYOUT_SIGNUP_CTA_CLICKED]: { location: string; tryout_id?: string };
+  [WEB_EVENTS.TRYOUT_ROI_CTA_CLICKED]: { template_slug?: string; email_domain?: string };
+  [WEB_EVENTS.RESOURCE_LEAD_SUBMITTED]: {
+    source: string;
+    resource: string;
+    intent?: string;
+    email_domain?: string;
+  };
+  [WEB_EVENTS.AGENT_OPPORTUNITY_REPORT_GENERATED]: {
+    verdict: string;
+    use_case_count: number;
+    company_size?: string;
+    current_pain?: string;
+  };
 }


### PR DESCRIPTION
## What & why

Follow-up to the PostHog instrumentation in #897. An audit against latest `main`
found coverage gaps; this PR closes them. **No new dependencies.**

### Backend — request attribution + noise hardening (`middleware.go`)
- `workspace_id` now falls back to the `{workspaceID}` route param when the
  `authorizeWorkspaceAccess` context is absent (previously only workspace-scoped
  routes that resolve access in middleware carried it).
- `org_id` is now deterministic: `{organizationID}` route param → else the
  caller's **single** org membership → else **omitted** (the old code picked a
  random membership via non-deterministic map iteration; a stable-but-wrong org
  pollutes per-org rollups, so multi-org callers get no guess).
- Skip `/v1/cli-auth/device/token` (the login-poll endpoint). **Finding:** the
  device-login routes already sit *outside* `trackUsage` (top-level router, not
  the authenticated `/v1` group), so they emit **nothing** today — the audit's
  "~120 events/login" never actually happens. The skip is defensive hardening,
  proven by `TestTrackUsageDeviceFlowEmitsNoEvents`.

### Web — wire dead events, close a funnel hole, instrument new surfaces
- Fire the previously **defined-but-dead** `web.org.created`,
  `web.pack.uploaded`, `web.regression.case_promoted`.
- **Funnel hole:** the onboarding wizard (`POST /v1/onboarding`) now fires
  `web.workspace.created`, so funnel step 3 counts wizard-path users, not just
  the standalone create-workspace dialog.
- **Tryouts minimal funnel** (6 events) on the public `/tryouts` surface:
  `session_started`, `launch_failed`, `message_sent`, `session_ended`,
  `signup_cta_clicked` (header/quota/save_rerun/end_session), `roi_cta_clicked`.
- **Lead surfaces:** `web.resource.lead_submitted`,
  `web.agent_opportunity.report_generated`.
- **Privacy:** lead/ROI events carry `email_domain` only — never the raw email
  or company name.

### Provisioning + docs
- `provision-dashboard.mjs`: new **Tryouts funnel** insight; DAU query excludes
  the shared `'anonymous'` distinct_id so unauthenticated traffic doesn't
  collapse into one fake active user.
- `docs/analytics.md`: full taxonomy, attribution fallback, skip rule, privacy.

## Verification
- backend: `go build ./...`, `go vet`, `go test -short -race ./...` ✓ (incl. 3
  new middleware tests: skip-list, attribution, device-flow-emits-nothing)
- web: `tsc --noEmit` ✓, `eslint` ✓ (0 errors), `vitest run` ✓ (465 passed)
- `node --check` on the provisioning script ✓

## Notes
- **Web events ship dark until the Vercel `NEXT_PUBLIC_POSTHOG_KEY` is set.**
  Backend attribution changes take effect on deploy regardless.
- Out of scope (unchanged): worker per-step events, Group analytics add-on,
  PostHog internal-user exclusion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
