### PR TITLE
fix(web): reorder benchmarks hub to lead with proof, drop empty scoreboard columns

### DIFF
--- a/web/src/components/marketing/benchmark-scoreboard.test.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.test.tsx
@@ -35,12 +35,38 @@ describe("BenchmarkScoreboard", () => {
     expect(html).not.toContain(">$0.00</td>");
   });
 
-  it("renders a missing score as an em dash, never NaN", () => {
+  it("renders a missing score as an em dash, never NaN, when the column is partly populated", () => {
+    // One row missing composite, another carrying it: the column survives the
+    // drop-all-null filter, so the gap must render as an em dash, not NaN.
     const html = renderToStaticMarkup(
-      <BenchmarkScoreboard results={[row({ composite: null })]} />,
+      <BenchmarkScoreboard
+        results={[
+          row({ model: "Alpha", composite: null }),
+          row({ model: "Bravo", composite: 0.5 }),
+        ]}
+      />,
     );
     expect(html).not.toContain("NaN");
     expect(html).toContain(EM_DASH);
+  });
+
+  it("drops a column that is null for every row instead of rendering a dash wall", () => {
+    // A report that measured neither latency nor $/correct should not show those
+    // columns at all, rather than a column of em dashes.
+    const html = renderToStaticMarkup(
+      <BenchmarkScoreboard
+        results={[
+          row({ model: "Alpha", latency: null, costPerCorrectUsd: null }),
+          row({ model: "Bravo", latency: null, costPerCorrectUsd: null }),
+        ]}
+      />,
+    );
+    expect(html).not.toContain("Latency");
+    expect(html).not.toContain("$/correct");
+    // Columns with data on at least one row stay.
+    expect(html).toContain("Composite");
+    // No cell should be an em dash once the empty columns are gone.
+    expect(html).not.toContain(EM_DASH);
   });
 
   it("renders the distinct rank each row carries", () => {

--- a/web/src/components/marketing/benchmark-scoreboard.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.tsx
@@ -47,9 +47,24 @@ const COLUMNS: Column[] = [
 export function BenchmarkScoreboard({ results, featuredModel }: Props) {
   if (results.length === 0) return null;
 
+  // A report may omit a metric for every row (e.g. latency was not measured, or
+  // the report deliberately does not assert dollar prices). Rendering those
+  // columns anyway produces a wall of em dashes, so drop any column whose values
+  // are null across the board and let the table narrow to what was measured.
+  const visibleColumns = COLUMNS.filter((col) =>
+    results.some((result) => result[col.key] !== null),
+  );
+
+  // Keep the horizontal-scroll floor proportional to the visible columns so a
+  // narrowed table is not forced to scroll on small screens for absent metrics.
+  const minWidthClass =
+    visibleColumns.length > 4 ? "min-w-[680px]" : "min-w-[520px]";
+
   return (
     <div className="w-full overflow-x-auto rounded-xl border border-white/[0.08] bg-white/[0.02]">
-      <table className="w-full min-w-[680px] border-collapse text-left">
+      <table
+        className={cn("w-full border-collapse text-left", minWidthClass)}
+      >
         <thead>
           <tr className="border-b border-white/[0.08]">
             <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
@@ -58,7 +73,7 @@ export function BenchmarkScoreboard({ results, featuredModel }: Props) {
             <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35">
               Model
             </th>
-            {COLUMNS.map((col) => (
+            {visibleColumns.map((col) => (
               <th
                 key={col.key}
                 className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-2xs uppercase tracking-[0.14em] text-white/35"
@@ -105,7 +120,7 @@ export function BenchmarkScoreboard({ results, featuredModel }: Props) {
                     </span>
                   )}
                 </td>
-                {COLUMNS.map((col) => (
+                {visibleColumns.map((col) => (
                   <td
                     key={col.key}
                     className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-sm tabular-nums text-white/70"

--- a/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
+++ b/web/src/components/marketing/benchmarks/benchmarks-hub-content.tsx
@@ -97,10 +97,8 @@ export function BenchmarksHubContent({ published }: Props) {
         Run the same benchmark on your agents when you are ready to gate releases.
       </p>
 
-      <BenchmarkRunCTA className="mt-8" />
-
       {latest ? (
-        <section className="mt-14" aria-labelledby="latest-report-heading">
+        <section className="mt-12" aria-labelledby="latest-report-heading">
           <SectionEyebrow>Latest report</SectionEyebrow>
           <SectionTitle>
             <span id="latest-report-heading">{latest.title}</span>
@@ -205,42 +203,6 @@ export function BenchmarksHubContent({ published }: Props) {
         </div>
       </section>
 
-      {latest && (
-        <section className="mt-14" aria-labelledby="monthly-cadence-heading">
-          <SectionEyebrow>Monthly cadence</SectionEyebrow>
-          <SectionTitle>
-            <span id="monthly-cadence-heading">How reports stay reproducible</span>
-          </SectionTitle>
-          <ol className="mt-6 flex flex-col gap-3">
-            {BENCHMARKS_MONTHLY_PROCESS.map((step, index) => (
-              <li
-                key={step}
-                className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
-              >
-                <span className="font-[family-name:var(--font-mono)] text-2xs text-white/30">
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-                <span className="text-sm leading-relaxed text-white/55">
-                  {step}
-                </span>
-              </li>
-            ))}
-          </ol>
-          <p className="mt-4 text-xs text-white/35">
-            Owner checklist and scorecard export format:{" "}
-            <a
-              href={BENCHMARKS_RUNBOOK_HREF}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-white/55 underline-offset-2 hover:text-white/75 hover:underline"
-            >
-              monthly benchmark runbook
-            </a>
-            .
-          </p>
-        </section>
-      )}
-
       <section className="mt-14" aria-labelledby="child-benchmarks-heading">
         <SectionEyebrow>Go deeper</SectionEyebrow>
         <SectionTitle>
@@ -285,7 +247,43 @@ export function BenchmarksHubContent({ published }: Props) {
         </ul>
       </section>
 
-      {published.length > 0 && (
+      {latest && (
+        <section className="mt-14" aria-labelledby="monthly-cadence-heading">
+          <SectionEyebrow>Monthly cadence</SectionEyebrow>
+          <SectionTitle>
+            <span id="monthly-cadence-heading">How reports stay reproducible</span>
+          </SectionTitle>
+          <ol className="mt-6 flex flex-col gap-3">
+            {BENCHMARKS_MONTHLY_PROCESS.map((step, index) => (
+              <li
+                key={step}
+                className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
+              >
+                <span className="font-[family-name:var(--font-mono)] text-2xs text-white/30">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="text-sm leading-relaxed text-white/55">
+                  {step}
+                </span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-4 text-xs text-white/35">
+            Owner checklist and scorecard export format:{" "}
+            <a
+              href={BENCHMARKS_RUNBOOK_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/55 underline-offset-2 hover:text-white/75 hover:underline"
+            >
+              monthly benchmark runbook
+            </a>
+            .
+          </p>
+        </section>
+      )}
+
+      {published.length > 1 && (
         <section className="mt-14" aria-labelledby="all-reports-heading">
           <SectionEyebrow>All reports</SectionEyebrow>
           <SectionTitle>


### PR DESCRIPTION
## Why

The `/benchmarks` hub read backwards. Section #2 — right under the hero, before a single result is shown — was the enterprise CTA *"Run this benchmark on your agents / Book eval workshop / Enterprise."* That's selling before showing proof, on a page whose whole pitch is *"not a vibes leaderboard, here's evidence."* And it was the **identical `BenchmarkRunCTA`** that already closed the page, so the ask ran twice with the first copy premature.

Compounding it: the lone published report rendered in full at the top *and* again as a card in "All reports," and the scoreboard showed two fully-empty columns (Latency, $/correct — all em-dashes) because that report omits those metrics.

## What changed

Order is now **evidence-first, sell-last**:

```
Hero → Latest report → Methodology → Go deeper / Packs / Reading
     → Monthly cadence (demoted) → All reports (only if >1) → single CTA
```

- **Remove the premature top CTA** (`benchmarks-hub-content.tsx`). The bottom CTA already closes the page.
- **Demote "Monthly cadence"** below the link sections — it's process detail.
- **Gate "All reports" on `published.length > 1`** so the single report doesn't duplicate the Latest-report section.
- **Drop all-null scoreboard columns** (`benchmark-scoreboard.tsx`): a report that didn't measure latency / $/correct now shows a narrower table instead of a dash wall, and the horizontal-scroll floor narrows with the visible column count.

## Tests

- Updated the "em dash" test to use a partially-populated column (the column survives the drop filter, gap renders as `—`), and added a test asserting all-null columns are dropped entirely.
- `npx tsc --noEmit`, `eslint`, and `vitest` (scoreboard + benchmarks lib + metadata, 24 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)