### PR TITLE
feat(agent-tryouts): strengthen task prompts to produce real office artifacts

### DIFF
--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -816,16 +816,92 @@ func agentTryoutHarnessSlug(template AgentTryoutTemplate) string {
 }
 
 func agentTryoutTaskPrompt(template AgentTryoutTemplate, input json.RawMessage) string {
-	return strings.Join([]string{
-		"You are running an AgentClash tryout template.",
-		"Template: " + template.Name + " (" + template.Slug + ")",
-		"Goal: " + template.Description,
-		"Use only the available sandbox tools and produce a concise, inspectable result for the user.",
-		"User input JSON:",
+	instructions := strings.TrimSpace(agentTryoutRuntimeInstructions(template.Runtime))
+	specs := expectedArtifactsFromRuntime(template.Runtime)
+
+	lines := []string{
+		"You are an expert AI agent completing a real office-work task inside a sandboxed Linux workspace at /workspace.",
+		"The user is judging the QUALITY of the files you deliver, so produce polished, professional, ready-to-use output — never a draft, outline, or plan-only response.",
+		"",
+		"TASK: " + template.Name + " (" + template.Slug + ")",
+		"GOAL: " + template.Description,
+	}
+	if instructions != "" {
+		lines = append(lines, "", "INSTRUCTIONS:", instructions)
+	}
+	if len(specs) > 0 {
+		lines = append(lines, "", "DELIVERABLES — create these exact files in /workspace (every one must exist and be non-empty when you finish):")
+		for _, spec := range specs {
+			path := strings.TrimSpace(spec.Path)
+			if path == "" {
+				continue
+			}
+			detail := fmt.Sprintf("- %s (%s)", path, strings.TrimSpace(spec.Type))
+			if key := strings.TrimSpace(spec.Key); key != "" {
+				detail += " — " + key
+			}
+			lines = append(lines, detail)
+		}
+	}
+	lines = append(lines,
+		"",
+		"TOOLCHAIN (pre-installed; no network access — do not attempt installs or downloads):",
+		"- Python 3 with: python-pptx, python-docx, openpyxl, xlsxwriter, pandas, numpy, matplotlib, seaborn, plotly+kaleido, reportlab, fpdf2, weasyprint, pypdf, pdfplumber, Pillow, Jinja2, markdown.",
+		"- CLI tools: pandoc, LibreOffice (soffice), poppler-utils, graphviz, sqlite3.",
+		"- Generate real binary files with these libraries. To convert a .pptx/.docx to PDF: soffice --headless --convert-to pdf <file>.",
+		"",
+		"QUALITY BAR:",
+		"- Use real content derived from the user's input below — no lorem ipsum or [placeholder] text.",
+		"- Any JSON deliverable must be valid JSON with the fields named in the instructions.",
+		"- Before finishing, verify each file: re-read JSON you wrote, and check that binary files are non-trivial in size.",
+		"",
+		"When you are done, end your final message with a short \"Deliverables\" summary listing each file you created and one line on what it contains.",
+		"Do not reveal secrets, API keys, or environment variables.",
+		"",
+		"USER INPUT:",
 		"```json",
-		string(input),
+		strings.TrimSpace(string(input)),
 		"```",
-	}, "\n")
+	)
+	return strings.Join(lines, "\n")
+}
+
+// agentTryoutRuntimeInstructions extracts the free-text "instructions" directive
+// from a template runtime blob, if present.
+func agentTryoutRuntimeInstructions(runtime json.RawMessage) string {
+	if len(runtime) == 0 {
+		return ""
+	}
+	var parsed struct {
+		Instructions string `json:"instructions"`
+	}
+	_ = json.Unmarshal(runtime, &parsed)
+	return parsed.Instructions
+}
+
+// agentTryoutArtifactSpec mirrors a runtime.expected_artifacts entry. It is a
+// deliberate structural twin of workflow.capturedArtifactSpec; the api and
+// workflow packages do not import one another for layering reasons, so this
+// small shape is duplicated rather than shared. Keep the JSON tags in sync.
+type agentTryoutArtifactSpec struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// expectedArtifactsFromRuntime parses runtime.expected_artifacts from a template
+// runtime blob so the task prompt can enumerate the exact deliverable files.
+func expectedArtifactsFromRuntime(runtime json.RawMessage) []agentTryoutArtifactSpec {
+	if len(runtime) == 0 {
+		return nil
+	}
+	var parsed struct {
+		ExpectedArtifacts []agentTryoutArtifactSpec `json:"expected_artifacts"`
+	}
+	if err := json.Unmarshal(runtime, &parsed); err != nil {
+		return nil
+	}
+	return parsed.ExpectedArtifacts
 }
 
 func agentTryoutEvaluationConfig(template AgentTryoutTemplate, tryout repository.AgentTryout) json.RawMessage {
@@ -1675,7 +1751,7 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Available:          true,
 			InputSchema:        json.RawMessage(`{"type":"object","required":["notes"],"additionalProperties":false,"properties":{"notes":{"type":"string"},"audience":{"type":"string"}}}`),
 			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
-			Runtime:            json.RawMessage(`{"adapter":"meeting_minutes_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"action_plan","type":"markdown","path":"action-plan.md"},{"key":"structured_minutes","type":"json","path":"minutes.json"}],"validation":{"validators":[{"key":"has_summary","type":"json_field","field":"summary"},{"key":"has_action_items","type":"json_field","field":"action_items"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			Runtime:            json.RawMessage(`{"adapter":"meeting_minutes_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"action_plan","type":"markdown","path":"action-plan.md"},{"key":"structured_minutes","type":"json","path":"minutes.json"}],"instructions":"Turn the notes or transcript into professional meeting minutes. Write action-plan.md as a clean, scannable document with sections: Summary, Key Decisions, Risks, and an Action Items table (columns: Item, Owner, Due). Write minutes.json with fields: summary (string), decisions (array of strings), risks (array of strings), action_items (array of {item, owner, due}). Ground every decision and action item in the notes — do not invent attendees, dates, or decisions that are not supported.","validation":{"validators":[{"key":"has_summary","type":"json_field","field":"summary"},{"key":"has_action_items","type":"json_field","field":"action_items"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_summary","type":"json_field","field":"summary"},{"key":"has_action_items","type":"json_field","field":"action_items"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
@@ -1721,7 +1797,7 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Available:          true,
 			InputSchema:        json.RawMessage(`{"type":"object","required":["data"],"additionalProperties":false,"properties":{"data":{"type":"string"},"instructions":{"type":"string"}}}`),
 			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
-			Runtime:            json.RawMessage(`{"adapter":"spreadsheet_builder_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"spreadsheet","type":"csv","path":"spreadsheet.csv"},{"key":"analysis","type":"json","path":"analysis.json"}],"validation":{"validators":[{"key":"has_columns","type":"json_field","field":"columns"},{"key":"has_insights","type":"json_field","field":"insights"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			Runtime:            json.RawMessage(`{"adapter":"spreadsheet_builder_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"spreadsheet","type":"csv","path":"spreadsheet.csv"},{"key":"analysis","type":"json","path":"analysis.json"}],"instructions":"Turn the pasted data or description into a clean, analysis-ready spreadsheet. Write spreadsheet.csv with a clear header row, the normalized source rows, and useful derived columns (totals, ratios, categories) when they help. Write analysis.json with fields: columns (array of column names), rows (number of data rows), insights (array of short factual findings), summary (string). Keep numbers internally consistent and clearly labeled; do not fabricate data points that are not implied by the input.","validation":{"validators":[{"key":"has_columns","type":"json_field","field":"columns"},{"key":"has_insights","type":"json_field","field":"insights"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_columns","type":"json_field","field":"columns"},{"key":"has_insights","type":"json_field","field":"insights"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
@@ -1736,7 +1812,7 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Available:          true,
 			InputSchema:        json.RawMessage(`{"type":"object","required":["updates"],"additionalProperties":false,"properties":{"updates":{"type":"string"},"period":{"type":"string"},"audience":{"type":"string"}}}`),
 			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
-			Runtime:            json.RawMessage(`{"adapter":"status_report_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"report","type":"markdown","path":"status-report.md"},{"key":"structured_report","type":"json","path":"report.json"}],"validation":{"validators":[{"key":"has_highlights","type":"json_field","field":"highlights"},{"key":"has_next_steps","type":"json_field","field":"next_steps"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			Runtime:            json.RawMessage(`{"adapter":"status_report_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"report","type":"markdown","path":"status-report.md"},{"key":"structured_report","type":"json","path":"report.json"}],"instructions":"Turn the scattered bullet updates into a polished, executive-ready status report. Write status-report.md with clear sections: Highlights, In Progress, Risks / Blockers, and Next Steps — grouped, scannable, and concise. Write report.json with fields: summary (string), highlights (array of strings), risks (array of strings), next_steps (array of strings). Reflect only what is in the updates; do not invent progress or commitments.","validation":{"validators":[{"key":"has_highlights","type":"json_field","field":"highlights"},{"key":"has_next_steps","type":"json_field","field":"next_steps"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_highlights","type":"json_field","field":"highlights"},{"key":"has_next_steps","type":"json_field","field":"next_steps"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
@@ -1751,7 +1827,7 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Available:          true,
 			InputSchema:        json.RawMessage(`{"type":"object","required":["emails"],"additionalProperties":false,"properties":{"emails":{"type":"string"},"priorities":{"type":"string"}}}`),
 			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
-			Runtime:            json.RawMessage(`{"adapter":"inbox_triage_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"triage_board","type":"markdown","path":"triage.md"},{"key":"structured_triage","type":"json","path":"triage.json"}],"validation":{"validators":[{"key":"has_queue","type":"json_field","field":"queue"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			Runtime:            json.RawMessage(`{"adapter":"inbox_triage_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"triage_board","type":"markdown","path":"triage.md"},{"key":"structured_triage","type":"json","path":"triage.json"}],"instructions":"Prioritize the pasted emails and draft replies. Write triage.md as a prioritized table (columns: Priority, Sender, Subject, Suggested Action) followed by a ready-to-send draft reply for each email that needs a response. Write triage.json with field queue (array of {sender, subject, priority (high|medium|low), needs_reply (boolean), draft_reply (string)}). Base priority on urgency and the provided priorities; do not invent senders or facts not in the emails.","validation":{"validators":[{"key":"has_queue","type":"json_field","field":"queue"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_queue","type":"json_field","field":"queue"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
@@ -1766,7 +1842,7 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Available:          true,
 			InputSchema:        json.RawMessage(`{"type":"object","required":["task"],"additionalProperties":false,"properties":{"task":{"type":"string"},"fixture":{"type":"string"}}}`),
 			ToolPolicy:         json.RawMessage(`{"tools":["sandbox_shell","file_editor"],"sandbox":{"filesystem":"workspace","shell":"allowed"},"network":{"mode":"disabled"},"external_side_effects":false}`),
-			Runtime:            json.RawMessage(`{"adapter":"tiny_bugfix_v1","sandbox":{"filesystem":"workspace","shell":"allowed","network":"disabled"},"expected_artifacts":[{"key":"diff","type":"patch","path":"changes.patch"},{"key":"test_result","type":"json","path":"test-result.json"}],"validation":{"validators":[{"key":"tests_pass","type":"command_exit_code"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			Runtime:            json.RawMessage(`{"adapter":"tiny_bugfix_v1","sandbox":{"filesystem":"workspace","shell":"allowed","network":"disabled"},"expected_artifacts":[{"key":"diff","type":"patch","path":"changes.patch"},{"key":"test_result","type":"json","path":"test-result.json"}],"instructions":"Inspect the fixture, find the root cause of the described bug, and make a minimal, focused fix. Save the change as changes.patch (a unified git diff). Run the tests and write test-result.json with fields: passed (boolean), tests_run (number), tests_failed (number), summary (string). Keep the diff minimal — do not reformat unrelated code or add unrelated features.","validation":{"validators":[{"key":"tests_pass","type":"command_exit_code"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"tests_pass","type":"command_exit_code"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   false,

--- a/backend/internal/api/agent_tryouts_prompt_test.go
+++ b/backend/internal/api/agent_tryouts_prompt_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestAgentTryoutTaskPromptForegroundsDeliverablesAndToolchain verifies the
+// rewritten prompt builder surfaces the template instructions, the exact
+// deliverable file paths, and the installed toolchain — the signals the agent
+// needs to produce real office files instead of a markdown outline.
+func TestAgentTryoutTaskPromptForegroundsDeliverablesAndToolchain(t *testing.T) {
+	template := AgentTryoutTemplate{
+		Slug:        "slide-deck",
+		Name:        "Brief to Slide Deck",
+		Description: "Turn a brief into a deck.",
+		Runtime:     json.RawMessage(`{"instructions":"Build deck.pptx and export deck.pdf.","expected_artifacts":[{"key":"presentation","type":"pptx","path":"deck.pptx"},{"key":"presentation_pdf","type":"pdf","path":"deck.pdf"}]}`),
+	}
+
+	prompt := agentTryoutTaskPrompt(template, json.RawMessage(`{"brief":"Q3 results"}`))
+
+	for _, want := range []string{
+		"DELIVERABLES",
+		"deck.pptx (pptx)",
+		"deck.pdf (pdf)",
+		"INSTRUCTIONS:",
+		"Build deck.pptx and export deck.pdf.",
+		"TOOLCHAIN",
+		"python-pptx",
+		"soffice",
+		"QUALITY BAR",
+		"Q3 results",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+}
+
+// TestEveryAvailableAgentTryoutTemplateHasInstructions guards the "capable
+// artifacts" contract: each available office template must give the agent
+// concrete instructions and an expected-artifacts manifest so the prompt builder
+// can foreground real deliverables.
+func TestEveryAvailableAgentTryoutTemplateHasInstructions(t *testing.T) {
+	for _, template := range builtinAgentTryoutTemplates() {
+		if !template.Available {
+			continue
+		}
+		if strings.TrimSpace(agentTryoutRuntimeInstructions(template.Runtime)) == "" {
+			t.Errorf("available template %q has no runtime instructions", template.Slug)
+		}
+		if len(expectedArtifactsFromRuntime(template.Runtime)) == 0 {
+			t.Errorf("available template %q declares no expected artifacts", template.Slug)
+		}
+		if !json.Valid(template.Runtime) {
+			t.Errorf("template %q runtime is not valid JSON: %s", template.Slug, template.Runtime)
+		}
+	}
+}

--- a/backend/internal/workflow/public_agent_tryout_prompt_test.go
+++ b/backend/internal/workflow/public_agent_tryout_prompt_test.go
@@ -1,0 +1,41 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+// TestPublicTryoutTaskPromptForegroundsDeliverables verifies the public-path
+// prompt builder produces the strong, structured task prompt (instructions,
+// deliverable paths, toolchain, quality bar) and still carries the user input.
+func TestPublicTryoutTaskPromptForegroundsDeliverables(t *testing.T) {
+	tryout := repository.AgentTryout{
+		TemplateSlug: "slide-deck",
+		TemplateSnapshot: json.RawMessage(`{"name":"Brief to Slide Deck","description":"Turn a brief into a deck.",` +
+			`"runtime":{"instructions":"Build deck.pptx with python-pptx and export deck.pdf.",` +
+			`"expected_artifacts":[{"key":"presentation","type":"pptx","path":"deck.pptx"},{"key":"presentation_pdf","type":"pdf","path":"deck.pdf"}]}}`),
+		InputSnapshot: json.RawMessage(`{"brief":"Q3 results"}`),
+	}
+
+	prompt := publicTryoutTaskPrompt(tryout)
+
+	for _, want := range []string{
+		"DELIVERABLES",
+		"deck.pptx (pptx)",
+		"deck.pdf (pdf)",
+		"INSTRUCTIONS:",
+		"Build deck.pptx with python-pptx",
+		"TOOLCHAIN",
+		"python-pptx",
+		"soffice",
+		"QUALITY BAR",
+		"Q3 results",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+}

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -592,26 +592,106 @@ func publicTryoutTaskPrompt(tryout repository.AgentTryout) string {
 	if description == "" {
 		description = "Complete the requested office-work task."
 	}
-	lines := []string{
-		"You are running a public AgentClash tryout.",
-		"Task: " + name + " (" + tryout.TemplateSlug + ")",
-		"Goal: " + description,
-		"Use the sandbox to produce concise, inspectable office-work outputs for the user.",
-		"Do not reveal secrets or environment variables.",
-		"User input JSON:",
-		"```json",
-		string(tryout.InputSnapshot),
-		"```",
-	}
+	lines := renderAgentTryoutTaskPromptLines(name, tryout.TemplateSlug, description, template.Runtime, tryout.InputSnapshot)
 	lines = append(lines, publicTryoutEvalSetupPrompt(tryout.InputSnapshot)...)
 	lines = append(lines, publicTryoutInputAttachmentsPrompt(tryout.InputSnapshot)...)
+	return strings.Join(lines, "\n")
+}
+
+// renderAgentTryoutTaskPromptLines builds the strong, structured task prompt
+// shared (by intent) by the public and workspace tryout paths. It foregrounds
+// the template's own instructions, enumerates the exact deliverable files the
+// agent must write (parsed from runtime.expected_artifacts), names the
+// pre-installed toolchain, and sets an explicit quality bar — so the agent
+// produces real, openable office files instead of stopping at a markdown
+// outline. Returns lines (not a joined string) so callers can append
+// path-specific sections before joining.
+//
+// NOTE: api/agent_tryouts.go intentionally keeps a structurally identical
+// agentTryoutRuntimeInstructions / expectedArtifactsFromRuntime / prompt builder.
+// The two packages do not import one another for layering reasons; keep them in
+// sync when the runtime blob schema changes.
+func renderAgentTryoutTaskPromptLines(name, slug, description string, runtime, input json.RawMessage) []string {
+	instructions := strings.TrimSpace(agentTryoutRuntimeInstructions(runtime))
+	specs := expectedArtifactsFromRuntime(runtime)
+
+	lines := []string{
+		"You are an expert AI agent completing a real office-work task inside a sandboxed Linux workspace at /workspace.",
+		"The user is judging the QUALITY of the files you deliver, so produce polished, professional, ready-to-use output — never a draft, outline, or plan-only response.",
+		"",
+		"TASK: " + name + " (" + slug + ")",
+		"GOAL: " + description,
+	}
+	if instructions != "" {
+		lines = append(lines, "", "INSTRUCTIONS:", instructions)
+	}
+	if len(specs) > 0 {
+		lines = append(lines, "", "DELIVERABLES — create these exact files in /workspace (every one must exist and be non-empty when you finish):")
+		for _, spec := range specs {
+			path := strings.TrimSpace(spec.Path)
+			if path == "" {
+				continue
+			}
+			detail := fmt.Sprintf("- %s (%s)", path, strings.TrimSpace(spec.Type))
+			if key := strings.TrimSpace(spec.Key); key != "" {
+				detail += " — " + key
+			}
+			lines = append(lines, detail)
+		}
+	}
 	lines = append(lines,
-		"Runtime instructions JSON:",
+		"",
+		"TOOLCHAIN (pre-installed; no network access — do not attempt installs or downloads):",
+		"- Python 3 with: python-pptx, python-docx, openpyxl, xlsxwriter, pandas, numpy, matplotlib, seaborn, plotly+kaleido, reportlab, fpdf2, weasyprint, pypdf, pdfplumber, Pillow, Jinja2, markdown.",
+		"- CLI tools: pandoc, LibreOffice (soffice), poppler-utils, graphviz, sqlite3.",
+		"- Generate real binary files with these libraries. To convert a .pptx/.docx to PDF: soffice --headless --convert-to pdf <file>. To embed a chart, render it with matplotlib/seaborn to a PNG under assets/ and place it in the document.",
+		"",
+		"QUALITY BAR:",
+		"- Use real content derived from the user's input below — no lorem ipsum or [placeholder] text.",
+		"- Slide decks: a title slide, well-structured content slides, at least one real chart or diagram, and speaker notes. Keep a consistent visual style.",
+		"- Spreadsheets: clean headers, correct derived columns/formulas, and a short written summary of insights.",
+		"- Documents/reports: clear structure, headings, and a scannable layout.",
+		"- Any JSON deliverable must be valid JSON with the fields named in the instructions.",
+		"- Before finishing, verify each file: re-read JSON you wrote, and check that binary files are non-trivial in size.",
+		"",
+		"When you are done, end your final message with a short \"Deliverables\" summary that lists each file you created and one line on what it contains.",
+		"Do not reveal secrets, API keys, or environment variables.",
+		"",
+		"USER INPUT:",
 		"```json",
-		string(template.Runtime),
+		strings.TrimSpace(string(input)),
 		"```",
 	)
-	return strings.Join(lines, "\n")
+	return lines
+}
+
+// agentTryoutRuntimeInstructions extracts the free-text "instructions" directive
+// from a template runtime blob, if present.
+func agentTryoutRuntimeInstructions(runtime json.RawMessage) string {
+	if len(runtime) == 0 {
+		return ""
+	}
+	var parsed struct {
+		Instructions string `json:"instructions"`
+	}
+	_ = json.Unmarshal(runtime, &parsed)
+	return parsed.Instructions
+}
+
+// expectedArtifactsFromRuntime parses runtime.expected_artifacts directly from a
+// template runtime blob (as opposed to expectedArtifactsFromExecutionConfig,
+// which reads the nested execution-config snapshot).
+func expectedArtifactsFromRuntime(runtime json.RawMessage) []capturedArtifactSpec {
+	if len(runtime) == 0 {
+		return nil
+	}
+	var parsed struct {
+		ExpectedArtifacts []capturedArtifactSpec `json:"expected_artifacts"`
+	}
+	if err := json.Unmarshal(runtime, &parsed); err != nil {
+		return nil
+	}
+	return parsed.ExpectedArtifacts
 }
 
 func publicTryoutEvalSetupPrompt(input json.RawMessage) []string {


### PR DESCRIPTION
## Why

The agent tryout produced poor artifacts — vague prompts dumped the runtime as a raw JSON blob and said "produce concise outputs," so agents often stopped at a markdown outline instead of a real PPT/spreadsheet. Several office templates also gave the agent **no instructions at all**.

## Scope note (rebased)

The original PR also added an LLM-judge eval. While it was open, **#1031 / main shipped a more complete public-tryout judge system** (`agent_tryout_judge.go`, `runPublicTryoutJudges`, template `judge_meta`/`llm_judges`, verdict semantics, and a full frontend judge UI). To avoid two competing implementations, this PR has been **rebased onto main and narrowed to the part main did not address: prompt quality.** The judge feature is entirely main's.

## What this PR does

- Rewrites both tryout prompt builders (`publicTryoutTaskPrompt` → shared `renderAgentTryoutTaskPromptLines`, and `agentTryoutTaskPrompt`) to:
  - foreground the template's `instructions`,
  - enumerate the **exact deliverable file paths** from `expected_artifacts`,
  - name the pre-installed toolchain (python-pptx, soffice→PDF, matplotlib, pandas…),
  - set an explicit quality bar (real binary files, charts, speaker notes, verify-before-finish, closing deliverables summary).
  - The public path still appends main's `publicTryoutEvalSetupPrompt` + `publicTryoutInputAttachmentsPrompt`.
- Adds concrete `instructions` to the office templates main left bare: meeting-minutes, spreadsheet-builder, status-report, inbox-triage, tiny-bugfix.

## Greptile follow-ups
- The partial-judge-availability concern was on the old `scorePublicTryout` — that code is gone (main owns judging now).
- The duplicated `agentTryoutRuntimeInstructions`/`expectedArtifactsFromRuntime` helpers across the api + workflow packages are intentional (no cross-package import for layering); each now carries a "keep in sync" comment, and `agentTryoutArtifactSpec` documents that it mirrors `workflow.capturedArtifactSpec`.

## Tests
- New prompt-content tests (api + workflow) and a guard that every available template has instructions + an expected-artifacts manifest.
- `go build/vet`, `go test -short -race` (api + workflow) all clean. Locked `json_field` office-template test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)