### PR TITLE
feat: interactive tool builder for primitive and composed tools

### DIFF
--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -509,11 +509,17 @@ func infraDeleteHandler[Row WorkspaceOwned](
 			return
 		}
 
-		if wsID := row.GetWorkspaceID(); wsID != nil {
-			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *wsID, ActionManageInfrastructure); err != nil {
-				writeAuthzError(w, err)
-				return
-			}
+		// A nil workspace means this row cannot be authorized via workspace
+		// membership. Rather than silently skipping authorization (which would
+		// let any authenticated caller delete global resources), deny it.
+		wsID := row.GetWorkspaceID()
+		if wsID == nil {
+			writeError(w, http.StatusNotFound, "not_found", resourceName+" not found")
+			return
+		}
+		if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *wsID, ActionManageInfrastructure); err != nil {
+			writeAuthzError(w, err)
+			return
 		}
 
 		if err := del(r.Context(), id); err != nil {
@@ -812,6 +818,16 @@ func updateToolHandler(logger *slog.Logger, authorizer WorkspaceAuthorizer, svc 
 		var input UpdateToolInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		// Only active/disabled are settable here; archiving goes through DELETE.
+		// Reject unknown values up front so an invalid status is a 400, not a 500
+		// from the DB CHECK constraint, and so "archived" can't create a row whose
+		// lifecycle_status disagrees with archived_at.
+		switch strings.TrimSpace(input.LifecycleStatus) {
+		case "", "active", "disabled":
+		default:
+			writeError(w, http.StatusBadRequest, "validation_error", `lifecycle_status must be "active" or "disabled"`)
 			return
 		}
 		row, err := svc.UpdateTool(r.Context(), caller, id, input)

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -49,6 +50,8 @@ type InfrastructureService interface {
 	CreateTool(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateToolInput) (repository.ToolRow, error)
 	ListTools(ctx context.Context, workspaceID uuid.UUID) ([]repository.ToolRow, error)
 	GetTool(ctx context.Context, id uuid.UUID) (repository.ToolRow, error)
+	UpdateTool(ctx context.Context, caller Caller, id uuid.UUID, input UpdateToolInput) (repository.ToolRow, error)
+	DeleteTool(ctx context.Context, id uuid.UUID) error
 
 	// Knowledge Sources
 	CreateKnowledgeSource(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateKnowledgeSourceInput) (repository.KnowledgeSourceRow, error)
@@ -120,13 +123,43 @@ func (i *CreateModelAliasInput) Validate() error {
 type CreateToolInput struct {
 	Name          string          `json:"name"`
 	ToolKind      string          `json:"tool_kind"`
-	CapabilityKey string          `json:"capability_key"`
+	CapabilityKey string          `json:"capability_key,omitempty"`
 	Definition    json.RawMessage `json:"definition,omitempty"`
 }
 
 func (i *CreateToolInput) Validate() error {
-	return requireFields(map[string]string{"name": i.Name, "tool_kind": i.ToolKind, "capability_key": i.CapabilityKey})
+	if err := requireFields(map[string]string{"name": i.Name, "tool_kind": i.ToolKind}); err != nil {
+		return err
+	}
+	return validateToolKind(i.ToolKind)
 }
+
+// UpdateToolInput carries the mutable fields of a tool. ToolKind and slug are
+// immutable; name, capability_key and lifecycle_status default to their existing
+// values when left empty.
+type UpdateToolInput struct {
+	Name            string          `json:"name,omitempty"`
+	CapabilityKey   string          `json:"capability_key,omitempty"`
+	Definition      json.RawMessage `json:"definition,omitempty"`
+	LifecycleStatus string          `json:"lifecycle_status,omitempty"`
+}
+
+func validateToolKind(kind string) error {
+	switch kind {
+	case toolspec.ToolTypePrimitive, toolspec.ToolTypeComposed:
+		return nil
+	default:
+		return fmt.Errorf("tool_kind must be %q or %q", toolspec.ToolTypePrimitive, toolspec.ToolTypeComposed)
+	}
+}
+
+// ToolDefinitionError wraps validation problems with a tool definition so handlers
+// can return a 400 with field-level detail instead of a 500.
+type ToolDefinitionError struct {
+	Errors toolspec.ValidationErrors
+}
+
+func (e *ToolDefinitionError) Error() string { return e.Errors.Error() }
 
 type CreateKnowledgeSourceInput struct {
 	Name             string          `json:"name"`
@@ -347,6 +380,11 @@ func infraCreateHandler[Input any, Row any, Resp any](
 		}
 		row, err := create(r.Context(), caller, wsID, input)
 		if err != nil {
+			var toolDefErr *ToolDefinitionError
+			if errors.As(err, &toolDefErr) {
+				writeError(w, http.StatusBadRequest, "validation_error", toolDefErr.Error())
+				return
+			}
 			if errors.Is(err, repository.ErrSlugTaken) {
 				writeError(w, http.StatusConflict, "slug_taken", "a resource with that name already exists")
 				return
@@ -728,5 +766,96 @@ func archiveRuntimeProfileHandler(logger *slog.Logger, svc InfrastructureService
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Tools: update + primitive catalog
+// --------------------------------------------------------------------------
+
+func updateToolHandler(logger *slog.Logger, authorizer WorkspaceAuthorizer, svc InfrastructureService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "toolID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+		// Fetch first to authorize against the tool's workspace.
+		existing, err := svc.GetTool(r.Context(), id)
+		if err != nil {
+			if isInfraNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", "tool not found")
+				return
+			}
+			logger.Error("get tool for update failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to get tool")
+			return
+		}
+		if existing.WorkspaceID != nil {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *existing.WorkspaceID, ActionManageInfrastructure); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		} else {
+			writeError(w, http.StatusNotFound, "not_found", "tool not found")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+		var input UpdateToolInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		row, err := svc.UpdateTool(r.Context(), caller, id, input)
+		if err != nil {
+			var toolDefErr *ToolDefinitionError
+			if errors.As(err, &toolDefErr) {
+				writeError(w, http.StatusBadRequest, "validation_error", toolDefErr.Error())
+				return
+			}
+			if isInfraNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", "tool not found")
+				return
+			}
+			logger.Error("update tool failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to update tool")
+			return
+		}
+		writeJSON(w, http.StatusOK, mapTool(row))
+	}
+}
+
+type toolPrimitiveResponse struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Kind        string          `json:"kind"`
+	Parameters  json.RawMessage `json:"parameters"`
+	Delegatable bool            `json:"delegatable"`
+}
+
+// listToolPrimitivesHandler returns the static catalog of base primitives a
+// custom tool can delegate to or compose. Global and read-only.
+func listToolPrimitivesHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		prims := toolspec.Primitives()
+		items := make([]toolPrimitiveResponse, len(prims))
+		for i, p := range prims {
+			items[i] = toolPrimitiveResponse{
+				Name:        p.Name,
+				Description: p.Description,
+				Kind:        string(p.Kind),
+				Parameters:  p.Parameters,
+				Delegatable: p.Delegatable,
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
 	}
 }

--- a/backend/internal/api/infrastructure_manager.go
+++ b/backend/internal/api/infrastructure_manager.go
@@ -383,7 +383,7 @@ func (m *InfrastructureManager) CreateTool(ctx context.Context, caller Caller, w
 	if capabilityKey == "" {
 		capabilityKey = slug
 	}
-	if err := m.validateToolDefinition(ctx, workspaceID, input.ToolKind, slug, input.Definition); err != nil {
+	if err := m.validateToolDefinition(ctx, &workspaceID, input.ToolKind, slug, input.Definition); err != nil {
 		return repository.ToolRow{}, err
 	}
 	return m.repo.CreateTool(ctx, repository.CreateToolParams{
@@ -420,10 +420,10 @@ func (m *InfrastructureManager) UpdateTool(ctx context.Context, caller Caller, i
 	}
 	// tool_kind and slug are immutable; validate the new definition against the
 	// existing tool_kind, excluding this tool's own slug to reject self-reference.
-	if existing.WorkspaceID != nil {
-		if err := m.validateToolDefinition(ctx, *existing.WorkspaceID, existing.ToolKind, existing.Slug, input.Definition); err != nil {
-			return repository.ToolRow{}, err
-		}
+	// A nil/empty definition is a partial update (rename, lifecycle toggle) and is
+	// left to the repository's COALESCE to preserve the stored value.
+	if err := m.validateToolDefinition(ctx, existing.WorkspaceID, existing.ToolKind, existing.Slug, input.Definition); err != nil {
+		return repository.ToolRow{}, err
 	}
 	return m.repo.UpdateTool(ctx, repository.UpdateToolParams{
 		ID:              id,
@@ -438,13 +438,20 @@ func (m *InfrastructureManager) DeleteTool(ctx context.Context, id uuid.UUID) er
 	return m.repo.ArchiveTool(ctx, id)
 }
 
-// validateToolDefinition runs the canonical toolspec validator. For composed
-// tools it loads the workspace's other tools so step refs of type "tool" can be
-// checked for existence (and self-reference rejected via selfSlug).
-func (m *InfrastructureManager) validateToolDefinition(ctx context.Context, workspaceID uuid.UUID, toolKind, selfSlug string, definition json.RawMessage) error {
+// validateToolDefinition runs the canonical toolspec validator. An empty
+// definition is treated as "no change" (partial update) and skips validation.
+// Validation otherwise runs for every caller, regardless of whether the tool is
+// workspace-scoped. For composed tools with a workspace, it loads the other
+// tools so step refs of type "tool" can be checked for existence (and
+// self-reference rejected via selfSlug); without a workspace, tool-ref existence
+// is not checked but every other rule still applies.
+func (m *InfrastructureManager) validateToolDefinition(ctx context.Context, workspaceID *uuid.UUID, toolKind, selfSlug string, definition json.RawMessage) error {
+	if len(strings.TrimSpace(string(definition))) == 0 {
+		return nil
+	}
 	opts := toolspec.ValidateOptions{SelfSlug: selfSlug}
-	if toolKind == toolspec.ToolTypeComposed {
-		tools, err := m.repo.ListToolsByWorkspaceID(ctx, workspaceID)
+	if toolKind == toolspec.ToolTypeComposed && workspaceID != nil {
+		tools, err := m.repo.ListToolsByWorkspaceID(ctx, *workspaceID)
 		if err != nil {
 			return fmt.Errorf("load workspace tools: %w", err)
 		}

--- a/backend/internal/api/infrastructure_manager.go
+++ b/backend/internal/api/infrastructure_manager.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
 	"github.com/google/uuid"
 )
 
@@ -43,6 +45,8 @@ type InfrastructureRepository interface {
 	CreateTool(ctx context.Context, p repository.CreateToolParams) (repository.ToolRow, error)
 	GetToolByID(ctx context.Context, id uuid.UUID) (repository.ToolRow, error)
 	ListToolsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ToolRow, error)
+	UpdateTool(ctx context.Context, p repository.UpdateToolParams) (repository.ToolRow, error)
+	ArchiveTool(ctx context.Context, id uuid.UUID) error
 
 	// Knowledge Sources
 	CreateKnowledgeSource(ctx context.Context, p repository.CreateKnowledgeSourceParams) (repository.KnowledgeSourceRow, error)
@@ -375,13 +379,20 @@ func (m *InfrastructureManager) CreateTool(ctx context.Context, caller Caller, w
 		return repository.ToolRow{}, fmt.Errorf("resolve org: %w", err)
 	}
 	slug := generateSlug(input.Name)
+	capabilityKey := strings.TrimSpace(input.CapabilityKey)
+	if capabilityKey == "" {
+		capabilityKey = slug
+	}
+	if err := m.validateToolDefinition(ctx, workspaceID, input.ToolKind, slug, input.Definition); err != nil {
+		return repository.ToolRow{}, err
+	}
 	return m.repo.CreateTool(ctx, repository.CreateToolParams{
 		OrganizationID: orgID,
 		WorkspaceID:    workspaceID,
 		Name:           input.Name,
 		Slug:           slug,
 		ToolKind:       input.ToolKind,
-		CapabilityKey:  input.CapabilityKey,
+		CapabilityKey:  capabilityKey,
 		Definition:     input.Definition,
 	})
 }
@@ -392,6 +403,61 @@ func (m *InfrastructureManager) ListTools(ctx context.Context, workspaceID uuid.
 
 func (m *InfrastructureManager) GetTool(ctx context.Context, id uuid.UUID) (repository.ToolRow, error) {
 	return m.repo.GetToolByID(ctx, id)
+}
+
+func (m *InfrastructureManager) UpdateTool(ctx context.Context, caller Caller, id uuid.UUID, input UpdateToolInput) (repository.ToolRow, error) {
+	existing, err := m.repo.GetToolByID(ctx, id)
+	if err != nil {
+		return repository.ToolRow{}, err
+	}
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		name = existing.Name
+	}
+	capabilityKey := strings.TrimSpace(input.CapabilityKey)
+	if capabilityKey == "" {
+		capabilityKey = existing.CapabilityKey
+	}
+	// tool_kind and slug are immutable; validate the new definition against the
+	// existing tool_kind, excluding this tool's own slug to reject self-reference.
+	if existing.WorkspaceID != nil {
+		if err := m.validateToolDefinition(ctx, *existing.WorkspaceID, existing.ToolKind, existing.Slug, input.Definition); err != nil {
+			return repository.ToolRow{}, err
+		}
+	}
+	return m.repo.UpdateTool(ctx, repository.UpdateToolParams{
+		ID:              id,
+		Name:            name,
+		CapabilityKey:   capabilityKey,
+		Definition:      input.Definition,
+		LifecycleStatus: strings.TrimSpace(input.LifecycleStatus),
+	})
+}
+
+func (m *InfrastructureManager) DeleteTool(ctx context.Context, id uuid.UUID) error {
+	return m.repo.ArchiveTool(ctx, id)
+}
+
+// validateToolDefinition runs the canonical toolspec validator. For composed
+// tools it loads the workspace's other tools so step refs of type "tool" can be
+// checked for existence (and self-reference rejected via selfSlug).
+func (m *InfrastructureManager) validateToolDefinition(ctx context.Context, workspaceID uuid.UUID, toolKind, selfSlug string, definition json.RawMessage) error {
+	opts := toolspec.ValidateOptions{SelfSlug: selfSlug}
+	if toolKind == toolspec.ToolTypeComposed {
+		tools, err := m.repo.ListToolsByWorkspaceID(ctx, workspaceID)
+		if err != nil {
+			return fmt.Errorf("load workspace tools: %w", err)
+		}
+		known := make(map[string]struct{}, len(tools))
+		for _, t := range tools {
+			known[t.Slug] = struct{}{}
+		}
+		opts.KnownToolSlugs = known
+	}
+	if errs := toolspec.ValidateDefinition(toolKind, definition, opts); len(errs) > 0 {
+		return &ToolDefinitionError{Errors: errs}
+	}
+	return nil
 }
 
 // --------------------------------------------------------------------------

--- a/backend/internal/api/infrastructure_manager_test.go
+++ b/backend/internal/api/infrastructure_manager_test.go
@@ -190,6 +190,12 @@ func (r *providerAccountTestRepo) GetToolByID(context.Context, uuid.UUID) (repos
 func (r *providerAccountTestRepo) ListToolsByWorkspaceID(context.Context, uuid.UUID) ([]repository.ToolRow, error) {
 	return nil, nil
 }
+func (r *providerAccountTestRepo) UpdateTool(context.Context, repository.UpdateToolParams) (repository.ToolRow, error) {
+	return repository.ToolRow{}, nil
+}
+func (r *providerAccountTestRepo) ArchiveTool(context.Context, uuid.UUID) error {
+	return nil
+}
 func (r *providerAccountTestRepo) CreateKnowledgeSource(context.Context, repository.CreateKnowledgeSourceParams) (repository.KnowledgeSourceRow, error) {
 	return repository.KnowledgeSourceRow{}, nil
 }

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -21,6 +21,9 @@ type stubInfraService struct {
 	providerTestResult  ProviderAccountTestResult
 	modelAlias          repository.ModelAliasRow
 	createModelAliasErr error
+	tool                repository.ToolRow
+	toolFound           bool
+	updateToolErr       error
 }
 
 func (s stubInfraService) CreateRuntimeProfile(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
@@ -83,7 +86,25 @@ func (s stubInfraService) ListTools(_ context.Context, _ uuid.UUID) ([]repositor
 	return nil, nil
 }
 func (s stubInfraService) GetTool(_ context.Context, _ uuid.UUID) (repository.ToolRow, error) {
+	if s.toolFound {
+		return s.tool, nil
+	}
 	return repository.ToolRow{}, repository.ErrToolNotFound
+}
+func (s stubInfraService) UpdateTool(_ context.Context, _ Caller, _ uuid.UUID, _ UpdateToolInput) (repository.ToolRow, error) {
+	if s.updateToolErr != nil {
+		return repository.ToolRow{}, s.updateToolErr
+	}
+	if !s.toolFound {
+		return repository.ToolRow{}, repository.ErrToolNotFound
+	}
+	return s.tool, nil
+}
+func (s stubInfraService) DeleteTool(_ context.Context, _ uuid.UUID) error {
+	if !s.toolFound {
+		return repository.ErrToolNotFound
+	}
+	return nil
 }
 func (s stubInfraService) CreateKnowledgeSource(_ context.Context, _ Caller, _ uuid.UUID, _ CreateKnowledgeSourceInput) (repository.KnowledgeSourceRow, error) {
 	return repository.KnowledgeSourceRow{}, nil

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -315,9 +315,12 @@ func registerProtectedRoutes(
 	router.Delete("/model-aliases/{aliasID}", infraDeleteHandler(logger, authorizer, "aliasID", infraService.GetModelAlias, infraService.DeleteModelAlias, "model alias"))
 
 	// Tools
+	router.Get("/tool-primitives", listToolPrimitivesHandler())
 	router.Method("POST", "/workspaces/{workspaceID}/tools", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateTool, mapTool)))
 	router.Method("GET", "/workspaces/{workspaceID}/tools", wsMiddleware(infraListHandler(logger, infraService.ListTools, mapTool)))
 	router.Get("/tools/{toolID}", infraGetHandler(logger, authorizer, "toolID", infraService.GetTool, mapTool, "tool"))
+	router.Patch("/tools/{toolID}", updateToolHandler(logger, authorizer, infraService))
+	router.Delete("/tools/{toolID}", infraDeleteHandler(logger, authorizer, "toolID", infraService.GetTool, infraService.DeleteTool, "tool"))
 
 	// Knowledge Sources
 	router.Method("POST", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateKnowledgeSource, mapKnowledgeSource)))

--- a/backend/internal/api/tools_test.go
+++ b/backend/internal/api/tools_test.go
@@ -317,6 +317,41 @@ func TestDeleteToolByAdmin(t *testing.T) {
 	}
 }
 
+func TestDeleteToolDeniedForGlobalTool(t *testing.T) {
+	toolID := uuid.New()
+	// Global tool (nil workspace_id) must not be deletable by a workspace caller.
+	svc := stubInfraService{toolFound: true, tool: repository.ToolRow{ID: toolID, WorkspaceID: nil, ToolKind: toolspec.ToolTypePrimitive}}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tools/"+toolID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_admin")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for global tool delete, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateToolInvalidLifecycleStatus(t *testing.T) {
+	wsID := uuid.New()
+	toolID := uuid.New()
+	svc := stubInfraService{toolFound: true, tool: repository.ToolRow{ID: toolID, WorkspaceID: &wsID, ToolKind: toolspec.ToolTypePrimitive}}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/tools/"+toolID.String(), strings.NewReader(`{"lifecycle_status":"archived"}`))
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, wsID.String()+":workspace_admin")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid lifecycle_status, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestDeleteToolNotFound(t *testing.T) {
 	toolID := uuid.New()
 	svc := stubInfraService{toolFound: false}

--- a/backend/internal/api/tools_test.go
+++ b/backend/internal/api/tools_test.go
@@ -1,0 +1,296 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
+	"github.com/google/uuid"
+)
+
+// toolManagerRepo embeds the no-op infra repo stub and overrides the tool methods
+// so manager-level logic (validation, defaulting, immutability) can be asserted
+// without a database.
+type toolManagerRepo struct {
+	*providerAccountTestRepo
+	orgID          uuid.UUID
+	existing       repository.ToolRow
+	workspaceTools []repository.ToolRow
+	created        *repository.CreateToolParams
+	updated        *repository.UpdateToolParams
+	archivedID     *uuid.UUID
+}
+
+func newToolManagerRepo() *toolManagerRepo {
+	return &toolManagerRepo{providerAccountTestRepo: &providerAccountTestRepo{}, orgID: uuid.New()}
+}
+
+func (r *toolManagerRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return r.orgID, nil
+}
+func (r *toolManagerRepo) CreateTool(_ context.Context, p repository.CreateToolParams) (repository.ToolRow, error) {
+	r.created = &p
+	ws := p.WorkspaceID
+	return repository.ToolRow{ID: uuid.New(), OrganizationID: p.OrganizationID, WorkspaceID: &ws, Name: p.Name, Slug: p.Slug, ToolKind: p.ToolKind, CapabilityKey: p.CapabilityKey, Definition: p.Definition, LifecycleStatus: "active"}, nil
+}
+func (r *toolManagerRepo) GetToolByID(context.Context, uuid.UUID) (repository.ToolRow, error) {
+	if r.existing.ID == uuid.Nil {
+		return repository.ToolRow{}, repository.ErrToolNotFound
+	}
+	return r.existing, nil
+}
+func (r *toolManagerRepo) ListToolsByWorkspaceID(context.Context, uuid.UUID) ([]repository.ToolRow, error) {
+	return r.workspaceTools, nil
+}
+func (r *toolManagerRepo) UpdateTool(_ context.Context, p repository.UpdateToolParams) (repository.ToolRow, error) {
+	r.updated = &p
+	out := r.existing
+	out.Name = p.Name
+	out.CapabilityKey = p.CapabilityKey
+	out.Definition = p.Definition
+	return out, nil
+}
+func (r *toolManagerRepo) ArchiveTool(_ context.Context, id uuid.UUID) error {
+	r.archivedID = &id
+	return nil
+}
+
+func primitiveMockDef() json.RawMessage {
+	return json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"static","response":{"ok":true}}}}`)
+}
+
+func TestManagerCreateToolDefaultsCapabilityKey(t *testing.T) {
+	repo := newToolManagerRepo()
+	m := NewInfrastructureManager(repo)
+	wsID := uuid.New()
+
+	row, err := m.CreateTool(context.Background(), Caller{}, wsID, CreateToolInput{
+		Name:       "Lookup Order",
+		ToolKind:   toolspec.ToolTypePrimitive,
+		Definition: primitiveMockDef(),
+	})
+	if err != nil {
+		t.Fatalf("CreateTool err: %v", err)
+	}
+	if repo.created == nil {
+		t.Fatal("expected CreateTool to reach repo")
+	}
+	if repo.created.Slug == "" || repo.created.CapabilityKey != repo.created.Slug {
+		t.Fatalf("capability_key should default to slug; slug=%q capability=%q", repo.created.Slug, repo.created.CapabilityKey)
+	}
+	if row.OrganizationID != repo.orgID {
+		t.Fatalf("org id = %v, want %v", row.OrganizationID, repo.orgID)
+	}
+}
+
+func TestManagerCreateToolRejectsInvalidDefinition(t *testing.T) {
+	repo := newToolManagerRepo()
+	m := NewInfrastructureManager(repo)
+
+	_, err := m.CreateTool(context.Background(), Caller{}, uuid.New(), CreateToolInput{
+		Name:       "Bad",
+		ToolKind:   toolspec.ToolTypePrimitive,
+		Definition: json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"delegate","primitive":"teleport","args":{}}}`),
+	})
+	var defErr *ToolDefinitionError
+	if err == nil || !errors.As(err, &defErr) {
+		t.Fatalf("expected ToolDefinitionError, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("invalid definition must not reach repo.CreateTool")
+	}
+}
+
+func TestManagerCreateComposedChecksToolRefExistence(t *testing.T) {
+	repo := newToolManagerRepo()
+	repo.workspaceTools = []repository.ToolRow{{Slug: "check_policy"}}
+	m := NewInfrastructureManager(repo)
+
+	def := json.RawMessage(`{"tool_type":"composed","parameters":{"type":"object","properties":{}},"steps":[{"id":"s1","ref":{"type":"tool","name":"ghost"},"inputs":{}}]}`)
+	_, err := m.CreateTool(context.Background(), Caller{}, uuid.New(), CreateToolInput{Name: "Flow", ToolKind: toolspec.ToolTypeComposed, Definition: def})
+	var defErr *ToolDefinitionError
+	if err == nil || !errors.As(err, &defErr) {
+		t.Fatalf("expected ToolDefinitionError for unknown tool ref, got %v", err)
+	}
+
+	repo.created = nil
+	okDef := json.RawMessage(`{"tool_type":"composed","parameters":{"type":"object","properties":{}},"steps":[{"id":"s1","ref":{"type":"tool","name":"check_policy"},"inputs":{}}]}`)
+	if _, err := m.CreateTool(context.Background(), Caller{}, uuid.New(), CreateToolInput{Name: "Flow", ToolKind: toolspec.ToolTypeComposed, Definition: okDef}); err != nil {
+		t.Fatalf("expected valid composed tool to pass, got %v", err)
+	}
+	if repo.created == nil {
+		t.Fatal("valid composed tool should reach repo")
+	}
+}
+
+func TestManagerUpdateToolImmutableSlugAndSelfRefRejected(t *testing.T) {
+	repo := newToolManagerRepo()
+	wsID := uuid.New()
+	repo.existing = repository.ToolRow{ID: uuid.New(), WorkspaceID: &wsID, Name: "Refund Flow", Slug: "refund_flow", ToolKind: toolspec.ToolTypeComposed, CapabilityKey: "refund_flow"}
+	repo.workspaceTools = []repository.ToolRow{{Slug: "refund_flow"}}
+	m := NewInfrastructureManager(repo)
+
+	// Self-reference must be rejected.
+	selfRef := json.RawMessage(`{"tool_type":"composed","steps":[{"id":"s1","ref":{"type":"tool","name":"refund_flow"},"inputs":{}}]}`)
+	if _, err := m.UpdateTool(context.Background(), Caller{}, repo.existing.ID, UpdateToolInput{Definition: selfRef}); err == nil {
+		t.Fatal("expected self-reference to be rejected")
+	}
+
+	// Valid update: empty name falls back to existing; slug/kind never sent to repo.
+	good := json.RawMessage(`{"tool_type":"composed","parameters":{"type":"object","properties":{}},"steps":[{"id":"s1","ref":{"type":"primitive","name":"http_request"},"inputs":{"method":"GET","url":"https://x"}}]}`)
+	if _, err := m.UpdateTool(context.Background(), Caller{}, repo.existing.ID, UpdateToolInput{Definition: good}); err != nil {
+		t.Fatalf("valid update err: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("expected UpdateTool to reach repo")
+	}
+	if repo.updated.Name != "Refund Flow" {
+		t.Fatalf("name should fall back to existing, got %q", repo.updated.Name)
+	}
+}
+
+func TestManagerDeleteToolArchives(t *testing.T) {
+	repo := newToolManagerRepo()
+	m := NewInfrastructureManager(repo)
+	id := uuid.New()
+	if err := m.DeleteTool(context.Background(), id); err != nil {
+		t.Fatalf("DeleteTool err: %v", err)
+	}
+	if repo.archivedID == nil || *repo.archivedID != id {
+		t.Fatalf("expected ArchiveTool(%v), got %v", id, repo.archivedID)
+	}
+}
+
+// --- Router/handler tests ---
+
+func newToolRouter(t *testing.T, svc stubInfraService) http.Handler {
+	t.Helper()
+	return newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func TestListToolPrimitivesHandlerReturnsCatalog(t *testing.T) {
+	router := newToolRouter(t, stubInfraService{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/tool-primitives", nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), toolspec.PrimitiveHTTPRequest) {
+		t.Fatalf("expected catalog to include http_request, got %s", rec.Body.String())
+	}
+}
+
+func TestUpdateToolForbiddenForNonAdmin(t *testing.T) {
+	wsID := uuid.New()
+	toolID := uuid.New()
+	svc := stubInfraService{toolFound: true, tool: repository.ToolRow{ID: toolID, WorkspaceID: &wsID, ToolKind: toolspec.ToolTypePrimitive}}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/tools/"+toolID.String(), strings.NewReader(`{"definition":{}}`))
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, wsID.String()+":workspace_member")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateToolAllowsAdmin(t *testing.T) {
+	wsID := uuid.New()
+	toolID := uuid.New()
+	svc := stubInfraService{toolFound: true, tool: repository.ToolRow{ID: toolID, WorkspaceID: &wsID, Name: "t", Slug: "t", ToolKind: toolspec.ToolTypePrimitive, Definition: json.RawMessage(`{}`), LifecycleStatus: "active"}}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/tools/"+toolID.String(), strings.NewReader(`{"definition":{"tool_type":"primitive"}}`))
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, wsID.String()+":workspace_admin")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateToolInvalidDefinitionReturns400(t *testing.T) {
+	wsID := uuid.New()
+	toolID := uuid.New()
+	svc := stubInfraService{
+		toolFound:     true,
+		tool:          repository.ToolRow{ID: toolID, WorkspaceID: &wsID, ToolKind: toolspec.ToolTypePrimitive},
+		updateToolErr: &ToolDefinitionError{Errors: toolspec.ValidationErrors{{Field: "definition.implementation.primitive", Message: "unknown primitive"}}},
+	}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/tools/"+toolID.String(), strings.NewReader(`{"definition":{"tool_type":"primitive"}}`))
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, wsID.String()+":workspace_admin")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid definition, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteToolByAdmin(t *testing.T) {
+	wsID := uuid.New()
+	toolID := uuid.New()
+	svc := stubInfraService{toolFound: true, tool: repository.ToolRow{ID: toolID, WorkspaceID: &wsID, ToolKind: toolspec.ToolTypePrimitive}}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tools/"+toolID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, wsID.String()+":workspace_admin")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteToolNotFound(t *testing.T) {
+	toolID := uuid.New()
+	svc := stubInfraService{toolFound: false}
+	router := newToolRouter(t, svc)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tools/"+toolID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_admin")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/api/tools_test.go
+++ b/backend/internal/api/tools_test.go
@@ -156,6 +156,44 @@ func TestManagerUpdateToolImmutableSlugAndSelfRefRejected(t *testing.T) {
 	}
 }
 
+func TestManagerUpdateToolAllowsPartialUpdateWithoutDefinition(t *testing.T) {
+	repo := newToolManagerRepo()
+	wsID := uuid.New()
+	repo.existing = repository.ToolRow{ID: uuid.New(), WorkspaceID: &wsID, Name: "Old", Slug: "refund_flow", ToolKind: toolspec.ToolTypeComposed, CapabilityKey: "refund_flow"}
+	m := NewInfrastructureManager(repo)
+
+	// Rename only — no definition supplied. Must not 400 on "definition required".
+	if _, err := m.UpdateTool(context.Background(), Caller{}, repo.existing.ID, UpdateToolInput{Name: "New name"}); err != nil {
+		t.Fatalf("partial update err: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("expected UpdateTool to reach repo")
+	}
+	if repo.updated.Name != "New name" {
+		t.Fatalf("name = %q, want updated", repo.updated.Name)
+	}
+	if len(repo.updated.Definition) != 0 {
+		t.Fatalf("expected nil definition for partial update (repo COALESCEs), got %s", repo.updated.Definition)
+	}
+}
+
+func TestManagerUpdateToolValidatesGlobalTool(t *testing.T) {
+	repo := newToolManagerRepo()
+	// Global (non-workspace) tool: validation must still run.
+	repo.existing = repository.ToolRow{ID: uuid.New(), WorkspaceID: nil, Name: "Global", Slug: "global", ToolKind: toolspec.ToolTypePrimitive, CapabilityKey: "global"}
+	m := NewInfrastructureManager(repo)
+
+	bad := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"delegate","primitive":"teleport","args":{}}}`)
+	_, err := m.UpdateTool(context.Background(), Caller{}, repo.existing.ID, UpdateToolInput{Definition: bad})
+	var defErr *ToolDefinitionError
+	if err == nil || !errors.As(err, &defErr) {
+		t.Fatalf("expected validation to run for global tool, got %v", err)
+	}
+	if repo.updated != nil {
+		t.Fatal("invalid definition must not reach repo.UpdateTool")
+	}
+}
+
 func TestManagerDeleteToolArchives(t *testing.T) {
 	repo := newToolManagerRepo()
 	m := NewInfrastructureManager(repo)

--- a/backend/internal/engine/primitive_catalog_sync_test.go
+++ b/backend/internal/engine/primitive_catalog_sync_test.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
+)
+
+// TestPrimitiveCatalogMatchesNativePrimitives guards against drift between the
+// engine's runtime primitive registry and the toolspec catalog the API exposes
+// to the tool builder. If a primitive is added/changed in primitive_tools.go,
+// toolspec.Primitives() must be updated to match (and vice versa).
+func TestPrimitiveCatalogMatchesNativePrimitives(t *testing.T) {
+	permissive := sandbox.ToolPolicy{
+		AllowShell:       true,
+		AllowedToolKinds: []string{toolKindFile, toolKindData, toolKindNetwork, toolKindBuild},
+	}
+	native := nativePrimitiveTools(permissive)
+
+	catalog := map[string]toolspec.PrimitiveSpec{}
+	for _, p := range toolspec.Primitives() {
+		catalog[p.Name] = p
+	}
+
+	if len(native) != len(catalog) {
+		t.Fatalf("primitive count mismatch: engine has %d, toolspec has %d", len(native), len(catalog))
+	}
+
+	for name, tool := range native {
+		spec, ok := catalog[name]
+		if !ok {
+			t.Errorf("engine primitive %q missing from toolspec.Primitives()", name)
+			continue
+		}
+		if spec.Description != tool.Description() {
+			t.Errorf("primitive %q description drift:\n engine:   %q\n toolspec: %q", name, tool.Description(), spec.Description)
+		}
+		if !jsonEqual(t, spec.Parameters, tool.Parameters()) {
+			t.Errorf("primitive %q parameters drift:\n engine:   %s\n toolspec: %s", name, tool.Parameters(), spec.Parameters)
+		}
+	}
+
+	for name := range catalog {
+		if _, ok := native[name]; !ok {
+			t.Errorf("toolspec primitive %q not present in engine native primitives (under permissive policy)", name)
+		}
+	}
+}
+
+func jsonEqual(t *testing.T, a, b json.RawMessage) bool {
+	t.Helper()
+	var va, vb any
+	if err := json.Unmarshal(a, &va); err != nil {
+		t.Fatalf("invalid JSON a: %v", err)
+	}
+	if err := json.Unmarshal(b, &vb); err != nil {
+		t.Fatalf("invalid JSON b: %v", err)
+	}
+	return reflect.DeepEqual(va, vb)
+}

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -712,20 +712,25 @@ type UpdateToolParams struct {
 
 // UpdateTool updates the mutable fields of a tool. The slug and tool_kind are
 // intentionally immutable so that composed tools referencing this tool by slug
-// keep resolving. An empty LifecycleStatus leaves the existing status unchanged.
+// keep resolving. An empty Definition or LifecycleStatus leaves the existing
+// value unchanged (COALESCE), so callers can perform partial updates.
 func (r *Repository) UpdateTool(ctx context.Context, p UpdateToolParams) (ToolRow, error) {
 	var row ToolRow
 	var createdAt, updatedAt pgtype.Timestamptz
+	var definitionArg any
+	if len(p.Definition) > 0 {
+		definitionArg = string(p.Definition)
+	}
 	err := r.db.QueryRow(ctx, `
 		UPDATE tools
 		SET name = $2,
 		    capability_key = $3,
-		    definition = $4,
+		    definition = COALESCE($4::jsonb, definition),
 		    lifecycle_status = COALESCE(NULLIF($5, ''), lifecycle_status),
 		    updated_at = now()
 		WHERE id = $1 AND archived_at IS NULL
 		RETURNING id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
-	`, p.ID, p.Name, p.CapabilityKey, defaultRawJSON(p.Definition), p.LifecycleStatus,
+	`, p.ID, p.Name, p.CapabilityKey, definitionArg, p.LifecycleStatus,
 	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
 		&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt)
 	if err != nil {

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -702,6 +702,56 @@ func (r *Repository) ListToolsByWorkspaceID(ctx context.Context, workspaceID uui
 	return result, nil
 }
 
+type UpdateToolParams struct {
+	ID              uuid.UUID
+	Name            string
+	CapabilityKey   string
+	Definition      json.RawMessage
+	LifecycleStatus string
+}
+
+// UpdateTool updates the mutable fields of a tool. The slug and tool_kind are
+// intentionally immutable so that composed tools referencing this tool by slug
+// keep resolving. An empty LifecycleStatus leaves the existing status unchanged.
+func (r *Repository) UpdateTool(ctx context.Context, p UpdateToolParams) (ToolRow, error) {
+	var row ToolRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		UPDATE tools
+		SET name = $2,
+		    capability_key = $3,
+		    definition = $4,
+		    lifecycle_status = COALESCE(NULLIF($5, ''), lifecycle_status),
+		    updated_at = now()
+		WHERE id = $1 AND archived_at IS NULL
+		RETURNING id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
+	`, p.ID, p.Name, p.CapabilityKey, defaultRawJSON(p.Definition), p.LifecycleStatus,
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
+		&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ToolRow{}, ErrToolNotFound
+		}
+		return ToolRow{}, fmt.Errorf("update tool: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+// ArchiveTool soft-deletes a tool by setting archived_at. Subsequent Get/List
+// calls (which filter archived_at IS NULL) will no longer return it.
+func (r *Repository) ArchiveTool(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE tools SET lifecycle_status = 'archived', archived_at = now(), updated_at = now() WHERE id = $1 AND archived_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("archive tool: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrToolNotFound
+	}
+	return nil
+}
+
 // --------------------------------------------------------------------------
 // Knowledge Sources
 // --------------------------------------------------------------------------

--- a/backend/internal/toolspec/catalog.go
+++ b/backend/internal/toolspec/catalog.go
@@ -139,14 +139,20 @@ func Primitives() []PrimitiveSpec {
 	}
 }
 
+// primitiveIndex is a name-to-spec map built once for O(1) lookups, since
+// PrimitiveByName is called repeatedly during definition validation.
+var primitiveIndex = func() map[string]PrimitiveSpec {
+	m := make(map[string]PrimitiveSpec)
+	for _, p := range Primitives() {
+		m[p.Name] = p
+	}
+	return m
+}()
+
 // PrimitiveByName returns the spec for a primitive name, or ok=false if unknown.
 func PrimitiveByName(name string) (PrimitiveSpec, bool) {
-	for _, p := range Primitives() {
-		if p.Name == name {
-			return p, true
-		}
-	}
-	return PrimitiveSpec{}, false
+	p, ok := primitiveIndex[name]
+	return p, ok
 }
 
 // PrimitiveNames returns the set of all primitive names.

--- a/backend/internal/toolspec/catalog.go
+++ b/backend/internal/toolspec/catalog.go
@@ -1,0 +1,159 @@
+// Package toolspec is the source of truth for the catalog of base primitive tools
+// and the canonical schema for user-authored tool definitions (primitive and
+// composed). It is dependency-free (stdlib only) so both the API server and the
+// engine can reference it without import cycles.
+//
+// The primitive catalog here mirrors engine.nativePrimitiveTools. An engine test
+// (TestPrimitiveCatalogMatchesNativePrimitives) asserts the two never drift.
+package toolspec
+
+import "encoding/json"
+
+// PrimitiveKind groups primitives by the tool policy that gates them at run time.
+type PrimitiveKind string
+
+const (
+	KindCore    PrimitiveKind = "core"
+	KindFile    PrimitiveKind = "file"
+	KindData    PrimitiveKind = "data"
+	KindNetwork PrimitiveKind = "network"
+	KindBuild   PrimitiveKind = "build"
+	KindShell   PrimitiveKind = "shell"
+)
+
+// PrimitiveSpec describes a base primitive a custom tool can delegate to.
+type PrimitiveSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Kind        PrimitiveKind   `json:"kind"`
+	Parameters  json.RawMessage `json:"parameters"`
+	// Delegatable reports whether a custom tool may delegate to this primitive.
+	// "submit" is the agent's final-answer tool and is not a useful building block.
+	Delegatable bool `json:"delegatable"`
+}
+
+// Primitive name constants, kept identical to the engine's executor_builders.go.
+const (
+	PrimitiveSubmit      = "submit"
+	PrimitiveReadFile    = "read_file"
+	PrimitiveWriteFile   = "write_file"
+	PrimitiveListFiles   = "list_files"
+	PrimitiveSearchFiles = "search_files"
+	PrimitiveSearchText  = "search_text"
+	PrimitiveQueryJSON   = "query_json"
+	PrimitiveQuerySQL    = "query_sql"
+	PrimitiveHTTPRequest = "http_request"
+	PrimitiveRunTests    = "run_tests"
+	PrimitiveBuild       = "build"
+	PrimitiveExec        = "exec"
+)
+
+// Primitives returns the full catalog of base primitives in a stable order.
+// The parameter schemas are byte-identical to the engine's definitions.
+func Primitives() []PrimitiveSpec {
+	return []PrimitiveSpec{
+		{
+			Name:        PrimitiveSubmit,
+			Description: "Submit your final answer for the benchmark when you are finished.",
+			Kind:        KindCore,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`),
+			Delegatable: false,
+		},
+		{
+			Name:        PrimitiveReadFile,
+			Description: "Read a file from the sandbox workspace.",
+			Kind:        KindFile,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveWriteFile,
+			Description: "Write text content to a file in the sandbox workspace.",
+			Kind:        KindFile,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveListFiles,
+			Description: "List files in the sandbox workspace under an optional path prefix.",
+			Kind:        KindFile,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"prefix":{"type":"string"}},"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveSearchFiles,
+			Description: "Search for files in the sandbox workspace by name or glob pattern.",
+			Kind:        KindFile,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"},"max_results":{"type":"integer","minimum":1}},"required":["pattern"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveSearchText,
+			Description: "Search file contents in the sandbox workspace using a regex pattern.",
+			Kind:        KindFile,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"},"include":{"type":"string"},"case_sensitive":{"type":"boolean"},"max_results":{"type":"integer","minimum":1}},"required":["pattern"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveQueryJSON,
+			Description: "Query JSON from a file or inline JSON string using jq.",
+			Kind:        KindData,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"},"file_path":{"type":"string"},"json":{"type":"string"},"output_path":{"type":"string"}},"required":["query"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveQuerySQL,
+			Description: "Run a SQL query against a supported database engine. Day-1 support is SQLite only.",
+			Kind:        KindData,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"engine":{"type":"string"},"query":{"type":"string"},"database_path":{"type":"string"},"output_path":{"type":"string"}},"required":["engine","query"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveHTTPRequest,
+			Description: "Make an HTTP request from inside the sandbox with structured response output.",
+			Kind:        KindNetwork,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"method":{"type":"string"},"url":{"type":"string"},"headers":{"type":"object","additionalProperties":{"type":"string"}},"body":{"type":"string"},"timeout_seconds":{"type":"integer","minimum":1},"output_path":{"type":"string"}},"required":["method","url"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveRunTests,
+			Description: "Run project tests in the sandbox workspace using an explicit or auto-detected command.",
+			Kind:        KindBuild,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"command":{"oneOf":[{"type":"string"},{"type":"array","items":{"type":"string"},"minItems":1}]},"working_directory":{"type":"string"},"environment":{"type":"object","additionalProperties":{"type":"string"}},"timeout_seconds":{"type":"integer","minimum":1}},"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveBuild,
+			Description: "Build the project in the sandbox workspace using an explicit or auto-detected command.",
+			Kind:        KindBuild,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"command":{"oneOf":[{"type":"string"},{"type":"array","items":{"type":"string"},"minItems":1}]},"working_directory":{"type":"string"},"environment":{"type":"object","additionalProperties":{"type":"string"}},"timeout_seconds":{"type":"integer","minimum":1}},"additionalProperties":false}`),
+			Delegatable: true,
+		},
+		{
+			Name:        PrimitiveExec,
+			Description: "Execute a shell command inside the sandbox workspace.",
+			Kind:        KindShell,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"working_directory":{"type":"string"},"environment":{"type":"object","additionalProperties":{"type":"string"}}},"required":["command"],"additionalProperties":false}`),
+			Delegatable: true,
+		},
+	}
+}
+
+// PrimitiveByName returns the spec for a primitive name, or ok=false if unknown.
+func PrimitiveByName(name string) (PrimitiveSpec, bool) {
+	for _, p := range Primitives() {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return PrimitiveSpec{}, false
+}
+
+// PrimitiveNames returns the set of all primitive names.
+func PrimitiveNames() map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, p := range Primitives() {
+		out[p.Name] = struct{}{}
+	}
+	return out
+}

--- a/backend/internal/toolspec/definition.go
+++ b/backend/internal/toolspec/definition.go
@@ -163,6 +163,7 @@ func validatePrimitive(raw json.RawMessage, declared map[string]struct{}) Valida
 			errs = append(errs, ValidationError{Field: "definition.implementation.primitive", Message: fmt.Sprintf("primitive %q cannot be used as a building block", primitive)})
 		}
 		errs = append(errs, validateArgsPlaceholders("definition.implementation.args", impl.Args, declared, primitive == PrimitiveHTTPRequest)...)
+		errs = append(errs, validatePrimitiveArgs("definition.implementation.args", spec, impl.Args)...)
 	case ModeMock:
 		errs = append(errs, validateMock("definition.implementation.mock", impl.Mock)...)
 	default:
@@ -177,15 +178,77 @@ func validateMock(field string, raw json.RawMessage) ValidationErrors {
 		return ValidationErrors{{Field: field, Message: "is required for mock mode"}}
 	}
 	var mock struct {
-		Strategy string `json:"strategy"`
+		Strategy  string          `json:"strategy"`
+		Response  json.RawMessage `json:"response"`
+		LookupKey string          `json:"lookup_key"`
+		Responses json.RawMessage `json:"responses"`
+		Template  json.RawMessage `json:"template"`
 	}
 	if err := json.Unmarshal(raw, &mock); err != nil {
 		return ValidationErrors{{Field: field, Message: "must be valid JSON"}}
 	}
-	if _, ok := mockStrategies[strings.TrimSpace(mock.Strategy)]; !ok {
+	strategy := strings.TrimSpace(mock.Strategy)
+	if _, ok := mockStrategies[strategy]; !ok {
 		return ValidationErrors{{Field: field + ".strategy", Message: `must be one of "static", "lookup", "echo"`}}
 	}
-	return nil
+	// Mirror the engine's per-strategy requirements (engine.newMockTool) so an
+	// incomplete mock is rejected at authoring time rather than failing at run time.
+	var errs ValidationErrors
+	switch strategy {
+	case "static":
+		if len(mock.Response) == 0 {
+			errs = append(errs, ValidationError{Field: field + ".response", Message: `is required for the "static" strategy`})
+		}
+	case "lookup":
+		if strings.TrimSpace(mock.LookupKey) == "" {
+			errs = append(errs, ValidationError{Field: field + ".lookup_key", Message: `is required for the "lookup" strategy`})
+		}
+		if len(mock.Responses) == 0 {
+			errs = append(errs, ValidationError{Field: field + ".responses", Message: `is required for the "lookup" strategy`})
+		}
+	case "echo":
+		if len(mock.Template) == 0 {
+			errs = append(errs, ValidationError{Field: field + ".template", Message: `is required for the "echo" strategy`})
+		}
+	}
+	return errs
+}
+
+// validatePrimitiveArgs checks the arg KEYS against the primitive's own JSON
+// schema: every required argument must be present (and non-blank), and no
+// unknown argument may be passed (primitives are additionalProperties:false).
+// Value types are not enforced because args are commonly templated strings.
+func validatePrimitiveArgs(field string, spec PrimitiveSpec, rawArgs json.RawMessage) ValidationErrors {
+	var errs ValidationErrors
+	args := map[string]json.RawMessage{}
+	if len(strings.TrimSpace(string(rawArgs))) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return ValidationErrors{{Field: field, Message: "must be a JSON object"}}
+		}
+	}
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	}
+	_ = json.Unmarshal(spec.Parameters, &schema)
+
+	for _, req := range schema.Required {
+		v, ok := args[req]
+		if !ok || isBlankJSON(v) {
+			errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("missing required argument %q for %s", req, spec.Name)})
+		}
+	}
+	for key := range args {
+		if _, ok := schema.Properties[key]; !ok {
+			errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("unknown argument %q for %s", key, spec.Name)})
+		}
+	}
+	return errs
+}
+
+func isBlankJSON(v json.RawMessage) bool {
+	s := strings.TrimSpace(string(v))
+	return s == "" || s == `""` || s == "null"
 }
 
 func validateComposed(raw json.RawMessage, declared map[string]struct{}, opts ValidateOptions) ValidationErrors {
@@ -227,6 +290,8 @@ func validateComposed(raw json.RawMessage, declared map[string]struct{}, opts Va
 				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: fmt.Sprintf("unknown primitive %q", refName)})
 			} else if !spec.Delegatable {
 				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: fmt.Sprintf("primitive %q cannot be used as a step", refName)})
+			} else {
+				errs = append(errs, validatePrimitiveArgs(field+".inputs", spec, step.Inputs)...)
 			}
 			isHTTP = refName == PrimitiveHTTPRequest
 		case "tool":

--- a/backend/internal/toolspec/definition.go
+++ b/backend/internal/toolspec/definition.go
@@ -1,0 +1,346 @@
+package toolspec
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Tool type discriminators. These must match the `tool_kind` column on the
+// tools table and the `tool_type` field inside the definition.
+const (
+	ToolTypePrimitive = "primitive"
+	ToolTypeComposed  = "composed"
+)
+
+// Primitive implementation modes.
+const (
+	ModeDelegate = "delegate"
+	ModeMock     = "mock"
+)
+
+var mockStrategies = map[string]struct{}{"static": {}, "lookup": {}, "echo": {}}
+
+// ValidationError is a single field-scoped problem with a tool definition.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string { return e.Field + ": " + e.Message }
+
+// ValidationErrors is a collection of validation problems.
+type ValidationErrors []ValidationError
+
+func (e ValidationErrors) Error() string {
+	parts := make([]string, len(e))
+	for i, ve := range e {
+		parts[i] = ve.Error()
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ValidateOptions carries context the validator needs beyond the definition itself.
+type ValidateOptions struct {
+	// KnownToolSlugs is the set of saved tool slugs in the same workspace, used to
+	// validate composed step refs of type "tool". When nil, tool-ref existence is
+	// not checked (structural validation only).
+	KnownToolSlugs map[string]struct{}
+	// SelfSlug is the slug of the tool being saved, used to reject self-reference.
+	SelfSlug string
+}
+
+var placeholderRe = regexp.MustCompile(`\$\{([^}]*)\}`)
+
+// ValidateDefinition validates a tool definition against the canonical schema.
+// toolKind is the value stored in tools.tool_kind ("primitive" or "composed").
+func ValidateDefinition(toolKind string, raw json.RawMessage, opts ValidateOptions) ValidationErrors {
+	var errs ValidationErrors
+
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return ValidationErrors{{Field: "definition", Message: "is required"}}
+	}
+
+	var top struct {
+		ToolType   string          `json:"tool_type"`
+		Parameters json.RawMessage `json:"parameters"`
+	}
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return ValidationErrors{{Field: "definition", Message: fmt.Sprintf("must be valid JSON: %v", err)}}
+	}
+
+	if top.ToolType == "" {
+		errs = append(errs, ValidationError{Field: "definition.tool_type", Message: "is required"})
+	} else if top.ToolType != toolKind {
+		errs = append(errs, ValidationError{
+			Field:   "definition.tool_type",
+			Message: fmt.Sprintf("must match tool_kind %q, got %q", toolKind, top.ToolType),
+		})
+	}
+
+	declared, paramErrs := declaredParameters(top.Parameters)
+	errs = append(errs, paramErrs...)
+
+	switch toolKind {
+	case ToolTypePrimitive:
+		errs = append(errs, validatePrimitive(raw, declared)...)
+	case ToolTypeComposed:
+		errs = append(errs, validateComposed(raw, declared, opts)...)
+	default:
+		errs = append(errs, ValidationError{
+			Field:   "tool_kind",
+			Message: fmt.Sprintf("must be %q or %q", ToolTypePrimitive, ToolTypeComposed),
+		})
+	}
+
+	return errs
+}
+
+// declaredParameters returns the set of declared parameter names from a JSON
+// Schema object and any structural errors.
+func declaredParameters(raw json.RawMessage) (map[string]struct{}, ValidationErrors) {
+	declared := map[string]struct{}{}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return declared, nil
+	}
+	var schema struct {
+		Type       string                     `json:"type"`
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return declared, ValidationErrors{{Field: "definition.parameters", Message: "must be a valid JSON Schema object"}}
+	}
+	if schema.Type != "" && schema.Type != "object" {
+		return declared, ValidationErrors{{Field: "definition.parameters.type", Message: `must be "object"`}}
+	}
+	for name := range schema.Properties {
+		declared[name] = struct{}{}
+	}
+	return declared, nil
+}
+
+func validatePrimitive(raw json.RawMessage, declared map[string]struct{}) ValidationErrors {
+	var errs ValidationErrors
+	var def struct {
+		Implementation *struct {
+			Mode      string          `json:"mode"`
+			Primitive string          `json:"primitive"`
+			Args      json.RawMessage `json:"args"`
+			Mock      json.RawMessage `json:"mock"`
+		} `json:"implementation"`
+	}
+	if err := json.Unmarshal(raw, &def); err != nil {
+		return ValidationErrors{{Field: "definition.implementation", Message: "must be valid JSON"}}
+	}
+	if def.Implementation == nil {
+		return ValidationErrors{{Field: "definition.implementation", Message: "is required"}}
+	}
+	impl := def.Implementation
+
+	mode := strings.TrimSpace(impl.Mode)
+	if mode == "" {
+		if len(impl.Mock) > 0 {
+			mode = ModeMock
+		} else {
+			mode = ModeDelegate
+		}
+	}
+
+	switch mode {
+	case ModeDelegate:
+		primitive := strings.TrimSpace(impl.Primitive)
+		if primitive == "" {
+			errs = append(errs, ValidationError{Field: "definition.implementation.primitive", Message: "is required for delegate mode"})
+			break
+		}
+		spec, ok := PrimitiveByName(primitive)
+		if !ok {
+			errs = append(errs, ValidationError{Field: "definition.implementation.primitive", Message: fmt.Sprintf("unknown primitive %q", primitive)})
+			break
+		}
+		if !spec.Delegatable {
+			errs = append(errs, ValidationError{Field: "definition.implementation.primitive", Message: fmt.Sprintf("primitive %q cannot be used as a building block", primitive)})
+		}
+		errs = append(errs, validateArgsPlaceholders("definition.implementation.args", impl.Args, declared, primitive == PrimitiveHTTPRequest)...)
+	case ModeMock:
+		errs = append(errs, validateMock("definition.implementation.mock", impl.Mock)...)
+	default:
+		errs = append(errs, ValidationError{Field: "definition.implementation.mode", Message: fmt.Sprintf("must be %q or %q", ModeDelegate, ModeMock)})
+	}
+
+	return errs
+}
+
+func validateMock(field string, raw json.RawMessage) ValidationErrors {
+	if len(raw) == 0 {
+		return ValidationErrors{{Field: field, Message: "is required for mock mode"}}
+	}
+	var mock struct {
+		Strategy string `json:"strategy"`
+	}
+	if err := json.Unmarshal(raw, &mock); err != nil {
+		return ValidationErrors{{Field: field, Message: "must be valid JSON"}}
+	}
+	if _, ok := mockStrategies[strings.TrimSpace(mock.Strategy)]; !ok {
+		return ValidationErrors{{Field: field + ".strategy", Message: `must be one of "static", "lookup", "echo"`}}
+	}
+	return nil
+}
+
+func validateComposed(raw json.RawMessage, declared map[string]struct{}, opts ValidateOptions) ValidationErrors {
+	var errs ValidationErrors
+	var def struct {
+		Steps []struct {
+			ID  string `json:"id"`
+			Ref struct {
+				Type string `json:"type"`
+				Name string `json:"name"`
+			} `json:"ref"`
+			Inputs json.RawMessage `json:"inputs"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal(raw, &def); err != nil {
+		return ValidationErrors{{Field: "definition.steps", Message: "must be valid JSON"}}
+	}
+	if len(def.Steps) == 0 {
+		return ValidationErrors{{Field: "definition.steps", Message: "must contain at least one step"}}
+	}
+
+	seenStepIDs := map[string]struct{}{}
+	for i, step := range def.Steps {
+		field := fmt.Sprintf("definition.steps[%d]", i)
+		id := strings.TrimSpace(step.ID)
+		if id == "" {
+			errs = append(errs, ValidationError{Field: field + ".id", Message: "is required"})
+		} else if _, dup := seenStepIDs[id]; dup {
+			errs = append(errs, ValidationError{Field: field + ".id", Message: fmt.Sprintf("duplicate step id %q", id)})
+		}
+
+		refType := strings.TrimSpace(step.Ref.Type)
+		refName := strings.TrimSpace(step.Ref.Name)
+		isHTTP := false
+		switch refType {
+		case "primitive":
+			spec, ok := PrimitiveByName(refName)
+			if !ok {
+				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: fmt.Sprintf("unknown primitive %q", refName)})
+			} else if !spec.Delegatable {
+				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: fmt.Sprintf("primitive %q cannot be used as a step", refName)})
+			}
+			isHTTP = refName == PrimitiveHTTPRequest
+		case "tool":
+			if refName == "" {
+				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: "is required"})
+			}
+			if opts.SelfSlug != "" && refName == opts.SelfSlug {
+				errs = append(errs, ValidationError{Field: field + ".ref.name", Message: "a tool cannot reference itself"})
+			}
+			if opts.KnownToolSlugs != nil && refName != "" {
+				if _, ok := opts.KnownToolSlugs[refName]; !ok {
+					errs = append(errs, ValidationError{Field: field + ".ref.name", Message: fmt.Sprintf("references unknown tool %q in this workspace", refName)})
+				}
+			}
+		default:
+			errs = append(errs, ValidationError{Field: field + ".ref.type", Message: `must be "primitive" or "tool"`})
+		}
+
+		errs = append(errs, validateComposedInputs(field+".inputs", step.Inputs, declared, seenStepIDs, isHTTP)...)
+
+		if id != "" {
+			seenStepIDs[id] = struct{}{}
+		}
+	}
+
+	return errs
+}
+
+// validateComposedInputs checks ${params.X} and ${steps.SID.*} placeholders. Only
+// earlier step ids (already in priorStepIDs) may be referenced — forward refs fail.
+func validateComposedInputs(field string, inputs json.RawMessage, declared, priorStepIDs map[string]struct{}, allowSecrets bool) ValidationErrors {
+	var errs ValidationErrors
+	for _, ph := range placeholdersIn(inputs) {
+		expr := strings.TrimSpace(ph)
+		switch {
+		case expr == "":
+			errs = append(errs, ValidationError{Field: field, Message: "empty placeholder ${}"})
+		case strings.HasPrefix(expr, "params."):
+			name := strings.TrimPrefix(expr, "params.")
+			if _, ok := declared[name]; !ok {
+				errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("references undeclared parameter %q", name)})
+			}
+		case strings.HasPrefix(expr, "steps."):
+			rest := strings.TrimPrefix(expr, "steps.")
+			sid := rest
+			if dot := strings.IndexByte(rest, '.'); dot >= 0 {
+				sid = rest[:dot]
+			}
+			if _, ok := priorStepIDs[sid]; !ok {
+				errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("references step %q which is not an earlier step", sid)})
+			}
+		case strings.HasPrefix(expr, "secrets."):
+			if !allowSecrets {
+				errs = append(errs, ValidationError{Field: field, Message: "secrets are only allowed in http_request steps"})
+			}
+		default:
+			errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("unsupported placeholder ${%s}; use ${params.X}, ${steps.ID.field} or ${secrets.NAME}", expr)})
+		}
+	}
+	return errs
+}
+
+// validateArgsPlaceholders checks ${param}, ${parameters} and ${secrets.X}
+// placeholders for primitive delegate args (engine-compatible syntax).
+func validateArgsPlaceholders(field string, args json.RawMessage, declared map[string]struct{}, allowSecrets bool) ValidationErrors {
+	var errs ValidationErrors
+	for _, ph := range placeholdersIn(args) {
+		expr := strings.TrimSpace(ph)
+		switch {
+		case expr == "":
+			errs = append(errs, ValidationError{Field: field, Message: "empty placeholder ${}"})
+		case expr == "parameters":
+			// whole-parameters object reference — always allowed
+		case strings.HasPrefix(expr, "secrets."):
+			if !allowSecrets {
+				errs = append(errs, ValidationError{Field: field, Message: "secrets are only allowed for http_request"})
+			}
+		default:
+			if _, ok := declared[expr]; !ok {
+				errs = append(errs, ValidationError{Field: field, Message: fmt.Sprintf("references undeclared parameter %q", expr)})
+			}
+		}
+	}
+	return errs
+}
+
+// placeholdersIn walks an arbitrary JSON value and returns every ${...} token
+// found inside any string value.
+func placeholdersIn(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	var out []string
+	var walk func(any)
+	walk = func(node any) {
+		switch t := node.(type) {
+		case string:
+			for _, m := range placeholderRe.FindAllStringSubmatch(t, -1) {
+				out = append(out, m[1])
+			}
+		case []any:
+			for _, item := range t {
+				walk(item)
+			}
+		case map[string]any:
+			for _, item := range t {
+				walk(item)
+			}
+		}
+	}
+	walk(v)
+	return out
+}

--- a/backend/internal/toolspec/toolspec_test.go
+++ b/backend/internal/toolspec/toolspec_test.go
@@ -2,6 +2,7 @@ package toolspec
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,15 @@ func mustErrField(t *testing.T, errs ValidationErrors, field string) {
 	t.Fatalf("expected a validation error on field %q; got %v", field, errs)
 }
 
+func containsMsg(errs ValidationErrors, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestValidateDefinition_Primitive_Delegate_OK(t *testing.T) {
 	def := json.RawMessage(`{
 		"tool_type":"primitive",
@@ -83,6 +93,47 @@ func TestValidateDefinition_Primitive_SecretsOnlyHTTP(t *testing.T) {
 	}`)
 	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
 	mustErrField(t, errs, "definition.implementation.args")
+}
+
+func TestValidateDefinition_Primitive_MissingRequiredArg(t *testing.T) {
+	// read_file requires "path"; empty args must be rejected.
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"delegate","primitive":"read_file","args":{}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.args")
+	if !containsMsg(errs, "missing required argument") {
+		t.Fatalf("expected missing-required-argument error; got %v", errs)
+	}
+}
+
+func TestValidateDefinition_Primitive_UnknownArg(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"primitive",
+		"parameters":{"type":"object","properties":{"p":{"type":"string"}}},
+		"implementation":{"mode":"delegate","primitive":"read_file","args":{"path":"${p}","bogus":"x"}}
+	}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	if !containsMsg(errs, "unknown argument") {
+		t.Fatalf("expected unknown-argument error; got %v", errs)
+	}
+}
+
+func TestValidateDefinition_Mock_Static_MissingResponse(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"static"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.mock.response")
+}
+
+func TestValidateDefinition_Mock_Lookup_MissingFields(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"lookup"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.mock.lookup_key")
+	mustErrField(t, errs, "definition.implementation.mock.responses")
+}
+
+func TestValidateDefinition_Mock_Echo_MissingTemplate(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"echo"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.mock.template")
 }
 
 func TestValidateDefinition_Primitive_Mock_OK(t *testing.T) {

--- a/backend/internal/toolspec/toolspec_test.go
+++ b/backend/internal/toolspec/toolspec_test.go
@@ -1,0 +1,170 @@
+package toolspec
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPrimitives_NonEmpty_WellFormed(t *testing.T) {
+	prims := Primitives()
+	if len(prims) == 0 {
+		t.Fatal("expected a non-empty primitive catalog")
+	}
+	seen := map[string]struct{}{}
+	for _, p := range prims {
+		if p.Name == "" {
+			t.Errorf("primitive with empty name: %+v", p)
+		}
+		if _, dup := seen[p.Name]; dup {
+			t.Errorf("duplicate primitive name %q", p.Name)
+		}
+		seen[p.Name] = struct{}{}
+		if p.Kind == "" {
+			t.Errorf("primitive %q has empty kind", p.Name)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(p.Parameters, &schema); err != nil {
+			t.Errorf("primitive %q has invalid parameters JSON: %v", p.Name, err)
+		}
+	}
+	if _, ok := PrimitiveByName(PrimitiveHTTPRequest); !ok {
+		t.Errorf("expected http_request in catalog")
+	}
+	if _, ok := PrimitiveByName("does_not_exist"); ok {
+		t.Errorf("did not expect unknown primitive to resolve")
+	}
+	if submit, _ := PrimitiveByName(PrimitiveSubmit); submit.Delegatable {
+		t.Errorf("submit should not be delegatable")
+	}
+}
+
+func mustErrField(t *testing.T, errs ValidationErrors, field string) {
+	t.Helper()
+	for _, e := range errs {
+		if e.Field == field {
+			return
+		}
+	}
+	t.Fatalf("expected a validation error on field %q; got %v", field, errs)
+}
+
+func TestValidateDefinition_Primitive_Delegate_OK(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"primitive",
+		"parameters":{"type":"object","properties":{"order_id":{"type":"string"}},"required":["order_id"]},
+		"implementation":{"mode":"delegate","primitive":"http_request","args":{"method":"GET","url":"https://api/orders/${order_id}","headers":{"Authorization":"Bearer ${secrets.API_KEY}"}}}
+	}`)
+	if errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{}); len(errs) != 0 {
+		t.Fatalf("expected no errors; got %v", errs)
+	}
+}
+
+func TestValidateDefinition_Primitive_UnknownPrimitive(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"delegate","primitive":"teleport","args":{}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.primitive")
+}
+
+func TestValidateDefinition_Primitive_BadPlaceholder(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"primitive",
+		"parameters":{"type":"object","properties":{"order_id":{"type":"string"}}},
+		"implementation":{"mode":"delegate","primitive":"http_request","args":{"url":"https://api/${missing}"}}
+	}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.args")
+}
+
+func TestValidateDefinition_Primitive_SecretsOnlyHTTP(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"primitive",
+		"parameters":{"type":"object","properties":{"p":{"type":"string"}}},
+		"implementation":{"mode":"delegate","primitive":"read_file","args":{"path":"${secrets.X}"}}
+	}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.args")
+}
+
+func TestValidateDefinition_Primitive_Mock_OK(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"static","response":{"ok":true}}}}`)
+	if errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{}); len(errs) != 0 {
+		t.Fatalf("expected no errors; got %v", errs)
+	}
+}
+
+func TestValidateDefinition_Primitive_Mock_BadStrategy(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","implementation":{"mode":"mock","mock":{"strategy":"telepathy"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.implementation.mock.strategy")
+}
+
+func TestValidateDefinition_Composed_OK(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"composed",
+		"parameters":{"type":"object","properties":{"order_id":{"type":"string"},"amount":{"type":"number"}}},
+		"steps":[
+			{"id":"s1","ref":{"type":"primitive","name":"http_request"},"inputs":{"method":"GET","url":"https://api/orders/${params.order_id}"}},
+			{"id":"s2","ref":{"type":"tool","name":"check_policy"},"inputs":{"total":"${params.amount}","order":"${steps.s1.body}"}}
+		]
+	}`)
+	opts := ValidateOptions{KnownToolSlugs: map[string]struct{}{"check_policy": {}}, SelfSlug: "refund_flow"}
+	if errs := ValidateDefinition(ToolTypeComposed, def, opts); len(errs) != 0 {
+		t.Fatalf("expected no errors; got %v", errs)
+	}
+}
+
+func TestValidateDefinition_Composed_EmptySteps(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"composed","steps":[]}`)
+	errs := ValidateDefinition(ToolTypeComposed, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.steps")
+}
+
+func TestValidateDefinition_Composed_ForwardStepRef(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"composed",
+		"parameters":{"type":"object","properties":{}},
+		"steps":[
+			{"id":"s1","ref":{"type":"primitive","name":"http_request"},"inputs":{"url":"${steps.s2.x}"}},
+			{"id":"s2","ref":{"type":"primitive","name":"http_request"},"inputs":{"url":"https://x"}}
+		]
+	}`)
+	errs := ValidateDefinition(ToolTypeComposed, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.steps[0].inputs")
+}
+
+func TestValidateDefinition_Composed_SelfReference(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"composed",
+		"steps":[{"id":"s1","ref":{"type":"tool","name":"refund_flow"},"inputs":{}}]
+	}`)
+	opts := ValidateOptions{KnownToolSlugs: map[string]struct{}{"refund_flow": {}}, SelfSlug: "refund_flow"}
+	errs := ValidateDefinition(ToolTypeComposed, def, opts)
+	mustErrField(t, errs, "definition.steps[0].ref.name")
+}
+
+func TestValidateDefinition_Composed_UnknownToolRef(t *testing.T) {
+	def := json.RawMessage(`{
+		"tool_type":"composed",
+		"steps":[{"id":"s1","ref":{"type":"tool","name":"ghost"},"inputs":{}}]
+	}`)
+	opts := ValidateOptions{KnownToolSlugs: map[string]struct{}{"check_policy": {}}}
+	errs := ValidateDefinition(ToolTypeComposed, def, opts)
+	mustErrField(t, errs, "definition.steps[0].ref.name")
+}
+
+func TestValidateDefinition_ToolTypeMismatch(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"composed","implementation":{"mode":"mock","mock":{"strategy":"static"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.tool_type")
+}
+
+func TestValidateDefinition_EmptyDefinition(t *testing.T) {
+	errs := ValidateDefinition(ToolTypePrimitive, json.RawMessage(``), ValidateOptions{})
+	mustErrField(t, errs, "definition")
+}
+
+func TestValidateDefinition_BadParametersType(t *testing.T) {
+	def := json.RawMessage(`{"tool_type":"primitive","parameters":{"type":"array"},"implementation":{"mode":"mock","mock":{"strategy":"static"}}}`)
+	errs := ValidateDefinition(ToolTypePrimitive, def, ValidateOptions{})
+	mustErrField(t, errs, "definition.parameters.type")
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2098,6 +2098,26 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
 
+  /v1/tool-primitives:
+    get:
+      operationId: listToolPrimitives
+      tags: [Tools]
+      summary: List base primitive tools available as building blocks
+      description: >-
+        Returns the static catalog of base primitives that primitive tools can
+        delegate to and composed tools can chain. Read-only and not workspace-scoped.
+      security:
+        - bearerJWT: []
+      responses:
+        "200":
+          description: Primitive catalog
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListToolPrimitivesResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
   /v1/tools/{toolID}:
     get:
       operationId: getTool
@@ -2116,6 +2136,58 @@ paths:
                 $ref: "#/components/schemas/ToolResponse"
         "400":
           $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+    patch:
+      operationId: updateTool
+      tags: [Tools]
+      summary: Update a tool definition
+      description: >-
+        Updates the mutable fields of a tool. The slug and tool_kind are
+        immutable so composed tools that reference this tool by slug keep
+        resolving. The definition is validated before it is persisted.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/ToolID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateToolRequest"
+      responses:
+        "200":
+          description: Tool updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+    delete:
+      operationId: deleteTool
+      tags: [Tools]
+      summary: Archive a tool definition
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/ToolID"
+      responses:
+        "204":
+          description: Tool archived
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "403":
@@ -8959,17 +9031,38 @@ components:
 
     CreateToolRequest:
       type: object
-      required: [name, tool_kind, capability_key]
+      required: [name, tool_kind]
       properties:
         name:
           type: string
         tool_kind:
+          type: string
+          enum: [primitive, composed]
+          description: Whether the tool is a single-operation primitive or a multi-step composed tool.
+        capability_key:
+          type: string
+          description: Optional stable capability identifier. Defaults to the generated slug when omitted.
+        definition:
+          type: object
+          additionalProperties: true
+          description: Canonical tool definition (see toolspec). Validated before persistence.
+
+    UpdateToolRequest:
+      type: object
+      description: >-
+        Mutable fields of a tool. tool_kind and slug are immutable. Omitted name,
+        capability_key and lifecycle_status keep their existing values.
+      properties:
+        name:
           type: string
         capability_key:
           type: string
         definition:
           type: object
           additionalProperties: true
+        lifecycle_status:
+          type: string
+          enum: [active, disabled]
 
     ToolResponse:
       type: object
@@ -9009,6 +9102,34 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ToolResponse"
+
+    ToolPrimitive:
+      type: object
+      required: [name, description, kind, parameters, delegatable]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        kind:
+          type: string
+          enum: [core, file, data, network, build, shell]
+        parameters:
+          type: object
+          additionalProperties: true
+          description: JSON Schema describing the primitive's arguments.
+        delegatable:
+          type: boolean
+          description: Whether a custom tool may delegate to or compose this primitive.
+
+    ListToolPrimitivesResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ToolPrimitive"
 
     # --- Knowledge Sources ---
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/page.tsx
@@ -1,0 +1,10 @@
+import { ToolEditClient } from "./tool-edit-client";
+
+export default async function EditToolPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; toolId: string }>;
+}) {
+  const { workspaceId, toolId } = await params;
+  return <ToolEditClient workspaceId={workspaceId} toolId={toolId} />;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/tool-edit-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/tool-edit-client.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useApiQuery } from "@/lib/api/swr";
+import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
+import { EmptyState } from "@/components/ui/empty-state";
+import { AlertTriangle } from "lucide-react";
+import { ToolBuilder } from "@/components/tools/tool-builder";
+import { isBuilderToolType, normalizeDefinition } from "@/components/tools/lib/definition";
+import type { ToolRecord } from "@/components/tools/lib/types";
+
+export function ToolEditClient({
+  workspaceId,
+  toolId,
+}: {
+  workspaceId: string;
+  toolId: string;
+}) {
+  const { data: tool, error, isLoading } = useApiQuery<ToolRecord>(`/v1/tools/${toolId}`);
+
+  if (isLoading && !tool) return <WorkspaceListLoading rows={4} />;
+
+  if (error || !tool) {
+    return (
+      <EmptyState
+        icon={<AlertTriangle className="size-9" />}
+        title="Tool not found"
+        description="This tool may have been deleted."
+        action={{ label: "Back to tools", href: `/workspaces/${workspaceId}/tools` }}
+      />
+    );
+  }
+
+  const rawDef = tool.definition as Record<string, unknown> | undefined;
+  const inferredType = (rawDef?.tool_type as string) || tool.tool_kind;
+
+  if (!isBuilderToolType(inferredType)) {
+    return (
+      <div className="space-y-4">
+        <EmptyState
+          icon={<AlertTriangle className="size-9" />}
+          title="Unsupported tool format"
+          description={`This tool (kind "${tool.tool_kind}") was created outside the visual builder and can't be edited here yet.`}
+          action={{ label: "Back to tools", href: `/workspaces/${workspaceId}/tools` }}
+        />
+        <pre className="max-h-96 overflow-auto rounded-lg border border-border bg-muted/30 p-3 font-[family-name:var(--font-mono)] text-[11px]">
+          {JSON.stringify(tool.definition, null, 2)}
+        </pre>
+      </div>
+    );
+  }
+
+  return (
+    <ToolBuilder
+      workspaceId={workspaceId}
+      mode="edit"
+      toolType={inferredType}
+      toolId={tool.id}
+      initialName={tool.name}
+      initialSlug={tool.slug}
+      initialDefinition={normalizeDefinition(inferredType, tool.definition)}
+    />
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
@@ -1,0 +1,16 @@
+import { ToolBuilder } from "@/components/tools/tool-builder";
+import { isBuilderToolType } from "@/components/tools/lib/definition";
+
+export default async function NewToolPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ workspaceId: string }>;
+  searchParams: Promise<{ type?: string }>;
+}) {
+  const { workspaceId } = await params;
+  const { type } = await searchParams;
+  const toolType = isBuilderToolType(type ?? "") ? (type as "primitive" | "composed") : "primitive";
+
+  return <ToolBuilder workspaceId={workspaceId} mode="create" toolType={toolType} />;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
@@ -1,52 +1,109 @@
 "use client";
 
-import { useApiListQuery } from "@/lib/api/swr";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
+import {
+  Boxes,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+  Workflow,
+  Wrench,
+} from "lucide-react";
+
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { useApiListQuery, useApiMutator } from "@/lib/api/swr";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
 import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
-import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
-import { Wrench } from "lucide-react";
-
-interface Tool {
-  id: string;
-  name: string;
-  slug: string;
-  tool_kind: string;
-  capability_key: string;
-  lifecycle_status: string;
-  created_at: string;
-}
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ConfirmProvider, useConfirm } from "@/components/ui/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ToolTypeBadge } from "@/components/tools/tool-type-badge";
+import type { ToolRecord } from "@/components/tools/lib/types";
 
 export function ToolsClient({ workspaceId }: { workspaceId: string }) {
-  const { data, error, isLoading } = useApiListQuery<Tool>(
+  return (
+    <ConfirmProvider>
+      <ToolsList workspaceId={workspaceId} />
+    </ConfirmProvider>
+  );
+}
+
+function ToolsList({ workspaceId }: { workspaceId: string }) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const { mutateMany } = useApiMutator();
+  const confirm = useConfirm();
+  const { data, error, isLoading } = useApiListQuery<ToolRecord>(
     `/v1/workspaces/${workspaceId}/tools`,
   );
   const items = data?.items ?? [];
 
-  if (isLoading && !data) {
-    return <WorkspaceListLoading rows={6} />;
+  async function handleDelete(tool: ToolRecord) {
+    const ok = await confirm({
+      title: `Delete "${tool.name}"?`,
+      description: "This archives the tool. Composed tools that reference it will no longer resolve.",
+      confirmLabel: "Delete",
+      variant: "danger",
+    });
+    if (!ok) return;
+    try {
+      const api = createApiClient((await getAccessToken()) ?? undefined);
+      await api.del(`/v1/tools/${tool.id}`);
+      await mutateMany([workspaceResourceKeys.tools(workspaceId)]);
+      toast.success("Tool deleted");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to delete tool");
+    }
   }
+
+  const newToolMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={<Button size="sm" />}>
+        <Plus data-icon="inline-start" className="size-4" />
+        New tool
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem render={<Link href={`/workspaces/${workspaceId}/tools/new?type=primitive`} />}>
+          <Boxes className="size-4" />
+          <div>
+            <div className="text-sm">Primitive</div>
+            <div className="text-xs text-muted-foreground">One operation (HTTP, shell, file, mock)</div>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem render={<Link href={`/workspaces/${workspaceId}/tools/new?type=composed`} />}>
+          <Workflow className="size-4" />
+          <div>
+            <div className="text-sm">Composed</div>
+            <div className="text-xs text-muted-foreground">Chain primitives and other tools</div>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  if (isLoading && !data) return <WorkspaceListLoading rows={6} />;
 
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-lg font-semibold tracking-tight">Tools</h1>
-        <CreateResourceDialog
-          title="New Tool"
-          description="Register a tool that agents can use during runs."
-          endpoint={`/v1/workspaces/${workspaceId}/tools`}
-          buttonLabel="New Tool"
-          fields={[
-            { key: "name", label: "Name", placeholder: "e.g. code-search", required: true },
-            { key: "tool_kind", label: "Tool Kind", placeholder: "e.g. function", required: true },
-            { key: "capability_key", label: "Capability Key", placeholder: "e.g. search", required: true },
-            { key: "definition", label: "Definition", type: "json", placeholder: "{}" },
-          ]}
-          invalidateKeys={[workspaceResourceKeys.tools(workspaceId)]}
-        />
-      </div>
+      <PageHeader
+        title="Tools"
+        description="Build tools agents can call during runs — single-operation primitives or composed multi-step tools."
+        actions={items.length > 0 ? newToolMenu : undefined}
+      />
 
       {error ? (
         <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
@@ -55,45 +112,63 @@ export function ToolsClient({ workspaceId }: { workspaceId: string }) {
       ) : items.length === 0 ? (
         <EmptyState
           icon={<Wrench className="size-10" />}
-          title="No tools"
-          description="Register tools that agents can use during challenge runs."
+          title="No tools yet"
+          description="Create a primitive tool (one operation) or a composed tool (a chain of steps) — no YAML required."
+          action={{ label: "New primitive tool", href: `/workspaces/${workspaceId}/tools/new?type=primitive` }}
         />
       ) : (
-        <div className="rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Kind</TableHead>
-                <TableHead>Capability</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {items.map((tool) => (
-                <TableRow key={tool.id}>
-                  <TableCell className="font-medium">{tool.name}</TableCell>
-                  <TableCell className="text-muted-foreground">{tool.tool_kind}</TableCell>
-                  <TableCell>
-                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
-                      {tool.capability_key}
-                    </code>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={tool.lifecycle_status === "active" ? "default" : "secondary"}>
-                      {tool.lifecycle_status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {new Date(tool.created_at).toLocaleDateString()}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {items.map((tool) => (
+            <div
+              key={tool.id}
+              className="group relative flex flex-col rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/20"
+            >
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <ToolTypeBadge kind={tool.tool_kind} />
+                <ToolActions onEdit={() => router.push(`/workspaces/${workspaceId}/tools/${tool.id}`)} onDelete={() => handleDelete(tool)} />
+              </div>
+              <Link
+                href={`/workspaces/${workspaceId}/tools/${tool.id}`}
+                className="font-medium tracking-tight hover:underline"
+              >
+                {tool.name}
+              </Link>
+              <code className="mt-0.5 font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
+                {tool.slug}
+              </code>
+              <div className="mt-3 flex items-center justify-between">
+                <Badge variant={tool.lifecycle_status === "active" ? "default" : "secondary"}>
+                  {tool.lifecycle_status}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(tool.created_at).toLocaleDateString()}
+                </span>
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>
+  );
+}
+
+function ToolActions({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Tool actions" />}>
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onEdit}>
+          <Pencil className="size-4" />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash2 className="size-4" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/web/src/components/tools/args-editor.tsx
+++ b/web/src/components/tools/args-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
 import { controlClass, monoControlClass } from "./field";
+import { useReportJsonValidity } from "./json-validity";
 import type { ToolPrimitive } from "./lib/types";
 
 /**
@@ -26,6 +27,7 @@ export function ArgsEditor({
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
   const [rawByKey, setRawByKey] = useState<Record<string, string>>({});
   const [errByKey, setErrByKey] = useState<Record<string, string>>({});
+  useReportJsonValidity(useId(), Object.values(errByKey).some(Boolean));
 
   if (!primitive) {
     return (

--- a/web/src/components/tools/args-editor.tsx
+++ b/web/src/components/tools/args-editor.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { controlClass, monoControlClass } from "./field";
+import type { ToolPrimitive } from "./lib/types";
+
+/**
+ * Edits the arguments passed to a delegated base primitive. Fields are derived
+ * from the primitive's own JSON schema; object-typed args (e.g. HTTP headers)
+ * get a JSON editor. A placeholder palette inserts ${param} / ${secrets.X}.
+ */
+export function ArgsEditor({
+  primitive,
+  args,
+  onChange,
+  paramNames,
+  allowSecrets,
+}: {
+  primitive: ToolPrimitive | null;
+  args: Record<string, unknown>;
+  onChange: (args: Record<string, unknown>) => void;
+  paramNames: string[];
+  allowSecrets: boolean;
+}) {
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  const [rawByKey, setRawByKey] = useState<Record<string, string>>({});
+  const [errByKey, setErrByKey] = useState<Record<string, string>>({});
+
+  if (!primitive) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+        Choose a primitive to configure its arguments.
+      </p>
+    );
+  }
+
+  const props = primitive.parameters?.properties ?? {};
+  const required = new Set(primitive.parameters?.required ?? []);
+  const entries = Object.entries(props);
+
+  function setScalar(key: string, value: string) {
+    const next = { ...args };
+    if (value === "") delete next[key];
+    else next[key] = value;
+    onChange(next);
+  }
+
+  function setObject(key: string, raw: string) {
+    setRawByKey((p) => ({ ...p, [key]: raw }));
+    if (raw.trim() === "") {
+      setErrByKey((p) => ({ ...p, [key]: "" }));
+      const next = { ...args };
+      delete next[key];
+      onChange(next);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      setErrByKey((p) => ({ ...p, [key]: "" }));
+      onChange({ ...args, [key]: parsed });
+    } catch {
+      setErrByKey((p) => ({ ...p, [key]: "Invalid JSON" }));
+    }
+  }
+
+  function insertPlaceholder(token: string) {
+    if (!focusedKey) return;
+    const current = typeof args[focusedKey] === "string" ? (args[focusedKey] as string) : "";
+    setScalar(focusedKey, current + token);
+  }
+
+  const chips = [
+    ...paramNames.map((p) => `\${${p}}`),
+    "${parameters}",
+    ...(allowSecrets ? ["${secrets.NAME}"] : []),
+  ];
+
+  return (
+    <div className="space-y-3">
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          This primitive takes no arguments.
+        </p>
+      ) : (
+        entries.map(([key, prop]) => {
+          const isObject = prop.type === "object" || prop.type === "array";
+          const raw =
+            rawByKey[key] ??
+            (args[key] !== undefined ? JSON.stringify(args[key], null, 2) : "");
+          return (
+            <div key={key}>
+              <label className="mb-1 flex items-center gap-2 text-sm font-medium">
+                <code className="font-[family-name:var(--font-mono)] text-xs">{key}</code>
+                <span className="text-xs font-normal text-muted-foreground">{prop.type}</span>
+                {required.has(key) && (
+                  <span className="text-xs font-normal text-muted-foreground">· required</span>
+                )}
+              </label>
+              {isObject ? (
+                <textarea
+                  value={raw}
+                  onChange={(e) => setObject(key, e.target.value)}
+                  rows={3}
+                  spellCheck={false}
+                  placeholder="{ }"
+                  className={cn(monoControlClass, errByKey[key] && "border-destructive")}
+                />
+              ) : (
+                <input
+                  value={typeof args[key] === "string" ? (args[key] as string) : ""}
+                  onChange={(e) => setScalar(key, e.target.value)}
+                  onFocus={() => setFocusedKey(key)}
+                  placeholder={prop.description ?? "value or ${param}"}
+                  className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+                />
+              )}
+              {errByKey[key] && <p className="mt-1 text-xs text-destructive">{errByKey[key]}</p>}
+            </div>
+          );
+        })
+      )}
+
+      {chips.length > 0 && entries.some(([, p]) => p.type !== "object" && p.type !== "array") && (
+        <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-muted/30 p-2">
+          <span className="text-xs text-muted-foreground">Insert:</span>
+          {chips.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => insertPlaceholder(c)}
+              disabled={!focusedKey}
+              className="rounded-md border border-border bg-background px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            >
+              {c}
+            </button>
+          ))}
+          <span className="text-xs text-muted-foreground">
+            {focusedKey ? `→ ${focusedKey}` : "focus a field first"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/composed-builder.tsx
+++ b/web/src/components/tools/composed-builder.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Plus, Workflow } from "lucide-react";
+import { ParametersEditor } from "./parameters-editor";
+import { StepCard } from "./step-card";
+import {
+  declaredParamNames,
+  newStepId,
+  paramsToSchema,
+  reorder,
+  schemaToParams,
+} from "./lib/definition";
+import type { ComposedDefinition, ComposedStep, ToolPrimitive } from "./lib/types";
+
+export function ComposedBuilder({
+  def,
+  onChange,
+  primitives,
+  tools,
+}: {
+  def: ComposedDefinition;
+  onChange: (def: ComposedDefinition) => void;
+  primitives: ToolPrimitive[];
+  tools: { slug: string; name: string }[];
+}) {
+  const dragIndex = useRef<number | null>(null);
+  const params = schemaToParams(def.parameters);
+  const paramNames = declaredParamNames(def);
+
+  function setSteps(steps: ComposedStep[]) {
+    onChange({ ...def, steps });
+  }
+  function addStep() {
+    const step: ComposedStep = {
+      id: newStepId(def.steps),
+      ref: { type: "primitive", name: "" },
+      inputs: {},
+    };
+    setSteps([...def.steps, step]);
+  }
+  function updateStep(index: number, step: ComposedStep) {
+    setSteps(def.steps.map((s, i) => (i === index ? step : s)));
+  }
+  function removeStep(index: number) {
+    setSteps(def.steps.filter((_, i) => i !== index));
+  }
+  function move(from: number, to: number) {
+    setSteps(reorder(def.steps, from, to));
+  }
+
+  return (
+    <div className="space-y-6">
+      <ParametersEditor
+        params={params}
+        onChange={(next) => onChange({ ...def, parameters: paramsToSchema(next) })}
+      />
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Steps</h3>
+          <Button type="button" variant="outline" size="sm" onClick={addStep}>
+            <Plus data-icon="inline-start" className="size-3.5" />
+            Add step
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Each step runs a primitive or another saved tool. Map its inputs from
+          the tool&apos;s parameters (
+          <code className="font-[family-name:var(--font-mono)]">{"${params.x}"}</code>)
+          or earlier steps (
+          <code className="font-[family-name:var(--font-mono)]">{"${steps.s1.output}"}</code>).
+          Drag to reorder.
+        </p>
+
+        {def.steps.length === 0 ? (
+          <EmptyState
+            icon={<Workflow className="size-9" />}
+            title="No steps yet"
+            description="Add the first step to start composing."
+          />
+        ) : (
+          <div className="space-y-0">
+            {def.steps.map((step, i) => (
+              <div key={step.id}>
+                {i > 0 && (
+                  <div className="flex justify-center py-1" aria-hidden>
+                    <div className="h-4 w-px bg-border" />
+                  </div>
+                )}
+                <StepCard
+                  step={step}
+                  index={i}
+                  total={def.steps.length}
+                  earlierStepIds={def.steps.slice(0, i).map((s) => s.id)}
+                  paramNames={paramNames}
+                  primitives={primitives}
+                  toolOptions={tools}
+                  onChange={(s) => updateStep(i, s)}
+                  onRemove={() => removeStep(i)}
+                  onMoveUp={() => move(i, i - 1)}
+                  onMoveDown={() => move(i, i + 1)}
+                  onDragStart={() => {
+                    dragIndex.current = i;
+                  }}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={() => {
+                    if (dragIndex.current !== null) move(dragIndex.current, i);
+                    dragIndex.current = null;
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/definition-preview.tsx
+++ b/web/src/components/tools/definition-preview.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { CheckCircle2, AlertTriangle } from "lucide-react";
+import type { ToolDefinition, ValidationIssue } from "./lib/types";
+
+/**
+ * Read-only, forward-rendered view of the compiled tool definition plus the
+ * current validation state. One-way (builder → definition) by design; this is
+ * the artifact that gets persisted.
+ */
+export function DefinitionPreview({
+  definition,
+  issues,
+}: {
+  definition: ToolDefinition;
+  issues: ValidationIssue[];
+}) {
+  return (
+    <div className="space-y-3">
+      {issues.length === 0 ? (
+        <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          <CheckCircle2 className="size-4 text-emerald-500" />
+          Definition is valid.
+        </div>
+      ) : (
+        <div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+          <div className="flex items-center gap-2 text-xs font-medium text-destructive">
+            <AlertTriangle className="size-4" />
+            {issues.length} issue{issues.length > 1 ? "s" : ""} to fix
+          </div>
+          <ul className="space-y-0.5">
+            {issues.map((issue, i) => (
+              <li key={i} className="text-xs text-destructive/90">
+                <code className="font-[family-name:var(--font-mono)]">{issue.path}</code>
+                {" — "}
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div>
+        <div className="mb-1.5 text-xs font-medium text-muted-foreground">
+          Compiled definition
+        </div>
+        <pre className="max-h-96 overflow-auto rounded-lg border border-border bg-muted/30 p-3 font-[family-name:var(--font-mono)] text-[11px] leading-relaxed">
+          {JSON.stringify(definition, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/field.tsx
+++ b/web/src/components/tools/field.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export const controlClass =
+  "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50 disabled:cursor-not-allowed";
+
+export const monoControlClass = cn(
+  controlClass,
+  "font-[family-name:var(--font-mono)] text-xs leading-relaxed",
+);
+
+export function Field({
+  label,
+  hint,
+  error,
+  htmlFor,
+  children,
+  className,
+}: {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: string;
+  htmlFor?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      {label && (
+        <label htmlFor={htmlFor} className="mb-1.5 block text-sm font-medium">
+          {label}
+        </label>
+      )}
+      {hint && <p className="mb-1.5 text-xs text-muted-foreground">{hint}</p>}
+      {children}
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/web/src/components/tools/json-validity.tsx
+++ b/web/src/components/tools/json-validity.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+
+type ReportFn = (id: string, invalid: boolean) => void;
+
+const JsonValidityContext = createContext<ReportFn | null>(null);
+
+/**
+ * Tracks JSON editors that currently hold unparseable text. `onChange` fires with
+ * `true` whenever at least one editor is invalid, so the builder can block saving
+ * stale/inconsistent definitions.
+ */
+export function JsonValidityProvider({
+  onChange,
+  children,
+}: {
+  onChange: (hasInvalid: boolean) => void;
+  children: ReactNode;
+}) {
+  const invalidIds = useRef<Set<string>>(new Set());
+  const report = useCallback<ReportFn>(
+    (id, invalid) => {
+      const had = invalidIds.current.size > 0;
+      if (invalid) invalidIds.current.add(id);
+      else invalidIds.current.delete(id);
+      const has = invalidIds.current.size > 0;
+      if (has !== had) onChange(has);
+    },
+    [onChange],
+  );
+  return (
+    <JsonValidityContext.Provider value={report}>{children}</JsonValidityContext.Provider>
+  );
+}
+
+/** Report this editor's parse validity to the nearest provider (no-op if none). */
+export function useReportJsonValidity(id: string, invalid: boolean) {
+  const report = useContext(JsonValidityContext);
+  useEffect(() => {
+    report?.(id, invalid);
+    return () => report?.(id, false);
+  }, [report, id, invalid]);
+}

--- a/web/src/components/tools/json-value-field.tsx
+++ b/web/src/components/tools/json-value-field.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
 import { monoControlClass } from "./field";
+import { useReportJsonValidity } from "./json-validity";
 
 /**
  * Edits an arbitrary JSON value with live parse + error. Reports `undefined`
@@ -28,6 +29,7 @@ export function JsonValueField({
     value === undefined ? "" : JSON.stringify(value, null, 2),
   );
   const [error, setError] = useState("");
+  useReportJsonValidity(useId(), error !== "");
 
   function handle(next: string) {
     setRaw(next);

--- a/web/src/components/tools/json-value-field.tsx
+++ b/web/src/components/tools/json-value-field.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { monoControlClass } from "./field";
+
+/**
+ * Edits an arbitrary JSON value with live parse + error. Reports `undefined`
+ * when emptied. Initial value is captured on mount, so render it only once the
+ * parent's value is ready (e.g. after an edit fetch resolves).
+ */
+export function JsonValueField({
+  label,
+  value,
+  onChange,
+  rows = 4,
+  hint,
+  placeholder = "{ }",
+}: {
+  label?: string;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  rows?: number;
+  hint?: string;
+  placeholder?: string;
+}) {
+  const [raw, setRaw] = useState<string>(() =>
+    value === undefined ? "" : JSON.stringify(value, null, 2),
+  );
+  const [error, setError] = useState("");
+
+  function handle(next: string) {
+    setRaw(next);
+    if (next.trim() === "") {
+      setError("");
+      onChange(undefined);
+      return;
+    }
+    try {
+      onChange(JSON.parse(next));
+      setError("");
+    } catch {
+      setError("Invalid JSON");
+    }
+  }
+
+  return (
+    <div>
+      {label && <label className="mb-1.5 block text-sm font-medium">{label}</label>}
+      {hint && <p className="mb-1.5 text-xs text-muted-foreground">{hint}</p>}
+      <textarea
+        value={raw}
+        onChange={(e) => handle(e.target.value)}
+        rows={rows}
+        spellCheck={false}
+        placeholder={placeholder}
+        className={cn(monoControlClass, error && "border-destructive")}
+      />
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/web/src/components/tools/lib/definition.ts
+++ b/web/src/components/tools/lib/definition.ts
@@ -1,0 +1,116 @@
+// Pure helpers for constructing and manipulating tool definitions. No React, no
+// I/O — fully unit-testable.
+
+import type {
+  ComposedDefinition,
+  ComposedStep,
+  JsonSchemaObject,
+  ParamField,
+  PrimitiveDefinition,
+  ToolDefinition,
+  ToolType,
+} from "./types";
+
+export const PLACEHOLDER_RE = /\$\{([^}]*)\}/g;
+
+export function emptySchema(): JsonSchemaObject {
+  return { type: "object", properties: {}, required: [], additionalProperties: false };
+}
+
+export function emptyPrimitiveDefinition(): PrimitiveDefinition {
+  return {
+    tool_type: "primitive",
+    description: "",
+    parameters: emptySchema(),
+    implementation: { mode: "delegate", primitive: "", args: {} },
+  };
+}
+
+export function emptyComposedDefinition(): ComposedDefinition {
+  return {
+    tool_type: "composed",
+    description: "",
+    parameters: emptySchema(),
+    steps: [],
+  };
+}
+
+export function emptyDefinition(type: ToolType): ToolDefinition {
+  return type === "primitive" ? emptyPrimitiveDefinition() : emptyComposedDefinition();
+}
+
+/** Convert a JSON Schema object into the friendly param-row representation. */
+export function schemaToParams(schema: JsonSchemaObject | undefined): ParamField[] {
+  if (!schema || !schema.properties) return [];
+  const required = new Set(schema.required ?? []);
+  return Object.entries(schema.properties).map(([name, prop]) => ({
+    name,
+    type: prop.type,
+    description: prop.description,
+    required: required.has(name),
+  }));
+}
+
+/** Convert friendly param rows back into a JSON Schema object. */
+export function paramsToSchema(params: ParamField[]): JsonSchemaObject {
+  const properties: JsonSchemaObject["properties"] = {};
+  const required: string[] = [];
+  for (const p of params) {
+    const name = p.name.trim();
+    if (!name) continue;
+    properties[name] = { type: p.type };
+    if (p.description?.trim()) properties[name].description = p.description.trim();
+    if (p.required) required.push(name);
+  }
+  return { type: "object", properties, required, additionalProperties: false };
+}
+
+/** The declared parameter names of a definition. */
+export function declaredParamNames(def: ToolDefinition): string[] {
+  return Object.keys(def.parameters?.properties ?? {});
+}
+
+let stepCounter = 0;
+/** Generate a stable-ish step id. Deterministic within a session is enough. */
+export function newStepId(existing: ComposedStep[]): string {
+  let id: string;
+  do {
+    stepCounter += 1;
+    id = `s${stepCounter}`;
+  } while (existing.some((s) => s.id === id));
+  return id;
+}
+
+/** Move an array item from one index to another (returns a new array). */
+export function reorder<T>(items: T[], from: number, to: number): T[] {
+  if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) {
+    return items;
+  }
+  const next = items.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+/** Extract every ${...} placeholder expression found in a value tree. */
+export function placeholdersIn(value: unknown): string[] {
+  const out: string[] = [];
+  const walk = (node: unknown) => {
+    if (typeof node === "string") {
+      for (const m of node.matchAll(PLACEHOLDER_RE)) out.push(m[1].trim());
+    } else if (Array.isArray(node)) {
+      node.forEach(walk);
+    } else if (node && typeof node === "object") {
+      Object.values(node).forEach(walk);
+    }
+  };
+  walk(value);
+  return out;
+}
+
+/** A short human label for a tool type. */
+export function toolTypeLabel(type: string): string {
+  if (type === "primitive") return "Primitive";
+  if (type === "composed") return "Composed";
+  return type;
+}

--- a/web/src/components/tools/lib/definition.ts
+++ b/web/src/components/tools/lib/definition.ts
@@ -108,6 +108,38 @@ export function placeholdersIn(value: unknown): string[] {
   return out;
 }
 
+/**
+ * Hydrate a possibly-partial stored definition into a complete, editable shape
+ * for the given tool type. Tolerates legacy/empty definitions.
+ */
+export function normalizeDefinition(type: ToolType, raw: unknown): ToolDefinition {
+  const base = emptyDefinition(type);
+  if (!raw || typeof raw !== "object") return base;
+  const r = raw as Record<string, unknown>;
+
+  if (type === "primitive" && base.tool_type === "primitive") {
+    const rawImpl = (r.implementation as Record<string, unknown> | undefined) ?? {};
+    return {
+      tool_type: "primitive",
+      description: typeof r.description === "string" ? r.description : base.description,
+      parameters: (r.parameters as ToolDefinition["parameters"]) ?? base.parameters,
+      implementation: { ...base.implementation, ...rawImpl } as PrimitiveDefinition["implementation"],
+    };
+  }
+
+  return {
+    tool_type: "composed",
+    description: typeof r.description === "string" ? r.description : base.description,
+    parameters: (r.parameters as ToolDefinition["parameters"]) ?? base.parameters,
+    steps: Array.isArray(r.steps) ? (r.steps as ComposedDefinition["steps"]) : [],
+  };
+}
+
+/** Whether a tool kind can be edited by the visual builder. */
+export function isBuilderToolType(kind: string): kind is ToolType {
+  return kind === "primitive" || kind === "composed";
+}
+
 /** A short human label for a tool type. */
 export function toolTypeLabel(type: string): string {
   if (type === "primitive") return "Primitive";

--- a/web/src/components/tools/lib/simulate.ts
+++ b/web/src/components/tools/lib/simulate.ts
@@ -8,12 +8,12 @@ import type { ComposedDefinition, PrimitiveDefinition, ToolDefinition } from "./
 export interface ResolvedStep {
   id: string;
   ref: string;
-  inputs: Record<string, string>;
+  inputs: Record<string, unknown>;
 }
 
 export interface SimulationResult {
   /** For primitive tools: the resolved args sent to the base primitive. */
-  args?: Record<string, string>;
+  args?: Record<string, unknown>;
   /** For composed tools: the resolved inputs per step. */
   steps?: ResolvedStep[];
   /** For mock primitive tools: a human note (no resolution needed). */
@@ -35,13 +35,24 @@ function resolveString(input: string, sample: Record<string, string>): string {
   });
 }
 
+function resolveValue(value: unknown, sample: Record<string, string>): unknown {
+  if (typeof value === "string") return resolveString(value, sample);
+  if (Array.isArray(value)) return value.map((v) => resolveValue(v, sample));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, resolveValue(v, sample)]),
+    );
+  }
+  return value;
+}
+
 function resolveRecord(
-  rec: Record<string, string> | undefined,
+  rec: Record<string, unknown> | undefined,
   sample: Record<string, string>,
-): Record<string, string> {
-  const out: Record<string, string> = {};
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(rec ?? {})) {
-    out[k] = typeof v === "string" ? resolveString(v, sample) : String(v);
+    out[k] = resolveValue(v, sample);
   }
   return out;
 }

--- a/web/src/components/tools/lib/simulate.ts
+++ b/web/src/components/tools/lib/simulate.ts
@@ -1,0 +1,79 @@
+// Client-side dry-run. Resolves ${...} placeholders against sample parameter
+// values so the user can see what each step/primitive would receive. This does
+// NOT execute anything in a sandbox — step outputs are shown as symbolic tokens.
+
+import { PLACEHOLDER_RE } from "./definition";
+import type { ComposedDefinition, PrimitiveDefinition, ToolDefinition } from "./types";
+
+export interface ResolvedStep {
+  id: string;
+  ref: string;
+  inputs: Record<string, string>;
+}
+
+export interface SimulationResult {
+  /** For primitive tools: the resolved args sent to the base primitive. */
+  args?: Record<string, string>;
+  /** For composed tools: the resolved inputs per step. */
+  steps?: ResolvedStep[];
+  /** For mock primitive tools: a human note (no resolution needed). */
+  note?: string;
+}
+
+function resolveString(input: string, sample: Record<string, string>): string {
+  return input.replace(PLACEHOLDER_RE, (_full, rawExpr: string) => {
+    const expr = rawExpr.trim();
+    if (expr === "parameters") return JSON.stringify(sample);
+    if (expr.startsWith("params.")) {
+      const name = expr.slice("params.".length);
+      return sample[name] ?? `⟨${name}⟩`;
+    }
+    if (expr.startsWith("secrets.")) return `⟨secret:${expr.slice("secrets.".length)}⟩`;
+    if (expr.startsWith("steps.")) return `⟨${expr}⟩`;
+    // bare ${param} (primitive delegate syntax)
+    return sample[expr] ?? `⟨${expr}⟩`;
+  });
+}
+
+function resolveRecord(
+  rec: Record<string, string> | undefined,
+  sample: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rec ?? {})) {
+    out[k] = typeof v === "string" ? resolveString(v, sample) : String(v);
+  }
+  return out;
+}
+
+export function simulate(
+  def: ToolDefinition,
+  sample: Record<string, string>,
+): SimulationResult {
+  if (def.tool_type === "primitive") return simulatePrimitive(def, sample);
+  return simulateComposed(def, sample);
+}
+
+function simulatePrimitive(
+  def: PrimitiveDefinition,
+  sample: Record<string, string>,
+): SimulationResult {
+  if (def.implementation.mode === "mock") {
+    const strategy = def.implementation.mock?.strategy ?? "static";
+    return { note: `Mock tool (${strategy}) — returns a canned response without calling out.` };
+  }
+  return { args: resolveRecord(def.implementation.args, sample) };
+}
+
+function simulateComposed(
+  def: ComposedDefinition,
+  sample: Record<string, string>,
+): SimulationResult {
+  return {
+    steps: def.steps.map((step) => ({
+      id: step.id,
+      ref: `${step.ref.type}:${step.ref.name}`,
+      inputs: resolveRecord(step.inputs, sample),
+    })),
+  };
+}

--- a/web/src/components/tools/lib/tools-lib.test.ts
+++ b/web/src/components/tools/lib/tools-lib.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyComposedDefinition,
+  emptyPrimitiveDefinition,
+  paramsToSchema,
+  placeholdersIn,
+  reorder,
+  schemaToParams,
+} from "./definition";
+import { validateDefinition } from "./validate";
+import { simulate } from "./simulate";
+import type { ComposedDefinition, PrimitiveDefinition } from "./types";
+
+const ctx = (over: Partial<Parameters<typeof validateDefinition>[1]> = {}) => ({
+  delegatablePrimitives: new Set(["http_request", "read_file"]),
+  knownToolSlugs: new Set(["check_policy"]),
+  ...over,
+});
+
+describe("definition helpers", () => {
+  it("round-trips params <-> schema", () => {
+    const params = [
+      { name: "order_id", type: "string" as const, required: true, description: "the id" },
+      { name: "amount", type: "number" as const, required: false },
+    ];
+    const schema = paramsToSchema(params);
+    expect(schema.properties.order_id).toEqual({ type: "string", description: "the id" });
+    expect(schema.required).toEqual(["order_id"]);
+    const back = schemaToParams(schema);
+    expect(back).toHaveLength(2);
+    expect(back[0]).toMatchObject({ name: "order_id", required: true });
+  });
+
+  it("drops nameless params", () => {
+    const schema = paramsToSchema([{ name: "  ", type: "string", required: true }]);
+    expect(Object.keys(schema.properties)).toHaveLength(0);
+  });
+
+  it("reorder moves items immutably", () => {
+    const a = [1, 2, 3];
+    const b = reorder(a, 0, 2);
+    expect(b).toEqual([2, 3, 1]);
+    expect(a).toEqual([1, 2, 3]);
+    expect(reorder(a, 0, 9)).toBe(a);
+  });
+
+  it("extracts placeholders from nested structures", () => {
+    const phs = placeholdersIn({ url: "https://x/${order_id}", h: { a: "${secrets.K}" }, list: ["${amount}"] });
+    expect(phs.sort()).toEqual(["amount", "order_id", "secrets.K"]);
+  });
+});
+
+describe("validateDefinition - primitive", () => {
+  it("passes a valid http delegate", () => {
+    const def = emptyPrimitiveDefinition();
+    def.parameters = paramsToSchema([{ name: "order_id", type: "string", required: true }]);
+    def.implementation = { mode: "delegate", primitive: "http_request", args: { url: "https://x/${order_id}", auth: "${secrets.K}" } };
+    expect(validateDefinition(def, ctx())).toEqual([]);
+  });
+
+  it("flags unknown primitive", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "delegate", primitive: "teleport", args: {} };
+    expect(validateDefinition(def, ctx()).some((i) => i.path === "implementation.primitive")).toBe(true);
+  });
+
+  it("flags undeclared placeholder", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "delegate", primitive: "http_request", args: { url: "${missing}" } };
+    expect(validateDefinition(def, ctx()).some((i) => i.path === "implementation.args")).toBe(true);
+  });
+
+  it("rejects secrets for non-http", () => {
+    const def = emptyPrimitiveDefinition();
+    def.parameters = paramsToSchema([{ name: "p", type: "string", required: false }]);
+    def.implementation = { mode: "delegate", primitive: "read_file", args: { path: "${secrets.X}" } };
+    expect(validateDefinition(def, ctx()).some((i) => i.path === "implementation.args")).toBe(true);
+  });
+
+  it("validates mock strategy", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "mock", mock: { strategy: "weird" as never } };
+    expect(validateDefinition(def, ctx()).some((i) => i.path === "implementation.mock.strategy")).toBe(true);
+  });
+});
+
+describe("validateDefinition - composed", () => {
+  const base = (): ComposedDefinition => {
+    const d = emptyComposedDefinition();
+    d.parameters = paramsToSchema([
+      { name: "order_id", type: "string", required: true },
+      { name: "amount", type: "number", required: false },
+    ]);
+    return d;
+  };
+
+  it("passes a valid two-step chain", () => {
+    const d = base();
+    d.steps = [
+      { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "https://x/${params.order_id}" } },
+      { id: "s2", ref: { type: "tool", name: "check_policy" }, inputs: { total: "${params.amount}", prior: "${steps.s1.body}" } },
+    ];
+    expect(validateDefinition(d, ctx({ selfSlug: "refund_flow" }))).toEqual([]);
+  });
+
+  it("flags empty steps", () => {
+    expect(validateDefinition(base(), ctx())[0].path).toBe("steps");
+  });
+
+  it("flags forward step reference", () => {
+    const d = base();
+    d.steps = [
+      { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "${steps.s2.x}" } },
+      { id: "s2", ref: { type: "primitive", name: "http_request" }, inputs: { url: "https://x" } },
+    ];
+    expect(validateDefinition(d, ctx()).some((i) => i.path === "steps[0].inputs")).toBe(true);
+  });
+
+  it("flags self reference and unknown tool", () => {
+    const d = base();
+    d.steps = [{ id: "s1", ref: { type: "tool", name: "refund_flow" }, inputs: {} }];
+    const issues = validateDefinition(d, ctx({ selfSlug: "refund_flow", knownToolSlugs: new Set(["refund_flow"]) }));
+    expect(issues.some((i) => i.message.includes("itself"))).toBe(true);
+  });
+});
+
+describe("simulate", () => {
+  it("resolves primitive args from sample", () => {
+    const def: PrimitiveDefinition = emptyPrimitiveDefinition();
+    def.implementation = { mode: "delegate", primitive: "http_request", args: { url: "https://x/${order_id}", k: "${secrets.K}" } };
+    const res = simulate(def, { order_id: "42" });
+    expect(res.args?.url).toBe("https://x/42");
+    expect(res.args?.k).toContain("secret:K");
+  });
+
+  it("notes mock tools", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "mock", mock: { strategy: "static", response: {} } };
+    expect(simulate(def, {}).note).toContain("Mock");
+  });
+
+  it("resolves composed step inputs and shows step outputs symbolically", () => {
+    const def = emptyComposedDefinition();
+    def.steps = [
+      { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "https://x/${params.order_id}" } },
+      { id: "s2", ref: { type: "tool", name: "check_policy" }, inputs: { prior: "${steps.s1.body}" } },
+    ];
+    const res = simulate(def, { order_id: "7" });
+    expect(res.steps?.[0].inputs.url).toBe("https://x/7");
+    expect(res.steps?.[1].inputs.prior).toBe("⟨steps.s1.body⟩");
+  });
+});

--- a/web/src/components/tools/lib/tools-lib.test.ts
+++ b/web/src/components/tools/lib/tools-lib.test.ts
@@ -9,10 +9,32 @@ import {
 } from "./definition";
 import { validateDefinition } from "./validate";
 import { simulate } from "./simulate";
-import type { ComposedDefinition, PrimitiveDefinition } from "./types";
+import type { ComposedDefinition, PrimitiveDefinition, ToolPrimitive } from "./types";
+
+const HTTP: ToolPrimitive = {
+  name: "http_request",
+  description: "",
+  kind: "network",
+  delegatable: true,
+  parameters: {
+    type: "object",
+    properties: { method: { type: "string" }, url: { type: "string" }, headers: { type: "object" }, body: { type: "string" } },
+    required: ["method", "url"],
+  },
+};
+const READ: ToolPrimitive = {
+  name: "read_file",
+  description: "",
+  kind: "file",
+  delegatable: true,
+  parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+};
 
 const ctx = (over: Partial<Parameters<typeof validateDefinition>[1]> = {}) => ({
-  delegatablePrimitives: new Set(["http_request", "read_file"]),
+  primitives: new Map<string, ToolPrimitive>([
+    ["http_request", HTTP],
+    ["read_file", READ],
+  ]),
   knownToolSlugs: new Set(["check_policy"]),
   ...over,
 });
@@ -54,8 +76,27 @@ describe("validateDefinition - primitive", () => {
   it("passes a valid http delegate", () => {
     const def = emptyPrimitiveDefinition();
     def.parameters = paramsToSchema([{ name: "order_id", type: "string", required: true }]);
-    def.implementation = { mode: "delegate", primitive: "http_request", args: { url: "https://x/${order_id}", auth: "${secrets.K}" } };
+    def.implementation = { mode: "delegate", primitive: "http_request", args: { method: "GET", url: "https://x/${order_id}", headers: "Bearer ${secrets.K}" } };
     expect(validateDefinition(def, ctx())).toEqual([]);
+  });
+
+  it("flags a missing required primitive argument", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "delegate", primitive: "read_file", args: {} };
+    expect(validateDefinition(def, ctx()).some((i) => i.message.includes("Missing required argument"))).toBe(true);
+  });
+
+  it("flags an unknown primitive argument", () => {
+    const def = emptyPrimitiveDefinition();
+    def.parameters = paramsToSchema([{ name: "p", type: "string", required: false }]);
+    def.implementation = { mode: "delegate", primitive: "read_file", args: { path: "${p}", bogus: "x" } };
+    expect(validateDefinition(def, ctx()).some((i) => i.message.includes("Unknown argument"))).toBe(true);
+  });
+
+  it("requires a response for the static mock strategy", () => {
+    const def = emptyPrimitiveDefinition();
+    def.implementation = { mode: "mock", mock: { strategy: "static" } };
+    expect(validateDefinition(def, ctx()).some((i) => i.path === "implementation.mock.response")).toBe(true);
   });
 
   it("flags unknown primitive", () => {
@@ -97,7 +138,7 @@ describe("validateDefinition - composed", () => {
   it("passes a valid two-step chain", () => {
     const d = base();
     d.steps = [
-      { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "https://x/${params.order_id}" } },
+      { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { method: "GET", url: "https://x/${params.order_id}" } },
       { id: "s2", ref: { type: "tool", name: "check_policy" }, inputs: { total: "${params.amount}", prior: "${steps.s1.body}" } },
     ];
     expect(validateDefinition(d, ctx({ selfSlug: "refund_flow" }))).toEqual([]);

--- a/web/src/components/tools/lib/types.ts
+++ b/web/src/components/tools/lib/types.ts
@@ -42,7 +42,7 @@ export type PrimitiveMode = "delegate" | "mock";
 export interface PrimitiveImplementation {
   mode: PrimitiveMode;
   primitive?: string;
-  args?: Record<string, string>;
+  args?: Record<string, unknown>;
   mock?: MockConfig;
 }
 
@@ -58,7 +58,7 @@ export type StepRefType = "primitive" | "tool";
 export interface ComposedStep {
   id: string;
   ref: { type: StepRefType; name: string };
-  inputs: Record<string, string>;
+  inputs: Record<string, unknown>;
 }
 
 export interface ComposedDefinition {

--- a/web/src/components/tools/lib/types.ts
+++ b/web/src/components/tools/lib/types.ts
@@ -1,0 +1,100 @@
+// Canonical client-side mirror of backend/internal/toolspec. The builder edits
+// these objects directly; they are persisted verbatim as the tool `definition`.
+
+export type ToolType = "primitive" | "composed";
+
+export type JsonSchemaType =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "object"
+  | "array";
+
+/** A single parameter row, the friendly editor representation of one property. */
+export interface ParamField {
+  name: string;
+  type: JsonSchemaType;
+  description?: string;
+  required: boolean;
+}
+
+/** The JSON Schema object stored in a definition's `parameters`. */
+export interface JsonSchemaObject {
+  type: "object";
+  properties: Record<string, { type: JsonSchemaType; description?: string }>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export type MockStrategy = "static" | "lookup" | "echo";
+
+export interface MockConfig {
+  strategy: MockStrategy;
+  response?: unknown;
+  lookup_key?: string;
+  responses?: Record<string, unknown>;
+  template?: unknown;
+}
+
+export type PrimitiveMode = "delegate" | "mock";
+
+export interface PrimitiveImplementation {
+  mode: PrimitiveMode;
+  primitive?: string;
+  args?: Record<string, string>;
+  mock?: MockConfig;
+}
+
+export interface PrimitiveDefinition {
+  tool_type: "primitive";
+  description?: string;
+  parameters: JsonSchemaObject;
+  implementation: PrimitiveImplementation;
+}
+
+export type StepRefType = "primitive" | "tool";
+
+export interface ComposedStep {
+  id: string;
+  ref: { type: StepRefType; name: string };
+  inputs: Record<string, string>;
+}
+
+export interface ComposedDefinition {
+  tool_type: "composed";
+  description?: string;
+  parameters: JsonSchemaObject;
+  steps: ComposedStep[];
+}
+
+export type ToolDefinition = PrimitiveDefinition | ComposedDefinition;
+
+/** One entry from GET /v1/tool-primitives. */
+export interface ToolPrimitive {
+  name: string;
+  description: string;
+  kind: "core" | "file" | "data" | "network" | "build" | "shell";
+  parameters: JsonSchemaObject;
+  delegatable: boolean;
+}
+
+/** A saved workspace tool (GET /v1/workspaces/{id}/tools and /v1/tools/{id}). */
+export interface ToolRecord {
+  id: string;
+  workspace_id?: string;
+  name: string;
+  slug: string;
+  tool_kind: string;
+  capability_key: string;
+  definition: ToolDefinition | Record<string, unknown>;
+  lifecycle_status: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+/** A validation problem surfaced to the user, scoped to a field path. */
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}

--- a/web/src/components/tools/lib/validate.ts
+++ b/web/src/components/tools/lib/validate.ts
@@ -1,0 +1,157 @@
+// Client-side mirror of backend/internal/toolspec ValidateDefinition. This gives
+// instant inline feedback in the builder; the server remains authoritative on save.
+
+import { placeholdersIn } from "./definition";
+import type {
+  ComposedDefinition,
+  PrimitiveDefinition,
+  ToolDefinition,
+  ValidationIssue,
+} from "./types";
+
+const MOCK_STRATEGIES = new Set(["static", "lookup", "echo"]);
+
+export interface ValidateContext {
+  /** Names of base primitives that may be delegated to / composed. */
+  delegatablePrimitives: Set<string>;
+  /** Slugs of other saved tools in the workspace (for composed tool refs). */
+  knownToolSlugs?: Set<string>;
+  /** Slug of the tool being edited (to reject self-reference). */
+  selfSlug?: string;
+}
+
+export function validateDefinition(
+  def: ToolDefinition,
+  ctx: ValidateContext,
+): ValidationIssue[] {
+  if (def.tool_type === "primitive") return validatePrimitive(def, ctx);
+  if (def.tool_type === "composed") return validateComposed(def, ctx);
+  return [{ path: "tool_type", message: "must be primitive or composed" }];
+}
+
+function declared(def: ToolDefinition): Set<string> {
+  return new Set(Object.keys(def.parameters?.properties ?? {}));
+}
+
+function validatePrimitive(
+  def: PrimitiveDefinition,
+  ctx: ValidateContext,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const impl = def.implementation;
+  const params = declared(def);
+
+  if (impl.mode === "delegate") {
+    const primitive = (impl.primitive ?? "").trim();
+    if (!primitive) {
+      issues.push({ path: "implementation.primitive", message: "Choose a primitive to delegate to." });
+    } else if (!ctx.delegatablePrimitives.has(primitive)) {
+      issues.push({ path: "implementation.primitive", message: `Unknown or non-delegatable primitive "${primitive}".` });
+    }
+    const isHTTP = primitive === "http_request";
+    for (const ph of placeholdersIn(impl.args ?? {})) {
+      issues.push(...checkArgPlaceholder(ph, params, isHTTP));
+    }
+  } else if (impl.mode === "mock") {
+    if (!impl.mock) {
+      issues.push({ path: "implementation.mock", message: "Configure the mock response." });
+    } else if (!MOCK_STRATEGIES.has(impl.mock.strategy)) {
+      issues.push({ path: "implementation.mock.strategy", message: "Strategy must be static, lookup or echo." });
+    }
+  } else {
+    issues.push({ path: "implementation.mode", message: "Mode must be delegate or mock." });
+  }
+
+  return issues;
+}
+
+function checkArgPlaceholder(ph: string, params: Set<string>, isHTTP: boolean): ValidationIssue[] {
+  const expr = ph.trim();
+  if (expr === "") return [{ path: "implementation.args", message: "Empty placeholder ${}." }];
+  if (expr === "parameters") return [];
+  if (expr.startsWith("secrets.")) {
+    return isHTTP ? [] : [{ path: "implementation.args", message: "Secrets are only allowed for http_request." }];
+  }
+  if (!params.has(expr)) {
+    return [{ path: "implementation.args", message: `Placeholder \${${expr}} is not a declared parameter.` }];
+  }
+  return [];
+}
+
+function validateComposed(
+  def: ComposedDefinition,
+  ctx: ValidateContext,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const params = declared(def);
+
+  if (!def.steps || def.steps.length === 0) {
+    return [{ path: "steps", message: "Add at least one step." }];
+  }
+
+  const seen = new Set<string>();
+  def.steps.forEach((step, i) => {
+    const base = `steps[${i}]`;
+    const id = step.id?.trim();
+    if (!id) {
+      issues.push({ path: `${base}.id`, message: "Step id is required." });
+    } else if (seen.has(id)) {
+      issues.push({ path: `${base}.id`, message: `Duplicate step id "${id}".` });
+    }
+
+    const refName = step.ref?.name?.trim() ?? "";
+    let isHTTP = false;
+    if (step.ref?.type === "primitive") {
+      if (!ctx.delegatablePrimitives.has(refName)) {
+        issues.push({ path: `${base}.ref.name`, message: `Unknown primitive "${refName}".` });
+      }
+      isHTTP = refName === "http_request";
+    } else if (step.ref?.type === "tool") {
+      if (!refName) {
+        issues.push({ path: `${base}.ref.name`, message: "Choose a tool." });
+      }
+      if (ctx.selfSlug && refName === ctx.selfSlug) {
+        issues.push({ path: `${base}.ref.name`, message: "A tool cannot reference itself." });
+      }
+      if (ctx.knownToolSlugs && refName && !ctx.knownToolSlugs.has(refName)) {
+        issues.push({ path: `${base}.ref.name`, message: `Unknown tool "${refName}".` });
+      }
+    } else {
+      issues.push({ path: `${base}.ref.type`, message: "Reference must be a primitive or a tool." });
+    }
+
+    for (const ph of placeholdersIn(step.inputs ?? {})) {
+      issues.push(...checkStepPlaceholder(ph, base, params, seen, isHTTP));
+    }
+
+    if (id) seen.add(id);
+  });
+
+  return issues;
+}
+
+function checkStepPlaceholder(
+  ph: string,
+  base: string,
+  params: Set<string>,
+  priorStepIds: Set<string>,
+  isHTTP: boolean,
+): ValidationIssue[] {
+  const expr = ph.trim();
+  if (expr === "") return [{ path: `${base}.inputs`, message: "Empty placeholder ${}." }];
+  if (expr.startsWith("params.")) {
+    const name = expr.slice("params.".length);
+    return params.has(name) ? [] : [{ path: `${base}.inputs`, message: `Unknown parameter "${name}".` }];
+  }
+  if (expr.startsWith("steps.")) {
+    const rest = expr.slice("steps.".length);
+    const sid = rest.includes(".") ? rest.slice(0, rest.indexOf(".")) : rest;
+    return priorStepIds.has(sid)
+      ? []
+      : [{ path: `${base}.inputs`, message: `Step "${sid}" is not an earlier step.` }];
+  }
+  if (expr.startsWith("secrets.")) {
+    return isHTTP ? [] : [{ path: `${base}.inputs`, message: "Secrets are only allowed in http_request steps." }];
+  }
+  return [{ path: `${base}.inputs`, message: `Use \${params.X}, \${steps.ID.field} or \${secrets.NAME} (got \${${expr}}).` }];
+}

--- a/web/src/components/tools/lib/validate.ts
+++ b/web/src/components/tools/lib/validate.ts
@@ -4,16 +4,18 @@
 import { placeholdersIn } from "./definition";
 import type {
   ComposedDefinition,
+  MockConfig,
   PrimitiveDefinition,
   ToolDefinition,
+  ToolPrimitive,
   ValidationIssue,
 } from "./types";
 
 const MOCK_STRATEGIES = new Set(["static", "lookup", "echo"]);
 
 export interface ValidateContext {
-  /** Names of base primitives that may be delegated to / composed. */
-  delegatablePrimitives: Set<string>;
+  /** Delegatable base primitives, keyed by name (carries each one's schema). */
+  primitives: Map<string, ToolPrimitive>;
   /** Slugs of other saved tools in the workspace (for composed tool refs). */
   knownToolSlugs?: Set<string>;
   /** Slug of the tool being edited (to reject self-reference). */
@@ -43,25 +45,71 @@ function validatePrimitive(
 
   if (impl.mode === "delegate") {
     const primitive = (impl.primitive ?? "").trim();
+    const spec = primitive ? ctx.primitives.get(primitive) : undefined;
     if (!primitive) {
       issues.push({ path: "implementation.primitive", message: "Choose a primitive to delegate to." });
-    } else if (!ctx.delegatablePrimitives.has(primitive)) {
+    } else if (!spec) {
       issues.push({ path: "implementation.primitive", message: `Unknown or non-delegatable primitive "${primitive}".` });
     }
     const isHTTP = primitive === "http_request";
     for (const ph of placeholdersIn(impl.args ?? {})) {
       issues.push(...checkArgPlaceholder(ph, params, isHTTP));
     }
+    if (spec) issues.push(...checkPrimitiveArgs("implementation.args", spec, impl.args));
   } else if (impl.mode === "mock") {
-    if (!impl.mock) {
-      issues.push({ path: "implementation.mock", message: "Configure the mock response." });
-    } else if (!MOCK_STRATEGIES.has(impl.mock.strategy)) {
-      issues.push({ path: "implementation.mock.strategy", message: "Strategy must be static, lookup or echo." });
-    }
+    issues.push(...checkMock(impl.mock));
   } else {
     issues.push({ path: "implementation.mode", message: "Mode must be delegate or mock." });
   }
 
+  return issues;
+}
+
+/** Required args must be present (non-blank); unknown args are rejected. */
+function checkPrimitiveArgs(
+  path: string,
+  spec: ToolPrimitive,
+  args: Record<string, unknown> | undefined,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const props = spec.parameters?.properties ?? {};
+  const required = spec.parameters?.required ?? [];
+  const a = args ?? {};
+  for (const r of required) {
+    const v = a[r];
+    if (v === undefined || v === null || (typeof v === "string" && v.trim() === "")) {
+      issues.push({ path, message: `Missing required argument "${r}" for ${spec.name}.` });
+    }
+  }
+  for (const k of Object.keys(a)) {
+    if (!(k in props)) {
+      issues.push({ path, message: `Unknown argument "${k}" for ${spec.name}.` });
+    }
+  }
+  return issues;
+}
+
+/** Mirror engine.newMockTool per-strategy requirements. */
+function checkMock(mock: MockConfig | undefined): ValidationIssue[] {
+  if (!mock) return [{ path: "implementation.mock", message: "Configure the mock response." }];
+  if (!MOCK_STRATEGIES.has(mock.strategy)) {
+    return [{ path: "implementation.mock.strategy", message: "Strategy must be static, lookup or echo." }];
+  }
+  const issues: ValidationIssue[] = [];
+  if (mock.strategy === "static" && mock.response === undefined) {
+    issues.push({ path: "implementation.mock.response", message: 'A response is required for the "static" strategy.' });
+  }
+  if (mock.strategy === "lookup") {
+    if (!mock.lookup_key?.trim()) {
+      issues.push({ path: "implementation.mock.lookup_key", message: 'A lookup key is required for the "lookup" strategy.' });
+    }
+    if (mock.responses === undefined) {
+      issues.push({ path: "implementation.mock.responses", message: 'Responses are required for the "lookup" strategy.' });
+    }
+  }
+  if (mock.strategy === "echo" && mock.template === undefined) {
+    issues.push({ path: "implementation.mock.template", message: 'A template is required for the "echo" strategy.' });
+  }
   return issues;
 }
 
@@ -102,8 +150,11 @@ function validateComposed(
     const refName = step.ref?.name?.trim() ?? "";
     let isHTTP = false;
     if (step.ref?.type === "primitive") {
-      if (!ctx.delegatablePrimitives.has(refName)) {
+      const spec = ctx.primitives.get(refName);
+      if (!spec) {
         issues.push({ path: `${base}.ref.name`, message: `Unknown primitive "${refName}".` });
+      } else {
+        issues.push(...checkPrimitiveArgs(`${base}.inputs`, spec, step.inputs));
       }
       isHTTP = refName === "http_request";
     } else if (step.ref?.type === "tool") {

--- a/web/src/components/tools/parameters-editor.tsx
+++ b/web/src/components/tools/parameters-editor.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Plus, Trash2 } from "lucide-react";
+import { controlClass } from "./field";
+import type { JsonSchemaType, ParamField } from "./lib/types";
+
+const TYPES: JsonSchemaType[] = ["string", "number", "integer", "boolean", "object", "array"];
+
+/**
+ * Edits a tool's input parameters as friendly rows. The parent converts to/from
+ * JSON Schema with schemaToParams / paramsToSchema.
+ */
+export function ParametersEditor({
+  params,
+  onChange,
+}: {
+  params: ParamField[];
+  onChange: (params: ParamField[]) => void;
+}) {
+  function update(index: number, patch: Partial<ParamField>) {
+    onChange(params.map((p, i) => (i === index ? { ...p, ...patch } : p)));
+  }
+  function remove(index: number) {
+    onChange(params.filter((_, i) => i !== index));
+  }
+  function add() {
+    onChange([...params, { name: "", type: "string", required: true }]);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Parameters</h3>
+        <Button type="button" variant="outline" size="sm" onClick={add}>
+          <Plus data-icon="inline-start" className="size-3.5" />
+          Add parameter
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        The inputs the agent provides when calling this tool. Reference them in
+        values with{" "}
+        <code className="font-[family-name:var(--font-mono)]">{"${name}"}</code>.
+      </p>
+
+      {params.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+          No parameters yet. Add one if the tool needs input.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {params.map((p, i) => (
+            <div
+              key={i}
+              className="grid grid-cols-[1fr_7rem_auto_auto] items-center gap-2 rounded-lg border border-border p-2"
+            >
+              <input
+                value={p.name}
+                onChange={(e) => update(i, { name: e.target.value })}
+                placeholder="name"
+                aria-label="Parameter name"
+                className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+              />
+              <select
+                value={p.type}
+                onChange={(e) => update(i, { type: e.target.value as JsonSchemaType })}
+                aria-label="Parameter type"
+                className={`${controlClass} py-1.5`}
+              >
+                {TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <label className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={p.required}
+                  onChange={(e) => update(i, { required: e.target.checked })}
+                  className="size-3.5 accent-primary"
+                />
+                required
+              </label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => remove(i)}
+                aria-label="Remove parameter"
+              >
+                <Trash2 className="size-3.5 text-muted-foreground" />
+              </Button>
+              <input
+                value={p.description ?? ""}
+                onChange={(e) => update(i, { description: e.target.value })}
+                placeholder="description (optional)"
+                aria-label="Parameter description"
+                className={`${controlClass} col-span-4 text-xs`}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/primitive-builder.tsx
+++ b/web/src/components/tools/primitive-builder.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { ArgsEditor } from "./args-editor";
+import { controlClass } from "./field";
+import { JsonValueField } from "./json-value-field";
+import { ParametersEditor } from "./parameters-editor";
+import { declaredParamNames, paramsToSchema, schemaToParams } from "./lib/definition";
+import type {
+  MockStrategy,
+  PrimitiveDefinition,
+  PrimitiveMode,
+  ToolPrimitive,
+} from "./lib/types";
+
+const MODES: { value: PrimitiveMode; label: string; hint: string }[] = [
+  { value: "delegate", label: "Call a primitive", hint: "Wrap one base operation (HTTP, shell, file, data)." },
+  { value: "mock", label: "Mock response", hint: "Return a canned response for rehearsing evals." },
+];
+
+const STRATEGIES: MockStrategy[] = ["static", "lookup", "echo"];
+
+export function PrimitiveBuilder({
+  def,
+  onChange,
+  primitives,
+}: {
+  def: PrimitiveDefinition;
+  onChange: (def: PrimitiveDefinition) => void;
+  primitives: ToolPrimitive[];
+}) {
+  const delegatable = useMemo(
+    () => primitives.filter((p) => p.delegatable),
+    [primitives],
+  );
+  const byKind = useMemo(() => {
+    const groups: Record<string, ToolPrimitive[]> = {};
+    for (const p of delegatable) (groups[p.kind] ??= []).push(p);
+    return groups;
+  }, [delegatable]);
+
+  const impl = def.implementation;
+  const selectedPrimitive =
+    delegatable.find((p) => p.name === impl.primitive) ?? null;
+  const params = schemaToParams(def.parameters);
+
+  function setImpl(patch: Partial<PrimitiveDefinition["implementation"]>) {
+    onChange({ ...def, implementation: { ...def.implementation, ...patch } });
+  }
+
+  return (
+    <div className="space-y-6">
+      <ParametersEditor
+        params={params}
+        onChange={(next) => onChange({ ...def, parameters: paramsToSchema(next) })}
+      />
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Implementation</h3>
+        <div className="grid grid-cols-2 gap-2">
+          {MODES.map((m) => (
+            <button
+              key={m.value}
+              type="button"
+              onClick={() => setImpl({ mode: m.value })}
+              className={cn(
+                "rounded-lg border p-3 text-left transition-colors",
+                impl.mode === m.value
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-foreground/30",
+              )}
+            >
+              <div className="text-sm font-medium">{m.label}</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">{m.hint}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {impl.mode === "delegate" ? (
+        <div className="space-y-3">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Primitive</label>
+            <select
+              value={impl.primitive ?? ""}
+              onChange={(e) => setImpl({ primitive: e.target.value })}
+              className={controlClass}
+            >
+              <option value="">Select a primitive…</option>
+              {Object.entries(byKind).map(([kind, items]) => (
+                <optgroup key={kind} label={kind}>
+                  {items.map((p) => (
+                    <option key={p.name} value={p.name}>
+                      {p.name}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            {selectedPrimitive && (
+              <p className="mt-1 text-xs text-muted-foreground">{selectedPrimitive.description}</p>
+            )}
+          </div>
+          <div>
+            <h4 className="mb-1.5 text-sm font-medium">Arguments</h4>
+            <ArgsEditor
+              primitive={selectedPrimitive}
+              args={impl.args ?? {}}
+              onChange={(args) => setImpl({ args })}
+              paramNames={declaredParamNames(def)}
+              allowSecrets={impl.primitive === "http_request"}
+            />
+          </div>
+        </div>
+      ) : (
+        <MockEditor
+          mock={impl.mock ?? { strategy: "static" }}
+          onChange={(mock) => setImpl({ mock })}
+        />
+      )}
+    </div>
+  );
+}
+
+function MockEditor({
+  mock,
+  onChange,
+}: {
+  mock: NonNullable<PrimitiveDefinition["implementation"]["mock"]>;
+  onChange: (mock: NonNullable<PrimitiveDefinition["implementation"]["mock"]>) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="mb-1.5 block text-sm font-medium">Strategy</label>
+        <select
+          value={mock.strategy}
+          onChange={(e) => onChange({ ...mock, strategy: e.target.value as MockStrategy })}
+          className={controlClass}
+        >
+          {STRATEGIES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {mock.strategy === "static" && (
+        <JsonValueField
+          label="Response"
+          hint="Returned verbatim on every call."
+          value={mock.response}
+          onChange={(response) => onChange({ ...mock, response })}
+        />
+      )}
+      {mock.strategy === "lookup" && (
+        <>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Lookup key</label>
+            <input
+              value={mock.lookup_key ?? ""}
+              onChange={(e) => onChange({ ...mock, lookup_key: e.target.value })}
+              placeholder="e.g. order_id"
+              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+            />
+          </div>
+          <JsonValueField
+            label="Responses"
+            hint='Map of key value → response, with "*" as the fallback.'
+            value={mock.responses}
+            onChange={(responses) =>
+              onChange({ ...mock, responses: responses as Record<string, unknown> })
+            }
+          />
+        </>
+      )}
+      {mock.strategy === "echo" && (
+        <JsonValueField
+          label="Template (optional)"
+          hint="Echoes the call input, merged over this template."
+          value={mock.template}
+          onChange={(template) => onChange({ ...mock, template })}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/simulate-panel.tsx
+++ b/web/src/components/tools/simulate-panel.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { Play } from "lucide-react";
+import { controlClass } from "./field";
+import { simulate } from "./lib/simulate";
+import type { ToolDefinition } from "./lib/types";
+
+/**
+ * A client-side dry run: the user enters sample parameter values and sees how
+ * placeholders resolve for each primitive call / step. No sandbox execution.
+ */
+export function SimulatePanel({
+  definition,
+  paramNames,
+}: {
+  definition: ToolDefinition;
+  paramNames: string[];
+}) {
+  const [sample, setSample] = useState<Record<string, string>>({});
+  const result = simulate(definition, sample);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Play className="size-3.5" />
+        Enter sample inputs to preview how placeholders resolve. Nothing is executed.
+      </div>
+
+      {paramNames.length === 0 ? (
+        <p className="text-xs text-muted-foreground">This tool has no parameters.</p>
+      ) : (
+        <div className="space-y-2">
+          {paramNames.map((name) => (
+            <div key={name} className="grid grid-cols-[10rem_1fr] items-center gap-2">
+              <code className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
+                {name}
+              </code>
+              <input
+                value={sample[name] ?? ""}
+                onChange={(e) => setSample((p) => ({ ...p, [name]: e.target.value }))}
+                placeholder="sample value"
+                className={`${controlClass} text-xs`}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div>
+        <div className="mb-1.5 text-xs font-medium text-muted-foreground">Resolved</div>
+        {result.note ? (
+          <p className="rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+            {result.note}
+          </p>
+        ) : result.args ? (
+          <pre className="overflow-auto rounded-lg border border-border bg-muted/30 p-3 font-[family-name:var(--font-mono)] text-[11px] leading-relaxed">
+            {JSON.stringify(result.args, null, 2)}
+          </pre>
+        ) : (
+          <div className="space-y-2">
+            {(result.steps ?? []).map((step) => (
+              <div key={step.id} className="rounded-lg border border-border bg-muted/30 p-2">
+                <div className="mb-1 flex items-center gap-2 text-xs">
+                  <span className="font-medium">{step.id}</span>
+                  <code className="font-[family-name:var(--font-mono)] text-muted-foreground">
+                    {step.ref}
+                  </code>
+                </div>
+                <pre className="overflow-auto font-[family-name:var(--font-mono)] text-[11px] leading-relaxed">
+                  {JSON.stringify(step.inputs, null, 2)}
+                </pre>
+              </div>
+            ))}
+            {(result.steps ?? []).length === 0 && (
+              <p className="text-xs text-muted-foreground">Add steps to simulate.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/step-card.tsx
+++ b/web/src/components/tools/step-card.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronUp, GripVertical, Plus, Trash2 } from "lucide-react";
+import { controlClass } from "./field";
+import type { ComposedStep, StepRefType, ToolPrimitive } from "./lib/types";
+
+export function StepCard({
+  step,
+  index,
+  total,
+  earlierStepIds,
+  paramNames,
+  primitives,
+  toolOptions,
+  onChange,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  onDragStart,
+  onDragOver,
+  onDrop,
+}: {
+  step: ComposedStep;
+  index: number;
+  total: number;
+  earlierStepIds: string[];
+  paramNames: string[];
+  primitives: ToolPrimitive[];
+  toolOptions: { slug: string; name: string }[];
+  onChange: (step: ComposedStep) => void;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDragStart: () => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: () => void;
+}) {
+  const delegatable = primitives.filter((p) => p.delegatable);
+  const isHTTP = step.ref.type === "primitive" && step.ref.name === "http_request";
+
+  function setRef(patch: Partial<ComposedStep["ref"]>) {
+    onChange({ ...step, ref: { ...step.ref, ...patch } });
+  }
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      className="rounded-lg border border-border bg-card"
+    >
+      <div className="flex items-center gap-2 border-b border-border px-2 py-1.5">
+        <GripVertical className="size-4 cursor-grab text-muted-foreground" aria-hidden />
+        <span className="flex size-5 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums">
+          {index + 1}
+        </span>
+        <code className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
+          {step.id}
+        </code>
+        <div className="ml-auto flex items-center">
+          <Button type="button" variant="ghost" size="icon-sm" onClick={onMoveUp} disabled={index === 0} aria-label="Move up">
+            <ChevronUp className="size-3.5" />
+          </Button>
+          <Button type="button" variant="ghost" size="icon-sm" onClick={onMoveDown} disabled={index === total - 1} aria-label="Move down">
+            <ChevronDown className="size-3.5" />
+          </Button>
+          <Button type="button" variant="ghost" size="icon-sm" onClick={onRemove} aria-label="Remove step">
+            <Trash2 className="size-3.5 text-muted-foreground" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3 p-3">
+        <div className="grid grid-cols-[8rem_1fr] gap-2">
+          <select
+            value={step.ref.type}
+            onChange={(e) => setRef({ type: e.target.value as StepRefType, name: "" })}
+            aria-label="Reference type"
+            className={controlClass}
+          >
+            <option value="primitive">Primitive</option>
+            <option value="tool">Saved tool</option>
+          </select>
+          {step.ref.type === "primitive" ? (
+            <select
+              value={step.ref.name}
+              onChange={(e) => setRef({ name: e.target.value })}
+              aria-label="Primitive"
+              className={controlClass}
+            >
+              <option value="">Select a primitive…</option>
+              {delegatable.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <select
+              value={step.ref.name}
+              onChange={(e) => setRef({ name: e.target.value })}
+              aria-label="Tool"
+              className={controlClass}
+            >
+              <option value="">Select a tool…</option>
+              {toolOptions.map((t) => (
+                <option key={t.slug} value={t.slug}>
+                  {t.name} ({t.slug})
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <StepInputsEditor
+          inputs={step.inputs}
+          onChange={(inputs) => onChange({ ...step, inputs })}
+          paramNames={paramNames}
+          earlierStepIds={earlierStepIds}
+          allowSecrets={isHTTP}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StepInputsEditor({
+  inputs,
+  onChange,
+  paramNames,
+  earlierStepIds,
+  allowSecrets,
+}: {
+  inputs: Record<string, unknown>;
+  onChange: (inputs: Record<string, unknown>) => void;
+  paramNames: string[];
+  earlierStepIds: string[];
+  allowSecrets: boolean;
+}) {
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  const rows = Object.entries(inputs);
+
+  function setKey(oldKey: string, newKey: string) {
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(inputs)) next[k === oldKey ? newKey : k] = v;
+    onChange(next);
+  }
+  function setValue(key: string, value: string) {
+    onChange({ ...inputs, [key]: value });
+  }
+  function remove(key: string) {
+    const next = { ...inputs };
+    delete next[key];
+    onChange(next);
+  }
+  function add() {
+    let name = "input";
+    let n = 1;
+    while (name in inputs) name = `input${++n}`;
+    onChange({ ...inputs, [name]: "" });
+  }
+  function insert(token: string) {
+    if (!focusedKey) return;
+    const cur = typeof inputs[focusedKey] === "string" ? (inputs[focusedKey] as string) : "";
+    setValue(focusedKey, cur + token);
+  }
+
+  const chips = [
+    ...paramNames.map((p) => `\${params.${p}}`),
+    ...earlierStepIds.map((s) => `\${steps.${s}.output}`),
+    ...(allowSecrets ? ["${secrets.NAME}"] : []),
+  ];
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Inputs</span>
+        <Button type="button" variant="ghost" size="xs" onClick={add}>
+          <Plus data-icon="inline-start" className="size-3" />
+          Add input
+        </Button>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No inputs mapped.</p>
+      ) : (
+        rows.map(([key, value]) => (
+          <div key={key} className="grid grid-cols-[10rem_1fr_auto] items-center gap-2">
+            <input
+              value={key}
+              onChange={(e) => setKey(key, e.target.value)}
+              aria-label="Input name"
+              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+            />
+            <input
+              value={typeof value === "string" ? value : JSON.stringify(value)}
+              onChange={(e) => setValue(key, e.target.value)}
+              onFocus={() => setFocusedKey(key)}
+              placeholder="value or ${params.x}"
+              aria-label="Input value"
+              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+            />
+            <Button type="button" variant="ghost" size="icon-sm" onClick={() => remove(key)} aria-label="Remove input">
+              <Trash2 className="size-3.5 text-muted-foreground" />
+            </Button>
+          </div>
+        ))
+      )}
+      {chips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {chips.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => insert(c)}
+              disabled={!focusedKey}
+              className={cn(
+                "rounded-md border border-border bg-background px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[11px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50",
+              )}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/tool-builder.tsx
+++ b/web/src/components/tools/tool-builder.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { useApiListQuery, useApiMutator } from "@/lib/api/swr";
+import { workspaceResourceKeys } from "@/lib/workspace-resource";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { ComposedBuilder } from "./composed-builder";
+import { PrimitiveBuilder } from "./primitive-builder";
+import { DefinitionPreview } from "./definition-preview";
+import { SimulatePanel } from "./simulate-panel";
+import { Field, controlClass } from "./field";
+import { ToolTypeBadge } from "./tool-type-badge";
+import { useToolPrimitives } from "./use-tool-primitives";
+import { declaredParamNames, emptyDefinition } from "./lib/definition";
+import { validateDefinition } from "./lib/validate";
+import type { ToolDefinition, ToolRecord, ToolType } from "./lib/types";
+
+export function ToolBuilder({
+  workspaceId,
+  mode,
+  toolType,
+  toolId,
+  initialName,
+  initialSlug,
+  initialDefinition,
+}: {
+  workspaceId: string;
+  mode: "create" | "edit";
+  toolType: ToolType;
+  toolId?: string;
+  initialName?: string;
+  initialSlug?: string;
+  initialDefinition?: ToolDefinition;
+}) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const { mutateMany } = useApiMutator();
+
+  const [name, setName] = useState(initialName ?? "");
+  const [definition, setDefinition] = useState<ToolDefinition>(
+    initialDefinition ?? emptyDefinition(toolType),
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  const { primitives } = useToolPrimitives();
+  const { data: toolsData } = useApiListQuery<ToolRecord>(
+    `/v1/workspaces/${workspaceId}/tools`,
+  );
+
+  const delegatablePrimitives = useMemo(
+    () => new Set(primitives.filter((p) => p.delegatable).map((p) => p.name)),
+    [primitives],
+  );
+  const toolOptions = useMemo(
+    () =>
+      (toolsData?.items ?? [])
+        .filter((t) => t.slug !== initialSlug)
+        .map((t) => ({ slug: t.slug, name: t.name })),
+    [toolsData, initialSlug],
+  );
+  const knownToolSlugs = useMemo(
+    () => new Set((toolsData?.items ?? []).map((t) => t.slug)),
+    [toolsData],
+  );
+
+  const primitivesReady = primitives.length > 0;
+  const issues = useMemo(
+    () =>
+      primitivesReady
+        ? validateDefinition(definition, {
+            delegatablePrimitives,
+            knownToolSlugs,
+            selfSlug: initialSlug,
+          })
+        : [],
+    [primitivesReady, definition, delegatablePrimitives, knownToolSlugs, initialSlug],
+  );
+
+  const paramNames = declaredParamNames(definition);
+  const canSave = primitivesReady && name.trim().length > 0 && issues.length === 0 && !submitting;
+
+  async function save() {
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const api = createApiClient((await getAccessToken()) ?? undefined);
+      if (mode === "create") {
+        await api.post(`/v1/workspaces/${workspaceId}/tools`, {
+          name: name.trim(),
+          tool_kind: toolType,
+          definition,
+        });
+      } else {
+        await api.patch(`/v1/tools/${toolId}`, { name: name.trim(), definition });
+      }
+      await mutateMany([workspaceResourceKeys.tools(workspaceId)]);
+      toast.success(mode === "create" ? "Tool created" : "Tool saved");
+      router.push(`/workspaces/${workspaceId}/tools`);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to save tool");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Tools", href: `/workspaces/${workspaceId}/tools` },
+          { label: mode === "create" ? "New tool" : (initialName ?? "Edit") },
+        ]}
+        title={mode === "create" ? "New tool" : (initialName ?? "Edit tool")}
+        description={
+          <span className="inline-flex items-center gap-2">
+            <ToolTypeBadge kind={toolType} />
+            {toolType === "primitive"
+              ? "A single operation agents can call."
+              : "An ordered chain of primitives and other tools."}
+          </span>
+        }
+        actions={
+          <>
+            <Button
+              variant="outline"
+              onClick={() => router.push(`/workspaces/${workspaceId}/tools`)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button onClick={save} disabled={!canSave}>
+              {submitting ? <Loader2 className="size-4 animate-spin" /> : "Save tool"}
+            </Button>
+          </>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
+        <div className="space-y-6">
+          <Field label="Name" htmlFor="tool-name" hint="A human-friendly name. A stable slug is derived from it.">
+            <input
+              id="tool-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={toolType === "primitive" ? "e.g. lookup_order" : "e.g. refund_flow"}
+              className={controlClass}
+            />
+          </Field>
+
+          {definition.tool_type === "primitive" ? (
+            <PrimitiveBuilder def={definition} onChange={setDefinition} primitives={primitives} />
+          ) : (
+            <ComposedBuilder
+              def={definition}
+              onChange={setDefinition}
+              primitives={primitives}
+              tools={toolOptions}
+            />
+          )}
+        </div>
+
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          <Tabs defaultValue="preview">
+            <TabsList className="w-full">
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+              <TabsTrigger value="simulate">Simulate</TabsTrigger>
+            </TabsList>
+            <TabsContent value="preview" className="pt-3">
+              <DefinitionPreview definition={definition} issues={issues} />
+            </TabsContent>
+            <TabsContent value="simulate" className="pt-3">
+              <SimulatePanel definition={definition} paramNames={paramNames} />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/tool-builder.tsx
+++ b/web/src/components/tools/tool-builder.tsx
@@ -20,6 +20,7 @@ import { DefinitionPreview } from "./definition-preview";
 import { SimulatePanel } from "./simulate-panel";
 import { Field, controlClass } from "./field";
 import { ToolTypeBadge } from "./tool-type-badge";
+import { JsonValidityProvider } from "./json-validity";
 import { useToolPrimitives } from "./use-tool-primitives";
 import { declaredParamNames, emptyDefinition } from "./lib/definition";
 import { validateDefinition } from "./lib/validate";
@@ -51,14 +52,15 @@ export function ToolBuilder({
     initialDefinition ?? emptyDefinition(toolType),
   );
   const [submitting, setSubmitting] = useState(false);
+  const [jsonInvalid, setJsonInvalid] = useState(false);
 
   const { primitives } = useToolPrimitives();
   const { data: toolsData } = useApiListQuery<ToolRecord>(
     `/v1/workspaces/${workspaceId}/tools`,
   );
 
-  const delegatablePrimitives = useMemo(
-    () => new Set(primitives.filter((p) => p.delegatable).map((p) => p.name)),
+  const primitivesByName = useMemo(
+    () => new Map(primitives.filter((p) => p.delegatable).map((p) => [p.name, p] as const)),
     [primitives],
   );
   const toolOptions = useMemo(
@@ -78,16 +80,21 @@ export function ToolBuilder({
     () =>
       primitivesReady
         ? validateDefinition(definition, {
-            delegatablePrimitives,
+            primitives: primitivesByName,
             knownToolSlugs,
             selfSlug: initialSlug,
           })
         : [],
-    [primitivesReady, definition, delegatablePrimitives, knownToolSlugs, initialSlug],
+    [primitivesReady, definition, primitivesByName, knownToolSlugs, initialSlug],
   );
 
+  const previewIssues = jsonInvalid
+    ? [...issues, { path: "editor", message: "Fix the invalid JSON in the highlighted field(s)." }]
+    : issues;
+
   const paramNames = declaredParamNames(definition);
-  const canSave = primitivesReady && name.trim().length > 0 && issues.length === 0 && !submitting;
+  const canSave =
+    primitivesReady && name.trim().length > 0 && issues.length === 0 && !jsonInvalid && !submitting;
 
   async function save() {
     if (!name.trim()) {
@@ -149,28 +156,30 @@ export function ToolBuilder({
       />
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
-        <div className="space-y-6">
-          <Field label="Name" htmlFor="tool-name" hint="A human-friendly name. A stable slug is derived from it.">
-            <input
-              id="tool-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={toolType === "primitive" ? "e.g. lookup_order" : "e.g. refund_flow"}
-              className={controlClass}
-            />
-          </Field>
+        <JsonValidityProvider onChange={setJsonInvalid}>
+          <div className="space-y-6">
+            <Field label="Name" htmlFor="tool-name" hint="A human-friendly name. A stable slug is derived from it.">
+              <input
+                id="tool-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={toolType === "primitive" ? "e.g. lookup_order" : "e.g. refund_flow"}
+                className={controlClass}
+              />
+            </Field>
 
-          {definition.tool_type === "primitive" ? (
-            <PrimitiveBuilder def={definition} onChange={setDefinition} primitives={primitives} />
-          ) : (
-            <ComposedBuilder
-              def={definition}
-              onChange={setDefinition}
-              primitives={primitives}
-              tools={toolOptions}
-            />
-          )}
-        </div>
+            {definition.tool_type === "primitive" ? (
+              <PrimitiveBuilder def={definition} onChange={setDefinition} primitives={primitives} />
+            ) : (
+              <ComposedBuilder
+                def={definition}
+                onChange={setDefinition}
+                primitives={primitives}
+                tools={toolOptions}
+              />
+            )}
+          </div>
+        </JsonValidityProvider>
 
         <div className="lg:sticky lg:top-4 lg:self-start">
           <Tabs defaultValue="preview">
@@ -179,7 +188,7 @@ export function ToolBuilder({
               <TabsTrigger value="simulate">Simulate</TabsTrigger>
             </TabsList>
             <TabsContent value="preview" className="pt-3">
-              <DefinitionPreview definition={definition} issues={issues} />
+              <DefinitionPreview definition={definition} issues={previewIssues} />
             </TabsContent>
             <TabsContent value="simulate" className="pt-3">
               <SimulatePanel definition={definition} paramNames={paramNames} />

--- a/web/src/components/tools/tool-type-badge.tsx
+++ b/web/src/components/tools/tool-type-badge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from "@/components/ui/badge";
+import { Boxes, Workflow } from "lucide-react";
+import { toolTypeLabel } from "./lib/definition";
+
+/** A consistent badge distinguishing primitive vs composed tools. */
+export function ToolTypeBadge({ kind }: { kind: string }) {
+  const isComposed = kind === "composed";
+  const Icon = isComposed ? Workflow : Boxes;
+  return (
+    <Badge variant="secondary" className="gap-1">
+      <Icon className="size-3" />
+      {toolTypeLabel(kind)}
+    </Badge>
+  );
+}

--- a/web/src/components/tools/use-tool-primitives.ts
+++ b/web/src/components/tools/use-tool-primitives.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useApiListQuery } from "@/lib/api/swr";
+import type { ToolPrimitive } from "./lib/types";
+
+/** Loads the static base-primitive catalog (GET /v1/tool-primitives). */
+export function useToolPrimitives() {
+  const { data, error, isLoading } = useApiListQuery<ToolPrimitive>(
+    "/v1/tool-primitives",
+    undefined,
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  );
+  return {
+    primitives: data?.items ?? [],
+    error,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## What

Makes the workspace **Tools** page a real, interactive builder for creating tools without writing code or YAML. Previously the page only listed tools and offered a raw `{name, tool_kind, capability_key, definition}` dialog; the `tools` table had no update/delete endpoints and there was no way to discover the base primitives.

Tools come in two kinds:
- **Primitive** — one operation: delegate to a base primitive (HTTP, shell, file, data) with an argument template, or return a **mock** response.
- **Composed** — an ordered chain of steps; each step runs a primitive or another saved tool, mapping its inputs from the tool's parameters or earlier steps.

## Why

The two tool concepts in the codebase were disconnected: the `tools` table (infra) had a bare CRUD surface, while the `primitive | composed | mock` taxonomy lived only in the challenge-pack engine and was authorable only via YAML. This bridges them — a guided UI that produces a canonical, validated `definition` designed to compile into challenge-pack `tools.custom` later.

## Backend

- **`internal/toolspec`** (new, dependency-free): canonical **primitive catalog** (mirrors `engine.nativePrimitiveTools`) + the canonical **definition schema and validator** for primitive/composed tools — placeholder references (`${param}`, `${params.X}`, `${steps.ID.field}`, `${secrets.NAME}`), primitive/tool refs, mock strategies, self-reference, and forward step refs. An engine test guards the catalog against drift.
- **Repository**: `UpdateTool` (slug + tool_kind immutable so composed refs keep resolving) and `ArchiveTool` (soft delete).
- **Manager**: `UpdateTool`/`DeleteTool`; `capability_key` now defaults to the slug; every create/update runs the validator, and composed `tool` refs are checked against the workspace's existing tools.
- **API**: `GET /v1/tool-primitives`, `PATCH /v1/tools/{toolID}`, `DELETE /v1/tools/{toolID}`. Definition validation failures return `400` with field-level detail.
- **OpenAPI** updated for all three routes + new schemas.

## Frontend

- Card list with primitive/composed badges, row actions, delete confirmation, and a New-tool type picker.
- **Primitive builder**: delegate vs mock; a schema-driven args editor (fields rendered from the chosen primitive's JSON schema) with a click-to-insert placeholder palette.
- **Composed builder**: a visual step canvas — add/remove steps, **drag to reorder** (native DnD + buttons), reference primitives or other tools, and map each step's inputs.
- Right-hand panel: read-only **compiled-definition preview** with inline validation, and a client-side **dry-run simulator** that resolves placeholders against sample inputs.
- Create + edit routes; edit normalizes partial/legacy definitions and declines unsupported formats gracefully.
- A pure, framework-free `components/tools/lib` (types, definition helpers, validator mirroring the backend, simulator) with vitest coverage.

## Testing

- Backend: `go build/vet ./...` clean; `go test -short -race ./...` green. New tests cover toolspec validation, catalog↔engine drift, manager validation/defaulting/immutability/delete, and router auth/status/catalog.
- Frontend: `tsc --noEmit` 0 errors, `eslint` 0 errors, `next build` compiles `/tools`, `/tools/new`, `/tools/[toolId]`; vitest 16/16 on the lib.

## Notes

- Server remains authoritative on save; the client validator is for instant feedback only.
- Simulation is client-side template resolution — no sandbox execution in this PR (deeper cross-tool cycle detection beyond self-reference is left to engine/pack compile).
- Repository update/delete have no DB integration tests here (they're `DATABASE_URL`-gated and mirror the existing `ArchiveModelAlias` pattern; logic is covered at the manager layer).
- `npx @redocly/cli lint` still reports **5 pre-existing errors** in unrelated dataset paths (broken `ErrorResponse` refs already on `main`); all tool refs resolve.
