### PR TITLE
feat(web): unified node-canvas tool builder (React Flow)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
+        "@xyflow/react": "^12.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
@@ -7211,8 +7212,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-contour": {
       "version": "3.0.6",
@@ -7244,7 +7244,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
       "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -7309,7 +7308,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -7363,8 +7361,7 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
@@ -7402,7 +7399,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
       "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -7412,7 +7408,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
       "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
@@ -8523,6 +8518,76 @@
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -9532,6 +9597,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -10096,7 +10167,6 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10132,7 +10202,6 @@
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10142,7 +10211,6 @@
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -10205,7 +10273,6 @@
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10276,7 +10343,6 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -10405,7 +10471,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10454,7 +10519,6 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10464,7 +10528,6 @@
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -10484,7 +10547,6 @@
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      '@xyflow/react':
+        specifier: ^12.11.0
+        version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -886,105 +889,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1302,28 +1289,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.15':
     resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.15':
     resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.15':
     resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.15':
     resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
@@ -2142,42 +2125,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -2333,28 +2310,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2681,49 +2654,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2880,6 +2845,22 @@ packages:
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
+  '@xyflow/react@12.11.0':
+    resolution: {integrity: sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.77':
+    resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
 
   abs-svg-path@0.1.1:
     resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
@@ -3170,6 +3151,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
@@ -4820,28 +4804,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6907,6 +6887,21 @@ packages:
     peerDependencies:
       react: '>=16.8'
     peerDependenciesMeta:
+      react:
+        optional: true
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
       react:
         optional: true
 
@@ -9752,6 +9747,31 @@ snapshots:
 
   '@xterm/xterm@5.5.0': {}
 
+  '@xyflow/react@12.11.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@xyflow/system': 0.0.77
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.77':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abs-svg-path@0.1.1: {}
 
   accepts@2.0.0:
@@ -10127,6 +10147,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  classcat@5.0.5: {}
 
   classnames@2.5.1: {}
 
@@ -14679,6 +14701,14 @@ snapshots:
 
   zustand@3.7.2(react@19.2.3):
     optionalDependencies:
+      react: 19.2.3
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.3):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
       react: 19.2.3
 
   zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/page.tsx
@@ -2,9 +2,12 @@ import { ToolEditClient } from "./tool-edit-client";
 
 export default async function EditToolPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ workspaceId: string; toolId: string }>;
+  searchParams: Promise<{ editor?: string }>;
 }) {
   const { workspaceId, toolId } = await params;
-  return <ToolEditClient workspaceId={workspaceId} toolId={toolId} />;
+  const { editor } = await searchParams;
+  return <ToolEditClient workspaceId={workspaceId} toolId={toolId} editor={editor} />;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/tool-edit-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/[toolId]/tool-edit-client.tsx
@@ -5,15 +5,18 @@ import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AlertTriangle } from "lucide-react";
 import { ToolBuilder } from "@/components/tools/tool-builder";
+import { ToolCanvasBuilder } from "@/components/tools/canvas-builder";
 import { isBuilderToolType, normalizeDefinition } from "@/components/tools/lib/definition";
 import type { ToolRecord } from "@/components/tools/lib/types";
 
 export function ToolEditClient({
   workspaceId,
   toolId,
+  editor,
 }: {
   workspaceId: string;
   toolId: string;
+  editor?: string;
 }) {
   const { data: tool, error, isLoading } = useApiQuery<ToolRecord>(`/v1/tools/${toolId}`);
 
@@ -49,15 +52,32 @@ export function ToolEditClient({
     );
   }
 
+  const definition = normalizeDefinition(inferredType, tool.definition);
+
+  if (editor === "form") {
+    return (
+      <ToolBuilder
+        workspaceId={workspaceId}
+        mode="edit"
+        toolType={inferredType}
+        toolId={tool.id}
+        initialName={tool.name}
+        initialSlug={tool.slug}
+        initialDefinition={definition}
+      />
+    );
+  }
+
   return (
-    <ToolBuilder
+    <ToolCanvasBuilder
       workspaceId={workspaceId}
       mode="edit"
-      toolType={inferredType}
+      lockedKind={inferredType}
       toolId={tool.id}
       initialName={tool.name}
       initialSlug={tool.slug}
-      initialDefinition={normalizeDefinition(inferredType, tool.definition)}
+      initialDefinition={definition}
+      formEditorHref={`/workspaces/${workspaceId}/tools/${tool.id}?editor=form`}
     />
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/new/page.tsx
@@ -1,28 +1,42 @@
 import { ToolBuilder } from "@/components/tools/tool-builder";
+import { ToolCanvasBuilder } from "@/components/tools/canvas-builder";
 import { ToolStartChooser } from "@/components/tools/tool-start-chooser";
-import { isBuilderToolType } from "@/components/tools/lib/definition";
+import { isBuilderToolType, presetDefinition } from "@/components/tools/lib/definition";
 
 export default async function NewToolPage({
   params,
   searchParams,
 }: {
   params: Promise<{ workspaceId: string }>;
-  searchParams: Promise<{ type?: string; start?: string }>;
+  searchParams: Promise<{ editor?: string; type?: string; start?: string }>;
 }) {
   const { workspaceId } = await params;
-  const { type, start } = await searchParams;
+  const { editor, type, start } = await searchParams;
 
-  // No (or unknown) type yet → let the user pick a plain-language starting point.
-  if (!isBuilderToolType(type ?? "")) {
-    return <ToolStartChooser workspaceId={workspaceId} />;
+  // Classic form editor (fallback). Needs a type — show the chooser first.
+  if (editor === "form") {
+    if (!isBuilderToolType(type ?? "")) {
+      return <ToolStartChooser workspaceId={workspaceId} />;
+    }
+    return (
+      <ToolBuilder
+        workspaceId={workspaceId}
+        mode="create"
+        toolType={type as "primitive" | "composed"}
+        start={start}
+      />
+    );
   }
 
+  // Default: the unified canvas builder. A quick-start preselects a first node.
+  const initialDefinition = start ? presetDefinition("primitive", start) : undefined;
   return (
-    <ToolBuilder
+    <ToolCanvasBuilder
       workspaceId={workspaceId}
       mode="create"
-      toolType={type as "primitive" | "composed"}
-      start={start}
+      initialName=""
+      initialDefinition={initialDefinition}
+      formEditorHref={`/workspaces/${workspaceId}/tools/new?editor=form`}
     />
   );
 }

--- a/web/src/components/tools/args-editor.tsx
+++ b/web/src/components/tools/args-editor.tsx
@@ -3,26 +3,28 @@
 import { JsonValueField } from "./json-value-field";
 import { KeyValueEditor } from "./key-value-editor";
 import { ValueField } from "./value-field";
-import { primitiveReferences, typeLabel } from "./lib/friendly";
+import { typeLabel, type ValueReference } from "./lib/friendly";
 import type { JsonSchemaType, ToolPrimitive } from "./lib/types";
 
 /**
  * Fills in what a base operation needs. Fields are derived from the operation's
  * own schema: plain values use a ValueField (type literal text or insert an agent
  * input), key/value groups use a KeyValueEditor, lists fall back to JSON. The user
- * never types `${...}` — references are inserted from a menu.
+ * never types `${...}` — references are inserted from a menu. The caller supplies
+ * the available references so this works for both primitive args and composed
+ * step inputs.
  */
 export function ArgsEditor({
   primitive,
   args,
   onChange,
-  paramNames,
+  references,
   allowSecrets,
 }: {
   primitive: ToolPrimitive | null;
   args: Record<string, unknown>;
   onChange: (args: Record<string, unknown>) => void;
-  paramNames: string[];
+  references: ValueReference[];
   allowSecrets: boolean;
 }) {
   if (!primitive) {
@@ -36,7 +38,6 @@ export function ArgsEditor({
   const props = primitive.parameters?.properties ?? {};
   const required = new Set(primitive.parameters?.required ?? []);
   const entries = Object.entries(props);
-  const references = primitiveReferences(paramNames);
 
   function setArg(key: string, value: unknown) {
     const next = { ...args };

--- a/web/src/components/tools/canvas-builder.tsx
+++ b/web/src/components/tools/canvas-builder.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import "@xyflow/react/dist/style.css";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
+import {
+  Background,
+  Controls,
+  Panel,
+  ReactFlow,
+  ReactFlowProvider,
+  addEdge,
+  useEdgesState,
+  useNodesState,
+  type Connection,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+import { Boxes, Loader2, MessageSquareDashed, PanelsTopLeft, Wrench } from "lucide-react";
+
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { useApiListQuery, useApiMutator } from "@/lib/api/swr";
+import { workspaceResourceKeys } from "@/lib/workspace-resource";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+
+import { DefinitionPreview } from "./definition-preview";
+import { Field, controlClass } from "./field";
+import { JsonValidityProvider } from "./json-validity";
+import { NodeInspector } from "./canvas/inspector";
+import { nodeTypes } from "./canvas/nodes";
+import { useToolPrimitives } from "./use-tool-primitives";
+import { operationLabel } from "./lib/friendly";
+import {
+  INPUTS_NODE_ID,
+  compileGraph,
+  inferKind,
+  nextStepId,
+  nodeReferences,
+  parseDefinition,
+  validateGraph,
+  type CanvasNode,
+  type CanvasNodeData,
+  type CanvasNodeKind,
+  type ToolGraph,
+} from "./lib/graph";
+import { emptyPrimitiveDefinition } from "./lib/definition";
+import { validateDefinition } from "./lib/validate";
+import type { ToolDefinition, ToolRecord, ToolType } from "./lib/types";
+
+function labelFor(node: CanvasNode): string {
+  if (node.kind === "operation") return node.data.primitive ? operationLabel(node.data.primitive) : "operation";
+  if (node.kind === "tool") return node.data.toolName || node.data.slug || "tool";
+  return "inputs";
+}
+
+function toRf(nodes: CanvasNode[]): Node[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    type: n.kind,
+    position: n.position,
+    data: n.data,
+    deletable: n.kind !== "inputs",
+  }));
+}
+
+function toCanvas(nodes: Node[]): CanvasNode[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    kind: (n.type ?? "operation") as CanvasNodeKind,
+    position: n.position,
+    data: n.data as CanvasNodeData,
+  }));
+}
+
+export function ToolCanvasBuilder(props: ToolCanvasBuilderProps) {
+  return (
+    <ReactFlowProvider>
+      <CanvasBuilderInner {...props} />
+    </ReactFlowProvider>
+  );
+}
+
+interface ToolCanvasBuilderProps {
+  workspaceId: string;
+  mode: "create" | "edit";
+  /** On edit, tool_kind is immutable — the graph must compile to this kind. */
+  lockedKind?: ToolType;
+  toolId?: string;
+  initialName?: string;
+  initialSlug?: string;
+  initialDefinition?: ToolDefinition;
+  /** Link to the classic form editor for the same tool. */
+  formEditorHref: string;
+}
+
+function CanvasBuilderInner({
+  workspaceId,
+  mode,
+  lockedKind,
+  toolId,
+  initialName,
+  initialSlug,
+  initialDefinition,
+  formEditorHref,
+}: ToolCanvasBuilderProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const { mutateMany } = useApiMutator();
+
+  const initialGraph = useMemo<ToolGraph>(
+    () => parseDefinition(initialDefinition ?? emptyPrimitiveDefinition()),
+    [initialDefinition],
+  );
+
+  const [name, setName] = useState(initialName ?? "");
+  const [description, setDescription] = useState(initialDefinition?.description ?? "");
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>(toRf(initialGraph.nodes));
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(initialGraph.edges as Edge[]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [jsonInvalid, setJsonInvalid] = useState(false);
+
+  const { primitives } = useToolPrimitives();
+  const { data: toolsData } = useApiListQuery<ToolRecord>(`/v1/workspaces/${workspaceId}/tools`);
+
+  const primitivesByName = useMemo(
+    () => new Map(primitives.filter((p) => p.delegatable).map((p) => [p.name, p] as const)),
+    [primitives],
+  );
+  const toolOptions = useMemo(
+    () =>
+      (toolsData?.items ?? [])
+        .filter((t) => t.slug !== initialSlug)
+        .map((t) => ({ slug: t.slug, name: t.name })),
+    [toolsData, initialSlug],
+  );
+  const knownToolSlugs = useMemo(
+    () => new Set((toolsData?.items ?? []).map((t) => t.slug)),
+    [toolsData],
+  );
+
+  const graph: ToolGraph = useMemo(
+    () => ({ nodes: toCanvas(nodes), edges: edges.map((e) => ({ id: e.id, source: e.source, target: e.target })) }),
+    [nodes, edges],
+  );
+  const kind: ToolType = lockedKind ?? inferKind(graph.nodes);
+  const definition = useMemo(
+    () => compileGraph(graph, kind, { description }),
+    [graph, kind, description],
+  );
+
+  const primitivesReady = primitives.length > 0;
+  const issues = useMemo(() => {
+    const graphIssues = validateGraph(graph, kind).map((i) => ({ path: "canvas", message: i.message }));
+    const defIssues = primitivesReady
+      ? validateDefinition(definition, { primitives: primitivesByName, knownToolSlugs, selfSlug: initialSlug })
+      : [];
+    return [...graphIssues, ...defIssues];
+  }, [graph, kind, definition, primitivesReady, primitivesByName, knownToolSlugs, initialSlug]);
+
+  const previewIssues = jsonInvalid
+    ? [...issues, { path: "editor", message: "Fix the invalid JSON in the highlighted field(s)." }]
+    : issues;
+
+  const selectedNode = graph.nodes.find((n) => n.id === selectedId) ?? null;
+  const references = selectedNode ? nodeReferences(selectedNode.id, graph, labelFor) : [];
+
+  const canSave =
+    primitivesReady && name.trim().length > 0 && issues.length === 0 && !jsonInvalid && !submitting;
+
+  const patchNode = useCallback(
+    (id: string, patch: Partial<CanvasNodeData>) => {
+      setNodes((ns) => ns.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...patch } } : n)));
+    },
+    [setNodes],
+  );
+
+  const addNode = useCallback(
+    (nodeKind: Exclude<CanvasNodeKind, "inputs">) => {
+      if (nodeKind === "canned" && nodes.some((n) => n.type === "canned")) {
+        toast.error("Only one canned response is allowed.");
+        return;
+      }
+      const canvasNodes = toCanvas(nodes);
+      const stepId = nextStepId(canvasNodes);
+      const id = nodeKind === "canned" ? "canned" : stepId;
+      const offset = nodes.filter((n) => n.type !== "inputs").length;
+      const data: CanvasNodeData =
+        nodeKind === "canned"
+          ? { mock: { strategy: "static" } }
+          : { stepId, inputs: {} };
+      const newNode: Node = {
+        id,
+        type: nodeKind,
+        position: { x: 320, y: 24 + offset * 130 },
+        data,
+        deletable: true,
+      };
+      setNodes((ns) => [...ns, newNode]);
+      if (nodeKind !== "canned") {
+        setEdges((es) => addEdge({ id: `e-${INPUTS_NODE_ID}-${id}`, source: INPUTS_NODE_ID, target: id }, es));
+      }
+      setSelectedId(id);
+    },
+    [nodes, setNodes, setEdges],
+  );
+
+  const deleteNode = useCallback(
+    (id: string) => {
+      setNodes((ns) => ns.filter((n) => n.id !== id));
+      setEdges((es) => es.filter((e) => e.source !== id && e.target !== id));
+      setSelectedId(null);
+    },
+    [setNodes, setEdges],
+  );
+
+  const onConnect = useCallback(
+    (c: Connection) => setEdges((es) => addEdge(c, es)),
+    [setEdges],
+  );
+
+  async function save() {
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const api = createApiClient((await getAccessToken()) ?? undefined);
+      if (mode === "create") {
+        await api.post(`/v1/workspaces/${workspaceId}/tools`, {
+          name: name.trim(),
+          tool_kind: kind,
+          definition,
+        });
+      } else {
+        await api.patch(`/v1/tools/${toolId}`, { name: name.trim(), definition });
+      }
+      await mutateMany([workspaceResourceKeys.tools(workspaceId)]);
+      toast.success(mode === "create" ? "Tool created" : "Tool saved");
+      router.push(`/workspaces/${workspaceId}/tools`);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to save tool");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Tools", href: `/workspaces/${workspaceId}/tools` },
+          { label: mode === "create" ? "New tool" : (initialName ?? "Edit") },
+        ]}
+        title={mode === "create" ? "New tool" : (initialName ?? "Edit tool")}
+        description="Drag from the right edge of a node to the next to connect steps. One node is a simple tool; connect a few to build a chain."
+        actions={
+          <>
+            <Button variant="ghost" size="sm" render={<Link href={formEditorHref} />}>
+              Use form editor
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => router.push(`/workspaces/${workspaceId}/tools`)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button onClick={save} disabled={!canSave}>
+              {submitting ? <Loader2 className="size-4 animate-spin" /> : "Save tool"}
+            </Button>
+          </>
+        }
+      />
+
+      <JsonValidityProvider onChange={setJsonInvalid}>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_24rem]">
+          <div className="h-[600px] overflow-hidden rounded-lg border border-border">
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={nodeTypes}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              onNodeClick={(_, node) => setSelectedId(node.id)}
+              onPaneClick={() => setSelectedId(null)}
+              onNodesDelete={(deleted) => {
+                if (deleted.some((n) => n.id === selectedId)) setSelectedId(null);
+              }}
+              fitView
+              colorMode="dark"
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background />
+              <Controls showInteractive={false} />
+              <Panel position="top-left" className="flex flex-wrap gap-1.5">
+                <Button type="button" variant="outline" size="sm" onClick={() => addNode("operation")}>
+                  <Boxes data-icon="inline-start" className="size-3.5" />
+                  Operation
+                </Button>
+                <Button type="button" variant="outline" size="sm" onClick={() => addNode("tool")}>
+                  <Wrench data-icon="inline-start" className="size-3.5" />
+                  Tool
+                </Button>
+                <Button type="button" variant="outline" size="sm" onClick={() => addNode("canned")}>
+                  <MessageSquareDashed data-icon="inline-start" className="size-3.5" />
+                  Canned response
+                </Button>
+              </Panel>
+            </ReactFlow>
+          </div>
+
+          <div className="lg:sticky lg:top-4 lg:self-start">
+            <div className="space-y-4 rounded-lg border border-border p-3">
+              <Field
+                label="Name"
+                htmlFor="tool-name"
+                hint="What the agent sees when it calls this tool."
+              >
+                <input
+                  id="tool-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. lookup_order"
+                  className={controlClass}
+                />
+              </Field>
+              <Field
+                label="Description"
+                htmlFor="tool-description"
+                hint="The agent reads this to decide when to use the tool."
+              >
+                <textarea
+                  id="tool-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                  placeholder="e.g. Look up an order by its id and return its status."
+                  className={controlClass}
+                />
+              </Field>
+            </div>
+
+            <div className="mt-4 min-h-[16rem] rounded-lg border border-border">
+              {selectedNode ? (
+                <NodeInspector
+                  node={selectedNode}
+                  references={references}
+                  primitives={primitives}
+                  tools={toolOptions}
+                  onPatch={(patch) => patchNode(selectedNode.id, patch)}
+                  onDelete={() => deleteNode(selectedNode.id)}
+                  onClose={() => setSelectedId(null)}
+                />
+              ) : (
+                <div className="space-y-3 p-3">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <PanelsTopLeft className="size-3.5" />
+                    Select a node to configure it.
+                  </div>
+                  <DefinitionPreview definition={definition} issues={previewIssues} />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </JsonValidityProvider>
+    </div>
+  );
+}

--- a/web/src/components/tools/canvas-builder.tsx
+++ b/web/src/components/tools/canvas-builder.tsx
@@ -221,7 +221,10 @@ function CanvasBuilderInner({
   );
 
   const onConnect = useCallback(
-    (c: Connection) => setEdges((es) => addEdge(c, es)),
+    (c: Connection) => {
+      if (c.source === c.target) return; // a step can't feed itself
+      setEdges((es) => addEdge(c, es));
+    },
     [setEdges],
   );
 
@@ -297,7 +300,6 @@ function CanvasBuilderInner({
               }}
               fitView
               colorMode="dark"
-              proOptions={{ hideAttribution: true }}
             >
               <Background />
               <Controls showInteractive={false} />

--- a/web/src/components/tools/canvas/inspector.tsx
+++ b/web/src/components/tools/canvas/inspector.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMemo } from "react";
+import { Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ArgsEditor } from "../args-editor";
+import { controlClass } from "../field";
+import { MockEditor } from "../primitive-builder";
+import { OperationPicker } from "../operation-picker";
+import { ParametersEditor } from "../parameters-editor";
+import { StepInputsEditor } from "../step-inputs-editor";
+import { paramsToSchema, schemaToParams } from "../lib/definition";
+import type { CanvasNode } from "../lib/graph";
+import type { MockConfig, ToolPrimitive } from "../lib/types";
+import type { ValueReference } from "../lib/friendly";
+
+/**
+ * Configures the selected canvas node. Each node kind reuses the same
+ * humanized editors as the form builder — only the wiring (what references are
+ * available) differs, and that comes from the node's incoming connections.
+ */
+export function NodeInspector({
+  node,
+  references,
+  primitives,
+  tools,
+  onPatch,
+  onDelete,
+  onClose,
+}: {
+  node: CanvasNode;
+  references: ValueReference[];
+  primitives: ToolPrimitive[];
+  tools: { slug: string; name: string }[];
+  onPatch: (data: Partial<CanvasNode["data"]>) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const delegatable = useMemo(() => primitives.filter((p) => p.delegatable), [primitives]);
+  const selectedPrimitive =
+    node.kind === "operation"
+      ? (delegatable.find((p) => p.name === node.data.primitive) ?? null)
+      : null;
+
+  const title =
+    node.kind === "inputs"
+      ? "Agent inputs"
+      : node.kind === "operation"
+        ? "Operation"
+        : node.kind === "tool"
+          ? "Tool reference"
+          : "Canned response";
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-sm font-medium">{title}</span>
+        <div className="flex items-center gap-1">
+          {node.kind !== "inputs" && (
+            <Button type="button" variant="ghost" size="icon-sm" onClick={onDelete} aria-label="Delete node">
+              <Trash2 className="size-3.5 text-muted-foreground" />
+            </Button>
+          )}
+          <Button type="button" variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close">
+            <X className="size-3.5 text-muted-foreground" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-4 overflow-auto p-3">
+        {node.kind === "inputs" && (
+          <ParametersEditor
+            params={schemaToParams(node.data.parameters)}
+            onChange={(next) => onPatch({ parameters: paramsToSchema(next) })}
+          />
+        )}
+
+        {node.kind === "operation" && (
+          <>
+            <div className="space-y-1.5">
+              <h4 className="text-sm font-medium">Operation</h4>
+              <OperationPicker
+                primitives={delegatable}
+                selected={node.data.primitive ?? ""}
+                onSelect={(name) => onPatch({ primitive: name })}
+              />
+            </div>
+            {selectedPrimitive && (
+              <div className="space-y-1.5">
+                <h4 className="text-sm font-medium">Details</h4>
+                <p className="text-xs text-muted-foreground">
+                  Type a value, or use Insert to pull in a wired-in input or result.
+                </p>
+                <ArgsEditor
+                  primitive={selectedPrimitive}
+                  args={node.data.inputs ?? {}}
+                  onChange={(inputs) => onPatch({ inputs })}
+                  references={references}
+                  allowSecrets={node.data.primitive === "http_request"}
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {node.kind === "tool" && (
+          <>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Which tool?</label>
+              <select
+                value={node.data.slug ?? ""}
+                onChange={(e) => {
+                  const slug = e.target.value;
+                  const name = tools.find((t) => t.slug === slug)?.name;
+                  onPatch({ slug, toolName: name });
+                }}
+                className={controlClass}
+              >
+                <option value="">Choose a tool…</option>
+                {tools.map((t) => (
+                  <option key={t.slug} value={t.slug}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <StepInputsEditor
+              inputs={node.data.inputs ?? {}}
+              onChange={(inputs) => onPatch({ inputs })}
+              references={references}
+              allowSecrets={false}
+              label="Inputs to pass in"
+              emptyHint="Add the inputs this tool needs."
+            />
+          </>
+        )}
+
+        {node.kind === "canned" && (
+          <MockEditor
+            mock={node.data.mock ?? { strategy: "static" }}
+            onChange={(mock: MockConfig) => onPatch({ mock })}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/tools/canvas/nodes.tsx
+++ b/web/src/components/tools/canvas/nodes.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Boxes, MessageSquareDashed, PlayCircle, Wrench } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { operationLabel } from "../lib/friendly";
+import type { CanvasNodeData } from "../lib/graph";
+
+const handleClass = "!size-2.5 !border-2 !border-background !bg-muted-foreground";
+
+function Shell({
+  selected,
+  icon,
+  tag,
+  title,
+  subtitle,
+  tone = "default",
+}: {
+  selected?: boolean;
+  icon: React.ReactNode;
+  tag: string;
+  title: string;
+  subtitle?: string;
+  tone?: "default" | "inputs" | "canned";
+}) {
+  return (
+    <div
+      className={cn(
+        "w-56 rounded-lg border bg-card px-3 py-2.5 shadow-sm transition-colors",
+        selected ? "border-primary ring-2 ring-primary/30" : "border-border",
+        tone === "inputs" && "bg-muted/40",
+      )}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {icon}
+        {tag}
+      </div>
+      <div className="truncate text-sm font-medium">{title}</div>
+      {subtitle && <div className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</div>}
+    </div>
+  );
+}
+
+export function InputsNode({ data, selected }: NodeProps) {
+  const d = data as CanvasNodeData;
+  const count = Object.keys(d.parameters?.properties ?? {}).length;
+  return (
+    <>
+      <Shell
+        selected={selected}
+        tone="inputs"
+        icon={<PlayCircle className="size-3.5" />}
+        tag="Start"
+        title="Agent inputs"
+        subtitle={count === 0 ? "No inputs defined" : `${count} input${count > 1 ? "s" : ""}`}
+      />
+      <Handle type="source" position={Position.Right} className={handleClass} />
+    </>
+  );
+}
+
+export function OperationNode({ data, selected }: NodeProps) {
+  const d = data as CanvasNodeData;
+  return (
+    <>
+      <Handle type="target" position={Position.Left} className={handleClass} />
+      <Shell
+        selected={selected}
+        icon={<Boxes className="size-3.5" />}
+        tag="Operation"
+        title={d.primitive ? operationLabel(d.primitive) : "Choose an operation"}
+        subtitle={d.primitive || "Click to configure"}
+      />
+      <Handle type="source" position={Position.Right} className={handleClass} />
+    </>
+  );
+}
+
+export function ToolNode({ data, selected }: NodeProps) {
+  const d = data as CanvasNodeData;
+  return (
+    <>
+      <Handle type="target" position={Position.Left} className={handleClass} />
+      <Shell
+        selected={selected}
+        icon={<Wrench className="size-3.5" />}
+        tag="Tool"
+        title={d.toolName || d.slug || "Choose a tool"}
+        subtitle={d.slug ? "Runs another saved tool" : "Click to configure"}
+      />
+      <Handle type="source" position={Position.Right} className={handleClass} />
+    </>
+  );
+}
+
+export function CannedNode({ data, selected }: NodeProps) {
+  const d = data as CanvasNodeData;
+  return (
+    <>
+      <Handle type="target" position={Position.Left} className={handleClass} />
+      <Shell
+        selected={selected}
+        tone="canned"
+        icon={<MessageSquareDashed className="size-3.5" />}
+        tag="Canned response"
+        title="Returns a fixed response"
+        subtitle={d.mock?.strategy ? `${d.mock.strategy} response` : "Click to configure"}
+      />
+    </>
+  );
+}
+
+export const nodeTypes = {
+  inputs: InputsNode,
+  operation: OperationNode,
+  tool: ToolNode,
+  canned: CannedNode,
+};

--- a/web/src/components/tools/lib/graph.test.ts
+++ b/web/src/components/tools/lib/graph.test.ts
@@ -196,4 +196,32 @@ describe("validateGraph", () => {
     const issues = validateGraph({ nodes: [inputs()], edges: [] }, "primitive");
     expect(issues.some((i) => /at least one/i.test(i.message))).toBe(true);
   });
+
+  it("flags a cycle between steps so a corrupt order can't be saved", () => {
+    const nodes: CanvasNode[] = [
+      inputs(),
+      { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s1", primitive: "http_request" } },
+      { id: "s2", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s2", primitive: "file_write" } },
+    ];
+    const edges = [
+      { id: "e1", source: "s1", target: "s2" },
+      { id: "e2", source: "s2", target: "s1" }, // back-edge → cycle
+    ];
+    const issues = validateGraph({ nodes, edges }, inferKind(nodes));
+    expect(issues.some((i) => /loop/i.test(i.message))).toBe(true);
+  });
+
+  it("does not flag a valid linear chain as a cycle", () => {
+    const nodes: CanvasNode[] = [
+      inputs(),
+      { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s1", primitive: "http_request" } },
+      { id: "s2", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s2", primitive: "file_write" } },
+    ];
+    const edges = [
+      { id: "e1", source: INPUTS_NODE_ID, target: "s1" },
+      { id: "e2", source: "s1", target: "s2" },
+    ];
+    const issues = validateGraph({ nodes, edges }, inferKind(nodes));
+    expect(issues.some((i) => /loop/i.test(i.message))).toBe(false);
+  });
 });

--- a/web/src/components/tools/lib/graph.test.ts
+++ b/web/src/components/tools/lib/graph.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileGraph,
+  inferKind,
+  INPUTS_NODE_ID,
+  nodeReferences,
+  parseDefinition,
+  validateGraph,
+  type CanvasNode,
+  type ToolGraph,
+} from "./graph";
+import type { ComposedDefinition, PrimitiveDefinition } from "./types";
+
+const schema = {
+  type: "object" as const,
+  properties: { order_id: { type: "string" as const } },
+  required: ["order_id"],
+  additionalProperties: false,
+};
+
+function inputs(): CanvasNode {
+  return { id: INPUTS_NODE_ID, kind: "inputs", position: { x: 0, y: 0 }, data: { parameters: schema } };
+}
+
+describe("inferKind", () => {
+  it("single operation → primitive", () => {
+    expect(inferKind([inputs(), { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: {} }])).toBe(
+      "primitive",
+    );
+  });
+  it("canned alone → primitive", () => {
+    expect(inferKind([inputs(), { id: "c", kind: "canned", position: { x: 0, y: 0 }, data: {} }])).toBe(
+      "primitive",
+    );
+  });
+  it("two operations → composed", () => {
+    expect(
+      inferKind([
+        inputs(),
+        { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: {} },
+        { id: "s2", kind: "operation", position: { x: 0, y: 0 }, data: {} },
+      ]),
+    ).toBe("composed");
+  });
+  it("single tool reference → composed", () => {
+    expect(inferKind([inputs(), { id: "s1", kind: "tool", position: { x: 0, y: 0 }, data: {} }])).toBe(
+      "composed",
+    );
+  });
+});
+
+describe("compileGraph primitive", () => {
+  it("delegate translates ${params.x} → ${x}", () => {
+    const graph: ToolGraph = {
+      nodes: [
+        inputs(),
+        {
+          id: "s1",
+          kind: "operation",
+          position: { x: 0, y: 0 },
+          data: {
+            stepId: "s1",
+            primitive: "http_request",
+            inputs: { url: "https://api/${params.order_id}" },
+          },
+        },
+      ],
+      edges: [{ id: "e", source: INPUTS_NODE_ID, target: "s1" }],
+    };
+    const def = compileGraph(graph, "primitive") as PrimitiveDefinition;
+    expect(def.tool_type).toBe("primitive");
+    expect(def.implementation.mode).toBe("delegate");
+    expect(def.implementation.primitive).toBe("http_request");
+    expect(def.implementation.args).toEqual({ url: "https://api/${order_id}" });
+  });
+
+  it("canned node → mock primitive", () => {
+    const graph: ToolGraph = {
+      nodes: [inputs(), { id: "c", kind: "canned", position: { x: 0, y: 0 }, data: { mock: { strategy: "static", response: { ok: true } } } }],
+      edges: [],
+    };
+    const def = compileGraph(graph, "primitive") as PrimitiveDefinition;
+    expect(def.implementation.mode).toBe("mock");
+    expect(def.implementation.mock).toEqual({ strategy: "static", response: { ok: true } });
+  });
+});
+
+describe("compileGraph composed", () => {
+  it("orders steps by edges and keeps composed syntax", () => {
+    const graph: ToolGraph = {
+      nodes: [
+        inputs(),
+        { id: "b", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s2", primitive: "file_write", inputs: { content: "${steps.s1.output}" } } },
+        { id: "a", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s1", primitive: "http_request", inputs: { url: "${params.order_id}" } } },
+      ],
+      // a (s1) must come before b (s2)
+      edges: [{ id: "e", source: "a", target: "b" }],
+    };
+    const def = compileGraph(graph, "composed") as ComposedDefinition;
+    expect(def.tool_type).toBe("composed");
+    expect(def.steps.map((s) => s.id)).toEqual(["s1", "s2"]);
+    expect(def.steps[1].inputs).toEqual({ content: "${steps.s1.output}" });
+  });
+});
+
+describe("parseDefinition", () => {
+  it("primitive delegate → one op node + inputs edge, args back to ${params.x}", () => {
+    const def: PrimitiveDefinition = {
+      tool_type: "primitive",
+      description: "",
+      parameters: schema,
+      implementation: { mode: "delegate", primitive: "http_request", args: { url: "https://api/${order_id}" } },
+    };
+    const g = parseDefinition(def);
+    const op = g.nodes.find((n) => n.kind === "operation")!;
+    expect(op.data.primitive).toBe("http_request");
+    expect(op.data.inputs).toEqual({ url: "https://api/${params.order_id}" });
+    expect(g.edges.some((e) => e.source === INPUTS_NODE_ID && e.target === op.id)).toBe(true);
+  });
+
+  it("composed → nodes + edges inferred from references", () => {
+    const def: ComposedDefinition = {
+      tool_type: "composed",
+      description: "",
+      parameters: schema,
+      steps: [
+        { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "${params.order_id}" } },
+        { id: "s2", ref: { type: "primitive", name: "file_write" }, inputs: { content: "${steps.s1.output}" } },
+      ],
+    };
+    const g = parseDefinition(def);
+    expect(g.nodes.filter((n) => n.kind === "operation")).toHaveLength(2);
+    expect(g.edges.some((e) => e.source === "s1" && e.target === "s2")).toBe(true);
+    expect(g.edges.some((e) => e.source === INPUTS_NODE_ID && e.target === "s1")).toBe(true);
+  });
+
+  it("round-trips a composed definition", () => {
+    const def: ComposedDefinition = {
+      tool_type: "composed",
+      description: "do things",
+      parameters: schema,
+      steps: [
+        { id: "s1", ref: { type: "primitive", name: "http_request" }, inputs: { url: "${params.order_id}" } },
+        { id: "s2", ref: { type: "tool", name: "save_it" }, inputs: { content: "${steps.s1.output}" } },
+      ],
+    };
+    const recompiled = compileGraph(parseDefinition(def), "composed", { description: "do things" });
+    expect(recompiled).toEqual(def);
+  });
+});
+
+describe("nodeReferences", () => {
+  it("offers agent inputs from a wired Inputs node and results from upstream steps", () => {
+    const graph: ToolGraph = {
+      nodes: [
+        inputs(),
+        { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s1", primitive: "http_request" } },
+        { id: "s2", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s2", primitive: "file_write" } },
+      ],
+      edges: [
+        { id: "e1", source: INPUTS_NODE_ID, target: "s2" },
+        { id: "e2", source: "s1", target: "s2" },
+      ],
+    };
+    const refs = nodeReferences("s2", graph, (n) => n.data.primitive ?? "op");
+    expect(refs).toEqual(
+      expect.arrayContaining([
+        { label: "order_id", group: "Agent inputs", token: "${params.order_id}" },
+        { label: "Result of http_request", group: "Earlier steps", token: "${steps.s1.output}" },
+      ]),
+    );
+  });
+
+  it("offers nothing to a node with no incoming wires", () => {
+    const graph: ToolGraph = {
+      nodes: [inputs(), { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: { stepId: "s1" } }],
+      edges: [],
+    };
+    expect(nodeReferences("s1", graph, () => "x")).toEqual([]);
+  });
+});
+
+describe("validateGraph", () => {
+  it("flags canned combined with steps", () => {
+    const nodes: CanvasNode[] = [
+      inputs(),
+      { id: "c", kind: "canned", position: { x: 0, y: 0 }, data: {} },
+      { id: "s1", kind: "operation", position: { x: 0, y: 0 }, data: {} },
+    ];
+    const issues = validateGraph({ nodes, edges: [] }, inferKind(nodes));
+    expect(issues.some((i) => /canned/i.test(i.message))).toBe(true);
+  });
+
+  it("flags an empty graph", () => {
+    const issues = validateGraph({ nodes: [inputs()], edges: [] }, "primitive");
+    expect(issues.some((i) => /at least one/i.test(i.message))).toBe(true);
+  });
+});

--- a/web/src/components/tools/lib/graph.ts
+++ b/web/src/components/tools/lib/graph.ts
@@ -164,10 +164,45 @@ function orderedSteps(nodes: CanvasNode[], edges: CanvasEdge[]): CanvasNode[] {
     }
     ready.sort((a, b) => order.indexOf(a) - order.indexOf(b));
   }
-  // Append any nodes left out by a cycle, in original order.
+  // Append any nodes left out by a cycle, in original order. A cyclic graph is
+  // blocked upstream by validateGraph (hasCycle), so this only runs defensively.
   for (const id of order) if (!seen.has(id)) result.push(id);
   const byId = new Map(steps.map((n) => [n.id, n]));
   return result.map((id) => byId.get(id)!).filter(Boolean);
+}
+
+/**
+ * True if the step nodes contain a directed cycle (e.g. a back-edge A → B → A).
+ * Such a graph can't be topologically ordered, so the compiled `composed`
+ * definition would list steps out of dependency order — a step could reference
+ * another whose result hasn't been computed yet. Uses the same edge filtering
+ * as `orderedSteps` (ignores self-loops and edges to/from non-step nodes).
+ */
+function hasCycle(nodes: CanvasNode[], edges: CanvasEdge[]): boolean {
+  const steps = stepNodes(nodes);
+  const ids = new Set(steps.map((n) => n.id));
+  const outs = new Map<string, string[]>(steps.map((n) => [n.id, []]));
+  for (const e of edges) {
+    if (ids.has(e.source) && ids.has(e.target) && e.source !== e.target) {
+      outs.get(e.source)!.push(e.target);
+    }
+  }
+  // 3-colour DFS: gray = on the current path, black = fully explored.
+  const color = new Map<string, 0 | 1 | 2>(steps.map((n) => [n.id, 0]));
+  const visit = (id: string): boolean => {
+    color.set(id, 1);
+    for (const t of outs.get(id) ?? []) {
+      const c = color.get(t);
+      if (c === 1) return true; // back-edge into the current path
+      if (c === 0 && visit(t)) return true;
+    }
+    color.set(id, 2);
+    return false;
+  };
+  for (const n of steps) {
+    if (color.get(n.id) === 0 && visit(n.id)) return true;
+  }
+  return false;
 }
 
 // --- compile: graph → definition --------------------------------------------
@@ -248,6 +283,11 @@ export function validateGraph(graph: ToolGraph, kind: ToolType): GraphIssue[] {
     issues.push({
       message:
         "This is a single-action tool, so it can't have multiple steps. Create a new tool to build a chain.",
+    });
+  }
+  if (hasCycle(graph.nodes, graph.edges)) {
+    issues.push({
+      message: "Steps are connected in a loop. Remove the connection that points back to an earlier step.",
     });
   }
   return issues;

--- a/web/src/components/tools/lib/graph.ts
+++ b/web/src/components/tools/lib/graph.ts
@@ -1,0 +1,402 @@
+// Pure, framework-agnostic translation between the visual node canvas and the
+// persisted tool `definition`. No React, no React Flow — fully unit-testable.
+//
+// The canvas hides the primitive/composed split: one operation node compiles to
+// a `primitive` tool, a canned-response node compiles to a `primitive` mock, and
+// anything wired into a chain compiles to a `composed` tool. Internally every
+// value reference is stored in composed syntax (`${params.x}`, `${steps.id.output}`)
+// and translated to bare `${x}` only when emitting a primitive definition.
+
+import { PLACEHOLDER_RE } from "./definition";
+import type { ValueReference } from "./friendly";
+import type {
+  ComposedDefinition,
+  ComposedStep,
+  JsonSchemaObject,
+  MockConfig,
+  PrimitiveDefinition,
+  ToolDefinition,
+  ToolType,
+} from "./types";
+
+export type CanvasNodeKind = "inputs" | "operation" | "tool" | "canned";
+
+// Extends Record so it satisfies React Flow's node-data constraint directly.
+export interface CanvasNodeData extends Record<string, unknown> {
+  /** Stable step id (`s1`, `s2`, …) for operation/tool nodes. */
+  stepId?: string;
+  /** operation: the base primitive name. */
+  primitive?: string;
+  /** tool: the referenced saved-tool slug + display name. */
+  slug?: string;
+  toolName?: string;
+  /** operation/tool: input map in composed syntax. */
+  inputs?: Record<string, unknown>;
+  /** canned: the mock response config. */
+  mock?: MockConfig;
+  /** inputs node: the tool's parameter schema (what the agent provides). */
+  parameters?: JsonSchemaObject;
+}
+
+export interface CanvasNode {
+  id: string;
+  kind: CanvasNodeKind;
+  position: { x: number; y: number };
+  data: CanvasNodeData;
+}
+
+export interface CanvasEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface ToolGraph {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+}
+
+export const INPUTS_NODE_ID = "inputs";
+
+// --- small helpers -----------------------------------------------------------
+
+function stepNodes(nodes: CanvasNode[]): CanvasNode[] {
+  return nodes.filter((n) => n.kind === "operation" || n.kind === "tool");
+}
+
+export function inputsNode(nodes: CanvasNode[]): CanvasNode | undefined {
+  return nodes.find((n) => n.kind === "inputs");
+}
+
+export function nextStepId(nodes: CanvasNode[]): string {
+  const used = new Set(nodes.map((n) => n.data.stepId).filter(Boolean));
+  let i = 1;
+  while (used.has(`s${i}`)) i += 1;
+  return `s${i}`;
+}
+
+/** Map every string in a value tree through `fn`. */
+function mapStrings(value: unknown, fn: (s: string) => string): unknown {
+  if (typeof value === "string") return fn(value);
+  if (Array.isArray(value)) return value.map((v) => mapStrings(v, fn));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, mapStrings(v, fn)]),
+    );
+  }
+  return value;
+}
+
+function mapInputs(
+  inputs: Record<string, unknown> | undefined,
+  fn: (s: string) => string,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(inputs ?? {})) out[k] = mapStrings(v, fn);
+  return out;
+}
+
+/** Composed/internal token syntax → primitive arg syntax (`${params.x}` → `${x}`). */
+function toPrimitiveInputs(inputs: Record<string, unknown> | undefined): Record<string, unknown> {
+  return mapInputs(inputs, (s) =>
+    s.replace(PLACEHOLDER_RE, (full, raw: string) => {
+      const expr = raw.trim();
+      return expr.startsWith("params.") ? `\${${expr.slice("params.".length)}}` : full;
+    }),
+  );
+}
+
+/** Primitive arg syntax → internal composed syntax (`${x}` → `${params.x}`). */
+function fromPrimitiveInputs(
+  args: Record<string, unknown> | undefined,
+  declared: Set<string>,
+): Record<string, unknown> {
+  return mapInputs(args, (s) =>
+    s.replace(PLACEHOLDER_RE, (full, raw: string) => {
+      const expr = raw.trim();
+      if (expr === "parameters" || expr.startsWith("secrets.") || expr.startsWith("params.")) {
+        return full;
+      }
+      return declared.has(expr) ? `\${params.${expr}}` : full;
+    }),
+  );
+}
+
+// --- kind inference ----------------------------------------------------------
+
+/** The tool_kind a freshly-built graph should be saved as. */
+export function inferKind(nodes: CanvasNode[]): ToolType {
+  const ops = nodes.filter((n) => n.kind === "operation").length;
+  const tools = nodes.filter((n) => n.kind === "tool").length;
+  const canned = nodes.filter((n) => n.kind === "canned").length;
+  if (canned > 0 && ops === 0 && tools === 0) return "primitive";
+  if (ops <= 1 && tools === 0 && canned === 0) return "primitive";
+  return "composed";
+}
+
+// --- ordering ----------------------------------------------------------------
+
+/** Topologically order step nodes so dependencies precede dependents. */
+function orderedSteps(nodes: CanvasNode[], edges: CanvasEdge[]): CanvasNode[] {
+  const steps = stepNodes(nodes);
+  const ids = new Set(steps.map((n) => n.id));
+  const indeg = new Map<string, number>(steps.map((n) => [n.id, 0]));
+  const outs = new Map<string, string[]>(steps.map((n) => [n.id, []]));
+  for (const e of edges) {
+    if (ids.has(e.source) && ids.has(e.target) && e.source !== e.target) {
+      outs.get(e.source)!.push(e.target);
+      indeg.set(e.target, (indeg.get(e.target) ?? 0) + 1);
+    }
+  }
+  // Stable: process in original array order among ready nodes.
+  const order = steps.map((n) => n.id);
+  const ready = order.filter((id) => (indeg.get(id) ?? 0) === 0);
+  const result: string[] = [];
+  const seen = new Set<string>();
+  while (ready.length) {
+    const id = ready.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+    for (const t of outs.get(id) ?? []) {
+      indeg.set(t, (indeg.get(t) ?? 1) - 1);
+      if ((indeg.get(t) ?? 0) === 0) ready.push(t);
+    }
+    ready.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+  }
+  // Append any nodes left out by a cycle, in original order.
+  for (const id of order) if (!seen.has(id)) result.push(id);
+  const byId = new Map(steps.map((n) => [n.id, n]));
+  return result.map((id) => byId.get(id)!).filter(Boolean);
+}
+
+// --- compile: graph → definition --------------------------------------------
+
+export function compileGraph(
+  graph: ToolGraph,
+  kind: ToolType,
+  opts: { description?: string } = {},
+): ToolDefinition {
+  const parameters = inputsNode(graph.nodes)?.data.parameters ?? emptySchema();
+  const description = opts.description ?? "";
+
+  if (kind === "primitive") {
+    const canned = graph.nodes.find((n) => n.kind === "canned");
+    if (canned) {
+      const def: PrimitiveDefinition = {
+        tool_type: "primitive",
+        description,
+        parameters,
+        implementation: { mode: "mock", mock: canned.data.mock ?? { strategy: "static" } },
+      };
+      return def;
+    }
+    const op = graph.nodes.find((n) => n.kind === "operation");
+    const def: PrimitiveDefinition = {
+      tool_type: "primitive",
+      description,
+      parameters,
+      implementation: {
+        mode: "delegate",
+        primitive: op?.data.primitive ?? "",
+        args: toPrimitiveInputs(op?.data.inputs),
+      },
+    };
+    return def;
+  }
+
+  const steps: ComposedStep[] = orderedSteps(graph.nodes, graph.edges).map((n) => ({
+    id: n.data.stepId ?? n.id,
+    ref:
+      n.kind === "operation"
+        ? { type: "primitive", name: n.data.primitive ?? "" }
+        : { type: "tool", name: n.data.slug ?? "" },
+    inputs: n.data.inputs ?? {},
+  }));
+  const def: ComposedDefinition = { tool_type: "composed", description, parameters, steps };
+  return def;
+}
+
+function emptySchema(): JsonSchemaObject {
+  return { type: "object", properties: {}, required: [], additionalProperties: false };
+}
+
+// --- graph-level validation (friendly, complements validateDefinition) -------
+
+export interface GraphIssue {
+  message: string;
+}
+
+export function validateGraph(graph: ToolGraph, kind: ToolType): GraphIssue[] {
+  const issues: GraphIssue[] = [];
+  const ops = graph.nodes.filter((n) => n.kind === "operation");
+  const tools = graph.nodes.filter((n) => n.kind === "tool");
+  const canned = graph.nodes.filter((n) => n.kind === "canned");
+
+  if (ops.length + tools.length + canned.length === 0) {
+    issues.push({ message: "Add at least one node — an operation, another tool, or a canned response." });
+  }
+  if (canned.length > 1) {
+    issues.push({ message: "Only one canned-response node is allowed." });
+  }
+  if (canned.length > 0 && ops.length + tools.length > 0) {
+    issues.push({
+      message: "A canned response can't be combined with other steps. Remove it, or remove the other nodes.",
+    });
+  }
+  if (kind === "primitive" && (ops.length + tools.length > 1 || tools.length > 0)) {
+    issues.push({
+      message:
+        "This is a single-action tool, so it can't have multiple steps. Create a new tool to build a chain.",
+    });
+  }
+  return issues;
+}
+
+// --- parse: definition → graph (with a simple layered layout) ----------------
+
+const COL = 280;
+const ROW = 140;
+
+export function parseDefinition(def: ToolDefinition): ToolGraph {
+  const declared = new Set(Object.keys(def.parameters?.properties ?? {}));
+  const nodes: CanvasNode[] = [
+    {
+      id: INPUTS_NODE_ID,
+      kind: "inputs",
+      position: { x: 0, y: 0 },
+      data: { parameters: def.parameters ?? emptySchema() },
+    },
+  ];
+  const edges: CanvasEdge[] = [];
+
+  if (def.tool_type === "primitive") {
+    if (def.implementation.mode === "mock") {
+      nodes.push({
+        id: "canned",
+        kind: "canned",
+        position: { x: COL, y: 0 },
+        data: { mock: def.implementation.mock ?? { strategy: "static" } },
+      });
+      edges.push({ id: "e-inputs-canned", source: INPUTS_NODE_ID, target: "canned" });
+    } else {
+      nodes.push({
+        id: "s1",
+        kind: "operation",
+        position: { x: COL, y: 0 },
+        data: {
+          stepId: "s1",
+          primitive: def.implementation.primitive ?? "",
+          inputs: fromPrimitiveInputs(def.implementation.args, declared),
+        },
+      });
+      edges.push({ id: "e-inputs-s1", source: INPUTS_NODE_ID, target: "s1" });
+    }
+    return layout({ nodes, edges });
+  }
+
+  // composed: one node per step, edges inferred from placeholder references.
+  const stepIdToNode = new Map<string, string>();
+  def.steps.forEach((step, i) => {
+    const nodeId = step.id || `s${i + 1}`;
+    stepIdToNode.set(step.id, nodeId);
+    nodes.push({
+      id: nodeId,
+      kind: step.ref.type === "tool" ? "tool" : "operation",
+      position: { x: COL, y: i * ROW },
+      data:
+        step.ref.type === "tool"
+          ? { stepId: step.id, slug: step.ref.name, toolName: step.ref.name, inputs: step.inputs ?? {} }
+          : { stepId: step.id, primitive: step.ref.name, inputs: step.inputs ?? {} },
+    });
+  });
+  // Edges from references inside each step's inputs.
+  def.steps.forEach((step) => {
+    const target = stepIdToNode.get(step.id)!;
+    const refs = referencesIn(step.inputs ?? {});
+    if (refs.usesParams) {
+      edges.push({ id: `e-inputs-${target}`, source: INPUTS_NODE_ID, target });
+    }
+    for (const fromStep of refs.stepIds) {
+      const source = stepIdToNode.get(fromStep);
+      if (source) edges.push({ id: `e-${source}-${target}`, source, target });
+    }
+  });
+  return layout({ nodes, edges });
+}
+
+function referencesIn(inputs: Record<string, unknown>): { usesParams: boolean; stepIds: string[] } {
+  let usesParams = false;
+  const stepIds = new Set<string>();
+  mapStrings(inputs, (s) => {
+    for (const m of s.matchAll(PLACEHOLDER_RE)) {
+      const expr = m[1].trim();
+      if (expr.startsWith("params.")) usesParams = true;
+      else if (expr.startsWith("steps.")) {
+        const rest = expr.slice("steps.".length);
+        stepIds.add(rest.includes(".") ? rest.slice(0, rest.indexOf(".")) : rest);
+      }
+    }
+    return s;
+  });
+  return { usesParams, stepIds: [...stepIds] };
+}
+
+/**
+ * The values a node can insert, based on what is wired into it: agent inputs
+ * (when the Inputs node feeds it) and the result of each upstream step.
+ */
+export function nodeReferences(
+  targetId: string,
+  graph: ToolGraph,
+  labelFor: (node: CanvasNode) => string,
+): ValueReference[] {
+  const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+  const sources = graph.edges.filter((e) => e.target === targetId).map((e) => byId.get(e.source));
+  const refs: ValueReference[] = [];
+  for (const src of sources) {
+    if (!src) continue;
+    if (src.kind === "inputs") {
+      for (const name of Object.keys(src.data.parameters?.properties ?? {})) {
+        refs.push({ label: name, group: "Agent inputs", token: `\${params.${name}}` });
+      }
+    } else if (src.data.stepId) {
+      refs.push({
+        label: `Result of ${labelFor(src)}`,
+        group: "Earlier steps",
+        token: `\${steps.${src.data.stepId}.output}`,
+      });
+    }
+  }
+  return refs;
+}
+
+/** Assign a simple left-to-right layered layout based on edge depth. */
+export function layout(graph: ToolGraph): ToolGraph {
+  const depth = new Map<string, number>();
+  const incoming = new Map<string, string[]>();
+  for (const n of graph.nodes) incoming.set(n.id, []);
+  for (const e of graph.edges) incoming.get(e.target)?.push(e.source);
+
+  const visiting = new Set<string>();
+  const compute = (id: string): number => {
+    if (depth.has(id)) return depth.get(id)!;
+    if (visiting.has(id)) return 0; // cycle guard
+    visiting.add(id);
+    const ins = incoming.get(id) ?? [];
+    const d = ins.length === 0 ? 0 : Math.max(...ins.map(compute)) + 1;
+    visiting.delete(id);
+    depth.set(id, d);
+    return d;
+  };
+  for (const n of graph.nodes) compute(n.id);
+
+  const rowByCol = new Map<number, number>();
+  const nodes = graph.nodes.map((n) => {
+    const col = n.kind === "inputs" ? 0 : (depth.get(n.id) ?? 1) || 1;
+    const row = rowByCol.get(col) ?? 0;
+    rowByCol.set(col, row + 1);
+    return { ...n, position: { x: col * COL, y: row * ROW } };
+  });
+  return { ...graph, nodes };
+}

--- a/web/src/components/tools/primitive-builder.tsx
+++ b/web/src/components/tools/primitive-builder.tsx
@@ -7,7 +7,7 @@ import { controlClass } from "./field";
 import { JsonValueField } from "./json-value-field";
 import { OperationPicker } from "./operation-picker";
 import { ParametersEditor } from "./parameters-editor";
-import { MOCK_STRATEGY_OPTIONS } from "./lib/friendly";
+import { MOCK_STRATEGY_OPTIONS, primitiveReferences } from "./lib/friendly";
 import { declaredParamNames, paramsToSchema, schemaToParams } from "./lib/definition";
 import type {
   MockStrategy,
@@ -104,7 +104,7 @@ export function PrimitiveBuilder({
                 primitive={selectedPrimitive}
                 args={impl.args ?? {}}
                 onChange={(args) => setImpl({ args })}
-                paramNames={declaredParamNames(def)}
+                references={primitiveReferences(declaredParamNames(def))}
                 allowSecrets={impl.primitive === "http_request"}
               />
             </div>
@@ -120,7 +120,7 @@ export function PrimitiveBuilder({
   );
 }
 
-function MockEditor({
+export function MockEditor({
   mock,
   onChange,
 }: {

--- a/web/src/components/tools/step-card.tsx
+++ b/web/src/components/tools/step-card.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronUp, GripVertical, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, GripVertical, Trash2 } from "lucide-react";
 import { controlClass } from "./field";
-import { ValueField } from "./value-field";
+import { StepInputsEditor } from "./step-inputs-editor";
 import { operationLabel, stepReferences } from "./lib/friendly";
 import type { ComposedStep, StepRefType, ToolPrimitive } from "./lib/types";
 
@@ -119,90 +119,12 @@ export function StepCard({
         <StepInputsEditor
           inputs={step.inputs}
           onChange={(inputs) => onChange({ ...step, inputs })}
-          paramNames={paramNames}
-          earlierStepIds={earlierStepIds}
-          stepNumberById={stepNumberById}
+          references={stepReferences(paramNames, earlierStepIds, stepNumberById)}
           allowSecrets={isHTTP}
+          label="Inputs for this step"
+          emptyHint="No inputs set for this step yet."
         />
       </div>
-    </div>
-  );
-}
-
-function StepInputsEditor({
-  inputs,
-  onChange,
-  paramNames,
-  earlierStepIds,
-  stepNumberById,
-  allowSecrets,
-}: {
-  inputs: Record<string, unknown>;
-  onChange: (inputs: Record<string, unknown>) => void;
-  paramNames: string[];
-  earlierStepIds: string[];
-  stepNumberById: Map<string, number>;
-  allowSecrets: boolean;
-}) {
-  const rows = Object.entries(inputs);
-  const references = stepReferences(paramNames, earlierStepIds, stepNumberById);
-
-  function setKey(oldKey: string, newKey: string) {
-    // Don't merge into an existing input — that would silently drop a value.
-    if (newKey !== oldKey && newKey in inputs) return;
-    const next: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(inputs)) next[k === oldKey ? newKey : k] = v;
-    onChange(next);
-  }
-  function setValue(key: string, value: string) {
-    onChange({ ...inputs, [key]: value });
-  }
-  function remove(key: string) {
-    const next = { ...inputs };
-    delete next[key];
-    onChange(next);
-  }
-  function add() {
-    let name = "input";
-    let n = 1;
-    while (name in inputs) name = `input${++n}`;
-    onChange({ ...inputs, [name]: "" });
-  }
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted-foreground">Inputs for this step</span>
-        <Button type="button" variant="ghost" size="xs" onClick={add}>
-          <Plus data-icon="inline-start" className="size-3" />
-          Add input
-        </Button>
-      </div>
-      {rows.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No inputs set for this step yet.</p>
-      ) : (
-        rows.map(([key, value]) => (
-          <div key={key} className="grid grid-cols-[9rem_1fr_auto] items-start gap-2">
-            <input
-              value={key}
-              onChange={(e) => setKey(key, e.target.value)}
-              aria-label="Input name"
-              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
-            />
-            <ValueField
-              value={typeof value === "string" ? value : JSON.stringify(value)}
-              onChange={(v) => setValue(key, v)}
-              placeholder="Type a value or insert one"
-              references={references}
-              allowSecret={allowSecrets}
-              ariaLabel="Input value"
-            />
-            <Button type="button" variant="ghost" size="icon-sm" onClick={() => remove(key)} aria-label="Remove input">
-              <Trash2 className="size-3.5 text-muted-foreground" />
-            </Button>
-          </div>
-        ))
-      )}
     </div>
   );
 }

--- a/web/src/components/tools/step-inputs-editor.tsx
+++ b/web/src/components/tools/step-inputs-editor.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Plus, Trash2 } from "lucide-react";
+import { controlClass } from "./field";
+import { ValueField } from "./value-field";
+import type { ValueReference } from "./lib/friendly";
+
+/**
+ * Edits a free-form map of inputs (name → value) for a step or tool reference,
+ * where the value can be literal text or an inserted reference. Used for tool
+ * references whose target schema we don't know, so keys are user-defined.
+ */
+export function StepInputsEditor({
+  inputs,
+  onChange,
+  references,
+  allowSecrets,
+  label = "Inputs",
+  emptyHint = "No inputs set yet.",
+}: {
+  inputs: Record<string, unknown>;
+  onChange: (inputs: Record<string, unknown>) => void;
+  references: ValueReference[];
+  allowSecrets: boolean;
+  label?: string;
+  emptyHint?: string;
+}) {
+  const rows = Object.entries(inputs);
+
+  function setKey(oldKey: string, newKey: string) {
+    // Don't merge into an existing input — that would silently drop a value.
+    if (newKey !== oldKey && newKey in inputs) return;
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(inputs)) next[k === oldKey ? newKey : k] = v;
+    onChange(next);
+  }
+  function setValue(key: string, value: string) {
+    onChange({ ...inputs, [key]: value });
+  }
+  function remove(key: string) {
+    const next = { ...inputs };
+    delete next[key];
+    onChange(next);
+  }
+  function add() {
+    let name = "input";
+    let n = 1;
+    while (name in inputs) name = `input${++n}`;
+    onChange({ ...inputs, [name]: "" });
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <Button type="button" variant="ghost" size="xs" onClick={add}>
+          <Plus data-icon="inline-start" className="size-3" />
+          Add input
+        </Button>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{emptyHint}</p>
+      ) : (
+        rows.map(([key, value]) => (
+          <div key={key} className="grid grid-cols-[9rem_1fr_auto] items-start gap-2">
+            <input
+              value={key}
+              onChange={(e) => setKey(key, e.target.value)}
+              aria-label="Input name"
+              className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
+            />
+            <ValueField
+              value={typeof value === "string" ? value : JSON.stringify(value)}
+              onChange={(v) => setValue(key, v)}
+              placeholder="Type a value or insert one"
+              references={references}
+              allowSecret={allowSecrets}
+              ariaLabel="Input value"
+            />
+            <Button type="button" variant="ghost" size="icon-sm" onClick={() => remove(key)} aria-label="Remove input">
+              <Trash2 className="size-3.5 text-muted-foreground" />
+            </Button>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tools/tool-start-chooser.tsx
+++ b/web/src/components/tools/tool-start-chooser.tsx
@@ -11,7 +11,8 @@ import { PageHeader } from "@/components/ui/page-header";
  * routes to the builder with a sensible starting point preselected.
  */
 export function ToolStartChooser({ workspaceId }: { workspaceId: string }) {
-  const base = `/workspaces/${workspaceId}/tools/new`;
+  // The chooser is the classic form-editor entry; keep links in form mode.
+  const base = `/workspaces/${workspaceId}/tools/new?editor=form`;
 
   return (
     <div>
@@ -26,18 +27,18 @@ export function ToolStartChooser({ workspaceId }: { workspaceId: string }) {
 
       <div className="grid gap-3 lg:grid-cols-2">
         <ChoiceCard
-          href={`${base}?type=primitive`}
+          href={`${base}&type=primitive`}
           icon={<Boxes className="size-5" />}
           title="A single action"
           description="The tool does one thing — call an API, run a command, read a file, or return a canned response for testing."
           quickStarts={[
-            { href: `${base}?type=primitive&start=api`, icon: <Globe className="size-3.5" />, label: "Call a web API" },
-            { href: `${base}?type=primitive&start=command`, icon: <Terminal className="size-3.5" />, label: "Run a command" },
-            { href: `${base}?type=primitive&start=mock`, icon: <MessageSquareDashed className="size-3.5" />, label: "Return a sample response" },
+            { href: `${base}&type=primitive&start=api`, icon: <Globe className="size-3.5" />, label: "Call a web API" },
+            { href: `${base}&type=primitive&start=command`, icon: <Terminal className="size-3.5" />, label: "Run a command" },
+            { href: `${base}&type=primitive&start=mock`, icon: <MessageSquareDashed className="size-3.5" />, label: "Return a sample response" },
           ]}
         />
         <ChoiceCard
-          href={`${base}?type=composed`}
+          href={`${base}&type=composed`}
           icon={<Workflow className="size-5" />}
           title="A sequence of steps"
           description="The tool runs several actions in order, passing each result into the next — for example, fetch data, then save it to a file."


### PR DESCRIPTION
## What

A unified, **node-canvas tool builder** (React Flow / n8n-style) that replaces the "primitive vs composite" mental model. You don't pick a type up front anymore — you drop nodes on a canvas and wire them together:

- **One node** (an operation, or a canned response) → saves as a `primitive` tool.
- **Several connected nodes** → saves as a `composed` (multi-step) tool.

The words "primitive" and "composed" never appear. The canvas *is* the unification.

### How it works
- An **Agent inputs** node (the tool's parameters) sits at the start.
- Add **Operation** nodes (a built-in action like "Call a web API"), **Tool** nodes (run another saved tool), or a **Canned response** node (a mock, for rehearsing evals).
- **Drag from a node's right edge to the next** to chain them. A wire means "this node can use that one's result."
- Click any node to configure it in the side panel — reusing the same humanized editors from the last PR (operation picker, key/value editor, and the Insert-a-value menu, so there's still no `${...}` typing or raw JSON).
- The side panel shows a live plain-language **summary** + validation when nothing is selected.

## The hard part: graph ↔ saved definition

The backend has strict rules I had to honor exactly:
- `definition.tool_type` **must equal** `tool_kind`, and **`tool_kind` is immutable on edit**.
- Single op/mock → `primitive`; anything chained → `composed` (DAG, `${params.x}` / `${steps.id.output}`, no explicit output field).

So the canvas compiles the graph to the right shape, infers the kind on create, and **locks the kind on edit** (if you try to add steps to a single-action tool, save is blocked with a clear message rather than hitting a 400). Internally everything is stored in composed syntax and translated to bare `${x}` only when emitting a primitive — verified by a round-trip test.

All of this translation lives in pure, framework-free functions (`lib/graph.ts`) with **14 unit tests** (compile both kinds, parse both kinds, edge inference, ordering, kind inference, reference wiring, round-trip).

## Compatibility / safety
- **No backend changes.** Same create/edit API, same `definition` payloads.
- The previous **form editor is kept** as a fallback at `?editor=form` (linked as "Use form editor" from the canvas) — so nothing is lost if the canvas is rough for an edge case. It was also refactored, not deleted: `ArgsEditor` and the step-inputs editor now take a `references` prop so both editors share them.
- Existing tools open on the canvas via `parseDefinition` (edges inferred from `${...}` references); unknown/legacy tool kinds still fall back to the raw-JSON view.

## Heads-up (not introduced by this PR)
The backend currently executes single-primitive delegation at runtime; multi-step `composed` tools **validate and save** but aren't executed by the engine yet. The builder is intentionally ahead of the runtime here — chains you build will persist and validate, ready for when multi-step execution lands.

## Verification
- `tsc --noEmit` clean · `eslint` clean on touched dirs · **33 tool unit tests pass** (incl. 14 new graph tests) · `pnpm build` succeeds.
- ⚠️ I could **not** render-test the canvas live (needs the full local stack + auth + a workspace with primitives). The compile/parse logic is unit-tested; the React Flow wiring follows standard patterns and builds clean, but the visual/interaction polish is unverified. Happy to do a live `/qa` pass once the stack is up.
