### PR TITLE
feat: move billing to freemium pricing

### DIFF
--- a/backend/internal/api/billing.go
+++ b/backend/internal/api/billing.go
@@ -188,52 +188,11 @@ func (m *BillingManager) StartTrial(ctx context.Context, caller Caller, orgID uu
 	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
 		return repository.BillingOverview{}, err
 	}
-	current, err := m.repo.GetOrganizationEntitlements(ctx, orgID)
-	if err != nil {
-		return repository.BillingOverview{}, err
-	}
-	if current.PlanKey != billingpkg.PlanFree {
-		return repository.BillingOverview{}, validationError("trial_not_available", "trial is only available from the Free plan")
-	}
-	planKey := strings.TrimSpace(input.PlanKey)
-	if planKey != billingpkg.PlanPro && planKey != billingpkg.PlanTeam {
-		return repository.BillingOverview{}, validationError("invalid_plan_key", "plan_key must be pro or team")
-	}
-	plan, ok := m.planByKey(planKey)
-	if !ok {
-		return repository.BillingOverview{}, validationError("invalid_plan_key", "plan_key must be pro or team")
-	}
-	period := strings.TrimSpace(input.BillingPeriod)
-	if period == "" {
-		period = billingpkg.PeriodMonthly
-	}
-	if err := billingpkg.ValidateBillingPeriod(plan, period); err != nil {
-		return repository.BillingOverview{}, validationError("invalid_billing_period", err.Error())
-	}
-	seatQuantity := plan.DefaultSeats
-	if seatQuantity < plan.MinimumSeats {
-		seatQuantity = plan.MinimumSeats
-	}
-	expiresAt := m.now().UTC().Add(45 * 24 * time.Hour)
-	entitlements := billingpkg.MaterializeEntitlements(plan, period, seatQuantity, billingpkg.EntitlementStatusTrialing)
-	entitlements.ExpiresAt = &expiresAt
-	if _, err := m.repo.CreateBillingTrialGrant(ctx, repository.BillingTrialGrantInput{
-		OrganizationID:  orgID,
-		PlanKey:         plan.Key,
-		BillingPeriod:   period,
-		StartedByUserID: caller.UserID,
-		StartedAt:       m.now().UTC(),
-		ExpiresAt:       expiresAt,
-	}); err != nil {
-		if errors.Is(err, repository.ErrBillingTrialAlreadyUsed) {
-			return repository.BillingOverview{}, validationError("trial_not_available", "this organization has already used its self-serve trial")
-		}
-		return repository.BillingOverview{}, err
-	}
-	if err := m.repo.UpsertOrganizationEntitlements(ctx, orgID, entitlements, nil, &expiresAt); err != nil {
-		return repository.BillingOverview{}, err
-	}
-	return m.repo.GetBillingOverview(ctx, orgID)
+	_ = input
+	return repository.BillingOverview{}, validationError(
+		"trial_retired",
+		"self-serve paid trials have been retired; use checkout when Free is not enough",
+	)
 }
 
 func (m *BillingManager) CreateCheckout(ctx context.Context, caller Caller, orgID uuid.UUID, input CreateBillingCheckoutInput) (CreateBillingCheckoutResult, error) {
@@ -641,9 +600,8 @@ func (m *BillingManager) createDodoCheckoutSession(ctx context.Context, caller C
 	if productID == "" {
 		return "", "", validationError("invalid_billing_period", "selected plan does not have a Dodo product for this billing period")
 	}
-	// Dodo subscription line items must have quantity=1; per-seat billing is
-	// expressed via add-ons, not by multiplying the subscription quantity.
-	// See https://docs.dodopayments.com/developer-resources/seat-based-pricing.
+	// AgentClash plans are workspace-priced. Keep the Dodo subscription line
+	// item at quantity=1 and store legacy quantity metadata for compatibility.
 	requestPayload := map[string]any{
 		"product_cart": []map[string]any{
 			{

--- a/backend/internal/api/billing_test.go
+++ b/backend/internal/api/billing_test.go
@@ -105,7 +105,7 @@ func TestBillingManagerGetWorkspaceQuotaSeparatesRaceAndConcurrencyUsage(t *test
 	repo.entitlements = billingpkg.MaterializeEntitlements(
 		billingpkg.MustPlan(billingpkg.PlanPro),
 		billingpkg.PeriodMonthly,
-		5,
+		1,
 		billingpkg.EntitlementStatusActive,
 	)
 	repo.usage.RaceCount = 47
@@ -130,9 +130,9 @@ func TestBillingManagerGetWorkspaceQuotaSeparatesRaceAndConcurrencyUsage(t *test
 	if result.PlanKey != billingpkg.PlanPro {
 		t.Fatalf("plan key = %q, want pro", result.PlanKey)
 	}
-	assertQuotaCounter(t, "monthly races", result.MonthlyRaces, 47, 2500, 2453)
+	assertQuotaCounter(t, "monthly races", result.MonthlyRaces, 47, 500, 453)
 	assertQuotaCounter(t, "concurrent races", result.ConcurrentRaces, 2, 3, 1)
-	assertQuotaCounter(t, "seats", result.Seats, 3, 25, 22)
+	assertQuotaUnlimited(t, "seats", result.Seats, 3)
 	assertTimePtr(t, "monthly races reset_at", result.MonthlyRaces.ResetAt, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	if !result.WindowStart.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
 		t.Fatalf("window start = %s, want 2026-05-01", result.WindowStart)
@@ -184,7 +184,7 @@ func TestBillingManagerProcessesSignedDodoWebhook(t *testing.T) {
 	if repo.entitlements.ExpiresAt != nil {
 		t.Fatalf("active paid entitlement expires_at = %v, want nil", repo.entitlements.ExpiresAt)
 	}
-	assertIntPtr(t, "pro materialized quota", repo.entitlements.RacesPerWorkspaceMonth, 2500)
+	assertIntPtr(t, "pro materialized quota", repo.entitlements.RacesPerWorkspaceMonth, 500)
 
 	result, err = manager.ProcessDodoWebhook(context.Background(), headers, []byte(body))
 	if err != nil {
@@ -220,7 +220,7 @@ func TestBillingManagerProcessesTrialingDodoWebhookWithExpiry(t *testing.T) {
 	if repo.entitlements.ExpiresAt == nil || repo.entitlements.ExpiresAt.Format(time.RFC3339) != "2026-06-13T00:00:00Z" {
 		t.Fatalf("expires_at = %v, want 2026-06-13T00:00:00Z", repo.entitlements.ExpiresAt)
 	}
-	assertIntPtr(t, "team trial quota", repo.entitlements.RacesPerWorkspaceMonth, 4000)
+	assertIntPtr(t, "team promotional quota", repo.entitlements.RacesPerWorkspaceMonth, 2000)
 	assertIntPtr(t, "team trial models", repo.entitlements.MaxModelsPerRace, 12)
 }
 
@@ -427,7 +427,7 @@ func TestCreateBillingCheckoutHandlerDecodesSnakeCaseJSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/organizations/"+repo.orgID.String()+"/billing/checkout", bytes.NewBufferString(`{
 		"plan_key":"pro",
 		"billing_period":"monthly",
-		"seat_quantity":5,
+		"seat_quantity":1,
 		"return_url":"http://localhost:3000/billing/return"
 	}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -439,49 +439,14 @@ func TestCreateBillingCheckoutHandlerDecodesSnakeCaseJSON(t *testing.T) {
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
 	}
-	if !strings.Contains(rr.Body.String(), `"plan_key":"pro"`) || !strings.Contains(rr.Body.String(), `"seat_quantity":5`) {
+	if !strings.Contains(rr.Body.String(), `"plan_key":"pro"`) || !strings.Contains(rr.Body.String(), `"seat_quantity":1`) {
 		t.Fatalf("checkout response did not preserve decoded fields: %s", rr.Body.String())
 	}
 }
 
-func TestBillingManagerStartTrialMaterializesSelectedPlan(t *testing.T) {
+func TestBillingManagerStartTrialIsRetired(t *testing.T) {
 	workspaceID := uuid.New()
 	repo := newFakeBillingRepository(workspaceID)
-	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
-	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
-		WebhookSecret: "secret",
-	})
-	manager.now = func() time.Time { return now }
-	caller := Caller{
-		UserID: uuid.New(),
-		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
-			repo.orgID: {OrganizationID: repo.orgID, Role: "org_admin"},
-		},
-	}
-
-	overview, err := manager.StartTrial(context.Background(), caller, repo.orgID, StartBillingTrialInput{
-		PlanKey:       billingpkg.PlanTeam,
-		BillingPeriod: billingpkg.PeriodMonthly,
-	})
-	if err != nil {
-		t.Fatalf("StartTrial returned error: %v", err)
-	}
-	if overview.Entitlements.PlanKey != billingpkg.PlanTeam {
-		t.Fatalf("plan = %q, want team", overview.Entitlements.PlanKey)
-	}
-	if overview.Entitlements.Status != billingpkg.EntitlementStatusTrialing {
-		t.Fatalf("status = %q, want trialing", overview.Entitlements.Status)
-	}
-	if overview.Entitlements.ExpiresAt == nil || !overview.Entitlements.ExpiresAt.Equal(now.Add(45*24*time.Hour)) {
-		t.Fatalf("expires_at = %v, want %v", overview.Entitlements.ExpiresAt, now.Add(45*24*time.Hour))
-	}
-	assertIntPtr(t, "team trial model limit", overview.Entitlements.MaxModelsPerRace, 12)
-}
-
-func TestBillingManagerStartTrialRejectsExistingPaidPlan(t *testing.T) {
-	workspaceID := uuid.New()
-	repo := newFakeBillingRepository(workspaceID)
-	repo.entitlements = billingpkg.MaterializeEntitlements(billingpkg.MustPlan(billingpkg.PlanPro), billingpkg.PeriodMonthly, 5, billingpkg.EntitlementStatusTrialing)
 	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
 		WebhookSecret: "secret",
 	})
@@ -500,35 +465,8 @@ func TestBillingManagerStartTrialRejectsExistingPaidPlan(t *testing.T) {
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("error = %v, want validation error", err)
 	}
-	if validationErr.Code != "trial_not_available" {
-		t.Fatalf("code = %q, want trial_not_available", validationErr.Code)
-	}
-}
-
-func TestBillingManagerStartTrialRejectsRepeatAfterReturnToFree(t *testing.T) {
-	workspaceID := uuid.New()
-	repo := newFakeBillingRepository(workspaceID)
-	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
-		WebhookSecret: "secret",
-	})
-	caller := Caller{
-		UserID: uuid.New(),
-		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
-			repo.orgID: {OrganizationID: repo.orgID, Role: "org_admin"},
-		},
-	}
-
-	if _, err := manager.StartTrial(context.Background(), caller, repo.orgID, StartBillingTrialInput{PlanKey: billingpkg.PlanPro}); err != nil {
-		t.Fatalf("first StartTrial returned error: %v", err)
-	}
-	repo.entitlements = billingpkg.DefaultEntitlements()
-	_, err := manager.StartTrial(context.Background(), caller, repo.orgID, StartBillingTrialInput{PlanKey: billingpkg.PlanTeam})
-	var validationErr validationErrorEnvelope
-	if !errors.As(err, &validationErr) {
-		t.Fatalf("error = %v, want validation error", err)
-	}
-	if validationErr.Code != "trial_not_available" {
-		t.Fatalf("code = %q, want trial_not_available", validationErr.Code)
+	if validationErr.Code != "trial_retired" {
+		t.Fatalf("code = %q, want trial_retired", validationErr.Code)
 	}
 }
 
@@ -570,7 +508,7 @@ func TestBillingManagerCreateCheckoutUsesDodoAPIWhenConfigured(t *testing.T) {
 	result, err := manager.CreateCheckout(context.Background(), caller, repo.orgID, CreateBillingCheckoutInput{
 		PlanKey:       "pro",
 		BillingPeriod: "monthly",
-		SeatQuantity:  5,
+		SeatQuantity:  1,
 		ReturnURL:     "http://localhost:3000/billing/return",
 	})
 	if err != nil {
@@ -606,8 +544,8 @@ func TestBillingManagerCreateCheckoutUsesDodoAPIWhenConfigured(t *testing.T) {
 	if metadata["organization_id"] != repo.orgID.String() || metadata["checkout_intent_id"] != result.CheckoutIntentID.String() || metadata["plan_key"] != "pro" {
 		t.Fatalf("metadata = %#v, want org/intent/plan", metadata)
 	}
-	if metadata["seat_quantity"] != "5" {
-		t.Fatalf("metadata seat_quantity = %#v, want string 5", metadata["seat_quantity"])
+	if metadata["seat_quantity"] != "1" {
+		t.Fatalf("metadata seat_quantity = %#v, want string 1", metadata["seat_quantity"])
 	}
 	returnURL, ok := capturedPayload["return_url"].(string)
 	if !ok || !strings.Contains(returnURL, "checkout=pending") || !strings.Contains(returnURL, "checkout_intent_id="+result.CheckoutIntentID.String()) {
@@ -721,7 +659,7 @@ func TestCreateBillingCheckoutHandlerKeepsDodoErrorGeneric(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/organizations/"+repo.orgID.String()+"/billing/checkout", bytes.NewBufferString(`{
 		"plan_key":"pro",
 		"billing_period":"monthly",
-		"seat_quantity":5,
+		"seat_quantity":1,
 		"return_url":"http://localhost:3000/billing/return"
 	}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1076,6 +1014,19 @@ func assertQuotaCounter(t *testing.T, label string, got QuotaCounter, wantUsed i
 	}
 	assertIntPtr(t, label+" limit", got.Limit, wantLimit)
 	assertIntPtr(t, label+" remaining", got.Remaining, wantRemaining)
+}
+
+func assertQuotaUnlimited(t *testing.T, label string, got QuotaCounter, wantUsed int) {
+	t.Helper()
+	if got.Used != wantUsed {
+		t.Fatalf("%s used = %d, want %d", label, got.Used, wantUsed)
+	}
+	if got.Limit != nil {
+		t.Fatalf("%s limit = %d, want nil", label, *got.Limit)
+	}
+	if got.Remaining != nil {
+		t.Fatalf("%s remaining = %d, want nil", label, *got.Remaining)
+	}
 }
 
 func assertTimePtr(t *testing.T, label string, got *time.Time, want time.Time) {

--- a/backend/internal/billing/catalog.go
+++ b/backend/internal/billing/catalog.go
@@ -111,7 +111,7 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodMonthly},
 			Limits: PlanLimits{
-				Seats:                  valueLimit(1),
+				Seats:                  unlimitedLimit(),
 				Workspaces:             valueLimit(1),
 				RacesPerWorkspaceMonth: valueLimit(25),
 				MaxModelsPerRace:       valueLimit(4),
@@ -128,13 +128,13 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 		{
 			Key:            PlanPro,
 			DisplayName:    "Pro",
-			MinimumSeats:   5,
-			DefaultSeats:   5,
+			MinimumSeats:   1,
+			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodMonthly, PeriodYearly},
 			Limits: PlanLimits{
-				Seats:                  perSeatLimit(5),
+				Seats:                  unlimitedLimit(),
 				Workspaces:             valueLimit(1),
-				RacesPerWorkspaceMonth: perSeatLimit(500),
+				RacesPerWorkspaceMonth: valueLimit(500),
 				MaxModelsPerRace:       valueLimit(8),
 				ReplayRetentionDays:    valueLimit(30),
 				ConcurrentRaces:        valueLimit(3),
@@ -156,9 +156,9 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodMonthly, PeriodYearly},
 			Limits: PlanLimits{
-				Seats:                  perSeatLimit(1),
+				Seats:                  unlimitedLimit(),
 				Workspaces:             unlimitedLimit(),
-				RacesPerWorkspaceMonth: perSeatLimit(2000),
+				RacesPerWorkspaceMonth: valueLimit(2000),
 				MaxModelsPerRace:       valueLimit(12),
 				ReplayRetentionDays:    valueLimit(90),
 				ConcurrentRaces:        valueLimit(10),
@@ -182,7 +182,7 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodCustom},
 			Limits: PlanLimits{
-				Seats:                  customLimit(),
+				Seats:                  unlimitedLimit(),
 				Workspaces:             customLimit(),
 				RacesPerWorkspaceMonth: customLimit(),
 				MaxModelsPerRace:       customLimit(),
@@ -270,7 +270,7 @@ func ValidateSeatQuantity(plan Plan, seatQuantity int) error {
 		return fmt.Errorf("%w: seat_quantity must be positive", ErrSeatQuantityBelowLimit)
 	}
 	if seatQuantity < plan.MinimumSeats {
-		return fmt.Errorf("%w: %s requires at least %d seats", ErrSeatQuantityBelowLimit, plan.Key, plan.MinimumSeats)
+		return fmt.Errorf("%w: %s requires subscription quantity of at least %d", ErrSeatQuantityBelowLimit, plan.Key, plan.MinimumSeats)
 	}
 	return nil
 }

--- a/backend/internal/billing/catalog_test.go
+++ b/backend/internal/billing/catalog_test.go
@@ -14,20 +14,22 @@ func TestCatalogContainsPublicPlansAndLimits(t *testing.T) {
 
 	free := MustPlan(PlanFree)
 	freeEntitlements := MaterializeEntitlements(free, PeriodMonthly, 1, "active")
-	assertIntPtr(t, "free seats", freeEntitlements.SeatsLimit, 1)
+	assertNilPtr(t, "free seats", freeEntitlements.SeatsLimit)
 	assertIntPtr(t, "free workspaces", freeEntitlements.WorkspacesLimit, 1)
 	assertIntPtr(t, "free quota", freeEntitlements.RacesPerWorkspaceMonth, 25)
 	assertIntPtr(t, "free models", freeEntitlements.MaxModelsPerRace, 4)
 	assertIntPtr(t, "free retention", freeEntitlements.ReplayRetentionDays, 7)
 	assertIntPtr(t, "free concurrency", freeEntitlements.ConcurrentRaces, 1)
 
-	proEntitlements := MaterializeEntitlements(MustPlan(PlanPro), PeriodMonthly, 5, "active")
-	assertIntPtr(t, "pro quota", proEntitlements.RacesPerWorkspaceMonth, 2500)
+	proEntitlements := MaterializeEntitlements(MustPlan(PlanPro), PeriodMonthly, 1, "active")
+	assertNilPtr(t, "pro seats", proEntitlements.SeatsLimit)
+	assertIntPtr(t, "pro quota", proEntitlements.RacesPerWorkspaceMonth, 500)
 	assertIntPtr(t, "pro models", proEntitlements.MaxModelsPerRace, 8)
 	assertIntPtr(t, "pro concurrency", proEntitlements.ConcurrentRaces, 3)
 
-	teamEntitlements := MaterializeEntitlements(MustPlan(PlanTeam), PeriodYearly, 2, "active")
-	assertIntPtr(t, "team quota", teamEntitlements.RacesPerWorkspaceMonth, 4000)
+	teamEntitlements := MaterializeEntitlements(MustPlan(PlanTeam), PeriodYearly, 1, "active")
+	assertNilPtr(t, "team seats", teamEntitlements.SeatsLimit)
+	assertIntPtr(t, "team quota", teamEntitlements.RacesPerWorkspaceMonth, 2000)
 	assertIntPtr(t, "team models", teamEntitlements.MaxModelsPerRace, 12)
 	assertIntPtr(t, "team retention", teamEntitlements.ReplayRetentionDays, 90)
 	assertIntPtr(t, "team concurrency", teamEntitlements.ConcurrentRaces, 10)
@@ -36,7 +38,7 @@ func TestCatalogContainsPublicPlansAndLimits(t *testing.T) {
 	}
 }
 
-func TestDodoProductMappingAndSeatValidation(t *testing.T) {
+func TestDodoProductMappingAndQuantityValidation(t *testing.T) {
 	plans := CatalogWithDodoProductIDs(testDodoProductIDs())
 	mapping, err := MapDodoProductFromCatalog("agentclash_pro_yearly", plans)
 	if err != nil {
@@ -49,7 +51,7 @@ func TestDodoProductMappingAndSeatValidation(t *testing.T) {
 	_, err = SubscriptionEntitlementsFromCatalog(DodoSubscriptionInput{
 		ProductID: "agentclash_pro_monthly",
 		Status:    "active",
-		Quantity:  4,
+		Quantity:  0,
 	}, plans)
 	if !errors.Is(err, ErrSeatQuantityBelowLimit) {
 		t.Fatalf("SubscriptionEntitlements error = %v, want ErrSeatQuantityBelowLimit", err)
@@ -58,7 +60,7 @@ func TestDodoProductMappingAndSeatValidation(t *testing.T) {
 	entitlements, err := SubscriptionEntitlementsFromCatalog(DodoSubscriptionInput{
 		ProductID: "agentclash_team_monthly",
 		Status:    "trialing",
-		Quantity:  3,
+		Quantity:  1,
 	}, plans)
 	if err != nil {
 		t.Fatalf("SubscriptionEntitlements returned error: %v", err)
@@ -69,7 +71,7 @@ func TestDodoProductMappingAndSeatValidation(t *testing.T) {
 	if entitlements.Status != EntitlementStatusTrialing {
 		t.Fatalf("entitlement status = %q, want trialing", entitlements.Status)
 	}
-	assertIntPtr(t, "team per-seat quota", entitlements.RacesPerWorkspaceMonth, 6000)
+	assertIntPtr(t, "team quota", entitlements.RacesPerWorkspaceMonth, 2000)
 }
 
 func TestInactiveDodoStatusDoesNotGrantPaidEntitlements(t *testing.T) {
@@ -157,5 +159,12 @@ func assertIntPtr(t *testing.T, label string, got *int, want int) {
 	}
 	if *got != want {
 		t.Fatalf("%s = %d, want %d", label, *got, want)
+	}
+}
+
+func assertNilPtr(t *testing.T, label string, got *int) {
+	t.Helper()
+	if got != nil {
+		t.Fatalf("%s = %d, want nil", label, *got)
 	}
 }

--- a/backend/internal/billing/gates.go
+++ b/backend/internal/billing/gates.go
@@ -59,7 +59,7 @@ func CheckEntitlementActive(entitlements EffectiveEntitlements, now time.Time) G
 		return GateDecision{
 			Allowed:       false,
 			Code:          GateCodeEntitlementExpired,
-			Message:       fmt.Sprintf("%s trial has expired. Add billing to continue.", entitlements.PlanKey),
+			Message:       fmt.Sprintf("%s access has expired. Add billing to continue.", entitlements.PlanKey),
 			PlanKey:       entitlements.PlanKey,
 			UpgradeTarget: expiredUpgradeTarget(entitlements.PlanKey, entitlements.UpgradeTarget),
 			ExpiresAt:     cloneTime(entitlements.ExpiresAt),
@@ -72,7 +72,7 @@ func CheckEntitlementActive(entitlements EffectiveEntitlements, now time.Time) G
 		return GateDecision{
 			Allowed:       false,
 			Code:          GateCodeEntitlementExpired,
-			Message:       fmt.Sprintf("%s trial has expired. Add billing to continue.", entitlements.PlanKey),
+			Message:       fmt.Sprintf("%s access has expired. Add billing to continue.", entitlements.PlanKey),
 			PlanKey:       entitlements.PlanKey,
 			UpgradeTarget: expiredUpgradeTarget(entitlements.PlanKey, entitlements.UpgradeTarget),
 			ExpiresAt:     cloneTime(entitlements.ExpiresAt),
@@ -170,7 +170,7 @@ func CheckSeatLimit(entitlements EffectiveEntitlements, activeSeats int, request
 	return GateDecision{
 		Allowed:       false,
 		Code:          GateCodeSeatLimitExceeded,
-		Message:       fmt.Sprintf("%s seat limit is exhausted", entitlements.PlanKey),
+		Message:       fmt.Sprintf("%s member limit is exhausted", entitlements.PlanKey),
 		PlanKey:       entitlements.PlanKey,
 		UpgradeTarget: entitlements.UpgradeTarget,
 		Limit:         cloneInt(entitlements.SeatsLimit),

--- a/cli/cmd/quota.go
+++ b/cli/cmd/quota.go
@@ -42,7 +42,6 @@ var quotaCmd = &cobra.Command{
 		}
 		rc.Output.PrintDetail("Monthly races", quotaCounterLine(mapObject(quota, "monthly_races")))
 		rc.Output.PrintDetail("Concurrent races", quotaCounterLine(mapObject(quota, "concurrent_races")))
-		rc.Output.PrintDetail("Seats", quotaCounterLine(mapObject(quota, "seats")))
 		if resetAt := mapString(mapObject(quota, "monthly_races"), "reset_at"); resetAt != "" {
 			rc.Output.PrintDetail("Quota resets", resetAt)
 		}

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -216,7 +216,7 @@ func (e *APIError) IsBillingGate() bool {
 func (e *APIError) BillingMessage() string {
 	current := planLabel(e.PlanKey)
 	upgrade := planLabel(e.UpgradeTarget)
-	action := "Open the organization billing page in the AgentClash web app to start a trial or upgrade."
+	action := "Open the organization billing page in the AgentClash web app to upgrade."
 	if e.UpgradeTarget == "" {
 		action = "Open the organization billing page in the AgentClash web app to update billing."
 	}
@@ -242,7 +242,7 @@ func (e *APIError) BillingMessage() string {
 			detail = fmt.Sprintf("%s Limit: %d.", detail, *e.Limit)
 		}
 	case "seat_limit_exceeded":
-		detail = fmt.Sprintf("%s seat limit is reached.", current)
+		detail = fmt.Sprintf("%s member limit is reached.", current)
 		if e.Limit != nil {
 			detail = fmt.Sprintf("%s Limit: %d.", detail, *e.Limit)
 		}

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -174,7 +174,7 @@ func TestAPIErrorBillingMessageIsActionable(t *testing.T) {
 		"Free monthly run quota is exhausted",
 		"Used 25 of 25",
 		"organization billing page",
-		"start a trial or upgrade",
+		"upgrade",
 	} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("message = %q, want %q", message, want)

--- a/testing/codex-freemium-pricing.md
+++ b/testing/codex-freemium-pricing.md
@@ -1,0 +1,37 @@
+# codex/freemium-pricing — Test Contract
+
+## Functional Behavior
+
+- Public pricing and enterprise/service marketing copy describe AgentClash as freemium: users can run a meaningful number of evals first, see value, and then pay when they need more capacity, retention, collaboration, or governance.
+- Pricing removes all seat-based language from public tiers and metadata. No public copy should say "seat", "seats", "per seat", "5-seat minimum", or equivalent.
+- Public marketing copy removes the 45-day trial offer. No public copy should say "45-day", "45 day", "free trial", "trial", or "no credit card" as the primary paid-tier offer.
+- Paid tiers should use workspace/month pricing and run quotas instead of seat/month pricing and per-seat quotas.
+- Pro and Team CTAs should preserve plan intent through login using `returnTo` or another explicit mechanism so a visitor who clicks a paid-plan CTA is routed toward billing/trial/upgrade intent after authentication.
+- Enterprise and services pages should no longer advertise a 45-day pilot/trial. They should emphasize a paid pilot, evaluation workshop, or fixed-scope service as appropriate.
+- Machine-readable pricing JSON-LD must stay consistent with human-visible pricing data.
+
+## Unit Tests
+
+- `web/src/components/marketing/json-ld.test.tsx` pricing/schema tests should pass if they cover price specifications.
+- Existing metadata and sitemap tests should continue to pass.
+- Add or update tests if the pricing data structure changes in a way existing tests do not cover.
+
+## Integration / Functional Tests
+
+- `pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts src/app/seo-landing-pages.test.tsx src/components/marketing/json-ld.test.tsx` should pass from `web/`.
+- Search the public marketing source for banned phrases and confirm remaining matches are unrelated product internals, historical changelog entries, or authenticated billing UI rather than current public pricing claims.
+
+## Smoke Tests
+
+- Build or targeted test run should confirm the Next metadata and sitemap routes still compile.
+- Public `/pricing`, `/enterprise`, and homepage pricing block should render without TypeScript errors.
+
+## E2E Tests
+
+- N/A — this PR changes marketing/pricing copy and CTA routing only. A browser QA pass would be useful before release but is not required for the PR.
+
+## Manual / cURL Tests
+
+- Verify `web/src/lib/pricing-data.ts` contains no seat-based public tier language.
+- Verify public marketing pages no longer mention the 45-day/free-trial offer.
+- Verify Pro and Team CTA URLs include a return target that can preserve selected plan intent after login.

--- a/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
+++ b/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
@@ -66,4 +66,4 @@ That is the gap [agent evals](/agent-evals) and the [agent evaluation platform](
 
 Run both. Do not ask prompt eval to stand in for release gates on tool-using agents.
 
-Book a discovery call from any post footer, or start the [enterprise pilot](/enterprise) if you want self-serve product access first.
+Book a discovery call from any post footer, or start the [enterprise rollout](/enterprise) if you want self-serve product access first.

--- a/web/content/blog/ai-agent-approval-security-compliance.mdx
+++ b/web/content/blog/ai-agent-approval-security-compliance.mdx
@@ -33,7 +33,7 @@ Picture a platform lead preparing a coding agent release. They do not send secur
 - replay links for the cases that drove the verdict
 - the gate policy (for example: no correctness regression, cost cap, automatic fail on policy violations)
 
-That mirrors the buyer workflow in our [enterprise pilot](/enterprise) narrative: benchmark first, replay second, gate third.
+That mirrors the buyer workflow in our [enterprise rollout](/enterprise) narrative: benchmark first, replay second, gate third.
 
 AgentClash supports review with immutable run history and replay shaped for decisions, not raw span dumps. See [AI agent regression testing](/platform/agent-regression-testing) for the product surface.
 
@@ -87,5 +87,4 @@ Run an exploratory benchmark, record the green run as baseline, then pin `baseli
 
 ## Next step
 
-Need a governed benchmark your security team can replay? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for a guided first gate.
-
+Need a governed benchmark your security team can replay? Start the [enterprise rollout](/enterprise) or ask about [Benchmark & Gate Setup](/services) for a guided first gate.

--- a/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
+++ b/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
@@ -26,9 +26,9 @@ Regional context: UAE and wider GCC buyers increasingly treat residency and AI g
 
 Be precise about deployment options:
 
-- **Hosted Team pilot:** runs on AgentClash standard cloud regions today, with BYOK so provider tokens bill to your accounts directly.
-- **Self-host or hybrid:** AgentClash is MIT-licensed; many enterprises run the stack in environments they control after the pilot.
-- **Enterprise architecture review:** dedicated deployment, private networking, and residency requirements can be discussed for enterprise contracts. See the [enterprise pilot FAQ](/enterprise) and contact `hello@agentclash.dev` for residency conversations.
+- **Hosted Team plan:** runs on AgentClash standard cloud regions today, with BYOK so provider tokens bill to your accounts directly.
+- **Self-host or hybrid:** AgentClash is MIT-licensed; many enterprises run the stack in environments they control after the first governed rollout.
+- **Enterprise architecture review:** dedicated deployment, private networking, and residency requirements can be discussed for enterprise contracts. See the [enterprise rollout FAQ](/enterprise) and contact `hello@agentclash.dev` for residency conversations.
 
 Do not read those options as "AgentClash is certified for every UAE sector." Read them as deployment paths your team can align with legal and infra decisions you already own.
 
@@ -71,9 +71,9 @@ Implementation details: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates). Pro
 
 ## FAQ
 
-### Does AgentClash guarantee UAE data residency on the hosted pilot?
+### Does AgentClash guarantee UAE data residency on hosted plans?
 
-No. Hosted pilots use standard cloud regions today. Discuss residency, private networking, or self-host during an enterprise architecture review, or run the open-source stack in infrastructure you control.
+No. Hosted plans use standard cloud regions today. Discuss residency, private networking, or self-host during an enterprise architecture review, or run the open-source stack in infrastructure you control.
 
 ### How is this different from sovereign AI infrastructure selection?
 
@@ -85,5 +85,4 @@ AgentClash exports replay, scorecards, and gate verdicts that support audit-frie
 
 ## Next step
 
-Evaluating agents for a UAE or GCC rollout? Start the [enterprise pilot](/enterprise) to run governed benchmarks, or ask about [Benchmark & Gate Setup](/services) if you want help encoding your first residency-aware workload.
-
+Evaluating agents for a UAE or GCC rollout? Start the [enterprise rollout](/enterprise) to run governed benchmarks, or ask about [Benchmark & Gate Setup](/services) if you want help encoding your first residency-aware workload.

--- a/web/content/blog/ai-platform-lead-agent-release-gates.mdx
+++ b/web/content/blog/ai-platform-lead-agent-release-gates.mdx
@@ -110,9 +110,8 @@ Run them in the same challenge pack with explicit evidence tier limits. Use comp
 
 ### What is the fastest path to a first gate?
 
-Freeze one real task as a challenge pack, record a baseline run, init the CI manifest, and gate a single agent repo. The [enterprise pilot](/enterprise) includes a 45-day Team pilot to run this loop self-serve.
+Freeze one real task as a challenge pack, record a baseline run, init the CI manifest, and gate a single agent repo. The [enterprise rollout](/enterprise) starts on Free, then upgrades the same workspace when this loop becomes release governance.
 
 ## Next step
 
-Platform lead shipping agent revisions this quarter? Start the [enterprise pilot](/enterprise) or ask about a [Benchmark & Gate Setup](/services) sprint for manifest and gate wiring.
-
+Platform lead shipping agent revisions this quarter? Start the [enterprise rollout](/enterprise) or ask about a [Benchmark & Gate Setup](/services) sprint for manifest and gate wiring.

--- a/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
+++ b/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
@@ -59,5 +59,4 @@ Follow [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) once you have a basel
 
 We publish field reports on [/benchmarks](/benchmarks) when we have reproducible packs and honest sample sizes. Your private benchmark should follow the same rule: publish internal scorecards, not vibes.
 
-If you want help freezing the first pack, see [eval services](/services) or the free [enterprise pilot](/enterprise).
-
+If you want help freezing the first pack, see [eval services](/services) or the free [enterprise rollout](/enterprise).

--- a/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
+++ b/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
@@ -21,7 +21,7 @@ Before you buy tools, align leadership on what a release decision contains:
 
 If compliance, security, and engineering cannot point at the same artifact, the program will stall in slide decks.
 
-AgentClash models that object end to end. Start with the [enterprise pilot](/enterprise) if you need a self-serve environment to socialize the shape.
+AgentClash models that object end to end. Start with the [enterprise rollout](/enterprise) if you need a self-serve environment to socialize the shape.
 
 ## Phase 1: Inventory workloads worth gating
 
@@ -119,5 +119,4 @@ Human-in-the-loop belongs in runtime policy for high-risk actions. Release gates
 
 ## Next step
 
-Standing up a governed eval program this half? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for hands-on pack and gate wiring.
-
+Standing up a governed eval program this half? Start the [enterprise rollout](/enterprise) or ask about [Benchmark & Gate Setup](/services) for hands-on pack and gate wiring.

--- a/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
+++ b/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
@@ -103,9 +103,8 @@ Yes. Label evidence tier (`hosted_black_box` vs `native_structured`) and gate pr
 
 ### Where does data residency fit?
 
-Residency is a deployment and legal decision. Bilingual eval proves behavioral readiness on your workload. See the [enterprise pilot](/enterprise) FAQ for hosted regions and enterprise residency discussions.
+Residency is a deployment and legal decision. Bilingual eval proves behavioral readiness on your workload. See the [enterprise rollout](/enterprise) FAQ for hosted regions and enterprise residency discussions.
 
 ## Next step
 
-Shipping bilingual support agents in the Gulf? Start the [enterprise pilot](/enterprise), build cases on the [support agent evaluation](/use-cases/support-agent-evaluation) workflow, or ask about [Benchmark & Gate Setup](/services) for pack authoring help.
-
+Shipping bilingual support agents in the Gulf? Start the [enterprise rollout](/enterprise), build cases on the [support agent evaluation](/use-cases/support-agent-evaluation) workflow, or ask about [Benchmark & Gate Setup](/services) for pack authoring help.

--- a/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
+++ b/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
@@ -77,5 +77,4 @@ Even strong pass^k scores do not remove code review. Evals tell you the agent co
 - [ ] Regression case for last production miss
 - [ ] Release gate owner named on the scorecard
 
-Start self-serve on the [enterprise pilot](/enterprise), or ask about [challenge pack build](/services) if you want hands-on help encoding your repos.
-
+Start self-serve on the [enterprise rollout](/enterprise), or ask about [challenge pack build](/services) if you want hands-on help encoding your repos.

--- a/web/content/blog/pass-k-reliability-enterprise-teams.mdx
+++ b/web/content/blog/pass-k-reliability-enterprise-teams.mdx
@@ -62,5 +62,4 @@ That transition is a maturity signal, not a moral judgment. Early exploration sh
 - [ ] Scorecard dimensions match the release committee questions
 - [ ] CI gate documented in the PR template
 
-Need a baseline and gate wired in two weeks? See [Benchmark & Gate Setup](/services) or start the [enterprise pilot](/enterprise).
-
+Need a baseline and gate wired in two weeks? See [Benchmark & Gate Setup](/services) or start the [enterprise rollout](/enterprise).

--- a/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
+++ b/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
@@ -87,5 +87,4 @@ One gate verdict plus three deltas vs baseline: correctness, cost per success, a
 
 ## Next step
 
-Restarting after a stalled pilot? Start the [enterprise pilot](/enterprise) and rerun your workload as a governed benchmark with replay and gate export.
-
+Restarting after a stalled pilot? Start the [enterprise rollout](/enterprise) and rerun your workload as a governed benchmark with replay and gate export.

--- a/web/content/docs/concepts/try-cli.mdx
+++ b/web/content/docs/concepts/try-cli.mdx
@@ -33,11 +33,11 @@ E2B_API_KEY=... bun run scripts/build-template.ts
 
 The build runs in E2B's cloud (Build System 2.0 — no local Docker). The demo's `template:` field references the alias.
 
-## Auth: free trial, then bring-your-own
+## Auth: free demo, then bring-your-own
 
-**Anonymous free trial.** For agents that can run on AgentClash credentials, visitors can try them for a few minutes with **no login and no key**. The CLI is wired to a metered server-side gateway that holds AgentClash's provider keys, mints a short-lived spend-capped token per session, and never lets the real key into the sandbox. A durable Redis-backed daily ceiling is the hard backstop. **Grok CLI is the exception — it is key-only**, so you bring your own xAI API key from the first session.
+**Anonymous free demo.** For agents that can run on AgentClash credentials, visitors can try them for a few minutes with **no login and no key**. The CLI is wired to a metered server-side gateway that holds AgentClash's provider keys, mints a short-lived spend-capped token per session, and never lets the real key into the sandbox. A durable Redis-backed daily ceiling is the hard backstop. **Grok CLI is the exception — it is key-only**, so you bring your own xAI API key from the first session.
 
-**Then sign in.** When the trial ends, signing in with AgentClash gives a longer session where you authenticate the CLI with your **own** account/key (running on your quota, not ours). We **never inject our keys** into the sandbox — that would violate provider terms and expose the key to anyone in the shell. Each demo's `auth:` block shows how to sign in with your own credentials:
+**Then sign in.** When the demo ends, signing in with AgentClash gives a longer session where you authenticate the CLI with your **own** account/key (running on your quota, not ours). We **never inject our keys** into the sandbox — that would violate provider terms and expose the key to anyone in the shell. Each demo's `auth:` block shows how to sign in with your own credentials:
 
 - **Claude Code** — `claude` → `/login` (paste-code) or `ANTHROPIC_API_KEY`
 - **Codex** — `codex login --device-auth` or an `OPENAI_API_KEY`

--- a/web/src/app/(org)/orgs/[orgSlug]/billing/billing-settings-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/billing/billing-settings-client.tsx
@@ -17,13 +17,12 @@ import {
   billingStatusLabel,
   formatBillingDate,
   formatBillingLimit,
-  isFreeActive,
   planLabel,
 } from "@/lib/billing";
 import { useOrgContext } from "../org-context";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CreditCard, ExternalLink, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { CreditCard, ExternalLink, Loader2, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 type SelfServePeriod = "monthly" | "yearly";
@@ -34,12 +33,12 @@ const PRICE_COPY: Record<string, Record<SelfServePeriod, { value: string; suffix
     yearly: { value: "$0", suffix: "/ month" },
   },
   pro: {
-    monthly: { value: "$49", suffix: "/ seat / month", note: "Billed monthly" },
-    yearly: { value: "$39", suffix: "/ seat / month", note: "$468 / seat / year" },
+    monthly: { value: "$49", suffix: "/ month", note: "Billed monthly" },
+    yearly: { value: "$39", suffix: "/ month", note: "$468 / year" },
   },
   team: {
-    monthly: { value: "$100", suffix: "/ seat / month", note: "Billed monthly" },
-    yearly: { value: "$80", suffix: "/ seat / month", note: "$960 / seat / year" },
+    monthly: { value: "$100", suffix: "/ month", note: "Billed monthly" },
+    yearly: { value: "$80", suffix: "/ month", note: "$960 / year" },
   },
 };
 
@@ -56,22 +55,17 @@ function PlanCard({
   plan,
   currentPlan,
   billingPeriod,
-  trialAvailable,
   busyAction,
-  onStartTrial,
   onCheckout,
 }: {
   plan: BillingPlan;
   currentPlan: string;
   billingPeriod: SelfServePeriod;
-  trialAvailable: boolean;
   busyAction: string | null;
-  onStartTrial: (plan: BillingPlan) => void;
   onCheckout: (plan: BillingPlan) => void;
 }) {
   const isCurrent = plan.key === currentPlan;
   const busy = busyAction === plan.key;
-  const canTrial = trialAvailable && (plan.key === "pro" || plan.key === "team");
   const canCheckout = plan.key !== "free" && plan.key !== "enterprise";
   const price = PRICE_COPY[plan.key]?.[billingPeriod];
 
@@ -82,10 +76,10 @@ function PlanCard({
           <h3 className="text-sm font-semibold">{plan.display_name}</h3>
           <p className="mt-1 text-xs text-muted-foreground">
             {plan.key === "free"
-              ? "Stay on Free while you evaluate."
+              ? "Run real evals before you pay."
               : plan.key === "enterprise"
                 ? "Custom limits and billing terms."
-                : "Start a 45-day trial or create checkout."}
+                : "Upgrade when you need more runs, retention, or governance."}
           </p>
         </div>
         {isCurrent && <Badge variant="secondary">Current</Badge>}
@@ -108,7 +102,6 @@ function PlanCard({
       )}
 
       <div className="mt-4 space-y-2">
-        <LimitRow label="Seats" value={plan.limits.seats.value} />
         <LimitRow
           label="Runs / workspace"
           value={plan.limits.races_per_workspace_month.value}
@@ -120,24 +113,9 @@ function PlanCard({
       </div>
 
       <div className="mt-auto flex flex-wrap gap-2 pt-4">
-        {canTrial && (
-          <Button
-            size="sm"
-            disabled={busy}
-            onClick={() => onStartTrial(plan)}
-          >
-            {busy ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Sparkles className="size-4" />
-            )}
-            Start Trial
-          </Button>
-        )}
         {canCheckout && (
           <Button
             size="sm"
-            variant={canTrial ? "outline" : "default"}
             disabled={busy}
             onClick={() => onCheckout(plan)}
           >
@@ -146,7 +124,7 @@ function PlanCard({
             ) : (
               <CreditCard className="size-4" />
             )}
-            Checkout
+            Upgrade
           </Button>
         )}
       </div>
@@ -201,7 +179,6 @@ export function BillingSettingsClient() {
     [plansData],
   );
   const entitlements = overview?.entitlements;
-  const trialAvailable = isFreeActive(entitlements);
   const hasDodoCustomer = Boolean(overview?.account?.dodo_customer_id);
   const checkoutReturned = searchParams.get("checkout") === "pending";
   const dodoReturnStatus = searchParams.get("status");
@@ -216,27 +193,6 @@ export function BillingSettingsClient() {
     }, 4000);
     return () => window.clearInterval(interval);
   }, [checkoutPending, checkoutReturned, mutate]);
-
-  async function startTrial(plan: BillingPlan) {
-    setBusyAction(plan.key);
-    try {
-      const token = await getAccessToken();
-      const api = createApiClient(token ?? undefined);
-      await api.post<BillingOverviewResponse>(
-        `/v1/organizations/${orgId}/billing/trial`,
-        {
-          plan_key: plan.key,
-          billing_period: billingPeriod,
-        },
-      );
-      toast.success(`${plan.display_name} trial started`);
-      await mutate();
-    } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Failed to start trial");
-    } finally {
-      setBusyAction(null);
-    }
-  }
 
   async function createCheckout(plan: BillingPlan) {
     setBusyAction(plan.key);
@@ -260,7 +216,7 @@ export function BillingSettingsClient() {
         {
           plan_key: plan.key,
           billing_period: billingPeriod,
-          seat_quantity: Math.max(plan.minimum_seats, plan.default_seats),
+          seat_quantity: 1,
           return_url: returnURL.toString(),
         },
       );
@@ -308,7 +264,7 @@ export function BillingSettingsClient() {
         <div>
           <h1 className="text-lg font-semibold tracking-tight">Billing</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Review your plan, trial status, and usage limits.
+            Review your plan, usage, and upgrade options.
           </p>
         </div>
         <Button
@@ -381,7 +337,7 @@ export function BillingSettingsClient() {
           </div>
           {entitlements.expires_at && (
             <div className="text-right text-sm">
-              <p className="text-muted-foreground">Trial ends</p>
+              <p className="text-muted-foreground">Access ends</p>
               <p className="font-medium">
                 {formatBillingDate(entitlements.expires_at)}
               </p>
@@ -389,7 +345,6 @@ export function BillingSettingsClient() {
           )}
         </div>
         <div className="mt-4 grid gap-2 sm:grid-cols-2">
-          <LimitRow label="Seats" value={entitlements.seats_limit} />
           <LimitRow label="Workspaces" value={entitlements.workspaces_limit} />
           <LimitRow
             label="Runs / workspace / month"
@@ -410,21 +365,6 @@ export function BillingSettingsClient() {
         </div>
       </section>
 
-      {trialAvailable && (
-        <section className="rounded-lg border border-primary/20 bg-primary/5 p-4">
-          <div className="flex items-start gap-3">
-            <RefreshCw className="mt-0.5 size-4 text-primary" />
-            <div>
-              <h2 className="text-sm font-semibold">Try a paid plan for 45 days</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Pick the plan you want to evaluate. The trial grants only that
-                plan&apos;s limits and expires automatically after 45 days.
-              </p>
-            </div>
-          </div>
-        </section>
-      )}
-
       <section>
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <h2 className="text-sm font-semibold">Plans</h2>
@@ -437,9 +377,7 @@ export function BillingSettingsClient() {
               plan={plan}
               currentPlan={entitlements.plan_key}
               billingPeriod={billingPeriod}
-              trialAvailable={trialAvailable}
               busyAction={busyAction}
-              onStartTrial={startTrial}
               onCheckout={createCheckout}
             />
           ))}

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -5,7 +5,7 @@ import { getRequiredServerAuth, toInitialAuth } from "@/lib/auth/server";
 import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
 import { OrgProvider } from "./org-context";
-import { TrialUpgradePrompt } from "@/components/billing/trial-upgrade-prompt";
+import { UpgradePrompt } from "@/components/billing/upgrade-prompt";
 import { PostHogIdentify } from "@/components/posthog-identify";
 
 export default async function OrgLayout({
@@ -56,7 +56,7 @@ export default async function OrgLayout({
             orgName={org.name}
             isAdmin={isAdmin}
           />
-          <TrialUpgradePrompt
+          <UpgradePrompt
             orgId={org.id}
             orgSlug={org.slug}
             isOrgAdmin={isAdmin}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -2,7 +2,7 @@ import { AuthenticatedAppProviders } from "@/app/providers";
 import { getRequiredInitialAuth, getWorkspaceShellData } from "@/lib/auth/server";
 import { Sidebar } from "@/components/app-shell/sidebar";
 import { TopBar } from "@/components/app-shell/top-bar";
-import { TrialUpgradePrompt } from "@/components/billing/trial-upgrade-prompt";
+import { UpgradePrompt } from "@/components/billing/upgrade-prompt";
 import { WorkspaceBillingBanner } from "@/components/billing/workspace-billing-banner";
 import { ActivationBanner } from "@/components/onboarding/activation-banner";
 import { PostHogIdentify } from "@/components/posthog-identify";
@@ -62,7 +62,7 @@ export default async function WorkspaceLayout({
             orgName={orgName}
             orgSlug={orgSlug}
           />
-          <TrialUpgradePrompt
+          <UpgradePrompt
             orgId={orgId}
             orgSlug={orgSlug}
             isOrgAdmin={orgRole === "org_admin"}

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -128,7 +128,7 @@ export default async function BlogPostPage({ params }: Props) {
         <ResearchAudienceCTA
           className="mt-12"
           headline="Ready to evaluate agents on your workloads?"
-          body="Book an eval workshop to map your agents to challenge packs, baselines, and release gates. Or see fixed-scope eval services and the enterprise pilot."
+          body="Book an eval workshop to map your agents to challenge packs, baselines, and release gates. Or see fixed-scope eval services and the enterprise rollout."
           secondaryHref="/services"
           secondaryLabel="Eval services"
         />

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -10,9 +10,28 @@ import type { SessionResponse, UserMeResponse } from "@/lib/api/types";
  *   - Has workspace memberships → /workspaces/{first workspace id}
  *   - Has org but no workspace → /orgs/{first org slug}/workspaces
  */
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ plan?: string }>;
+}) {
+  return DashboardRedirectPage({ searchParams: await searchParams });
+}
+
+function planIntent(searchParams?: { plan?: string }): "pro" | "team" | null {
+  return searchParams?.plan === "pro" || searchParams?.plan === "team"
+    ? searchParams.plan
+    : null;
+}
+
+async function DashboardRedirectPage({
+  searchParams,
+}: {
+  searchParams?: { plan?: string };
+}) {
   const { user, accessToken } = await withAuth();
   if (!user) redirect("/auth/login");
+  const requestedPlan = planIntent(searchParams);
 
   let session: SessionResponse | null = null;
   let errorMessage: string | null = null;
@@ -57,7 +76,24 @@ export default async function DashboardPage() {
 
   // Redirects must be outside try/catch — Next.js redirect() throws internally.
   if (session.organization_memberships.length === 0) {
-    redirect("/onboard");
+    redirect(requestedPlan ? `/onboard?plan=${requestedPlan}` : "/onboard");
+  }
+
+  let billingRedirectTarget: string | null = null;
+  if (requestedPlan) {
+    try {
+      const api = createApiClient(accessToken);
+      const userMe = await api.get<UserMeResponse>("/v1/users/me");
+      const firstOrg = userMe.organizations[0];
+      if (firstOrg) {
+        billingRedirectTarget = `/orgs/${firstOrg.slug}/billing?plan=${requestedPlan}`;
+      }
+    } catch {
+      // Fall back to the normal dashboard routing below.
+    }
+  }
+  if (billingRedirectTarget) {
+    redirect(billingRedirectTarget);
   }
 
   const firstWorkspace = session.workspace_memberships[0];
@@ -80,5 +116,5 @@ export default async function DashboardPage() {
     redirect(orgRedirectTarget);
   }
 
-  redirect("/onboard");
+  redirect(requestedPlan ? `/onboard?plan=${requestedPlan}` : "/onboard");
 }

--- a/web/src/app/enterprise/page.tsx
+++ b/web/src/app/enterprise/page.tsx
@@ -15,9 +15,9 @@ import { ogImageUrl } from "@/lib/seo";
 
 const PAGE_PATH = "/enterprise";
 const PAGE_TITLE =
-  "Enterprise AI Agent Evaluation — Release Gates & Pilot | AgentClash";
+  "Enterprise AI Agent Evaluation — Release Gates | AgentClash";
 const PAGE_DESCRIPTION =
-  "Prove which agent is safe to ship with governed benchmarks, replay evidence, scorecards, and CI release gates. Start a 45-day Team pilot with no credit card.";
+  "Prove which agent is safe to ship with governed benchmarks, replay evidence, scorecards, and CI release gates. Start free, then run a paid rollout when evaluation becomes part of shipping.";
 const SOCIAL_IMAGE = ogImageUrl({
   title: "Enterprise Agent Evaluation",
   subtitle: "Release gates platform teams can defend",
@@ -29,7 +29,7 @@ const enterpriseTier = PRICING_TIERS.find((tier) => tier.name === "Enterprise");
 const trustItems = [
   "MIT open source",
   "Bring your own keys",
-  "45-day Team pilot",
+  "Freemium hosted plan",
   "No token markup",
 ];
 
@@ -84,7 +84,7 @@ const workflow = [
   },
 ];
 
-const pilotIncludes = [
+const rolloutIncludes = [
   "Dedicated workspace on the Team tier",
   "Challenge packs and replay retention",
   "CI integration and audit logs",
@@ -93,9 +93,9 @@ const pilotIncludes = [
 
 const faqItems = [
   {
-    question: "Can we self-host instead of using the hosted pilot?",
+    question: "Can we self-host instead of using the hosted product?",
     answer:
-      "Yes. AgentClash is MIT-licensed and open source. Many enterprises start hosted for the 45-day Team pilot, then move to self-host or a hybrid model. See the self-host guide in docs for the full stack.",
+      "Yes. AgentClash is MIT-licensed and open source. Many enterprises start hosted on Free or Team, then move to self-host or a hybrid model. See the self-host guide in docs for the full stack.",
   },
   {
     question: "Do you mark up LLM tokens?",
@@ -105,12 +105,12 @@ const faqItems = [
   {
     question: "What about data residency for UAE and other regions?",
     answer:
-      "Hosted pilots run on our standard cloud regions today. Enterprise contracts can discuss dedicated deployment, private networking, and residency requirements during the architecture review. Contact hello@agentclash.dev.",
+      "Hosted plans run on our standard cloud regions today. Enterprise contracts can discuss dedicated deployment, private networking, and residency requirements during the architecture review. Contact hello@agentclash.dev.",
   },
   {
-    question: "How is the 45-day Team pilot different from a services engagement?",
+    question: "How is the Team plan different from a services engagement?",
     answer:
-      "The pilot is product access on the Team tier: your workspace, challenge packs, and gates, with no credit card required. Optional hands-on eval sprints (pack build, benchmark setup) are fixed-scope services. Ask us about a 2-week eval sprint intro.",
+      "Team is product access: your workspace, challenge packs, and gates. Optional hands-on eval sprints (pack build, benchmark setup) are fixed-scope paid services. Ask us about a 2-week eval sprint intro.",
   },
 ];
 
@@ -334,21 +334,21 @@ export default function EnterprisePage() {
         </div>
       </section>
 
-      {/* Pilot offer */}
+      {/* Rollout offer */}
       <section className="px-6 pt-28 sm:px-12 sm:pt-40">
         <div className="mx-auto max-w-[1080px]">
           <div className="rounded-2xl border border-white/[0.1] bg-white/[0.02] p-8 sm:p-12">
-            <p className={eyebrowClass}>Pilot offer</p>
+            <p className={eyebrowClass}>Rollout offer</p>
             <h2 className="mt-4 max-w-[18ch] text-3xl font-sans font-semibold tracking-[-0.02em] text-white sm:text-[2.5rem] sm:leading-[1.1]">
-              Start with a 45-day Team pilot
+              Start free, then roll into Team when the benchmark matters
             </h2>
             <p className="mt-5 max-w-[58ch] text-base leading-7 text-white/60">
-              Run governed benchmarks on your workloads in a dedicated
-              workspace: challenge packs, replay retention, CI integration, and
-              workspace audit logs. No credit card required.
+              Run the first evals on Free. When you need more run volume,
+              replay retention, CI integration, and workspace audit logs,
+              upgrade the same workspace to Team.
             </p>
             <ul className="mt-10 grid gap-x-12 gap-y-4 border-t border-white/[0.08] pt-8 sm:grid-cols-2">
-              {pilotIncludes.map((item) => (
+              {rolloutIncludes.map((item) => (
                 <li
                   key={item}
                   className="text-base leading-7 text-white/70"
@@ -359,10 +359,10 @@ export default function EnterprisePage() {
             </ul>
             <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <Link
-                href="/auth/login?plan=team"
+                href="/auth/login?mode=signup&returnTo=/dashboard%3Fplan%3Dteam"
                 className="inline-flex items-center justify-center rounded-lg bg-white px-7 py-3.5 text-sm font-semibold text-[#060606] transition-colors hover:bg-white/90"
               >
-                Start Team pilot
+                Start free
               </Link>
               <a
                 href="mailto:hello@agentclash.dev?subject=AgentClash%202-week%20eval%20sprint"
@@ -372,8 +372,8 @@ export default function EnterprisePage() {
               </a>
             </div>
             <p className="mt-6 max-w-[64ch] text-sm leading-6 text-white/45">
-              The Team pilot is self-serve product access. Fixed-scope eval
-              sprints are optional{" "}
+              Team is self-serve product access for active evaluation programs.
+              Fixed-scope eval sprints are optional{" "}
               <Link
                 href="/services"
                 className="text-white/65 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/85"
@@ -432,7 +432,7 @@ export default function EnterprisePage() {
           </h2>
           <p className="mt-6 max-w-[52ch] text-lg leading-8 text-white/55">
             Book a 30-minute eval architecture review, or email us to scope a
-            Team pilot on your workloads.
+            Team rollout on your workloads.
           </p>
           <EnterprisePageCTA className="mt-10" />
         </div>

--- a/web/src/app/landing-2/page.tsx
+++ b/web/src/app/landing-2/page.tsx
@@ -126,7 +126,7 @@ export default function Landing2() {
             }}>
               Start for free
             </button>
-            <span style={{ fontSize: "13px", color: "var(--text-3)" }}>No credit card</span>
+            <span style={{ fontSize: "13px", color: "var(--text-3)" }}>Free workspace</span>
           </div>
         </section>
 
@@ -342,7 +342,7 @@ export default function Landing2() {
             Ship agents with <em style={{ color: "var(--accent)" }}>proof</em>.
           </h2>
           <p style={{ color: "var(--text-2)", marginBottom: "28px", fontSize: "16px" }}>
-            Free to start. No credit card.
+            Free to start. Upgrade when evals become release gates.
           </p>
           <button style={{
             padding: "12px 28px",

--- a/web/src/app/pricing/page.tsx
+++ b/web/src/app/pricing/page.tsx
@@ -12,9 +12,9 @@ import { ogImageUrl } from "@/lib/seo";
 import { CompareShell } from "../compare/_components/compare-shell";
 
 const PAGE_PATH = "/pricing";
-const PAGE_TITLE = "AgentClash Pricing: Free, Open-Source, Pro, Team & Enterprise";
+const PAGE_TITLE = "AgentClash Pricing: Free, Pro, Team & Enterprise";
 const PAGE_DESCRIPTION =
-  "AgentClash pricing — a free hosted tier and free open-source self-hosting, Pro at $49/seat/mo and Team at $100/seat/mo (cheaper billed annually), and custom Enterprise. Bring your own LLM keys on every tier; we never mark up tokens.";
+  "AgentClash pricing — start free with hosted runs or self-host the open-source engine, then upgrade to Pro at $49/mo or Team at $100/mo when you need more runs, retention, and governance. Bring your own LLM keys on every tier; we never mark up tokens.";
 const SOCIAL_IMAGE = ogImageUrl({
   title: "AgentClash Pricing",
   subtitle: "Free and open-source, with hosted Pro, Team & Enterprise",
@@ -27,12 +27,12 @@ const faqItems = [
   {
     question: "Is AgentClash free?",
     answer:
-      "Yes. AgentClash is open source under the MIT license, so you can self-host the engine on your own infrastructure for free. There is also a free hosted tier with 25 eval runs per month, one seat, and bring-your-own LLM keys — no credit card required.",
+      "Yes. AgentClash is open source under the MIT license, so you can self-host the engine on your own infrastructure for free. There is also a free hosted tier with 25 eval runs per month and bring-your-own LLM keys, so you can run real evals before upgrading.",
   },
   {
     question: "How much does AgentClash cost?",
     answer:
-      "Self-hosting is free. The hosted Free tier is $0. Pro is $49 per seat per month ($39 billed annually) with a five-seat minimum, Team is $100 per seat per month ($80 billed annually), and Enterprise is custom. Pro and Team include a free 45-day trial with no credit card.",
+      "Self-hosting is free. The hosted Free tier is $0. Pro is $49 per month ($39 billed annually), Team is $100 per month ($80 billed annually), and Enterprise is custom.",
   },
   {
     question: "Do you mark up LLM tokens?",
@@ -42,7 +42,7 @@ const faqItems = [
   {
     question: "Can I self-host AgentClash instead of paying?",
     answer:
-      "Yes. The engine is MIT-licensed and open source. You can run the full stack on your own infrastructure at no license cost; the paid hosted tiers exist to skip the ops and add team features like private challenge packs, CI integration, SSO, and audit logs.",
+      "Yes. The engine is MIT-licensed and open source. You can run the full stack on your own infrastructure at no license cost; the paid hosted tiers exist to skip the ops and add more runs, private challenge packs, CI integration, SSO, and audit logs.",
   },
 ];
 
@@ -95,7 +95,7 @@ export default function PricingPage() {
               Pricing
             </p>
             <h1 className="mt-5 max-w-[20ch] font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
-              Free and open-source. Hosted when you want to skip the ops.
+              Start free. Pay when evals become part of shipping.
             </h1>
             <p className="mt-8 max-w-[64ch] text-base leading-8 text-white/62 sm:text-lg">
               {PAGE_DESCRIPTION}

--- a/web/src/app/resources/eval-checklist/thank-you/page.tsx
+++ b/web/src/app/resources/eval-checklist/thank-you/page.tsx
@@ -64,7 +64,7 @@ export default function EvalChecklistThankYouPage() {
                 href="/enterprise"
                 className="inline-flex min-h-11 items-center justify-center rounded-lg bg-white px-5 text-sm font-semibold text-[#060606] transition-colors hover:bg-white/90"
               >
-                See enterprise pilot
+                See enterprise rollout
               </Link>
               <a
                 href="mailto:hello@agentclash.dev?subject=AgentClash%20eval%20architecture%20review"

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -63,7 +63,7 @@ const offerings = [
 const guardrails = [
   "Every engagement produces artifacts in your AgentClash workspace: packs, baselines, gates, or CI handoff.",
   "We do not run black-box evals outside your tenancy. You own the packs and the evidence.",
-  "Services are paid engagements. The free 45-day Team pilot is still the default path if you want to self-serve first.",
+  "Services are paid engagements. The hosted Free plan is still the default path if you want to run evals yourself first.",
   "No vague SOWs. Each package above has a fixed duration and named deliverable.",
 ];
 
@@ -79,8 +79,8 @@ const intakeFields = [
 const crossLinks = [
   {
     href: "/enterprise",
-    label: "Enterprise pilot",
-    description: "45-day Team pilot with no credit card. Self-serve product access first.",
+    label: "Enterprise rollout",
+    description: "Start free, then upgrade when evals become part of release governance.",
   },
   {
     href: "/pricing",
@@ -101,9 +101,9 @@ const crossLinks = [
 
 const faqItems = [
   {
-    question: "How is this different from the Team pilot?",
+    question: "How is this different from the Team plan?",
     answer:
-      "The Team pilot is product access in your workspace. Services are fixed-scope engagements where our team builds packs, baselines, or gates with you. Many teams start the pilot and add a 2-week Benchmark & Gate Setup sprint.",
+      "Team is product access in your workspace. Services are fixed-scope paid engagements where our team builds packs, baselines, or gates with you. Many teams start on Free or Team and add a 2-week Benchmark & Gate Setup sprint.",
   },
   {
     question: "Do we keep the challenge packs after the engagement?",
@@ -123,7 +123,7 @@ const faqItems = [
   {
     question: "Are services free?",
     answer:
-      "No. The four packages above are paid, fixed-scope engagements. The discovery call is free. Product access starts free on the Team pilot and paid tiers on the pricing page.",
+      "No. The four packages above are paid, fixed-scope engagements. The discovery call is free. Product access starts on the hosted Free plan or paid tiers on the pricing page.",
   },
 ];
 
@@ -192,12 +192,12 @@ export default function ServicesPage() {
           <p className="mt-4 max-w-[58ch] text-sm leading-6 text-white/45">
             These packages are paid engagements, scoped after discovery. The{" "}
             <Link
-              href="/enterprise"
+              href="/pricing"
               className="text-white/65 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/85"
             >
-              Team pilot
+              hosted Free plan
             </Link>{" "}
-            is free self-serve product access if you want to start on your own.
+            is self-serve product access if you want to start on your own.
           </p>
           <EnterprisePageCTA className="mt-10" />
         </div>
@@ -332,7 +332,7 @@ export default function ServicesPage() {
               href="/enterprise"
               className="text-white/80 underline decoration-white/25 underline-offset-4 transition-colors hover:text-white"
             >
-              Team pilot
+              Free plan
             </Link>{" "}
             if that is the better first step.
           </p>

--- a/web/src/components/billing/upgrade-prompt.tsx
+++ b/web/src/components/billing/upgrade-prompt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useApiQuery } from "@/lib/api/swr";
 import type {
@@ -28,6 +28,22 @@ function storageKey(orgId: string) {
   return `agentclash:billing-upgrade-prompt-dismissed:${orgId}`;
 }
 
+const DISMISSED_EVENT = "agentclash:billing-upgrade-prompt-dismissed";
+
+function subscribeDismissed(callback: () => void) {
+  window.addEventListener("storage", callback);
+  window.addEventListener(DISMISSED_EVENT, callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    window.removeEventListener(DISMISSED_EVENT, callback);
+  };
+}
+
+function dismissedSnapshot(orgId?: string, isOrgAdmin = false) {
+  if (!orgId || !isOrgAdmin) return true;
+  return window.localStorage.getItem(storageKey(orgId)) === "true";
+}
+
 export function UpgradePrompt({
   orgId,
   orgSlug,
@@ -35,7 +51,6 @@ export function UpgradePrompt({
 }: UpgradePromptProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const [dismissed, setDismissed] = useState(true);
   const shouldFetch = Boolean(orgId && isOrgAdmin);
   const { data: overview } = useApiQuery<BillingOverviewResponse>(
     shouldFetch ? `/v1/organizations/${orgId}/billing` : null,
@@ -43,11 +58,11 @@ export function UpgradePrompt({
   const { data: plansData } = useApiQuery<BillingPlansResponse>(
     shouldFetch ? "/v1/billing/plans" : null,
   );
-
-  useEffect(() => {
-    if (!orgId || !isOrgAdmin) return;
-    setDismissed(window.localStorage.getItem(storageKey(orgId)) === "true");
-  }, [isOrgAdmin, orgId]);
+  const dismissed = useSyncExternalStore(
+    subscribeDismissed,
+    useCallback(() => dismissedSnapshot(orgId, isOrgAdmin), [isOrgAdmin, orgId]),
+    () => true,
+  );
 
   const upgradePlans = useMemo(
     () => (plansData?.items ?? []).filter((plan) => plan.key === "pro" || plan.key === "team"),
@@ -62,7 +77,7 @@ export function UpgradePrompt({
 
   function dismiss() {
     if (orgId) window.localStorage.setItem(storageKey(orgId), "true");
-    setDismissed(true);
+    window.dispatchEvent(new Event(DISMISSED_EVENT));
   }
 
   return (

--- a/web/src/components/billing/upgrade-prompt.tsx
+++ b/web/src/components/billing/upgrade-prompt.tsx
@@ -2,13 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { createApiClient } from "@/lib/api/client";
-import { ApiError } from "@/lib/api/errors";
 import { useApiQuery } from "@/lib/api/swr";
 import type {
   BillingOverviewResponse,
-  BillingPlan,
   BillingPlansResponse,
 } from "@/lib/api/types";
 import { isFreeActive } from "@/lib/billing";
@@ -21,31 +17,27 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
 
-interface TrialUpgradePromptProps {
+interface UpgradePromptProps {
   orgId?: string;
   orgSlug?: string;
   isOrgAdmin?: boolean;
 }
 
 function storageKey(orgId: string) {
-  return `agentclash:billing-trial-prompt-dismissed:${orgId}`;
+  return `agentclash:billing-upgrade-prompt-dismissed:${orgId}`;
 }
 
-export function TrialUpgradePrompt({
+export function UpgradePrompt({
   orgId,
   orgSlug,
   isOrgAdmin = false,
-}: TrialUpgradePromptProps) {
+}: UpgradePromptProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const { getAccessToken } = useAccessToken();
   const [dismissed, setDismissed] = useState(true);
-  const [busyPlan, setBusyPlan] = useState<string | null>(null);
   const shouldFetch = Boolean(orgId && isOrgAdmin);
-  const { data: overview, mutate } = useApiQuery<BillingOverviewResponse>(
+  const { data: overview } = useApiQuery<BillingOverviewResponse>(
     shouldFetch ? `/v1/organizations/${orgId}/billing` : null,
   );
   const { data: plansData } = useApiQuery<BillingPlansResponse>(
@@ -57,7 +49,7 @@ export function TrialUpgradePrompt({
     setDismissed(window.localStorage.getItem(storageKey(orgId)) === "true");
   }, [isOrgAdmin, orgId]);
 
-  const trialPlans = useMemo(
+  const upgradePlans = useMemo(
     () => (plansData?.items ?? []).filter((plan) => plan.key === "pro" || plan.key === "team"),
     [plansData],
   );
@@ -73,26 +65,6 @@ export function TrialUpgradePrompt({
     setDismissed(true);
   }
 
-  async function startTrial(plan: BillingPlan) {
-    if (!orgId) return;
-    setBusyPlan(plan.key);
-    try {
-      const token = await getAccessToken();
-      const api = createApiClient(token ?? undefined);
-      await api.post<BillingOverviewResponse>(
-        `/v1/organizations/${orgId}/billing/trial`,
-        { plan_key: plan.key, billing_period: "monthly" },
-      );
-      toast.success(`${plan.display_name} trial started`);
-      dismiss();
-      await mutate();
-    } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Failed to start trial");
-    } finally {
-      setBusyPlan(null);
-    }
-  }
-
   return (
     <Dialog
       open={open}
@@ -102,29 +74,30 @@ export function TrialUpgradePrompt({
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Try AgentClash with higher limits</DialogTitle>
+          <DialogTitle>Need more AgentClash runs?</DialogTitle>
           <DialogDescription>
-            You are on Free. You can keep using Free, or start a 45-day trial
-            for the plan you want to evaluate.
+            You are on Free. Keep using it, or upgrade when you need more run
+            volume, replay retention, and governance controls.
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-2">
-          {trialPlans.map((plan) => (
+          {upgradePlans.map((plan) => (
             <button
               key={plan.key}
               type="button"
-              disabled={Boolean(busyPlan)}
-              onClick={() => startTrial(plan)}
+              onClick={() => {
+                dismiss();
+                if (orgSlug) {
+                  router.push(`/orgs/${orgSlug}/billing?plan=${plan.key}`);
+                }
+              }}
               className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-3 text-left transition-colors hover:bg-white/[0.06] disabled:opacity-60"
             >
               <div className="flex items-center justify-between gap-3">
                 <span className="text-sm font-medium">
-                  Start {plan.display_name} trial
+                  View {plan.display_name}
                 </span>
-                {busyPlan === plan.key && (
-                  <Loader2 className="size-4 animate-spin" />
-                )}
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
                 {plan.limits.max_models_per_race.value ?? "Unlimited"} models
@@ -136,13 +109,12 @@ export function TrialUpgradePrompt({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={dismiss} disabled={Boolean(busyPlan)}>
+          <Button variant="outline" onClick={dismiss}>
             Keep Free
           </Button>
           {orgSlug && (
             <Button
               variant="secondary"
-              disabled={Boolean(busyPlan)}
               onClick={() => {
                 dismiss();
                 router.push(`/orgs/${orgSlug}/billing`);

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -121,7 +121,6 @@ export function pricingSchema(): Record<string, unknown> {
   const offers = PRICING_TIERS.map((tier) => {
     const monthly = tier.prices.monthly;
     const amount = parsePriceAmount(monthly.value);
-    const perSeat = monthly.suffix.includes("seat");
 
     const base: Record<string, unknown> = {
       "@type": "Offer",
@@ -153,7 +152,7 @@ export function pricingSchema(): Record<string, unknown> {
         "@type": "UnitPriceSpecification",
         price: amount,
         priceCurrency: "USD",
-        unitText: perSeat ? "seat per month" : "month",
+        unitText: "workspace per month",
         billingIncrement: 1,
       },
     };

--- a/web/src/components/marketing/pricing-block.tsx
+++ b/web/src/components/marketing/pricing-block.tsx
@@ -19,11 +19,11 @@ export function PricingBlock() {
         <div className="mx-auto max-w-[1440px]">
           <div className="text-center">
             <h2 className="text-3xl sm:text-5xl font-semibold tracking-tight text-white">
-              Free for 45 days.
+              Run real evals for free.
             </h2>
             <p className="mt-4 mx-auto max-w-[44ch] text-sm leading-6 text-white/75">
-              No credit card. Self-host the engine for free, or skip the ops
-              with hosted.
+              Start on hosted Free or self-host the engine. Upgrade only when
+              you need more runs, retention, or governance.
             </p>
 
             <div className="mt-10 flex justify-center">

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -148,7 +148,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
       setDemo(d);
 
       // Resume an existing live session for this demo on reload (so a refresh
-      // doesn't burn the one free trial); otherwise start a fresh one.
+      // doesn't burn the one free demo); otherwise start a fresh one.
       let saved: { id: string; slug: string; expiresAt: number } | null = null;
       try {
         const raw = localStorage.getItem(SESSION_KEY);
@@ -239,7 +239,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
             <Sparkles className="size-5 text-white/80" />
           </div>
           <h1 className="font-[family-name:var(--font-display)] text-[clamp(2rem,4vw,3rem)] font-normal leading-[1.05] tracking-[-0.03em]">
-            That&apos;s your free trial.
+            That&apos;s your free demo.
           </h1>
           <p className="mx-auto mt-4 max-w-sm text-white/55">
             Hope {demo?.name ?? "it"} felt good. Sign in with AgentClash to keep going —
@@ -344,7 +344,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
                   }`}
                 />
               </span>
-              Free trial · {remaining || "—"}
+              Free demo · {remaining || "—"}
             </span>
           ) : (
             <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
@@ -371,11 +371,11 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         <aside className="w-full shrink-0 space-y-7 overflow-y-auto border-b border-white/[0.06] p-5 md:w-80 md:border-b-0 md:border-r">
-          {/* Free-trial card (anonymous, gateway-backed) */}
+          {/* Free-demo card (anonymous, gateway-backed) */}
           {trial && (
             <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/[0.06] p-4">
               <h2 className="text-xs font-medium uppercase tracking-wide text-emerald-300">
-                Free trial · no key needed
+                Free demo · no key needed
               </h2>
               <p className="mt-2 text-xs leading-relaxed text-white/60">
                 Running on AgentClash credentials for a few minutes — just run the commands

--- a/web/src/lib/auth/__tests__/return-to.test.ts
+++ b/web/src/lib/auth/__tests__/return-to.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildInviteReturnTo,
   buildGitHubSetupReturnTo,
+  buildDashboardReturnTo,
   buildDeviceReturnTo,
   normalizeDeviceUserCode,
   sanitizeReturnTo,
@@ -29,6 +30,13 @@ describe("sanitizeReturnTo", () => {
     ).toBe(
       "/github/setup?installation_id=42&state=abc_DEF-123.sig_456&setup_action=install",
     );
+  });
+
+  it("preserves paid plan intent on the dashboard return path", () => {
+    expect(sanitizeReturnTo("/dashboard?plan=pro&evil=https://example.com")).toBe(
+      "/dashboard?plan=pro",
+    );
+    expect(sanitizeReturnTo("/dashboard?plan=enterprise")).toBe("/dashboard");
   });
 
   it("preserves invite accept routes", () => {
@@ -59,6 +67,17 @@ describe("github setup return-to helpers", () => {
   it("requires installation id and signed state", () => {
     expect(buildGitHubSetupReturnTo(new URLSearchParams("installation_id=x"))).toBe(
       "/github/setup",
+    );
+  });
+});
+
+describe("dashboard return-to helpers", () => {
+  it("keeps only supported paid plan intent", () => {
+    expect(buildDashboardReturnTo(new URLSearchParams("plan=team"))).toBe(
+      "/dashboard?plan=team",
+    );
+    expect(buildDashboardReturnTo(new URLSearchParams("plan=free"))).toBe(
+      "/dashboard",
     );
   });
 });

--- a/web/src/lib/auth/return-to.ts
+++ b/web/src/lib/auth/return-to.ts
@@ -11,6 +11,7 @@ const ALLOWED_RETURN_PATHS = new Set([
   DEVICE_PATH,
   GITHUB_SETUP_PATH,
 ]);
+const PLAN_INTENT_PATTERN = /^(pro|team)$/;
 const RETURN_TO_BASE_URL = "http://agentclash.local";
 
 export function sanitizeReturnTo(raw: string | null | undefined): string {
@@ -49,7 +50,19 @@ export function sanitizeReturnTo(raw: string | null | undefined): string {
     return buildGitHubSetupReturnTo(parsed.searchParams);
   }
 
+  if (parsed.pathname === DEFAULT_RETURN_TO) {
+    return buildDashboardReturnTo(parsed.searchParams);
+  }
+
   return DEFAULT_RETURN_TO;
+}
+
+export function buildDashboardReturnTo(searchParams: URLSearchParams): string {
+  const plan = searchParams.get("plan");
+  if (!plan || !PLAN_INTENT_PATTERN.test(plan)) {
+    return DEFAULT_RETURN_TO;
+  }
+  return `${DEFAULT_RETURN_TO}?${new URLSearchParams({ plan }).toString()}`;
 }
 
 export function buildInviteReturnTo(

--- a/web/src/lib/benchmarks-hub.ts
+++ b/web/src/lib/benchmarks-hub.ts
@@ -12,7 +12,7 @@ export const BENCHMARKS_HUB_FAQ = [
   {
     question: "Can we run the same benchmark on our agents?",
     answer:
-      "Yes. Book an eval workshop or start a Team pilot. We pin the same pack on your workloads, baseline your current agent, and deliver scorecards and CI gates your platform team can ship on.",
+      "Yes. Book an eval workshop or start a Team workspace. We pin the same pack on your workloads, baseline your current agent, and deliver scorecards and CI gates your platform team can ship on.",
   },
   {
     question: "How often do you publish benchmark reports?",

--- a/web/src/lib/billing.test.ts
+++ b/web/src/lib/billing.test.ts
@@ -22,8 +22,8 @@ describe("billing helpers", () => {
       isFreeActive({
         plan_key: "pro",
         billing_period: "monthly",
-        status: "trialing",
-        seat_quantity: 5,
+        status: "active",
+        seat_quantity: 1,
         feature_flags: {},
       }),
     ).toBe(false);
@@ -46,6 +46,6 @@ describe("billing helpers", () => {
 
     expect(message).toContain("Free");
     expect(message).toContain("25");
-    expect(message).toContain("Start a trial");
+    expect(message).toContain("Upgrade");
   });
 });

--- a/web/src/lib/billing.ts
+++ b/web/src/lib/billing.ts
@@ -16,7 +16,7 @@ export function planLabel(planKey?: string): string {
 export function billingStatusLabel(status?: string): string {
   switch (status) {
     case "trialing":
-      return "Trial";
+      return "Promotional";
     case "active":
       return "Active";
     case "expired":
@@ -67,21 +67,21 @@ export function billingGateToastMessage(err: unknown): string | null {
   const current = planLabel(err.planKey);
   const upgrade = planLabel(err.upgradeTarget);
   const reset = err.resetAt ? ` Resets ${formatBillingDate(err.resetAt)}.` : "";
-  const expiry = err.expiresAt ? ` Trial ended ${formatBillingDate(err.expiresAt)}.` : "";
+  const expiry = err.expiresAt ? ` Access ended ${formatBillingDate(err.expiresAt)}.` : "";
 
   switch (err.code) {
     case "feature_not_entitled":
-      return `${current} does not include this feature. Start a trial or upgrade to ${upgrade}.`;
+      return `${current} does not include this feature. Upgrade to ${upgrade}.`;
     case "quota_exceeded":
-      return `${current} has used ${err.used ?? "all"} of ${formatBillingLimit(err.limit)} monthly runs.${reset} Start a trial or upgrade to continue.`;
+      return `${current} has used ${err.used ?? "all"} of ${formatBillingLimit(err.limit)} monthly runs.${reset} Upgrade to continue.`;
     case "concurrency_limit_exceeded":
       return `${current} allows ${formatBillingLimit(err.limit)} concurrent run${err.limit === 1 ? "" : "s"}. Try again after one finishes, or upgrade to ${upgrade}.`;
     case "plan_limit_exceeded":
-      return `${current} allows up to ${formatBillingLimit(err.limit)} models per run. Start a trial or upgrade to ${upgrade}.`;
+      return `${current} allows up to ${formatBillingLimit(err.limit)} models per run. Upgrade to ${upgrade}.`;
     case "seat_limit_exceeded":
-      return `${current} has reached its seat limit. Start a trial or upgrade to ${upgrade}.`;
+      return `${current} has reached its member limit. Upgrade to ${upgrade}.`;
     case "workspace_limit_exceeded":
-      return `${current} has reached its workspace limit. Start a trial or upgrade to ${upgrade}.`;
+      return `${current} has reached its workspace limit. Upgrade to ${upgrade}.`;
     case "entitlement_expired":
       return `${current} access has expired.${expiry} Add billing to continue.`;
     case "entitlement_inactive":

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -80,9 +80,9 @@ const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
     title: "AgentClash Pricing",
     href: "/pricing",
     description:
-      "AgentClash pricing — a free hosted tier and open-source self-hosting, paid Pro ($49/seat/mo) and Team ($100/seat/mo) tiers, and custom Enterprise. Bring your own LLM keys on every tier.",
+      "AgentClash pricing — a free hosted tier and open-source self-hosting, paid Pro ($49/mo) and Team ($100/mo) tiers, and custom Enterprise. Bring your own LLM keys on every tier.",
     searchKeywords:
-      "AgentClash pricing cost plans tiers free open source self-host Pro Team Enterprise per seat BYOK bring your own key managed hosted",
+      "AgentClash pricing cost plans tiers free open source self-host Pro Team Enterprise workspace BYOK bring your own key managed hosted",
   },
   {
     title: "Product Changelog",

--- a/web/src/lib/pricing-data.ts
+++ b/web/src/lib/pricing-data.ts
@@ -44,10 +44,10 @@ export const PRICING_TIERS: Tier[] = [
       yearly: { value: "$0", suffix: "/ month" },
     },
     blurb:
-      "Hosted, no ops. Generous enough to actually evaluate the product on your task.",
-    cta: { label: "Run your first eval", href: "/auth/login" },
+      "Run real evals first. Upgrade only when you need more runs, retention, or team controls.",
+    cta: { label: "Start free", href: "/auth/login?mode=signup" },
     features: [
-      "1 seat, 1 workspace",
+      "1 workspace",
       "25 eval runs / month",
       "Up to 4 models per run",
       "7-day replay retention",
@@ -62,26 +62,26 @@ export const PRICING_TIERS: Tier[] = [
     prices: {
       monthly: {
         value: "$49",
-        suffix: "/ seat / month",
+        suffix: "/ month",
         note: "Billed monthly",
       },
       yearly: {
         value: "$39",
-        suffix: "/ seat / month",
-        note: "Billed annually · $468 / seat / yr",
+        suffix: "/ month",
+        note: "Billed annually · $468 / yr",
       },
     },
     blurb:
-      "For teams running real evals against real production tasks. Five seats minimum.",
+      "For teams moving from evaluation to repeated release checks.",
     cta: {
-      label: "Start free 45-day trial",
-      href: "/auth/login?plan=pro",
+      label: "Upgrade to Pro",
+      href: "/auth/login?mode=signup&returnTo=/dashboard%3Fplan%3Dpro",
       primary: true,
-      sublabel: "No credit card required",
+      sublabel: "Start on Free, pay when you need more",
     },
     features: [
       "Everything in Free, plus:",
-      "500 eval runs / seat / month",
+      "500 eval runs / workspace / month",
       "Up to 8 models per run",
       "30-day replay retention",
       "Hosted sandbox with included credit",
@@ -97,25 +97,25 @@ export const PRICING_TIERS: Tier[] = [
     prices: {
       monthly: {
         value: "$100",
-        suffix: "/ seat / month",
+        suffix: "/ month",
         note: "Billed monthly",
       },
       yearly: {
         value: "$80",
-        suffix: "/ seat / month",
-        note: "Billed annually · $960 / seat / yr",
+        suffix: "/ month",
+        note: "Billed annually · $960 / yr",
       },
     },
     blurb:
       "For teams running evals across multiple products and surfaces.",
     cta: {
-      label: "Start free 45-day trial",
-      href: "/auth/login?plan=team",
-      sublabel: "No credit card required",
+      label: "Upgrade to Team",
+      href: "/auth/login?mode=signup&returnTo=/dashboard%3Fplan%3Dteam",
+      sublabel: "For higher run volume and governance",
     },
     features: [
       "Everything in Pro, plus:",
-      "2,000 eval runs / seat / month",
+      "2,000 eval runs / workspace / month",
       "Up to 12 models per run",
       "90-day replay retention",
       "10 concurrent eval runs",
@@ -133,7 +133,7 @@ export const PRICING_TIERS: Tier[] = [
       yearly: { value: "Custom", suffix: "" },
     },
     blurb:
-      "Compliance, SSO, dedicated support. 45-day pilot available — no card needed.",
+      "Compliance, SSO, dedicated support, and paid rollout help.",
     cta: { label: "Talk to us", href: "mailto:hello@agentclash.dev" },
     features: [
       "Everything in Team, plus:",


### PR DESCRIPTION
## Summary
- Remove customer-facing seat pricing and the 45-day paid trial offer from pricing, enterprise, services, billing UI, SEO metadata, docs, and related blog CTAs.
- Make Free the default freemium path, with Pro/Team checkout intent preserved through auth via `/dashboard?plan=pro|team`.
- Retire the self-serve paid trial endpoint behavior with a `trial_retired` validation response while preserving compatibility routes/fields.
- Update plan limits to workspace-priced quotas: Free 25 runs, Pro 500 runs/workspace/month, Team 2,000 runs/workspace/month, with unlimited member limits.

## Test contract
- `testing/codex-freemium-pricing.md`

## Verification
- `go test ./internal/billing ./internal/api` from `backend/`
- `go test ./cmd ./internal/api` from `cli/`
- `/Users/atharva/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ./node_modules/vitest/vitest.mjs run src/lib/billing.test.ts src/lib/auth/__tests__/return-to.test.ts src/components/marketing/json-ld.test.tsx` from `web/`
- `/Users/atharva/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ./node_modules/typescript/bin/tsc --noEmit` from `web/`
- `git diff --check`
- Public-copy scan for old trial/seat pricing terms

Note: local Homebrew `node` is currently missing `libllhttp.9.3.dylib`, so web verification used the bundled Codex Node runtime.
