### PR TITLE
feat(web): immersive tool builder + guided tour, hide React Flow badge

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "@xyflow/react": "^12.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "driver.js": "^1.4.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.577.0",
         "next": "^15.5.15",
@@ -10985,6 +10986,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "driver.js": "^1.4.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.577.0",
     "next": "^15.5.15",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -889,89 +892,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1289,24 +1308,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.15':
     resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.15':
     resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.15':
     resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.15':
     resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
@@ -2125,36 +2148,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -2310,24 +2339,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2654,41 +2687,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3625,6 +3666,9 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4804,24 +4848,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -10594,6 +10642,8 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@17.4.2: {}
+
+  driver.js@1.4.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -846,3 +846,59 @@ body {
     background-color: rgba(12, 12, 14, 0.92);
   }
 }
+
+/* Guided tour (driver.js) — themed to match the dark app. Applied via the
+   `agentclash-tour` popoverClass set in use-guided-tour.ts. */
+.driver-popover.agentclash-tour {
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+  max-width: 320px;
+}
+.driver-popover.agentclash-tour .driver-popover-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--popover-foreground);
+}
+.driver-popover.agentclash-tour .driver-popover-description {
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+.driver-popover.agentclash-tour .driver-popover-progress-text {
+  color: var(--muted-foreground);
+}
+.driver-popover.agentclash-tour .driver-popover-close-btn {
+  color: var(--muted-foreground);
+}
+.driver-popover.agentclash-tour .driver-popover-close-btn:hover,
+.driver-popover.agentclash-tour .driver-popover-close-btn:focus {
+  color: var(--foreground);
+}
+.driver-popover.agentclash-tour .driver-popover-footer button {
+  background-color: var(--secondary);
+  color: var(--secondary-foreground);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-shadow: none;
+  padding: 4px 12px;
+}
+.driver-popover.agentclash-tour .driver-popover-footer button:hover,
+.driver-popover.agentclash-tour .driver-popover-footer button:focus {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+/* Recolor only the visible (non-transparent) arrow border for each side. */
+.driver-popover.agentclash-tour .driver-popover-arrow-side-left {
+  border-left-color: var(--popover);
+}
+.driver-popover.agentclash-tour .driver-popover-arrow-side-right {
+  border-right-color: var(--popover);
+}
+.driver-popover.agentclash-tour .driver-popover-arrow-side-top {
+  border-top-color: var(--popover);
+}
+.driver-popover.agentclash-tour .driver-popover-arrow-side-bottom {
+  border-bottom-color: var(--popover);
+}

--- a/web/src/components/onboarding/use-guided-tour.ts
+++ b/web/src/components/onboarding/use-guided-tour.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { driver, type Config, type DriveStep, type Driver } from "driver.js";
+import "driver.js/dist/driver.css";
+
+// Page-agnostic guided-tour hook built on driver.js. Each tour is keyed by a
+// stable `tourId`; the "already seen" flag persists in localStorage (mirroring
+// the dismissal pattern in activation-banner.tsx) so a tour auto-runs only once
+// but can be re-launched from a button at any time. Reusable across features —
+// it knows nothing about tools or the canvas.
+
+const seenKey = (tourId: string) => `agentclash:tour-seen:${tourId}`;
+
+function readSeen(tourId: string): boolean {
+  try {
+    return window.localStorage.getItem(seenKey(tourId)) === "1";
+  } catch {
+    return false; // private mode / storage disabled
+  }
+}
+
+function markSeen(tourId: string): void {
+  try {
+    window.localStorage.setItem(seenKey(tourId), "1");
+  } catch {
+    // ignore
+  }
+}
+
+export interface GuidedTourOptions {
+  /** Auto-run the tour the first time this user sees it (persisted per tourId). */
+  autoStartOnce?: boolean;
+  /** Gate auto-start until anchor elements exist (e.g. async data has loaded). */
+  ready?: boolean;
+  /** Extra driver.js config overrides. */
+  config?: Partial<Config>;
+}
+
+export interface GuidedTour {
+  /** Start (or restart) the tour now. Safe to call repeatedly. */
+  start: () => void;
+  /** Whether this tour has been shown before. */
+  hasSeen: () => boolean;
+  /** True while the tour overlay is on screen — gate Esc/shortcuts on this. */
+  isActive: () => boolean;
+}
+
+export function useGuidedTour(
+  tourId: string,
+  steps: DriveStep[],
+  { autoStartOnce = false, ready = true, config }: GuidedTourOptions = {},
+): GuidedTour {
+  const driverRef = useRef<Driver | null>(null);
+
+  const start = useCallback(() => {
+    if (typeof window === "undefined") return;
+    // Recreate the driver each launch so it always reflects the latest steps,
+    // and so re-running after a previous tour starts cleanly from step one.
+    driverRef.current?.destroy();
+    const d = driver({
+      showProgress: true,
+      allowClose: true,
+      overlayColor: "rgba(2, 6, 23, 0.72)",
+      stagePadding: 6,
+      stageRadius: 10,
+      popoverClass: "agentclash-tour",
+      nextBtnText: "Next",
+      prevBtnText: "Back",
+      doneBtnText: "Got it",
+      ...config,
+      steps,
+    });
+    driverRef.current = d;
+    d.drive();
+    markSeen(tourId);
+  }, [steps, config, tourId]);
+
+  // Auto-start once, after anchors are ready.
+  useEffect(() => {
+    if (!autoStartOnce || !ready) return;
+    if (typeof window === "undefined" || readSeen(tourId)) return;
+    // Defer a frame so anchor elements are mounted and measurable.
+    const t = window.setTimeout(start, 400);
+    return () => window.clearTimeout(t);
+  }, [autoStartOnce, ready, tourId, start]);
+
+  // Tear down the driver instance (and any open overlay) on unmount.
+  useEffect(() => {
+    return () => {
+      driverRef.current?.destroy();
+      driverRef.current = null;
+    };
+  }, []);
+
+  const hasSeen = useCallback(
+    () => (typeof window === "undefined" ? false : readSeen(tourId)),
+    [tourId],
+  );
+  const isActive = useCallback(() => driverRef.current?.isActive() ?? false, []);
+
+  // Stable object so consumers can safely use it in effect dependency arrays.
+  return useMemo(
+    () => ({ start, hasSeen, isActive }),
+    [start, hasSeen, isActive],
+  );
+}

--- a/web/src/components/onboarding/use-guided-tour.ts
+++ b/web/src/components/onboarding/use-guided-tour.ts
@@ -52,9 +52,19 @@ export function useGuidedTour(
   { autoStartOnce = false, ready = true, config }: GuidedTourOptions = {},
 ): GuidedTour {
   const driverRef = useRef<Driver | null>(null);
+  // Hold the latest steps/config in refs so `start` stays referentially stable
+  // even when a caller passes inline arrays/objects. An unstable `start` would
+  // otherwise re-run the auto-start effect on every render.
+  const stepsRef = useRef(steps);
+  const configRef = useRef(config);
+  useEffect(() => {
+    stepsRef.current = steps;
+    configRef.current = config;
+  });
 
   const start = useCallback(() => {
     if (typeof window === "undefined") return;
+    const userConfig = configRef.current;
     // Recreate the driver each launch so it always reflects the latest steps,
     // and so re-running after a previous tour starts cleanly from step one.
     driverRef.current?.destroy();
@@ -68,13 +78,19 @@ export function useGuidedTour(
       nextBtnText: "Next",
       prevBtnText: "Back",
       doneBtnText: "Got it",
-      ...config,
-      steps,
+      ...userConfig,
+      steps: stepsRef.current,
+      // Mark "seen" only once the tour actually ends (completed or dismissed) —
+      // not the instant it launches. A tour that never renders (e.g. a missing
+      // anchor) then won't suppress the next visit's auto-start.
+      onDestroyed: (element, step, opts) => {
+        markSeen(tourId);
+        userConfig?.onDestroyed?.(element, step, opts);
+      },
     });
     driverRef.current = d;
     d.drive();
-    markSeen(tourId);
-  }, [steps, config, tourId]);
+  }, [tourId]);
 
   // Auto-start once, after anchors are ready.
   useEffect(() => {

--- a/web/src/components/tools/canvas-builder.tsx
+++ b/web/src/components/tools/canvas-builder.tsx
@@ -2,7 +2,7 @@
 
 import "@xyflow/react/dist/style.css";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
@@ -53,6 +53,10 @@ import {
 import { emptyPrimitiveDefinition } from "./lib/definition";
 import { validateDefinition } from "./lib/validate";
 import type { ToolDefinition, ToolRecord, ToolType } from "./lib/types";
+
+// Stable reference — React Flow compares proOptions by identity, so an inline
+// object would trigger redundant internal updates on every render.
+const HIDE_ATTRIBUTION = { hideAttribution: true } as const;
 
 function labelFor(node: CanvasNode): string {
   if (node.kind === "operation") return node.data.primitive ? operationLabel(node.data.primitive) : "operation";
@@ -143,7 +147,13 @@ function CanvasBuilderInner({
   }, [immersive, tour]);
 
   // The canvas resizes when entering/leaving fullscreen; recenter the graph.
+  // Skip the initial mount — <ReactFlow fitView> already fits on first render.
+  const didToggleMount = useRef(false);
   useEffect(() => {
+    if (!didToggleMount.current) {
+      didToggleMount.current = true;
+      return;
+    }
     const t = window.setTimeout(() => fitView({ duration: 200 }), 80);
     return () => window.clearTimeout(t);
   }, [immersive, fitView]);
@@ -318,7 +328,7 @@ function CanvasBuilderInner({
               }}
               fitView
               colorMode="dark"
-              proOptions={{ hideAttribution: true }}
+              proOptions={HIDE_ATTRIBUTION}
             >
               <Background />
               <Controls showInteractive={false} />

--- a/web/src/components/tools/canvas-builder.tsx
+++ b/web/src/components/tools/canvas-builder.tsx
@@ -2,37 +2,38 @@
 
 import "@xyflow/react/dist/style.css";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
 import {
   Background,
   Controls,
-  Panel,
   ReactFlow,
   ReactFlowProvider,
   addEdge,
   useEdgesState,
   useNodesState,
+  useReactFlow,
   type Connection,
   type Edge,
   type Node,
 } from "@xyflow/react";
-import { Boxes, Loader2, MessageSquareDashed, PanelsTopLeft, Wrench } from "lucide-react";
+import { PanelsTopLeft } from "lucide-react";
 
+import { cn } from "@/lib/utils";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import { useApiListQuery, useApiMutator } from "@/lib/api/swr";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
-import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
+import { useGuidedTour } from "@/components/onboarding/use-guided-tour";
 
 import { DefinitionPreview } from "./definition-preview";
 import { Field, controlClass } from "./field";
 import { JsonValidityProvider } from "./json-validity";
 import { NodeInspector } from "./canvas/inspector";
+import { EditorToolbar } from "./canvas/editor-toolbar";
+import { CANVAS_TOUR_ID, canvasTourSteps } from "./canvas/tour-steps";
 import { nodeTypes } from "./canvas/nodes";
 import { useToolPrimitives } from "./use-tool-primitives";
 import { operationLabel } from "./lib/friendly";
@@ -125,6 +126,27 @@ function CanvasBuilderInner({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [jsonInvalid, setJsonInvalid] = useState(false);
+  // Immersive (full-viewport) by default; minimize drops back into the page.
+  const [immersive, setImmersive] = useState(true);
+
+  const { fitView } = useReactFlow();
+  const tour = useGuidedTour(CANVAS_TOUR_ID, canvasTourSteps, { autoStartOnce: true });
+
+  // Esc leaves fullscreen — but only when the guided tour isn't using Esc itself.
+  useEffect(() => {
+    if (!immersive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !tour.isActive()) setImmersive(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [immersive, tour]);
+
+  // The canvas resizes when entering/leaving fullscreen; recenter the graph.
+  useEffect(() => {
+    const t = window.setTimeout(() => fitView({ duration: 200 }), 80);
+    return () => window.clearTimeout(t);
+  }, [immersive, fitView]);
 
   const { primitives } = useToolPrimitives();
   const { data: toolsData } = useApiListQuery<ToolRecord>(`/v1/workspaces/${workspaceId}/tools`);
@@ -256,36 +278,32 @@ function CanvasBuilderInner({
   }
 
   return (
-    <div>
-      <PageHeader
-        breadcrumbs={[
-          { label: "Tools", href: `/workspaces/${workspaceId}/tools` },
-          { label: mode === "create" ? "New tool" : (initialName ?? "Edit") },
-        ]}
-        title={mode === "create" ? "New tool" : (initialName ?? "Edit tool")}
-        description="Drag from the right edge of a node to the next to connect steps. One node is a simple tool; connect a few to build a chain."
-        actions={
-          <>
-            <Button variant="ghost" size="sm" render={<Link href={formEditorHref} />}>
-              Use form editor
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => router.push(`/workspaces/${workspaceId}/tools`)}
-              disabled={submitting}
-            >
-              Cancel
-            </Button>
-            <Button onClick={save} disabled={!canSave}>
-              {submitting ? <Loader2 className="size-4 animate-spin" /> : "Save tool"}
-            </Button>
-          </>
-        }
+    <div
+      className={cn(
+        "flex flex-col bg-background",
+        immersive
+          ? "fixed inset-0 z-50"
+          : "h-[calc(100dvh-8rem)] min-h-[30rem] overflow-hidden rounded-lg border border-border",
+      )}
+    >
+      <EditorToolbar
+        mode={mode}
+        name={name}
+        onNameChange={setName}
+        onAdd={addNode}
+        onStartTour={tour.start}
+        immersive={immersive}
+        onToggleImmersive={() => setImmersive((v) => !v)}
+        formEditorHref={formEditorHref}
+        onExit={() => router.push(`/workspaces/${workspaceId}/tools`)}
+        onSave={save}
+        canSave={canSave}
+        saving={submitting}
       />
 
       <JsonValidityProvider onChange={setJsonInvalid}>
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_24rem]">
-          <div className="h-[600px] overflow-hidden rounded-lg border border-border">
+        <div className="flex min-h-0 flex-1">
+          <div className="min-w-0 flex-1">
             <ReactFlow
               nodes={nodes}
               edges={edges}
@@ -300,79 +318,53 @@ function CanvasBuilderInner({
               }}
               fitView
               colorMode="dark"
+              proOptions={{ hideAttribution: true }}
             >
               <Background />
               <Controls showInteractive={false} />
-              <Panel position="top-left" className="flex flex-wrap gap-1.5">
-                <Button type="button" variant="outline" size="sm" onClick={() => addNode("operation")}>
-                  <Boxes data-icon="inline-start" className="size-3.5" />
-                  Operation
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={() => addNode("tool")}>
-                  <Wrench data-icon="inline-start" className="size-3.5" />
-                  Tool
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={() => addNode("canned")}>
-                  <MessageSquareDashed data-icon="inline-start" className="size-3.5" />
-                  Canned response
-                </Button>
-              </Panel>
             </ReactFlow>
           </div>
 
-          <div className="lg:sticky lg:top-4 lg:self-start">
-            <div className="space-y-4 rounded-lg border border-border p-3">
-              <Field
-                label="Name"
-                htmlFor="tool-name"
-                hint="What the agent sees when it calls this tool."
-              >
-                <input
-                  id="tool-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. lookup_order"
-                  className={controlClass}
-                />
-              </Field>
-              <Field
-                label="Description"
-                htmlFor="tool-description"
-                hint="The agent reads this to decide when to use the tool."
-              >
-                <textarea
-                  id="tool-description"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  rows={2}
-                  placeholder="e.g. Look up an order by its id and return its status."
-                  className={controlClass}
-                />
-              </Field>
-            </div>
-
-            <div className="mt-4 min-h-[16rem] rounded-lg border border-border">
-              {selectedNode ? (
-                <NodeInspector
-                  node={selectedNode}
-                  references={references}
-                  primitives={primitives}
-                  tools={toolOptions}
-                  onPatch={(patch) => patchNode(selectedNode.id, patch)}
-                  onDelete={() => deleteNode(selectedNode.id)}
-                  onClose={() => setSelectedId(null)}
-                />
-              ) : (
-                <div className="space-y-3 p-3">
+          <aside
+            data-tour="sidebar"
+            className="flex w-80 flex-shrink-0 flex-col overflow-y-auto border-l border-border"
+          >
+            {selectedNode ? (
+              <NodeInspector
+                node={selectedNode}
+                references={references}
+                primitives={primitives}
+                tools={toolOptions}
+                onPatch={(patch) => patchNode(selectedNode.id, patch)}
+                onDelete={() => deleteNode(selectedNode.id)}
+                onClose={() => setSelectedId(null)}
+              />
+            ) : (
+              <div className="space-y-4 p-3">
+                <Field
+                  label="Description"
+                  htmlFor="tool-description"
+                  hint="The agent reads this to decide when to use the tool."
+                >
+                  <textarea
+                    id="tool-description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    rows={2}
+                    placeholder="e.g. Look up an order by its id and return its status."
+                    className={controlClass}
+                  />
+                </Field>
+                <div className="space-y-3 border-t border-border pt-3">
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
                     <PanelsTopLeft className="size-3.5" />
                     Select a node to configure it.
                   </div>
                   <DefinitionPreview definition={definition} issues={previewIssues} />
                 </div>
-              )}
-            </div>
-          </div>
+              </div>
+            )}
+          </aside>
         </div>
       </JsonValidityProvider>
     </div>

--- a/web/src/components/tools/canvas/editor-toolbar.tsx
+++ b/web/src/components/tools/canvas/editor-toolbar.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Boxes,
+  ChevronLeft,
+  HelpCircle,
+  Loader2,
+  Maximize2,
+  MessageSquareDashed,
+  Minimize2,
+  PencilRuler,
+  Wrench,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { CanvasNodeKind } from "../lib/graph";
+
+type AddableKind = Exclude<CanvasNodeKind, "inputs">;
+
+export interface EditorToolbarProps {
+  mode: "create" | "edit";
+  name: string;
+  onNameChange: (value: string) => void;
+  onAdd: (kind: AddableKind) => void;
+  onStartTour: () => void;
+  immersive: boolean;
+  onToggleImmersive: () => void;
+  formEditorHref: string;
+  onExit: () => void;
+  onSave: () => void;
+  canSave: boolean;
+  saving: boolean;
+}
+
+const palette: { kind: AddableKind; label: string; icon: typeof Boxes }[] = [
+  { kind: "operation", label: "Operation", icon: Boxes },
+  { kind: "tool", label: "Tool", icon: Wrench },
+  { kind: "canned", label: "Canned response", icon: MessageSquareDashed },
+];
+
+/**
+ * The editor's top bar: an inline tool-name field on the left, the node palette
+ * in the middle ("options to pick"), and actions on the right. Stateless — the
+ * canvas owns all state and passes handlers down.
+ */
+export function EditorToolbar({
+  mode,
+  name,
+  onNameChange,
+  onAdd,
+  onStartTour,
+  immersive,
+  onToggleImmersive,
+  formEditorHref,
+  onExit,
+  onSave,
+  canSave,
+  saving,
+}: EditorToolbarProps) {
+  return (
+    <TooltipProvider delay={200}>
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button variant="ghost" size="icon-sm" onClick={onExit} aria-label="Back to tools" />
+            }
+          >
+            <ChevronLeft className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Back to tools</TooltipContent>
+        </Tooltip>
+
+        <input
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="Untitled tool"
+          aria-label="Tool name"
+          className="w-40 rounded-md bg-transparent px-2 py-1 text-sm font-medium outline-none placeholder:text-muted-foreground/60 focus:bg-muted/50 sm:w-48"
+        />
+
+        <Separator orientation="vertical" className="mx-1 h-6" />
+
+        <div data-tour="palette" className="flex items-center gap-1.5">
+          {palette.map(({ kind, label, icon: Icon }) => (
+            <Button key={kind} type="button" variant="outline" size="sm" onClick={() => onAdd(kind)}>
+              <Icon data-icon="inline-start" className="size-3.5" />
+              <span className="hidden sm:inline">{label}</span>
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex-1" />
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onStartTour}
+                aria-label="Show guided tour"
+              />
+            }
+          >
+            <HelpCircle className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Guided tour</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="ghost" size="icon-sm" render={<Link href={formEditorHref} />} />}
+          >
+            <PencilRuler className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Use the form editor</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onToggleImmersive}
+                aria-label={immersive ? "Exit fullscreen" : "Enter fullscreen"}
+              />
+            }
+          >
+            {immersive ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{immersive ? "Exit fullscreen" : "Fullscreen"}</TooltipContent>
+        </Tooltip>
+
+        <Separator orientation="vertical" className="mx-1 h-6" />
+
+        <Button data-tour="save" onClick={onSave} disabled={!canSave}>
+          {saving ? <Loader2 className="size-4 animate-spin" /> : mode === "create" ? "Save tool" : "Save"}
+        </Button>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/web/src/components/tools/canvas/tour-steps.test.ts
+++ b/web/src/components/tools/canvas/tour-steps.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { INPUTS_NODE_ID } from "../lib/graph";
+import { CANVAS_TOUR_ID, canvasTourSteps } from "./tour-steps";
+
+describe("canvas tour steps", () => {
+  it("has a stable tour id", () => {
+    expect(CANVAS_TOUR_ID).toBe("tools-canvas");
+  });
+
+  it("every step has copy a non-engineer can read", () => {
+    expect(canvasTourSteps.length).toBeGreaterThan(0);
+    for (const step of canvasTourSteps) {
+      expect(step.popover?.title?.trim()).toBeTruthy();
+      expect(step.popover?.description?.trim()).toBeTruthy();
+    }
+  });
+
+  it("anchors to the toolbar palette, sidebar, and save button", () => {
+    const selectors = canvasTourSteps.map((s) => s.element).filter((e): e is string => typeof e === "string");
+    expect(selectors).toContain('[data-tour="palette"]');
+    expect(selectors).toContain('[data-tour="sidebar"]');
+    expect(selectors).toContain('[data-tour="save"]');
+  });
+
+  it("targets the Inputs node by the same id the canvas renders — guards against drift", () => {
+    const selectors = canvasTourSteps.map((s) => s.element).filter((e): e is string => typeof e === "string");
+    // React Flow stamps data-id={node.id}; if INPUTS_NODE_ID is renamed without
+    // updating the selector, the highlight would silently miss. Keep them tied.
+    expect(selectors.some((sel) => sel.includes(`[data-id="${INPUTS_NODE_ID}"]`))).toBe(true);
+  });
+});

--- a/web/src/components/tools/canvas/tour-steps.ts
+++ b/web/src/components/tools/canvas/tour-steps.ts
@@ -1,0 +1,64 @@
+import type { DriveStep } from "driver.js";
+
+// Walkthrough for the tool canvas builder, in plain language for non-engineers.
+// Anchored to [data-tour="…"] hooks on the toolbar palette, the sidebar, and
+// the Save button, plus React Flow's own data-id on the Inputs node — keep
+// those selectors in sync with this file.
+export const CANVAS_TOUR_ID = "tools-canvas";
+
+export const canvasTourSteps: DriveStep[] = [
+  {
+    popover: {
+      title: "Build a tool, visually",
+      description:
+        "Drop nodes on the canvas and wire them together. One node makes a simple tool; connect a few to build a multi-step chain — no code, no JSON.",
+    },
+  },
+  {
+    element: '[data-tour="palette"]',
+    popover: {
+      title: "Add a step",
+      description:
+        "Add an Operation (a built-in action like calling a web API), another saved Tool, or a Canned response for rehearsing evals.",
+      side: "bottom",
+      align: "start",
+    },
+  },
+  {
+    element: '.react-flow__node[data-id="inputs"]',
+    popover: {
+      title: "Start from the agent's inputs",
+      description:
+        "This node holds the parameters the agent passes in. Click any node to configure it in the panel on the right.",
+      side: "right",
+    },
+  },
+  {
+    element: '.react-flow__node[data-id="inputs"]',
+    popover: {
+      title: "Connect the steps",
+      description:
+        "Drag from a node's right edge to the next node to chain them. A wire means “this step can use that one's result.”",
+      side: "right",
+    },
+  },
+  {
+    element: '[data-tour="sidebar"]',
+    popover: {
+      title: "Configure on the right",
+      description:
+        "Select a node to set it up here — pick the operation and fill in values. With nothing selected you get a plain-language summary and a checklist of what's left.",
+      side: "left",
+    },
+  },
+  {
+    element: '[data-tour="save"]',
+    popover: {
+      title: "Save when it's ready",
+      description:
+        "We validate as you go. Once everything checks out, save — and you can replay this tour anytime from the “?” button.",
+      side: "bottom",
+      align: "end",
+    },
+  },
+];


### PR DESCRIPTION
## What

Turns the tool canvas builder into a **full-viewport, Paint-style editor** and adds an **always-available guided tour** — addressing three things on the builder shipped in #1064:

1. **No more React Flow badge.** We removed `hideAttribution` in #1064 thinking it was Pro-gated. That was wrong: xyflow's current license + maintainers state anyone may remove it (it's MIT; Pro is optional support). The watermark is gone.
2. **Onboarding.** A first-time, non-engineer user landed on a blank canvas with zero guidance. Now a guided tour walks them through it — and they can re-open it anytime.
3. **Immersive layout.** The old cramped two-column grid (fixed 600px canvas, palette floating in a corner) is replaced by a real editor surface.

## Layout

```
┌─ TOP TOOLBAR ─────────────────────────────────────────────────────────┐
│ [‹] [name]  │  + Operation  + Tool  + Canned   …   [?] [form] [⛶] [Save] │
├──────────────────────────────────────────────┬───────────────────────┤
│  CANVAS (fills all remaining space, no badge) │  SIDEBAR (config)      │
│                                                │  • node → inspector    │
│                                                │  • none → description + │
│                                                │    live summary/checks │
└──────────────────────────────────────────────┴───────────────────────┘
```

- **Top toolbar:** inline tool-name field (document-title style), the node palette ("options to pick"), and actions — tour, form-editor, fullscreen toggle, Save.
- **Sidebar:** the existing node inspector when a node is selected; otherwise the description field + plain-language summary and validation checklist.
- **Immersive by default:** opens as `fixed inset-0` covering the app nav/topbar. A fullscreen toggle (and **Esc**) minimize it back into the page when you want the app chrome.

## Guided tour (driver.js)

- Anchored to the palette, the Inputs node, the sidebar, and Save — plain-language copy, no jargon.
- **Auto-runs once** per user (persisted in `localStorage`, mirroring the activation-banner pattern), and is **replayable anytime** from the `?` button.
- Logic lives in a generic, page-agnostic `useGuidedTour` hook (`components/onboarding/`) so other pages can reuse it; popover is themed to the dark UI in `globals.css`.

## Safety / scope

- **No backend or graph-logic changes** — `lib/graph.ts`, the inspector, and the create/edit API are untouched. The #1064 cycle/validation guards still apply.
- The classic **form editor** (`?editor=form`) is unchanged as a fallback.
- `driver.js` added to `package.json` and **both** lockfiles (`package-lock.json` + `pnpm-lock.yaml`) — CI's `npm ci` validates the npm lockfile (the thing that broke #1064).

## Verification

- `tsc --noEmit` clean · eslint clean · **39 web tests pass** (35 existing + 4 new tour-step invariants, incl. a guard that the tour's Inputs-node selector stays in sync with `INPUTS_NODE_ID`) · `pnpm build` succeeds · `npm ci` exits 0 (lockfile in sync).
- The immersive layout, fullscreen toggle, and tour interaction need a real session to click through — best done on this PR's **Vercel preview** (auth + a workspace with primitives). I verified everything that's checkable headlessly; happy to do a live `/qa` pass on the preview.
