### PR TITLE
fix(web): stack the Agent-inputs row so it fits the canvas sidebar

### DIFF
--- a/web/src/components/tools/canvas-builder.tsx
+++ b/web/src/components/tools/canvas-builder.tsx
@@ -337,7 +337,7 @@ function CanvasBuilderInner({
 
           <aside
             data-tour="sidebar"
-            className="flex w-80 flex-shrink-0 flex-col overflow-y-auto border-l border-border"
+            className="flex w-96 flex-shrink-0 flex-col overflow-y-auto overflow-x-hidden border-l border-border"
           >
             {selectedNode ? (
               <NodeInspector

--- a/web/src/components/tools/parameters-editor.tsx
+++ b/web/src/components/tools/parameters-editor.tsx
@@ -77,53 +77,55 @@ export function ParametersEditor({
       ) : (
         <div className="space-y-2">
           {rows.map((p, i) => (
-            <div
-              key={i}
-              className="grid grid-cols-[1fr_9.5rem_auto_auto] items-center gap-2 rounded-lg border border-border p-2"
-            >
+            // Stacked layout so a row fits a narrow side panel: name on its own
+            // line (never crushed), then type + required + delete, then description.
+            <div key={i} className="space-y-2 rounded-lg border border-border p-2">
               <input
                 value={p.name}
                 onChange={(e) => update(i, { name: e.target.value })}
-                placeholder="name"
+                placeholder="name (e.g. order_id)"
                 aria-label="Input name"
                 className={`${controlClass} font-[family-name:var(--font-mono)] text-xs`}
               />
-              <select
-                value={p.type}
-                onChange={(e) => update(i, { type: e.target.value as JsonSchemaType })}
-                aria-label="Input type"
-                className={`${controlClass} py-1.5`}
-              >
-                {TYPE_OPTIONS.map((t) => (
-                  <option key={t.value} value={t.value}>
-                    {t.label}
-                  </option>
-                ))}
-              </select>
-              <label className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={p.required}
-                  onChange={(e) => update(i, { required: e.target.checked })}
-                  className="size-3.5 accent-primary"
-                />
-                required
-              </label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => remove(i)}
-                aria-label="Remove input"
-              >
-                <Trash2 className="size-3.5 text-muted-foreground" />
-              </Button>
+              <div className="flex items-center gap-2">
+                <select
+                  value={p.type}
+                  onChange={(e) => update(i, { type: e.target.value as JsonSchemaType })}
+                  aria-label="Input type"
+                  className={`${controlClass} min-w-0 flex-1 py-1.5`}
+                >
+                  {TYPE_OPTIONS.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={p.required}
+                    onChange={(e) => update(i, { required: e.target.checked })}
+                    className="size-3.5 accent-primary"
+                  />
+                  required
+                </label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0"
+                  onClick={() => remove(i)}
+                  aria-label="Remove input"
+                >
+                  <Trash2 className="size-3.5 text-muted-foreground" />
+                </Button>
+              </div>
               <input
                 value={p.description ?? ""}
                 onChange={(e) => update(i, { description: e.target.value })}
                 placeholder="What is this input? (optional)"
                 aria-label="Input description"
-                className={`${controlClass} col-span-4 text-xs`}
+                className={`${controlClass} text-xs`}
               />
             </div>
           ))}


### PR DESCRIPTION
Follow-up to #1067. That PR fixed the *logic* (Add input adds a row), but the **layout** fix landed one commit too late and wasn't included in the merge — so the visual bug is still live.

## The bug
In the narrow canvas side panel, the input row used a wide 4-column grid built for the full-width form editor. It overflowed and **crushed the name field into a tiny circle** (so `order_id` ended up in the description box), and clipped the delete button.

## Fix
- Stack the row: **name** on its own full-width line, then **type + required + delete**, then **description**. Fits any panel width.
- Widen the canvas side panel `w-80` → `w-96` and clip horizontal overflow.

tsc ✓ · eslint ✓ · build ✓ (verified before merge of the prior commit; cherry-picked clean onto current main).