### PR TITLE
feat(web): humanize the tools builder for non-engineers

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
@@ -1,4 +1,5 @@
 import { ToolBuilder } from "@/components/tools/tool-builder";
+import { ToolStartChooser } from "@/components/tools/tool-start-chooser";
 import { isBuilderToolType } from "@/components/tools/lib/definition";
 
 export default async function NewToolPage({
@@ -6,11 +7,22 @@ export default async function NewToolPage({
   searchParams,
 }: {
   params: Promise<{ workspaceId: string }>;
-  searchParams: Promise<{ type?: string }>;
+  searchParams: Promise<{ type?: string; start?: string }>;
 }) {
   const { workspaceId } = await params;
-  const { type } = await searchParams;
-  const toolType = isBuilderToolType(type ?? "") ? (type as "primitive" | "composed") : "primitive";
+  const { type, start } = await searchParams;
 
-  return <ToolBuilder workspaceId={workspaceId} mode="create" toolType={toolType} />;
+  // No (or unknown) type yet → let the user pick a plain-language starting point.
+  if (!isBuilderToolType(type ?? "")) {
+    return <ToolStartChooser workspaceId={workspaceId} />;
+  }
+
+  return (
+    <ToolBuilder
+      workspaceId={workspaceId}
+      mode="create"
+      toolType={type as "primitive" | "composed"}
+      start={start}
+    />
+  );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
@@ -4,15 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
-import {
-  Boxes,
-  MoreHorizontal,
-  Pencil,
-  Plus,
-  Trash2,
-  Workflow,
-  Wrench,
-} from "lucide-react";
+import { MoreHorizontal, Pencil, Plus, Trash2, Wrench } from "lucide-react";
 
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
@@ -70,29 +62,11 @@ function ToolsList({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  const newToolMenu = (
-    <DropdownMenu>
-      <DropdownMenuTrigger render={<Button size="sm" />}>
-        <Plus data-icon="inline-start" className="size-4" />
-        New tool
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem render={<Link href={`/workspaces/${workspaceId}/tools/new?type=primitive`} />}>
-          <Boxes className="size-4" />
-          <div>
-            <div className="text-sm">Primitive</div>
-            <div className="text-xs text-muted-foreground">One operation (HTTP, shell, file, mock)</div>
-          </div>
-        </DropdownMenuItem>
-        <DropdownMenuItem render={<Link href={`/workspaces/${workspaceId}/tools/new?type=composed`} />}>
-          <Workflow className="size-4" />
-          <div>
-            <div className="text-sm">Composed</div>
-            <div className="text-xs text-muted-foreground">Chain primitives and other tools</div>
-          </div>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+  const newToolButton = (
+    <Button size="sm" render={<Link href={`/workspaces/${workspaceId}/tools/new`} />}>
+      <Plus data-icon="inline-start" className="size-4" />
+      New tool
+    </Button>
   );
 
   if (isLoading && !data) return <WorkspaceListLoading rows={6} />;
@@ -101,8 +75,8 @@ function ToolsList({ workspaceId }: { workspaceId: string }) {
     <div>
       <PageHeader
         title="Tools"
-        description="Build tools agents can call during runs — single-operation primitives or composed multi-step tools."
-        actions={items.length > 0 ? newToolMenu : undefined}
+        description="Give agents tools they can use during a run — like calling an API or running a command. No code or YAML."
+        actions={items.length > 0 ? newToolButton : undefined}
       />
 
       {error ? (
@@ -113,8 +87,8 @@ function ToolsList({ workspaceId }: { workspaceId: string }) {
         <EmptyState
           icon={<Wrench className="size-10" />}
           title="No tools yet"
-          description="Create a primitive tool (one operation) or a composed tool (a chain of steps) — no YAML required."
-          action={{ label: "New primitive tool", href: `/workspaces/${workspaceId}/tools/new?type=primitive` }}
+          description="Build a tool agents can use during a run — call an API, run a command, or chain a few steps together. No code required."
+          action={{ label: "New tool", href: `/workspaces/${workspaceId}/tools/new` }}
         />
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">

--- a/web/src/components/tools/args-editor.tsx
+++ b/web/src/components/tools/args-editor.tsx
@@ -2,14 +2,18 @@
 
 import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
-import { controlClass, monoControlClass } from "./field";
+import { monoControlClass } from "./field";
 import { useReportJsonValidity } from "./json-validity";
-import type { ToolPrimitive } from "./lib/types";
+import { KeyValueEditor } from "./key-value-editor";
+import { ValueField } from "./value-field";
+import { primitiveReferences, typeLabel } from "./lib/friendly";
+import type { JsonSchemaType, ToolPrimitive } from "./lib/types";
 
 /**
- * Edits the arguments passed to a delegated base primitive. Fields are derived
- * from the primitive's own JSON schema; object-typed args (e.g. HTTP headers)
- * get a JSON editor. A placeholder palette inserts ${param} / ${secrets.X}.
+ * Fills in what a base operation needs. Fields are derived from the operation's
+ * own schema: plain values use a ValueField (type literal text or insert an agent
+ * input), key/value groups use a KeyValueEditor, lists fall back to JSON. The user
+ * never types `${...}` — references are inserted from a menu.
  */
 export function ArgsEditor({
   primitive,
@@ -24,15 +28,10 @@ export function ArgsEditor({
   paramNames: string[];
   allowSecrets: boolean;
 }) {
-  const [focusedKey, setFocusedKey] = useState<string | null>(null);
-  const [rawByKey, setRawByKey] = useState<Record<string, string>>({});
-  const [errByKey, setErrByKey] = useState<Record<string, string>>({});
-  useReportJsonValidity(useId(), Object.values(errByKey).some(Boolean));
-
   if (!primitive) {
     return (
       <p className="rounded-lg border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
-        Choose a primitive to configure its arguments.
+        Choose an operation above to set up its details.
       </p>
     );
   }
@@ -40,108 +39,110 @@ export function ArgsEditor({
   const props = primitive.parameters?.properties ?? {};
   const required = new Set(primitive.parameters?.required ?? []);
   const entries = Object.entries(props);
+  const references = primitiveReferences(paramNames);
 
-  function setScalar(key: string, value: string) {
+  function setArg(key: string, value: unknown) {
     const next = { ...args };
-    if (value === "") delete next[key];
+    if (value === undefined || value === "") delete next[key];
     else next[key] = value;
     onChange(next);
   }
 
-  function setObject(key: string, raw: string) {
-    setRawByKey((p) => ({ ...p, [key]: raw }));
-    if (raw.trim() === "") {
-      setErrByKey((p) => ({ ...p, [key]: "" }));
-      const next = { ...args };
-      delete next[key];
-      onChange(next);
+  if (entries.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        This operation doesn’t need any details.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {entries.map(([key, prop]) => (
+        <div key={key}>
+          <label className="mb-1 flex items-center gap-2 text-sm font-medium">
+            {key}
+            <span className="text-xs font-normal text-muted-foreground">
+              {typeLabel(prop.type as JsonSchemaType)}
+            </span>
+            {required.has(key) && (
+              <span className="text-xs font-normal text-muted-foreground">· required</span>
+            )}
+          </label>
+          {prop.description && (
+            <p className="mb-1.5 text-xs text-muted-foreground">{prop.description}</p>
+          )}
+          {prop.type === "object" ? (
+            <KeyValueEditor
+              value={args[key]}
+              onChange={(v) => setArg(key, v)}
+              references={references}
+              allowSecret={allowSecrets}
+            />
+          ) : prop.type === "array" ? (
+            <JsonArgField
+              value={args[key]}
+              onChange={(v) => setArg(key, v)}
+              placeholder="[ ]"
+            />
+          ) : (
+            <ValueField
+              value={typeof args[key] === "string" ? (args[key] as string) : ""}
+              onChange={(v) => setArg(key, v)}
+              placeholder={prop.description ?? "Type a value or insert an input"}
+              references={references}
+              allowSecret={allowSecrets}
+              ariaLabel={key}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** A small JSON editor for list/array arguments, with live parse + validity. */
+function JsonArgField({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: unknown;
+  onChange: (value: unknown) => void;
+  placeholder?: string;
+}) {
+  const [raw, setRaw] = useState(() =>
+    value === undefined ? "" : JSON.stringify(value, null, 2),
+  );
+  const [error, setError] = useState("");
+  useReportJsonValidity(useId(), error !== "");
+
+  function handle(next: string) {
+    setRaw(next);
+    if (next.trim() === "") {
+      setError("");
+      onChange(undefined);
       return;
     }
     try {
-      const parsed = JSON.parse(raw);
-      setErrByKey((p) => ({ ...p, [key]: "" }));
-      onChange({ ...args, [key]: parsed });
+      onChange(JSON.parse(next));
+      setError("");
     } catch {
-      setErrByKey((p) => ({ ...p, [key]: "Invalid JSON" }));
+      setError("Invalid JSON");
     }
   }
 
-  function insertPlaceholder(token: string) {
-    if (!focusedKey) return;
-    const current = typeof args[focusedKey] === "string" ? (args[focusedKey] as string) : "";
-    setScalar(focusedKey, current + token);
-  }
-
-  const chips = [
-    ...paramNames.map((p) => `\${${p}}`),
-    "${parameters}",
-    ...(allowSecrets ? ["${secrets.NAME}"] : []),
-  ];
-
   return (
-    <div className="space-y-3">
-      {entries.length === 0 ? (
-        <p className="text-xs text-muted-foreground">
-          This primitive takes no arguments.
-        </p>
-      ) : (
-        entries.map(([key, prop]) => {
-          const isObject = prop.type === "object" || prop.type === "array";
-          const raw =
-            rawByKey[key] ??
-            (args[key] !== undefined ? JSON.stringify(args[key], null, 2) : "");
-          return (
-            <div key={key}>
-              <label className="mb-1 flex items-center gap-2 text-sm font-medium">
-                <code className="font-[family-name:var(--font-mono)] text-xs">{key}</code>
-                <span className="text-xs font-normal text-muted-foreground">{prop.type}</span>
-                {required.has(key) && (
-                  <span className="text-xs font-normal text-muted-foreground">· required</span>
-                )}
-              </label>
-              {isObject ? (
-                <textarea
-                  value={raw}
-                  onChange={(e) => setObject(key, e.target.value)}
-                  rows={3}
-                  spellCheck={false}
-                  placeholder="{ }"
-                  className={cn(monoControlClass, errByKey[key] && "border-destructive")}
-                />
-              ) : (
-                <input
-                  value={typeof args[key] === "string" ? (args[key] as string) : ""}
-                  onChange={(e) => setScalar(key, e.target.value)}
-                  onFocus={() => setFocusedKey(key)}
-                  placeholder={prop.description ?? "value or ${param}"}
-                  className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
-                />
-              )}
-              {errByKey[key] && <p className="mt-1 text-xs text-destructive">{errByKey[key]}</p>}
-            </div>
-          );
-        })
-      )}
-
-      {chips.length > 0 && entries.some(([, p]) => p.type !== "object" && p.type !== "array") && (
-        <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-muted/30 p-2">
-          <span className="text-xs text-muted-foreground">Insert:</span>
-          {chips.map((c) => (
-            <button
-              key={c}
-              type="button"
-              onClick={() => insertPlaceholder(c)}
-              disabled={!focusedKey}
-              className="rounded-md border border-border bg-background px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
-            >
-              {c}
-            </button>
-          ))}
-          <span className="text-xs text-muted-foreground">
-            {focusedKey ? `→ ${focusedKey}` : "focus a field first"}
-          </span>
-        </div>
-      )}
+    <div>
+      <textarea
+        value={raw}
+        onChange={(e) => handle(e.target.value)}
+        rows={3}
+        spellCheck={false}
+        placeholder={placeholder}
+        className={cn(monoControlClass, error && "border-destructive")}
+      />
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
     </div>
   );
 }

--- a/web/src/components/tools/args-editor.tsx
+++ b/web/src/components/tools/args-editor.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useId, useState } from "react";
-import { cn } from "@/lib/utils";
-import { monoControlClass } from "./field";
-import { useReportJsonValidity } from "./json-validity";
+import { JsonValueField } from "./json-value-field";
 import { KeyValueEditor } from "./key-value-editor";
 import { ValueField } from "./value-field";
 import { primitiveReferences, typeLabel } from "./lib/friendly";
@@ -80,9 +77,10 @@ export function ArgsEditor({
               allowSecret={allowSecrets}
             />
           ) : prop.type === "array" ? (
-            <JsonArgField
+            <JsonValueField
               value={args[key]}
               onChange={(v) => setArg(key, v)}
+              rows={3}
               placeholder="[ ]"
             />
           ) : (
@@ -97,52 +95,6 @@ export function ArgsEditor({
           )}
         </div>
       ))}
-    </div>
-  );
-}
-
-/** A small JSON editor for list/array arguments, with live parse + validity. */
-function JsonArgField({
-  value,
-  onChange,
-  placeholder,
-}: {
-  value: unknown;
-  onChange: (value: unknown) => void;
-  placeholder?: string;
-}) {
-  const [raw, setRaw] = useState(() =>
-    value === undefined ? "" : JSON.stringify(value, null, 2),
-  );
-  const [error, setError] = useState("");
-  useReportJsonValidity(useId(), error !== "");
-
-  function handle(next: string) {
-    setRaw(next);
-    if (next.trim() === "") {
-      setError("");
-      onChange(undefined);
-      return;
-    }
-    try {
-      onChange(JSON.parse(next));
-      setError("");
-    } catch {
-      setError("Invalid JSON");
-    }
-  }
-
-  return (
-    <div>
-      <textarea
-        value={raw}
-        onChange={(e) => handle(e.target.value)}
-        rows={3}
-        spellCheck={false}
-        placeholder={placeholder}
-        className={cn(monoControlClass, error && "border-destructive")}
-      />
-      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
     </div>
   );
 }

--- a/web/src/components/tools/composed-builder.tsx
+++ b/web/src/components/tools/composed-builder.tsx
@@ -29,6 +29,7 @@ export function ComposedBuilder({
   const dragIndex = useRef<number | null>(null);
   const params = schemaToParams(def.parameters);
   const paramNames = declaredParamNames(def);
+  const stepNumberById = new Map(def.steps.map((s, i) => [s.id, i + 1] as const));
 
   function setSteps(steps: ComposedStep[]) {
     onChange({ ...def, steps });
@@ -60,26 +61,23 @@ export function ComposedBuilder({
 
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium">Steps</h3>
+          <h3 className="text-sm font-medium">Steps, run in order</h3>
           <Button type="button" variant="outline" size="sm" onClick={addStep}>
             <Plus data-icon="inline-start" className="size-3.5" />
             Add step
           </Button>
         </div>
         <p className="text-xs text-muted-foreground">
-          Each step runs a primitive or another saved tool. Map its inputs from
-          the tool&apos;s parameters (
-          <code className="font-[family-name:var(--font-mono)]">{"${params.x}"}</code>)
-          or earlier steps (
-          <code className="font-[family-name:var(--font-mono)]">{"${steps.s1.output}"}</code>).
-          Drag to reorder.
+          Each step does one operation or runs another saved tool. In a step’s
+          inputs, use “Insert” to pass in an agent input or an earlier step’s
+          result. Drag to reorder.
         </p>
 
         {def.steps.length === 0 ? (
           <EmptyState
             icon={<Workflow className="size-9" />}
             title="No steps yet"
-            description="Add the first step to start composing."
+            description="Add the first step to get started."
           />
         ) : (
           <div className="space-y-0">
@@ -95,6 +93,7 @@ export function ComposedBuilder({
                   index={i}
                   total={def.steps.length}
                   earlierStepIds={def.steps.slice(0, i).map((s) => s.id)}
+                  stepNumberById={stepNumberById}
                   paramNames={paramNames}
                   primitives={primitives}
                   toolOptions={tools}

--- a/web/src/components/tools/definition-preview.tsx
+++ b/web/src/components/tools/definition-preview.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { CheckCircle2, AlertTriangle } from "lucide-react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { MOCK_STRATEGY_OPTIONS, operationLabel, typeLabel } from "./lib/friendly";
+import { schemaToParams } from "./lib/definition";
 import type { ToolDefinition, ValidationIssue } from "./lib/types";
 
 /**
- * Read-only, forward-rendered view of the compiled tool definition plus the
- * current validation state. One-way (builder → definition) by design; this is
- * the artifact that gets persisted.
+ * A plain-language summary of what the tool does, plus the current validation
+ * state. The exact persisted JSON is tucked behind a disclosure for the rare
+ * reader who wants it — non-engineers never have to look at it.
  */
 export function DefinitionPreview({
   definition,
@@ -15,24 +17,24 @@ export function DefinitionPreview({
   definition: ToolDefinition;
   issues: ValidationIssue[];
 }) {
+  const params = schemaToParams(definition.parameters);
+
   return (
     <div className="space-y-3">
       {issues.length === 0 ? (
         <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
           <CheckCircle2 className="size-4 text-emerald-500" />
-          Definition is valid.
+          Ready to save.
         </div>
       ) : (
         <div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
           <div className="flex items-center gap-2 text-xs font-medium text-destructive">
             <AlertTriangle className="size-4" />
-            {issues.length} issue{issues.length > 1 ? "s" : ""} to fix
+            {issues.length} thing{issues.length > 1 ? "s" : ""} to finish
           </div>
           <ul className="space-y-0.5">
             {issues.map((issue, i) => (
               <li key={i} className="text-xs text-destructive/90">
-                <code className="font-[family-name:var(--font-mono)]">{issue.path}</code>
-                {" — "}
                 {issue.message}
               </li>
             ))}
@@ -40,14 +42,60 @@ export function DefinitionPreview({
         </div>
       )}
 
-      <div>
-        <div className="mb-1.5 text-xs font-medium text-muted-foreground">
-          Compiled definition
-        </div>
-        <pre className="max-h-96 overflow-auto rounded-lg border border-border bg-muted/30 p-3 font-[family-name:var(--font-mono)] text-[11px] leading-relaxed">
+      <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs">
+        <div className="font-medium">What this tool does</div>
+        <p className="mt-1 text-muted-foreground">{describe(definition)}</p>
+
+        <div className="mt-3 font-medium">Inputs from the agent</div>
+        {params.length === 0 ? (
+          <p className="mt-1 text-muted-foreground">None.</p>
+        ) : (
+          <ul className="mt-1 space-y-0.5 text-muted-foreground">
+            {params.map((p) => (
+              <li key={p.name}>
+                <span className="text-foreground">{p.name || "(unnamed)"}</span> ·{" "}
+                {typeLabel(p.type)}
+                {p.required ? " · required" : ""}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <details className="group">
+        <summary className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-foreground">
+          Show technical definition (JSON)
+        </summary>
+        <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-border bg-muted/30 p-3 font-[family-name:var(--font-mono)] text-[11px] leading-relaxed">
           {JSON.stringify(definition, null, 2)}
         </pre>
-      </div>
+      </details>
     </div>
   );
+}
+
+function describe(def: ToolDefinition): string {
+  if (def.tool_type === "primitive") {
+    const impl = def.implementation;
+    if (impl.mode === "mock") {
+      const strategy = MOCK_STRATEGY_OPTIONS.find((s) => s.value === impl.mock?.strategy);
+      return `Returns a canned response — ${
+        strategy ? strategy.label.toLowerCase() : "for testing"
+      }. Nothing real is called.`;
+    }
+    if (!impl.primitive) return "Performs one operation — pick which one above.";
+    return `Performs one operation: ${operationLabel(impl.primitive)}.`;
+  }
+
+  if (def.steps.length === 0) return "Runs a sequence of steps — add the first one above.";
+  const parts = def.steps.map((s, i) => {
+    const what =
+      s.ref.type === "primitive"
+        ? s.ref.name
+          ? operationLabel(s.ref.name)
+          : "(unset)"
+        : s.ref.name || "(unset tool)";
+    return `${i + 1}. ${what}`;
+  });
+  return `Runs ${def.steps.length} step${def.steps.length > 1 ? "s" : ""} in order — ${parts.join(", ")}.`;
 }

--- a/web/src/components/tools/json-value-field.tsx
+++ b/web/src/components/tools/json-value-field.tsx
@@ -5,10 +5,13 @@ import { cn } from "@/lib/utils";
 import { monoControlClass } from "./field";
 import { useReportJsonValidity } from "./json-validity";
 
+const serialize = (value: unknown) => (value === undefined ? "" : JSON.stringify(value));
+
 /**
  * Edits an arbitrary JSON value with live parse + error. Reports `undefined`
- * when emptied. Initial value is captured on mount, so render it only once the
- * parent's value is ready (e.g. after an edit fetch resolves).
+ * when emptied. Resyncs the textarea if the parent replaces `value` out from
+ * under it (e.g. switching operations), but leaves in-progress invalid text
+ * alone so the user never loses what they're typing.
  */
 export function JsonValueField({
   label,
@@ -29,18 +32,33 @@ export function JsonValueField({
     value === undefined ? "" : JSON.stringify(value, null, 2),
   );
   const [error, setError] = useState("");
+  // Serialized form of the value this textarea is in sync with. Updated by our
+  // own edits below; if it diverges from the incoming prop, the parent replaced
+  // the value out from under us and we resync (the React-endorsed pattern of
+  // adjusting state during render rather than in an effect).
+  const [synced, setSynced] = useState(() => serialize(value));
   useReportJsonValidity(useId(), error !== "");
+
+  const incoming = serialize(value);
+  if (incoming !== synced) {
+    setSynced(incoming);
+    setRaw(value === undefined ? "" : JSON.stringify(value, null, 2));
+    setError("");
+  }
 
   function handle(next: string) {
     setRaw(next);
     if (next.trim() === "") {
       setError("");
+      setSynced("");
       onChange(undefined);
       return;
     }
     try {
-      onChange(JSON.parse(next));
+      const parsed = JSON.parse(next);
       setError("");
+      setSynced(serialize(parsed));
+      onChange(parsed);
     } catch {
       setError("Invalid JSON");
     }

--- a/web/src/components/tools/key-value-editor.tsx
+++ b/web/src/components/tools/key-value-editor.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useState } from "react";
 import { Code, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { controlClass, monoControlClass } from "./field";
-import { useReportJsonValidity } from "./json-validity";
+import { controlClass } from "./field";
+import { JsonValueField } from "./json-value-field";
 import { ValueField } from "./value-field";
 import type { ValueReference } from "./lib/friendly";
 
@@ -35,7 +34,7 @@ export function KeyValueEditor({
   if (jsonMode) {
     return (
       <div className="space-y-1.5">
-        <JsonMode value={value} onChange={onChange} />
+        <JsonValueField value={value} onChange={onChange} rows={3} placeholder="{ }" />
         <ModeToggle
           icon={<Plus className="size-3" />}
           label="Switch to key/value rows"
@@ -56,6 +55,9 @@ export function KeyValueEditor({
     onChange(Object.keys(next).length === 0 ? undefined : next);
   }
   function setKey(oldKey: string, newKey: string) {
+    // Refuse a rename that would collide with another row — otherwise the two
+    // would merge and one value would be silently dropped.
+    if (newKey !== oldKey && rows.some(([k]) => k === newKey)) return;
     const next: Record<string, string> = {};
     for (const [k, v] of rows) next[k === oldKey ? newKey : k] = v;
     commit(next);
@@ -156,49 +158,6 @@ function ModeToggle({
       {icon}
       {label}
     </button>
-  );
-}
-
-function JsonMode({
-  value,
-  onChange,
-}: {
-  value: unknown;
-  onChange: (value: unknown) => void;
-}) {
-  const [raw, setRaw] = useState(() =>
-    value === undefined ? "" : JSON.stringify(value, null, 2),
-  );
-  const [error, setError] = useState("");
-  useReportJsonValidity(useId(), error !== "");
-
-  function handle(next: string) {
-    setRaw(next);
-    if (next.trim() === "") {
-      setError("");
-      onChange(undefined);
-      return;
-    }
-    try {
-      onChange(JSON.parse(next));
-      setError("");
-    } catch {
-      setError("Invalid JSON");
-    }
-  }
-
-  return (
-    <div>
-      <textarea
-        value={raw}
-        onChange={(e) => handle(e.target.value)}
-        rows={3}
-        spellCheck={false}
-        placeholder="{ }"
-        className={cn(monoControlClass, error && "border-destructive")}
-      />
-      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
-    </div>
   );
 }
 

--- a/web/src/components/tools/key-value-editor.tsx
+++ b/web/src/components/tools/key-value-editor.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Code, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { controlClass, monoControlClass } from "./field";
+import { useReportJsonValidity } from "./json-validity";
+import { ValueField } from "./value-field";
+import type { ValueReference } from "./lib/friendly";
+
+/**
+ * Edits an object-typed argument (e.g. HTTP headers) as friendly key/value rows
+ * instead of raw JSON. Anything that isn't a flat map of scalars (nested objects,
+ * arrays) falls back to a JSON editor, which the user can also switch to manually.
+ */
+export function KeyValueEditor({
+  value,
+  onChange,
+  references,
+  allowSecret,
+  keyPlaceholder = "name",
+  valuePlaceholder = "value",
+}: {
+  value: unknown;
+  onChange: (value: unknown) => void;
+  references: ValueReference[];
+  allowSecret: boolean;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+}) {
+  const flat = asFlatMap(value);
+  const [jsonMode, setJsonMode] = useState(value !== undefined && flat === null);
+
+  if (jsonMode) {
+    return (
+      <div className="space-y-1.5">
+        <JsonMode value={value} onChange={onChange} />
+        <ModeToggle
+          icon={<Plus className="size-3" />}
+          label="Switch to key/value rows"
+          onClick={() => {
+            // Only safe to switch back when the current value is a flat map.
+            if (asFlatMap(value) !== null || value === undefined) setJsonMode(false);
+          }}
+          disabled={asFlatMap(value) === null && value !== undefined}
+          disabledHint="Simplify the JSON to a flat list of values to switch back."
+        />
+      </div>
+    );
+  }
+
+  const rows = Object.entries(flat ?? {});
+
+  function commit(next: Record<string, string>) {
+    onChange(Object.keys(next).length === 0 ? undefined : next);
+  }
+  function setKey(oldKey: string, newKey: string) {
+    const next: Record<string, string> = {};
+    for (const [k, v] of rows) next[k === oldKey ? newKey : k] = v;
+    commit(next);
+  }
+  function setVal(key: string, val: string) {
+    commit({ ...(flat ?? {}), [key]: val });
+  }
+  function remove(key: string) {
+    const next = { ...(flat ?? {}) };
+    delete next[key];
+    commit(next);
+  }
+  function add() {
+    let name = "";
+    let n = 0;
+    const current = flat ?? {};
+    do {
+      name = n === 0 ? "name" : `name${n}`;
+      n += 1;
+    } while (name in current);
+    commit({ ...current, [name]: "" });
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+          No values yet.
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {rows.map(([key, val]) => (
+            <div key={key} className="grid grid-cols-[9rem_1fr_auto] items-start gap-1.5">
+              <input
+                value={key}
+                onChange={(e) => setKey(key, e.target.value)}
+                placeholder={keyPlaceholder}
+                aria-label="Name"
+                className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+              />
+              <ValueField
+                value={val}
+                onChange={(v) => setVal(key, v)}
+                placeholder={valuePlaceholder}
+                references={references}
+                allowSecret={allowSecret}
+                ariaLabel="Value"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => remove(key)}
+                aria-label="Remove"
+              >
+                <Trash2 className="size-3.5 text-muted-foreground" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={add}>
+          <Plus data-icon="inline-start" className="size-3.5" />
+          Add value
+        </Button>
+        <ModeToggle
+          icon={<Code className="size-3" />}
+          label="Edit as JSON"
+          onClick={() => setJsonMode(true)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ModeToggle({
+  icon,
+  label,
+  onClick,
+  disabled,
+  disabledHint,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={disabled ? disabledHint : undefined}
+      className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function JsonMode({
+  value,
+  onChange,
+}: {
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const [raw, setRaw] = useState(() =>
+    value === undefined ? "" : JSON.stringify(value, null, 2),
+  );
+  const [error, setError] = useState("");
+  useReportJsonValidity(useId(), error !== "");
+
+  function handle(next: string) {
+    setRaw(next);
+    if (next.trim() === "") {
+      setError("");
+      onChange(undefined);
+      return;
+    }
+    try {
+      onChange(JSON.parse(next));
+      setError("");
+    } catch {
+      setError("Invalid JSON");
+    }
+  }
+
+  return (
+    <div>
+      <textarea
+        value={raw}
+        onChange={(e) => handle(e.target.value)}
+        rows={3}
+        spellCheck={false}
+        placeholder="{ }"
+        className={cn(monoControlClass, error && "border-destructive")}
+      />
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+/** Returns the value as a flat string map, or null if it isn't one. */
+function asFlatMap(value: unknown): Record<string, string> | null {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+    else if (typeof v === "number" || typeof v === "boolean") out[k] = String(v);
+    else return null;
+  }
+  return out;
+}

--- a/web/src/components/tools/lib/definition.ts
+++ b/web/src/components/tools/lib/definition.ts
@@ -39,6 +39,33 @@ export function emptyDefinition(type: ToolType): ToolDefinition {
   return type === "primitive" ? emptyPrimitiveDefinition() : emptyComposedDefinition();
 }
 
+/**
+ * An empty definition pre-filled for a plain-language starting point chosen on
+ * the chooser screen (e.g. "Call a web API"). Falls back to an empty definition.
+ */
+export function presetDefinition(type: ToolType, start?: string): ToolDefinition {
+  if (type !== "primitive") return emptyComposedDefinition();
+  switch (start) {
+    case "api":
+      return {
+        ...emptyPrimitiveDefinition(),
+        implementation: { mode: "delegate", primitive: "http_request", args: {} },
+      };
+    case "command":
+      return {
+        ...emptyPrimitiveDefinition(),
+        implementation: { mode: "delegate", primitive: "shell_exec", args: {} },
+      };
+    case "mock":
+      return {
+        ...emptyPrimitiveDefinition(),
+        implementation: { mode: "mock", mock: { strategy: "static" } },
+      };
+    default:
+      return emptyPrimitiveDefinition();
+  }
+}
+
 /** Convert a JSON Schema object into the friendly param-row representation. */
 export function schemaToParams(schema: JsonSchemaObject | undefined): ParamField[] {
   if (!schema || !schema.properties) return [];
@@ -140,9 +167,9 @@ export function isBuilderToolType(kind: string): kind is ToolType {
   return kind === "primitive" || kind === "composed";
 }
 
-/** A short human label for a tool type. */
+/** A short, plain-language label for a tool type. */
 export function toolTypeLabel(type: string): string {
-  if (type === "primitive") return "Primitive";
-  if (type === "composed") return "Composed";
+  if (type === "primitive") return "Single action";
+  if (type === "composed") return "Multi-step";
   return type;
 }

--- a/web/src/components/tools/lib/friendly.ts
+++ b/web/src/components/tools/lib/friendly.ts
@@ -1,0 +1,151 @@
+// Plain-language labels and reference helpers. The builder's data model stays in
+// engineer terms (primitive / composed / ${placeholders}); everything here is the
+// translation layer that lets a non-engineer read and build a tool without ever
+// learning that vocabulary or typing template syntax by hand.
+
+import type { JsonSchemaType } from "./types";
+
+/** Friendly name for a JSON Schema type, shown in the inputs editor. */
+export function typeLabel(type: JsonSchemaType): string {
+  switch (type) {
+    case "string":
+      return "Text";
+    case "number":
+      return "Number";
+    case "integer":
+      return "Whole number";
+    case "boolean":
+      return "Yes / No";
+    case "object":
+      return "Group of values";
+    case "array":
+      return "List";
+    default:
+      return type;
+  }
+}
+
+/** The friendly type options offered in the inputs editor, in a sensible order. */
+export const TYPE_OPTIONS: { value: JsonSchemaType; label: string }[] = [
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+].map((t) => ({ value: t as JsonSchemaType, label: typeLabel(t as JsonSchemaType) }));
+
+/** Friendly name for a base operation (primitive). Falls back to the raw name. */
+export function operationLabel(name: string): string {
+  return OPERATION_LABELS[name] ?? name;
+}
+
+const OPERATION_LABELS: Record<string, string> = {
+  http_request: "Call a web API",
+  shell_exec: "Run a shell command",
+  file_read: "Read a file",
+  file_write: "Write a file",
+  file_list: "List files",
+  search_text: "Search file contents",
+  search_files: "Find files by name",
+};
+
+/** Friendly heading for a primitive `kind` group. */
+export function operationGroupLabel(kind: string): string {
+  switch (kind) {
+    case "core":
+      return "General";
+    case "file":
+      return "Files";
+    case "data":
+      return "Data";
+    case "network":
+      return "Network";
+    case "build":
+      return "Build";
+    case "shell":
+      return "Shell";
+    default:
+      return kind;
+  }
+}
+
+/** Friendly label + one-liner for each mock strategy. */
+export const MOCK_STRATEGY_OPTIONS: {
+  value: "static" | "lookup" | "echo";
+  label: string;
+  hint: string;
+}[] = [
+  {
+    value: "static",
+    label: "Always return the same response",
+    hint: "Every call gets one fixed response.",
+  },
+  {
+    value: "lookup",
+    label: "Return a different response per input",
+    hint: "Match one input value to a response, with a fallback.",
+  },
+  {
+    value: "echo",
+    label: "Echo the input back",
+    hint: "Returns whatever the agent sent, optionally merged with a template.",
+  },
+];
+
+// --- References: the values a non-engineer can drop into a field --------------
+
+/** One insertable value reference (renders the friendly label, inserts the token). */
+export interface ValueReference {
+  /** What the user reads, e.g. "order_id". */
+  label: string;
+  /** A short category for grouping in the menu, e.g. "Agent inputs". */
+  group: string;
+  /** The token spliced into the field, e.g. "${order_id}". Hidden from the user. */
+  token: string;
+}
+
+/**
+ * References available inside a primitive tool's arguments. Bare `${name}` syntax,
+ * plus an "all inputs" object and (for HTTP) secrets.
+ */
+export function primitiveReferences(paramNames: string[]): ValueReference[] {
+  const refs: ValueReference[] = paramNames
+    .filter((name) => name.trim())
+    .map((name) => ({
+      label: name.trim(),
+      group: "Agent inputs",
+      token: `\${${name.trim()}}`,
+    }));
+  refs.push({
+    label: "All inputs (as one object)",
+    group: "Agent inputs",
+    token: "${parameters}",
+  });
+  return refs;
+}
+
+/**
+ * References available inside a composed step's inputs: `${params.x}` for the
+ * tool's own inputs and `${steps.ID.output}` for the result of an earlier step.
+ */
+export function stepReferences(
+  paramNames: string[],
+  earlierStepIds: string[],
+  stepNumberById: Map<string, number>,
+): ValueReference[] {
+  const refs: ValueReference[] = paramNames.map((name) => ({
+    label: name,
+    group: "Agent inputs",
+    token: `\${params.${name}}`,
+  }));
+  for (const id of earlierStepIds) {
+    const n = stepNumberById.get(id);
+    refs.push({
+      label: n ? `Result of step ${n}` : `Result of ${id}`,
+      group: "Earlier steps",
+      token: `\${steps.${id}.output}`,
+    });
+  }
+  return refs;
+}

--- a/web/src/components/tools/operation-picker.tsx
+++ b/web/src/components/tools/operation-picker.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { controlClass } from "./field";
+import { operationGroupLabel, operationLabel } from "./lib/friendly";
+import type { ToolPrimitive } from "./lib/types";
+
+/**
+ * Picks the base operation a tool performs. Renders each primitive as a card
+ * with a friendly name and its description, grouped by kind — far easier to scan
+ * than a bare <select> of names like `http_request`. Filterable when long.
+ */
+export function OperationPicker({
+  primitives,
+  selected,
+  onSelect,
+}: {
+  primitives: ToolPrimitive[];
+  selected: string;
+  onSelect: (name: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = primitives.filter((p) => {
+      if (!q) return true;
+      return (
+        p.name.toLowerCase().includes(q) ||
+        operationLabel(p.name).toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q)
+      );
+    });
+    const byKind = new Map<string, ToolPrimitive[]>();
+    for (const p of filtered) {
+      if (!byKind.has(p.kind)) byKind.set(p.kind, []);
+      byKind.get(p.kind)!.push(p);
+    }
+    return [...byKind.entries()];
+  }, [primitives, query]);
+
+  return (
+    <div className="space-y-2">
+      {primitives.length > 6 && (
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search operations…"
+            className={cn(controlClass, "pl-8")}
+          />
+        </div>
+      )}
+
+      <div className="max-h-80 space-y-3 overflow-auto pr-1">
+        {groups.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+            No operations match “{query}”.
+          </p>
+        ) : (
+          groups.map(([kind, items]) => (
+            <div key={kind} className="space-y-1.5">
+              <div className="text-xs font-medium text-muted-foreground">
+                {operationGroupLabel(kind)}
+              </div>
+              <div className="grid gap-1.5 sm:grid-cols-2">
+                {items.map((p) => {
+                  const active = p.name === selected;
+                  return (
+                    <button
+                      key={p.name}
+                      type="button"
+                      onClick={() => onSelect(p.name)}
+                      className={cn(
+                        "flex flex-col rounded-lg border p-2.5 text-left transition-colors",
+                        active
+                          ? "border-primary bg-primary/5"
+                          : "border-border hover:border-foreground/30",
+                      )}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium">{operationLabel(p.name)}</span>
+                        {active && <Check className="size-3.5 shrink-0 text-primary" />}
+                      </div>
+                      <span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                        {p.description}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/parameters-editor.tsx
+++ b/web/src/components/tools/parameters-editor.tsx
@@ -3,9 +3,8 @@
 import { Button } from "@/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
 import { controlClass } from "./field";
+import { TYPE_OPTIONS } from "./lib/friendly";
 import type { JsonSchemaType, ParamField } from "./lib/types";
-
-const TYPES: JsonSchemaType[] = ["string", "number", "integer", "boolean", "object", "array"];
 
 /**
  * Edits a tool's input parameters as friendly rows. The parent converts to/from
@@ -31,45 +30,44 @@ export function ParametersEditor({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium">Parameters</h3>
+        <h3 className="text-sm font-medium">Inputs the agent provides</h3>
         <Button type="button" variant="outline" size="sm" onClick={add}>
           <Plus data-icon="inline-start" className="size-3.5" />
-          Add parameter
+          Add input
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">
-        The inputs the agent provides when calling this tool. Reference them in
-        values with{" "}
-        <code className="font-[family-name:var(--font-mono)]">{"${name}"}</code>.
+        The values the agent fills in when it calls this tool. You can drop these
+        into the fields below using the “Insert” button.
       </p>
 
       {params.length === 0 ? (
         <div className="rounded-lg border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
-          No parameters yet. Add one if the tool needs input.
+          No inputs yet. Add one if the tool needs information from the agent.
         </div>
       ) : (
         <div className="space-y-2">
           {params.map((p, i) => (
             <div
               key={i}
-              className="grid grid-cols-[1fr_7rem_auto_auto] items-center gap-2 rounded-lg border border-border p-2"
+              className="grid grid-cols-[1fr_9.5rem_auto_auto] items-center gap-2 rounded-lg border border-border p-2"
             >
               <input
                 value={p.name}
                 onChange={(e) => update(i, { name: e.target.value })}
                 placeholder="name"
-                aria-label="Parameter name"
+                aria-label="Input name"
                 className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
               />
               <select
                 value={p.type}
                 onChange={(e) => update(i, { type: e.target.value as JsonSchemaType })}
-                aria-label="Parameter type"
+                aria-label="Input type"
                 className={`${controlClass} py-1.5`}
               >
-                {TYPES.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
+                {TYPE_OPTIONS.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
                   </option>
                 ))}
               </select>
@@ -87,15 +85,15 @@ export function ParametersEditor({
                 variant="ghost"
                 size="icon-sm"
                 onClick={() => remove(i)}
-                aria-label="Remove parameter"
+                aria-label="Remove input"
               >
                 <Trash2 className="size-3.5 text-muted-foreground" />
               </Button>
               <input
                 value={p.description ?? ""}
                 onChange={(e) => update(i, { description: e.target.value })}
-                placeholder="description (optional)"
-                aria-label="Parameter description"
+                placeholder="What is this input? (optional)"
+                aria-label="Input description"
                 className={`${controlClass} col-span-4 text-xs`}
               />
             </div>

--- a/web/src/components/tools/primitive-builder.tsx
+++ b/web/src/components/tools/primitive-builder.tsx
@@ -5,7 +5,9 @@ import { cn } from "@/lib/utils";
 import { ArgsEditor } from "./args-editor";
 import { controlClass } from "./field";
 import { JsonValueField } from "./json-value-field";
+import { OperationPicker } from "./operation-picker";
 import { ParametersEditor } from "./parameters-editor";
+import { MOCK_STRATEGY_OPTIONS } from "./lib/friendly";
 import { declaredParamNames, paramsToSchema, schemaToParams } from "./lib/definition";
 import type {
   MockStrategy,
@@ -15,11 +17,17 @@ import type {
 } from "./lib/types";
 
 const MODES: { value: PrimitiveMode; label: string; hint: string }[] = [
-  { value: "delegate", label: "Call a primitive", hint: "Wrap one base operation (HTTP, shell, file, data)." },
-  { value: "mock", label: "Mock response", hint: "Return a canned response for rehearsing evals." },
+  {
+    value: "delegate",
+    label: "Do it for real",
+    hint: "Perform an actual operation — call an API, run a command, touch a file.",
+  },
+  {
+    value: "mock",
+    label: "Return a canned response",
+    hint: "Skip the real work and return a fixed answer. Handy for rehearsing evals.",
+  },
 ];
-
-const STRATEGIES: MockStrategy[] = ["static", "lookup", "echo"];
 
 export function PrimitiveBuilder({
   def,
@@ -34,11 +42,6 @@ export function PrimitiveBuilder({
     () => primitives.filter((p) => p.delegatable),
     [primitives],
   );
-  const byKind = useMemo(() => {
-    const groups: Record<string, ToolPrimitive[]> = {};
-    for (const p of delegatable) (groups[p.kind] ??= []).push(p);
-    return groups;
-  }, [delegatable]);
 
   const impl = def.implementation;
   const selectedPrimitive =
@@ -57,7 +60,7 @@ export function PrimitiveBuilder({
       />
 
       <div className="space-y-2">
-        <h3 className="text-sm font-medium">Implementation</h3>
+        <h3 className="text-sm font-medium">When the agent calls this tool…</h3>
         <div className="grid grid-cols-2 gap-2">
           {MODES.map((m) => (
             <button
@@ -79,39 +82,33 @@ export function PrimitiveBuilder({
       </div>
 
       {impl.mode === "delegate" ? (
-        <div className="space-y-3">
-          <div>
-            <label className="mb-1.5 block text-sm font-medium">Primitive</label>
-            <select
-              value={impl.primitive ?? ""}
-              onChange={(e) => setImpl({ primitive: e.target.value })}
-              className={controlClass}
-            >
-              <option value="">Select a primitive…</option>
-              {Object.entries(byKind).map(([kind, items]) => (
-                <optgroup key={kind} label={kind}>
-                  {items.map((p) => (
-                    <option key={p.name} value={p.name}>
-                      {p.name}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
-            {selectedPrimitive && (
-              <p className="mt-1 text-xs text-muted-foreground">{selectedPrimitive.description}</p>
-            )}
-          </div>
-          <div>
-            <h4 className="mb-1.5 text-sm font-medium">Arguments</h4>
-            <ArgsEditor
-              primitive={selectedPrimitive}
-              args={impl.args ?? {}}
-              onChange={(args) => setImpl({ args })}
-              paramNames={declaredParamNames(def)}
-              allowSecrets={impl.primitive === "http_request"}
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <h4 className="text-sm font-medium">Operation</h4>
+            <p className="text-xs text-muted-foreground">
+              The action this tool performs under the hood.
+            </p>
+            <OperationPicker
+              primitives={delegatable}
+              selected={impl.primitive ?? ""}
+              onSelect={(name) => setImpl({ primitive: name })}
             />
           </div>
+          {selectedPrimitive && (
+            <div className="space-y-1.5">
+              <h4 className="text-sm font-medium">Details</h4>
+              <p className="text-xs text-muted-foreground">
+                Fill these in with fixed text, or insert an agent input.
+              </p>
+              <ArgsEditor
+                primitive={selectedPrimitive}
+                args={impl.args ?? {}}
+                onChange={(args) => setImpl({ args })}
+                paramNames={declaredParamNames(def)}
+                allowSecrets={impl.primitive === "http_request"}
+              />
+            </div>
+          )}
         </div>
       ) : (
         <MockEditor
@@ -130,27 +127,30 @@ function MockEditor({
   mock: NonNullable<PrimitiveDefinition["implementation"]["mock"]>;
   onChange: (mock: NonNullable<PrimitiveDefinition["implementation"]["mock"]>) => void;
 }) {
+  const activeHint = MOCK_STRATEGY_OPTIONS.find((s) => s.value === mock.strategy)?.hint;
+
   return (
     <div className="space-y-3">
       <div>
-        <label className="mb-1.5 block text-sm font-medium">Strategy</label>
+        <label className="mb-1.5 block text-sm font-medium">How should the response be chosen?</label>
         <select
           value={mock.strategy}
           onChange={(e) => onChange({ ...mock, strategy: e.target.value as MockStrategy })}
           className={controlClass}
         >
-          {STRATEGIES.map((s) => (
-            <option key={s} value={s}>
-              {s}
+          {MOCK_STRATEGY_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
             </option>
           ))}
         </select>
+        {activeHint && <p className="mt-1 text-xs text-muted-foreground">{activeHint}</p>}
       </div>
 
       {mock.strategy === "static" && (
         <JsonValueField
           label="Response"
-          hint="Returned verbatim on every call."
+          hint="Returned on every call. Enter it as JSON, e.g. { &quot;status&quot;: &quot;ok&quot; }."
           value={mock.response}
           onChange={(response) => onChange({ ...mock, response })}
         />
@@ -158,7 +158,7 @@ function MockEditor({
       {mock.strategy === "lookup" && (
         <>
           <div>
-            <label className="mb-1.5 block text-sm font-medium">Lookup key</label>
+            <label className="mb-1.5 block text-sm font-medium">Which input decides the response?</label>
             <input
               value={mock.lookup_key ?? ""}
               onChange={(e) => onChange({ ...mock, lookup_key: e.target.value })}
@@ -167,8 +167,8 @@ function MockEditor({
             />
           </div>
           <JsonValueField
-            label="Responses"
-            hint='Map of key value → response, with "*" as the fallback.'
+            label="Responses by value"
+            hint='A JSON object mapping each input value to its response. Use "*" for the fallback.'
             value={mock.responses}
             onChange={(responses) =>
               onChange({ ...mock, responses: responses as Record<string, unknown> })
@@ -179,7 +179,7 @@ function MockEditor({
       {mock.strategy === "echo" && (
         <JsonValueField
           label="Template (optional)"
-          hint="Echoes the call input, merged over this template."
+          hint="Returns the agent's input, merged over this JSON template."
           value={mock.template}
           onChange={(template) => onChange({ ...mock, template })}
         />

--- a/web/src/components/tools/simulate-panel.tsx
+++ b/web/src/components/tools/simulate-panel.tsx
@@ -24,11 +24,11 @@ export function SimulatePanel({
     <div className="space-y-3">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <Play className="size-3.5" />
-        Enter sample inputs to preview how placeholders resolve. Nothing is executed.
+        Enter example inputs to preview what each step would receive. Nothing actually runs.
       </div>
 
       {paramNames.length === 0 ? (
-        <p className="text-xs text-muted-foreground">This tool has no parameters.</p>
+        <p className="text-xs text-muted-foreground">This tool takes no inputs.</p>
       ) : (
         <div className="space-y-2">
           {paramNames.map((name) => (
@@ -48,7 +48,7 @@ export function SimulatePanel({
       )}
 
       <div>
-        <div className="mb-1.5 text-xs font-medium text-muted-foreground">Resolved</div>
+        <div className="mb-1.5 text-xs font-medium text-muted-foreground">What gets sent</div>
         {result.note ? (
           <p className="rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
             {result.note}

--- a/web/src/components/tools/step-card.tsx
+++ b/web/src/components/tools/step-card.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronUp, GripVertical, Plus, Trash2 } from "lucide-react";
 import { controlClass } from "./field";
+import { ValueField } from "./value-field";
+import { operationLabel, stepReferences } from "./lib/friendly";
 import type { ComposedStep, StepRefType, ToolPrimitive } from "./lib/types";
 
 export function StepCard({
@@ -12,6 +12,7 @@ export function StepCard({
   index,
   total,
   earlierStepIds,
+  stepNumberById,
   paramNames,
   primitives,
   toolOptions,
@@ -27,6 +28,7 @@ export function StepCard({
   index: number;
   total: number;
   earlierStepIds: string[];
+  stepNumberById: Map<string, number>;
   paramNames: string[];
   primitives: ToolPrimitive[];
   toolOptions: { slug: string; name: string }[];
@@ -58,9 +60,7 @@ export function StepCard({
         <span className="flex size-5 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums">
           {index + 1}
         </span>
-        <code className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
-          {step.id}
-        </code>
+        <span className="text-xs font-medium text-muted-foreground">Step {index + 1}</span>
         <div className="ml-auto flex items-center">
           <Button type="button" variant="ghost" size="icon-sm" onClick={onMoveUp} disabled={index === 0} aria-label="Move up">
             <ChevronUp className="size-3.5" />
@@ -75,27 +75,27 @@ export function StepCard({
       </div>
 
       <div className="space-y-3 p-3">
-        <div className="grid grid-cols-[8rem_1fr] gap-2">
+        <div className="grid grid-cols-[9rem_1fr] gap-2">
           <select
             value={step.ref.type}
             onChange={(e) => setRef({ type: e.target.value as StepRefType, name: "" })}
-            aria-label="Reference type"
+            aria-label="What this step runs"
             className={controlClass}
           >
-            <option value="primitive">Primitive</option>
-            <option value="tool">Saved tool</option>
+            <option value="primitive">Built-in operation</option>
+            <option value="tool">Another saved tool</option>
           </select>
           {step.ref.type === "primitive" ? (
             <select
               value={step.ref.name}
               onChange={(e) => setRef({ name: e.target.value })}
-              aria-label="Primitive"
+              aria-label="Operation"
               className={controlClass}
             >
-              <option value="">Select a primitive…</option>
+              <option value="">Choose an operation…</option>
               {delegatable.map((p) => (
                 <option key={p.name} value={p.name}>
-                  {p.name}
+                  {operationLabel(p.name)}
                 </option>
               ))}
             </select>
@@ -106,10 +106,10 @@ export function StepCard({
               aria-label="Tool"
               className={controlClass}
             >
-              <option value="">Select a tool…</option>
+              <option value="">Choose a tool…</option>
               {toolOptions.map((t) => (
                 <option key={t.slug} value={t.slug}>
-                  {t.name} ({t.slug})
+                  {t.name}
                 </option>
               ))}
             </select>
@@ -121,6 +121,7 @@ export function StepCard({
           onChange={(inputs) => onChange({ ...step, inputs })}
           paramNames={paramNames}
           earlierStepIds={earlierStepIds}
+          stepNumberById={stepNumberById}
           allowSecrets={isHTTP}
         />
       </div>
@@ -133,16 +134,18 @@ function StepInputsEditor({
   onChange,
   paramNames,
   earlierStepIds,
+  stepNumberById,
   allowSecrets,
 }: {
   inputs: Record<string, unknown>;
   onChange: (inputs: Record<string, unknown>) => void;
   paramNames: string[];
   earlierStepIds: string[];
+  stepNumberById: Map<string, number>;
   allowSecrets: boolean;
 }) {
-  const [focusedKey, setFocusedKey] = useState<string | null>(null);
   const rows = Object.entries(inputs);
+  const references = stepReferences(paramNames, earlierStepIds, stepNumberById);
 
   function setKey(oldKey: string, newKey: string) {
     const next: Record<string, unknown> = {};
@@ -163,68 +166,40 @@ function StepInputsEditor({
     while (name in inputs) name = `input${++n}`;
     onChange({ ...inputs, [name]: "" });
   }
-  function insert(token: string) {
-    if (!focusedKey) return;
-    const cur = typeof inputs[focusedKey] === "string" ? (inputs[focusedKey] as string) : "";
-    setValue(focusedKey, cur + token);
-  }
-
-  const chips = [
-    ...paramNames.map((p) => `\${params.${p}}`),
-    ...earlierStepIds.map((s) => `\${steps.${s}.output}`),
-    ...(allowSecrets ? ["${secrets.NAME}"] : []),
-  ];
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted-foreground">Inputs</span>
+        <span className="text-xs font-medium text-muted-foreground">Inputs for this step</span>
         <Button type="button" variant="ghost" size="xs" onClick={add}>
           <Plus data-icon="inline-start" className="size-3" />
           Add input
         </Button>
       </div>
       {rows.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No inputs mapped.</p>
+        <p className="text-xs text-muted-foreground">No inputs set for this step yet.</p>
       ) : (
         rows.map(([key, value]) => (
-          <div key={key} className="grid grid-cols-[10rem_1fr_auto] items-center gap-2">
+          <div key={key} className="grid grid-cols-[9rem_1fr_auto] items-start gap-2">
             <input
               value={key}
               onChange={(e) => setKey(key, e.target.value)}
               aria-label="Input name"
               className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
             />
-            <input
+            <ValueField
               value={typeof value === "string" ? value : JSON.stringify(value)}
-              onChange={(e) => setValue(key, e.target.value)}
-              onFocus={() => setFocusedKey(key)}
-              placeholder="value or ${params.x}"
-              aria-label="Input value"
-              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+              onChange={(v) => setValue(key, v)}
+              placeholder="Type a value or insert one"
+              references={references}
+              allowSecret={allowSecrets}
+              ariaLabel="Input value"
             />
             <Button type="button" variant="ghost" size="icon-sm" onClick={() => remove(key)} aria-label="Remove input">
               <Trash2 className="size-3.5 text-muted-foreground" />
             </Button>
           </div>
         ))
-      )}
-      {chips.length > 0 && (
-        <div className="flex flex-wrap items-center gap-1.5">
-          {chips.map((c) => (
-            <button
-              key={c}
-              type="button"
-              onClick={() => insert(c)}
-              disabled={!focusedKey}
-              className={cn(
-                "rounded-md border border-border bg-background px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[11px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50",
-              )}
-            >
-              {c}
-            </button>
-          ))}
-        </div>
       )}
     </div>
   );

--- a/web/src/components/tools/step-card.tsx
+++ b/web/src/components/tools/step-card.tsx
@@ -148,6 +148,8 @@ function StepInputsEditor({
   const references = stepReferences(paramNames, earlierStepIds, stepNumberById);
 
   function setKey(oldKey: string, newKey: string) {
+    // Don't merge into an existing input — that would silently drop a value.
+    if (newKey !== oldKey && newKey in inputs) return;
     const next: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(inputs)) next[k === oldKey ? newKey : k] = v;
     onChange(next);

--- a/web/src/components/tools/tool-builder.tsx
+++ b/web/src/components/tools/tool-builder.tsx
@@ -22,7 +22,7 @@ import { Field, controlClass } from "./field";
 import { ToolTypeBadge } from "./tool-type-badge";
 import { JsonValidityProvider } from "./json-validity";
 import { useToolPrimitives } from "./use-tool-primitives";
-import { declaredParamNames, emptyDefinition } from "./lib/definition";
+import { declaredParamNames, presetDefinition } from "./lib/definition";
 import { validateDefinition } from "./lib/validate";
 import type { ToolDefinition, ToolRecord, ToolType } from "./lib/types";
 
@@ -34,6 +34,7 @@ export function ToolBuilder({
   initialName,
   initialSlug,
   initialDefinition,
+  start,
 }: {
   workspaceId: string;
   mode: "create" | "edit";
@@ -42,6 +43,7 @@ export function ToolBuilder({
   initialName?: string;
   initialSlug?: string;
   initialDefinition?: ToolDefinition;
+  start?: string;
 }) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
@@ -49,7 +51,7 @@ export function ToolBuilder({
 
   const [name, setName] = useState(initialName ?? "");
   const [definition, setDefinition] = useState<ToolDefinition>(
-    initialDefinition ?? emptyDefinition(toolType),
+    initialDefinition ?? presetDefinition(toolType, start),
   );
   const [submitting, setSubmitting] = useState(false);
   const [jsonInvalid, setJsonInvalid] = useState(false);
@@ -135,8 +137,8 @@ export function ToolBuilder({
           <span className="inline-flex items-center gap-2">
             <ToolTypeBadge kind={toolType} />
             {toolType === "primitive"
-              ? "A single operation agents can call."
-              : "An ordered chain of primitives and other tools."}
+              ? "A single action the agent can take during a run."
+              : "Several actions the agent runs in order."}
           </span>
         }
         actions={
@@ -158,12 +160,33 @@ export function ToolBuilder({
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
         <JsonValidityProvider onChange={setJsonInvalid}>
           <div className="space-y-6">
-            <Field label="Name" htmlFor="tool-name" hint="A human-friendly name. A stable slug is derived from it.">
+            <Field
+              label="Name"
+              htmlFor="tool-name"
+              hint="What the agent sees when it calls this tool. A short id is generated automatically."
+            >
               <input
                 id="tool-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={toolType === "primitive" ? "e.g. lookup_order" : "e.g. refund_flow"}
+                className={controlClass}
+              />
+            </Field>
+
+            <Field
+              label="Description"
+              htmlFor="tool-description"
+              hint="The agent reads this to decide when to use the tool. Be specific about what it does."
+            >
+              <textarea
+                id="tool-description"
+                value={definition.description ?? ""}
+                onChange={(e) =>
+                  setDefinition({ ...definition, description: e.target.value })
+                }
+                rows={2}
+                placeholder="e.g. Look up an order by its id and return its status and items."
                 className={controlClass}
               />
             </Field>
@@ -182,15 +205,15 @@ export function ToolBuilder({
         </JsonValidityProvider>
 
         <div className="lg:sticky lg:top-4 lg:self-start">
-          <Tabs defaultValue="preview">
+          <Tabs defaultValue="summary">
             <TabsList className="w-full">
-              <TabsTrigger value="preview">Preview</TabsTrigger>
-              <TabsTrigger value="simulate">Simulate</TabsTrigger>
+              <TabsTrigger value="summary">Summary</TabsTrigger>
+              <TabsTrigger value="test">Test it</TabsTrigger>
             </TabsList>
-            <TabsContent value="preview" className="pt-3">
+            <TabsContent value="summary" className="pt-3">
               <DefinitionPreview definition={definition} issues={previewIssues} />
             </TabsContent>
-            <TabsContent value="simulate" className="pt-3">
+            <TabsContent value="test" className="pt-3">
               <SimulatePanel definition={definition} paramNames={paramNames} />
             </TabsContent>
           </Tabs>

--- a/web/src/components/tools/tool-start-chooser.tsx
+++ b/web/src/components/tools/tool-start-chooser.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Boxes, Globe, MessageSquareDashed, Terminal, Workflow } from "lucide-react";
+
+import { PageHeader } from "@/components/ui/page-header";
+
+/**
+ * The first screen of tool creation. Instead of asking a non-engineer to choose
+ * between "primitive" and "composed", it asks what they want the tool to do and
+ * routes to the builder with a sensible starting point preselected.
+ */
+export function ToolStartChooser({ workspaceId }: { workspaceId: string }) {
+  const base = `/workspaces/${workspaceId}/tools/new`;
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Tools", href: `/workspaces/${workspaceId}/tools` },
+          { label: "New tool" },
+        ]}
+        title="What should this tool do?"
+        description="Pick a starting point. You can change everything in the next step."
+      />
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <ChoiceCard
+          href={`${base}?type=primitive`}
+          icon={<Boxes className="size-5" />}
+          title="A single action"
+          description="The tool does one thing — call an API, run a command, read a file, or return a canned response for testing."
+          quickStarts={[
+            { href: `${base}?type=primitive&start=api`, icon: <Globe className="size-3.5" />, label: "Call a web API" },
+            { href: `${base}?type=primitive&start=command`, icon: <Terminal className="size-3.5" />, label: "Run a command" },
+            { href: `${base}?type=primitive&start=mock`, icon: <MessageSquareDashed className="size-3.5" />, label: "Return a sample response" },
+          ]}
+        />
+        <ChoiceCard
+          href={`${base}?type=composed`}
+          icon={<Workflow className="size-5" />}
+          title="A sequence of steps"
+          description="The tool runs several actions in order, passing each result into the next — for example, fetch data, then save it to a file."
+        />
+      </div>
+    </div>
+  );
+}
+
+function ChoiceCard({
+  href,
+  icon,
+  title,
+  description,
+  quickStarts,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  quickStarts?: { href: string; icon: React.ReactNode; label: string }[];
+}) {
+  return (
+    <div className="flex flex-col rounded-lg border border-border bg-card p-5 transition-colors hover:border-foreground/20">
+      <Link href={href} className="group flex flex-col">
+        <div className="mb-3 flex size-10 items-center justify-center rounded-lg bg-muted text-foreground">
+          {icon}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-base font-medium tracking-tight">{title}</span>
+          <ArrowRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </Link>
+
+      {quickStarts && (
+        <div className="mt-4 flex flex-wrap gap-1.5 border-t border-border pt-3">
+          {quickStarts.map((q) => (
+            <Link
+              key={q.href}
+              href={q.href}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+            >
+              {q.icon}
+              {q.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/value-field.tsx
+++ b/web/src/components/tools/value-field.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useRef } from "react";
+import { ChevronDown, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { controlClass } from "./field";
+import type { ValueReference } from "./lib/friendly";
+
+/**
+ * A single-line value input that a non-engineer can fill without learning the
+ * `${...}` template syntax. They type literal text, then use the "Insert value"
+ * menu to drop in an agent input, an earlier step's result, or a secret — the
+ * token is spliced at the cursor and the syntax stays hidden.
+ */
+export function ValueField({
+  value,
+  onChange,
+  placeholder,
+  references,
+  allowSecret = false,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  references: ValueReference[];
+  allowSecret?: boolean;
+  ariaLabel?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Where to splice an inserted token. Tracked so the menu (which steals focus)
+  // can still insert at the spot the user last had their cursor.
+  const caret = useRef<{ start: number; end: number }>({
+    start: value.length,
+    end: value.length,
+  });
+
+  function rememberCaret() {
+    const el = inputRef.current;
+    if (!el) return;
+    caret.current = {
+      start: el.selectionStart ?? value.length,
+      end: el.selectionEnd ?? value.length,
+    };
+  }
+
+  function insertAtCaret(token: string, selectInsideFrom?: string) {
+    const { start, end } = caret.current;
+    const next = value.slice(0, start) + token + value.slice(end);
+    onChange(next);
+    // Restore focus and place the caret sensibly after React re-renders.
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      if (selectInsideFrom && token.includes(selectInsideFrom)) {
+        const selStart = start + token.indexOf(selectInsideFrom);
+        el.setSelectionRange(selStart, selStart + selectInsideFrom.length);
+      } else {
+        const pos = start + token.length;
+        el.setSelectionRange(pos, pos);
+      }
+      caret.current = {
+        start: el.selectionStart ?? next.length,
+        end: el.selectionEnd ?? next.length,
+      };
+    });
+  }
+
+  const groups = groupReferences(references);
+  const hasMenu = references.length > 0 || allowSecret;
+
+  return (
+    <div className="flex items-stretch gap-1.5">
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onSelect={rememberCaret}
+        onKeyUp={rememberCaret}
+        onClick={rememberCaret}
+        onBlur={rememberCaret}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className={cn(controlClass, "font-[family-name:var(--font-mono)] text-xs")}
+      />
+      {hasMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={<Button type="button" variant="outline" size="sm" className="shrink-0" />}
+          >
+            <Plus data-icon="inline-start" className="size-3.5" />
+            Insert
+            <ChevronDown data-icon="inline-end" className="size-3.5 opacity-60" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="max-h-72 w-64 overflow-auto">
+            {groups.length === 0 && !allowSecret ? (
+              <DropdownMenuLabel>Nothing to insert yet</DropdownMenuLabel>
+            ) : (
+              groups.map((g, gi) => (
+                <DropdownMenuGroup key={g.group}>
+                  {gi > 0 && <DropdownMenuSeparator />}
+                  <DropdownMenuLabel>{g.group}</DropdownMenuLabel>
+                  {g.items.map((ref) => (
+                    <DropdownMenuItem
+                      key={ref.token}
+                      onClick={() => insertAtCaret(ref.token)}
+                    >
+                      {ref.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              ))
+            )}
+            {allowSecret && (
+              <>
+                {groups.length > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuLabel>Secrets</DropdownMenuLabel>
+                <DropdownMenuItem
+                  onClick={() => insertAtCaret("${secrets.NAME}", "NAME")}
+                >
+                  A stored secret…
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+function groupReferences(
+  references: ValueReference[],
+): { group: string; items: ValueReference[] }[] {
+  const order: string[] = [];
+  const byGroup = new Map<string, ValueReference[]>();
+  for (const ref of references) {
+    if (!byGroup.has(ref.group)) {
+      byGroup.set(ref.group, []);
+      order.push(ref.group);
+    }
+    byGroup.get(ref.group)!.push(ref);
+  }
+  return order.map((group) => ({ group, items: byGroup.get(group)! }));
+}


### PR DESCRIPTION
## Why

The tools builder was built for engineers, not the people who actually design challenges and evals. To create a tool you had to:

- choose **"Primitive"** vs **"Composed"** before knowing what either means,
- read jargon — *delegate*, *mock*, *strategy*, *parameters*, *arguments*, *primitive*,
- hand-write **`${order_id}`**, **`${params.x}`**, **`${steps.s1.output}`**, **`${secrets.NAME}`** template syntax, and
- type **raw JSON** into textareas for things like HTTP headers and mock responses.

For a non-AI-engineer, it didn't make sense.

This PR rebuilds the **presentation layer only**. The persisted `definition` payload, the API calls, and all the validation/simulation libs are **unchanged** — so there is **no backend change and no migration**. Existing tools open and save exactly as before.

## What changed

**1. Plain-language entry point.** "New tool" now opens a chooser — *"A single action"* vs *"A sequence of steps"* — with quick-starts (*Call a web API*, *Run a command*, *Return a sample response*) that preselect a sensible setup. No more "Primitive/Composed" dropdown.

**2. No more `${...}` typing.** A new **`ValueField`** lets you type literal text and click **Insert** to drop in an agent input ("order_id"), an earlier step's result ("Result of step 2"), or a secret. The template token is spliced in at the cursor — the syntax stays hidden.

**3. No more raw JSON for the common cases.** Object arguments (e.g. HTTP headers) use a **key/value editor** instead of a JSON textarea, with an *"Edit as JSON"* escape hatch for power users. Only arbitrary lists still use a small JSON field.

**4. A real Description field.** The agent-facing description was never editable in the builder before; now it is, with a hint that it's how the agent decides when to use the tool.

**5. Friendly operation picker.** Choosing what a tool does is now a card list with friendly names ("Call a web API") and descriptions, instead of a `<select>` of `http_request`-style identifiers.

**6. Plain-language everywhere.** Inputs (not "parameters"), "When the agent calls this tool…" (not "Implementation"), "Do it for real / Return a canned response" (not "delegate/mock"), friendly types (Text, Number, Yes/No, List…), and a **Summary** panel that describes the tool in a sentence — with the raw JSON tucked behind a "Show technical definition" disclosure.

## Safety / scope

- `definition` JSON written to the API is byte-for-byte the same shape as before; `validate.ts` / `simulate.ts` / `definition.ts` signatures are untouched (existing unit tests pass).
- Frontend-only. No routes, schemas, or DB touched.

## Verification

- `npx tsc --noEmit` — clean
- `pnpm lint` — no new errors
- `pnpm exec vitest run src/components/tools` — 19/19 pass
- `pnpm build` — succeeds; all three `/tools` routes build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
