### PR TITLE
feat(agents): one-step quick-create agent flow

### DIFF
--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -1240,7 +1240,7 @@ func decodeQuickCreateAgentInput(body quickCreateAgentRequest) (QuickCreateAgent
 	}
 
 	input := QuickCreateAgentInput{
-		Name:             body.Name,
+		Name:             strings.TrimSpace(body.Name),
 		Description:      body.Description,
 		Instructions:     body.Instructions,
 		AgentKind:        body.AgentKind,

--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -47,6 +47,7 @@ type AgentBuildService interface {
 	ValidateVersion(ctx context.Context, id uuid.UUID) (ValidateBuildVersionResult, error)
 	MarkVersionReady(ctx context.Context, id uuid.UUID) error
 	CreateDeployment(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error)
+	QuickCreate(ctx context.Context, caller Caller, workspaceID uuid.UUID, input QuickCreateAgentInput) (QuickCreateAgentResult, error)
 }
 
 type CreateAgentBuildInput struct {
@@ -81,6 +82,33 @@ type CreateAgentDeploymentInput struct {
 	ProviderAccountID *uuid.UUID
 	Model             string
 	DeploymentConfig  json.RawMessage
+}
+
+// QuickCreateAgentInput collapses the build -> version -> ready -> deployment
+// chain into a single request. Callers supply only what an agent fundamentally
+// is (a name and its instructions) and what it should run on (a model on a
+// provider account, against a runtime profile); the build, its first version,
+// the ready transition, and the deployment are all derived for them.
+type QuickCreateAgentInput struct {
+	Name              string
+	Description       string
+	Instructions      string
+	AgentKind         string
+	Template          string
+	ModelSpec         json.RawMessage
+	RuntimeProfileID  uuid.UUID
+	ProviderAccountID *uuid.UUID
+	Model             string
+	DeploymentConfig  json.RawMessage
+}
+
+// QuickCreateAgentResult returns every object materialized by QuickCreate so the
+// caller can link to the build/version for the advanced views and run the
+// deployment immediately.
+type QuickCreateAgentResult struct {
+	Build      repository.AgentBuild
+	Version    repository.AgentBuildVersion
+	Deployment repository.AgentDeploymentRow
 }
 
 type ValidateBuildVersionResult struct {
@@ -299,6 +327,92 @@ func (m *AgentBuildManager) CreateDeployment(ctx context.Context, caller Caller,
 	})
 }
 
+// QuickCreate runs the full build -> version -> ready -> deployment chain in one
+// call. It orchestrates the existing manager methods rather than introducing a
+// new persistence path, so each step keeps its own validation and the
+// deployment snapshot is created exactly as it is for the advanced flow.
+//
+// The steps are not wrapped in a single transaction: a mid-chain failure can
+// leave an orphaned build/version (a harmless draft/ready definition with no
+// deployment). The deployment-time inputs are therefore validated up front so
+// the common failure modes are rejected before anything is written.
+func (m *AgentBuildManager) QuickCreate(ctx context.Context, caller Caller, workspaceID uuid.UUID, input QuickCreateAgentInput) (QuickCreateAgentResult, error) {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return QuickCreateAgentResult{}, AgentBuildValidationError{Code: "invalid_name", Message: "name is required"}
+	}
+
+	instructions := strings.TrimSpace(input.Instructions)
+	template := strings.TrimSpace(input.Template)
+	if instructions == "" && template == "" {
+		return QuickCreateAgentResult{}, AgentBuildValidationError{
+			Code:    "missing_instructions",
+			Message: "instructions or template is required",
+		}
+	}
+
+	// Validate the deployment target before writing the build so a bad model or
+	// provider account does not leave an orphaned build behind.
+	if input.RuntimeProfileID == uuid.Nil {
+		return QuickCreateAgentResult{}, AgentBuildValidationError{Code: "missing_runtime_profile", Message: "runtime_profile_id is required"}
+	}
+	if input.ProviderAccountID == nil {
+		return QuickCreateAgentResult{}, AgentBuildValidationError{Code: "missing_provider_account", Message: "provider_account_id is required"}
+	}
+	if strings.TrimSpace(input.Model) == "" {
+		return QuickCreateAgentResult{}, AgentBuildValidationError{Code: "missing_model", Message: "model (e.g. \"gpt-4.1\") is required"}
+	}
+
+	build, err := m.CreateBuild(ctx, caller, workspaceID, CreateAgentBuildInput{
+		Name:        name,
+		Description: input.Description,
+	})
+	if err != nil {
+		return QuickCreateAgentResult{}, err
+	}
+
+	versionInput := CreateAgentBuildVersionInput{
+		Template:  template,
+		AgentKind: input.AgentKind,
+		ModelSpec: input.ModelSpec,
+	}
+	// An explicit instructions string wins; otherwise the template supplies the
+	// policy spec (and therefore the required "instructions" field).
+	if instructions != "" {
+		policySpec, marshalErr := json.Marshal(map[string]string{"instructions": instructions})
+		if marshalErr != nil {
+			return QuickCreateAgentResult{}, marshalErr
+		}
+		versionInput.PolicySpec = policySpec
+	}
+
+	version, err := m.CreateVersion(ctx, caller, build.ID, versionInput)
+	if err != nil {
+		return QuickCreateAgentResult{}, err
+	}
+
+	if err := m.MarkVersionReady(ctx, version.ID); err != nil {
+		return QuickCreateAgentResult{}, err
+	}
+	// MarkVersionReady mutates persisted state, not the local copy.
+	version.VersionStatus = "ready"
+
+	deployment, err := m.CreateDeployment(ctx, caller, workspaceID, CreateAgentDeploymentInput{
+		Name:              name,
+		AgentBuildID:      build.ID,
+		BuildVersionID:    version.ID,
+		RuntimeProfileID:  input.RuntimeProfileID,
+		ProviderAccountID: input.ProviderAccountID,
+		Model:             input.Model,
+		DeploymentConfig:  input.DeploymentConfig,
+	})
+	if err != nil {
+		return QuickCreateAgentResult{}, err
+	}
+
+	return QuickCreateAgentResult{Build: build, Version: version, Deployment: deployment}, nil
+}
+
 // --- Request types ---
 
 type createAgentBuildRequest struct {
@@ -330,6 +444,19 @@ type createAgentDeploymentRequest struct {
 	RuntimeProfileID  string          `json:"runtime_profile_id"`
 	ProviderAccountID *string         `json:"provider_account_id,omitempty"`
 	Model             string          `json:"model,omitempty"`
+	DeploymentConfig  json.RawMessage `json:"deployment_config,omitempty"`
+}
+
+type quickCreateAgentRequest struct {
+	Name              string          `json:"name"`
+	Description       string          `json:"description,omitempty"`
+	Instructions      string          `json:"instructions,omitempty"`
+	AgentKind         string          `json:"agent_kind,omitempty"`
+	Template          string          `json:"template,omitempty"`
+	ModelSpec         json.RawMessage `json:"model_spec,omitempty"`
+	RuntimeProfileID  string          `json:"runtime_profile_id"`
+	ProviderAccountID *string         `json:"provider_account_id"`
+	Model             string          `json:"model"`
 	DeploymentConfig  json.RawMessage `json:"deployment_config,omitempty"`
 }
 
@@ -425,6 +552,15 @@ type agentDeploymentCreateResponse struct {
 	Status                string    `json:"status"`
 	CreatedAt             time.Time `json:"created_at"`
 	UpdatedAt             time.Time `json:"updated_at"`
+}
+
+// quickCreateAgentResponse surfaces all three objects the quick-create flow
+// produces. The deployment is the runnable result; the build and version are
+// included so the UI can deep-link into the advanced views.
+type quickCreateAgentResponse struct {
+	Build      agentBuildResponse            `json:"build"`
+	Version    agentBuildVersionResponse     `json:"version"`
+	Deployment agentDeploymentCreateResponse `json:"deployment"`
 }
 
 // --- Error type ---
@@ -886,17 +1022,72 @@ func createAgentDeploymentHandler(logger *slog.Logger, service AgentBuildService
 			return
 		}
 
-		writeJSON(w, http.StatusCreated, agentDeploymentCreateResponse{
-			ID:                    dep.ID,
-			WorkspaceID:           dep.WorkspaceID,
-			AgentBuildID:          dep.AgentBuildID,
-			CurrentBuildVersionID: dep.CurrentBuildVersionID,
-			Name:                  dep.Name,
-			Slug:                  dep.Slug,
-			DeploymentType:        dep.DeploymentType,
-			Status:                dep.Status,
-			CreatedAt:             dep.CreatedAt,
-			UpdatedAt:             dep.UpdatedAt,
+		writeJSON(w, http.StatusCreated, buildAgentDeploymentCreateResponse(dep))
+	}
+}
+
+func quickCreateAgentHandler(logger *slog.Logger, service AgentBuildService, authorizer WorkspaceAuthorizer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		// Quick-create runs the whole build -> version -> ready -> deployment
+		// chain, so the caller must be authorized for every step, not just the
+		// terminal deployment.
+		for _, action := range []Action{
+			ActionCreateAgentBuild,
+			ActionCreateAgentBuildVersion,
+			ActionMarkAgentBuildReady,
+			ActionCreateAgentDeployment,
+		} {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, workspaceID, action); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAgentBuildRequestBytes)
+
+		var body quickCreateAgentRequest
+		if err := decodeJSON(r, &body); err != nil {
+			handleDecodeError(w, logger, r, err)
+			return
+		}
+
+		input, err := decodeQuickCreateAgentInput(body)
+		if err != nil {
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		result, err := service.QuickCreate(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildNotFound) || errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build or version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, quickCreateAgentResponse{
+			Build:      buildAgentBuildResponse(result.Build),
+			Version:    buildAgentBuildVersionResponse(result.Version),
+			Deployment: buildAgentDeploymentCreateResponse(result.Deployment),
 		})
 	}
 }
@@ -936,6 +1127,21 @@ func buildAgentBuildVersionResponse(v repository.AgentBuildVersion) agentBuildVe
 		Tools:            buildToolBindingResponses(v.Tools),
 		KnowledgeSources: buildKnowledgeSourceBindingResponses(v.KnowledgeSources),
 		CreatedAt:        v.CreatedAt,
+	}
+}
+
+func buildAgentDeploymentCreateResponse(dep repository.AgentDeploymentRow) agentDeploymentCreateResponse {
+	return agentDeploymentCreateResponse{
+		ID:                    dep.ID,
+		WorkspaceID:           dep.WorkspaceID,
+		AgentBuildID:          dep.AgentBuildID,
+		CurrentBuildVersionID: dep.CurrentBuildVersionID,
+		Name:                  dep.Name,
+		Slug:                  dep.Slug,
+		DeploymentType:        dep.DeploymentType,
+		Status:                dep.Status,
+		CreatedAt:             dep.CreatedAt,
+		UpdatedAt:             dep.UpdatedAt,
 	}
 }
 
@@ -1015,6 +1221,48 @@ func decodeCreateAgentDeploymentInput(body createAgentDeploymentRequest) (Create
 		Model:             strings.TrimSpace(body.Model),
 		DeploymentConfig:  body.DeploymentConfig,
 	}, nil
+}
+
+func decodeQuickCreateAgentInput(body quickCreateAgentRequest) (QuickCreateAgentInput, error) {
+	if strings.TrimSpace(body.Name) == "" {
+		return QuickCreateAgentInput{}, AgentBuildValidationError{
+			Code:    "invalid_name",
+			Message: "name is required",
+		}
+	}
+
+	runtimeProfileID, err := uuid.Parse(strings.TrimSpace(body.RuntimeProfileID))
+	if err != nil {
+		return QuickCreateAgentInput{}, AgentBuildValidationError{
+			Code:    "invalid_runtime_profile_id",
+			Message: "runtime_profile_id must be a valid UUID",
+		}
+	}
+
+	input := QuickCreateAgentInput{
+		Name:             body.Name,
+		Description:      body.Description,
+		Instructions:     body.Instructions,
+		AgentKind:        body.AgentKind,
+		Template:         body.Template,
+		ModelSpec:        body.ModelSpec,
+		RuntimeProfileID: runtimeProfileID,
+		Model:            strings.TrimSpace(body.Model),
+		DeploymentConfig: body.DeploymentConfig,
+	}
+
+	if body.ProviderAccountID != nil && strings.TrimSpace(*body.ProviderAccountID) != "" {
+		providerAccountID, parseErr := uuid.Parse(strings.TrimSpace(*body.ProviderAccountID))
+		if parseErr != nil {
+			return QuickCreateAgentInput{}, AgentBuildValidationError{
+				Code:    "invalid_provider_account_id",
+				Message: "provider_account_id must be a valid UUID",
+			}
+		}
+		input.ProviderAccountID = &providerAccountID
+	}
+
+	return input, nil
 }
 
 func decodeCreateAgentBuildVersionInput(body createAgentBuildVersionRequest) (CreateAgentBuildVersionInput, error) {

--- a/backend/internal/api/agent_builds_test.go
+++ b/backend/internal/api/agent_builds_test.go
@@ -73,6 +73,278 @@ func (s testAgentBuildService) CreateDeployment(_ context.Context, _ Caller, _ u
 	return repository.AgentDeploymentRow{}, errors.New("not implemented")
 }
 
+func (s testAgentBuildService) QuickCreate(_ context.Context, _ Caller, _ uuid.UUID, _ QuickCreateAgentInput) (QuickCreateAgentResult, error) {
+	return QuickCreateAgentResult{}, errors.New("not implemented")
+}
+
+// quickCreateFakeRepo is a minimal in-memory AgentBuildRepository used to drive
+// the real AgentBuildManager through the quick-create orchestration.
+type quickCreateFakeRepo struct {
+	orgID       uuid.UUID
+	builds      map[uuid.UUID]repository.AgentBuild
+	versions    map[uuid.UUID]repository.AgentBuildVersion
+	deployments []repository.CreateAgentDeploymentParams
+}
+
+func newQuickCreateFakeRepo() *quickCreateFakeRepo {
+	return &quickCreateFakeRepo{
+		orgID:    uuid.New(),
+		builds:   map[uuid.UUID]repository.AgentBuild{},
+		versions: map[uuid.UUID]repository.AgentBuildVersion{},
+	}
+}
+
+func (r *quickCreateFakeRepo) GetOrganizationIDByWorkspaceID(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+	return r.orgID, nil
+}
+
+func (r *quickCreateFakeRepo) CreateAgentBuild(_ context.Context, params repository.CreateAgentBuildParams) (repository.AgentBuild, error) {
+	build := repository.AgentBuild{
+		ID:              uuid.New(),
+		OrganizationID:  params.OrganizationID,
+		WorkspaceID:     params.WorkspaceID,
+		Name:            params.Name,
+		Slug:            params.Slug,
+		Description:     params.Description,
+		LifecycleStatus: "active",
+		CreatedByUserID: params.CreatedByUserID,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	r.builds[build.ID] = build
+	return build, nil
+}
+
+func (r *quickCreateFakeRepo) GetAgentBuildByID(_ context.Context, id uuid.UUID) (repository.AgentBuild, error) {
+	build, ok := r.builds[id]
+	if !ok {
+		return repository.AgentBuild{}, repository.ErrAgentBuildNotFound
+	}
+	return build, nil
+}
+
+func (r *quickCreateFakeRepo) ListAgentBuildsByWorkspaceID(_ context.Context, _ uuid.UUID) ([]repository.AgentBuild, error) {
+	return nil, nil
+}
+
+func (r *quickCreateFakeRepo) CreateAgentBuildVersion(_ context.Context, params repository.CreateAgentBuildVersionParams) (repository.AgentBuildVersion, error) {
+	version := repository.AgentBuildVersion{
+		ID:               uuid.New(),
+		AgentBuildID:     params.AgentBuildID,
+		VersionNumber:    params.VersionNumber,
+		VersionStatus:    "draft",
+		AgentKind:        params.AgentKind,
+		InterfaceSpec:    params.InterfaceSpec,
+		PolicySpec:       params.PolicySpec,
+		ReasoningSpec:    params.ReasoningSpec,
+		MemorySpec:       params.MemorySpec,
+		WorkflowSpec:     params.WorkflowSpec,
+		GuardrailSpec:    params.GuardrailSpec,
+		ModelSpec:        params.ModelSpec,
+		OutputSchema:     params.OutputSchema,
+		TraceContract:    params.TraceContract,
+		PublicationSpec:  params.PublicationSpec,
+		Tools:            params.Tools,
+		KnowledgeSources: params.KnowledgeSources,
+		CreatedByUserID:  params.CreatedByUserID,
+		CreatedAt:        time.Now(),
+	}
+	r.versions[version.ID] = version
+	return version, nil
+}
+
+func (r *quickCreateFakeRepo) GetAgentBuildVersionByID(_ context.Context, id uuid.UUID) (repository.AgentBuildVersion, error) {
+	version, ok := r.versions[id]
+	if !ok {
+		return repository.AgentBuildVersion{}, repository.ErrAgentBuildVersionNotFound
+	}
+	return version, nil
+}
+
+func (r *quickCreateFakeRepo) GetLatestVersionNumberForBuild(_ context.Context, agentBuildID uuid.UUID) (int32, error) {
+	var latest int32
+	for _, v := range r.versions {
+		if v.AgentBuildID == agentBuildID && v.VersionNumber > latest {
+			latest = v.VersionNumber
+		}
+	}
+	return latest, nil
+}
+
+func (r *quickCreateFakeRepo) ListAgentBuildVersionsByBuildID(_ context.Context, _ uuid.UUID) ([]repository.AgentBuildVersion, error) {
+	return nil, nil
+}
+
+func (r *quickCreateFakeRepo) UpdateAgentBuildVersionDraft(_ context.Context, _ repository.UpdateAgentBuildVersionDraftParams) error {
+	return nil
+}
+
+func (r *quickCreateFakeRepo) MarkAgentBuildVersionReady(_ context.Context, id uuid.UUID) error {
+	version, ok := r.versions[id]
+	if !ok {
+		return repository.ErrAgentBuildVersionNotFound
+	}
+	version.VersionStatus = "ready"
+	r.versions[id] = version
+	return nil
+}
+
+func (r *quickCreateFakeRepo) CreateAgentDeployment(_ context.Context, params repository.CreateAgentDeploymentParams) (repository.AgentDeploymentRow, error) {
+	r.deployments = append(r.deployments, params)
+	return repository.AgentDeploymentRow{
+		ID:                    uuid.New(),
+		OrganizationID:        params.OrganizationID,
+		WorkspaceID:           params.WorkspaceID,
+		AgentBuildID:          params.AgentBuildID,
+		CurrentBuildVersionID: params.CurrentBuildVersionID,
+		Name:                  params.Name,
+		Slug:                  params.Slug,
+		DeploymentType:        "native",
+		Status:                "active",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+	}, nil
+}
+
+func (r *quickCreateFakeRepo) GetProviderAccountByID(_ context.Context, _ uuid.UUID) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, nil
+}
+
+func TestQuickCreateAgentOrchestratesChain(t *testing.T) {
+	repo := newQuickCreateFakeRepo()
+	mgr := NewAgentBuildManager(repo)
+	providerAccountID := uuid.New()
+	runtimeProfileID := uuid.New()
+
+	result, err := mgr.QuickCreate(context.Background(), Caller{UserID: uuid.New()}, uuid.New(), QuickCreateAgentInput{
+		Name:              "Refund agent",
+		Instructions:      "Help users get refunds without inventing policy.",
+		RuntimeProfileID:  runtimeProfileID,
+		ProviderAccountID: &providerAccountID,
+		Model:             "gpt-4.1",
+	})
+	if err != nil {
+		t.Fatalf("QuickCreate returned error: %v", err)
+	}
+
+	if result.Build.ID == uuid.Nil {
+		t.Error("expected a build to be created")
+	}
+	if result.Version.VersionNumber != 1 {
+		t.Errorf("expected first version number 1, got %d", result.Version.VersionNumber)
+	}
+	if result.Version.VersionStatus != "ready" {
+		t.Errorf("expected returned version status ready, got %q", result.Version.VersionStatus)
+	}
+	if result.Deployment.AgentBuildID != result.Build.ID {
+		t.Error("deployment should point at the created build")
+	}
+	if result.Deployment.CurrentBuildVersionID != result.Version.ID {
+		t.Error("deployment should point at the created version")
+	}
+
+	// The persisted version must carry the instructions so MarkVersionReady's
+	// validation (which requires policy_spec.instructions) passes, and it must be
+	// flipped to ready in storage.
+	stored := repo.versions[result.Version.ID]
+	if !jsonHasKey(stored.PolicySpec, "instructions") {
+		t.Errorf("expected policy_spec to contain instructions, got %s", stored.PolicySpec)
+	}
+	if stored.VersionStatus != "ready" {
+		t.Errorf("expected stored version to be ready, got %q", stored.VersionStatus)
+	}
+	if stored.AgentKind != "llm_agent" {
+		t.Errorf("expected default agent_kind llm_agent, got %q", stored.AgentKind)
+	}
+
+	if len(repo.deployments) != 1 {
+		t.Fatalf("expected exactly one deployment, got %d", len(repo.deployments))
+	}
+	if repo.deployments[0].Model != "gpt-4.1" {
+		t.Errorf("expected model gpt-4.1, got %q", repo.deployments[0].Model)
+	}
+	if repo.deployments[0].RuntimeProfileID != runtimeProfileID {
+		t.Error("deployment should carry the supplied runtime profile")
+	}
+}
+
+func TestQuickCreateAgentValidationRejectsBeforeWriting(t *testing.T) {
+	providerAccountID := uuid.New()
+	base := QuickCreateAgentInput{
+		Name:              "Agent",
+		Instructions:      "Be helpful.",
+		RuntimeProfileID:  uuid.New(),
+		ProviderAccountID: &providerAccountID,
+		Model:             "gpt-4.1",
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(QuickCreateAgentInput) QuickCreateAgentInput
+		wantErr string
+	}{
+		{"missing name", func(in QuickCreateAgentInput) QuickCreateAgentInput { in.Name = "  "; return in }, "invalid_name"},
+		{"no instructions or template", func(in QuickCreateAgentInput) QuickCreateAgentInput {
+			in.Instructions = ""
+			in.Template = ""
+			return in
+		}, "missing_instructions"},
+		{"missing runtime profile", func(in QuickCreateAgentInput) QuickCreateAgentInput { in.RuntimeProfileID = uuid.Nil; return in }, "missing_runtime_profile"},
+		{"missing provider account", func(in QuickCreateAgentInput) QuickCreateAgentInput { in.ProviderAccountID = nil; return in }, "missing_provider_account"},
+		{"missing model", func(in QuickCreateAgentInput) QuickCreateAgentInput { in.Model = " "; return in }, "missing_model"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newQuickCreateFakeRepo()
+			mgr := NewAgentBuildManager(repo)
+
+			_, err := mgr.QuickCreate(context.Background(), Caller{UserID: uuid.New()}, uuid.New(), tc.mutate(base))
+
+			var verr AgentBuildValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("expected AgentBuildValidationError, got %v", err)
+			}
+			if verr.Code != tc.wantErr {
+				t.Errorf("expected code %q, got %q", tc.wantErr, verr.Code)
+			}
+			if len(repo.builds) != 0 {
+				t.Errorf("expected no build to be written on validation failure, got %d", len(repo.builds))
+			}
+		})
+	}
+}
+
+func TestDecodeQuickCreateAgentInput(t *testing.T) {
+	runtimeProfileID := uuid.New()
+	providerAccountID := uuid.New()
+	providerStr := providerAccountID.String()
+
+	input, err := decodeQuickCreateAgentInput(quickCreateAgentRequest{
+		Name:              "Agent",
+		Instructions:      "Be helpful.",
+		RuntimeProfileID:  runtimeProfileID.String(),
+		ProviderAccountID: &providerStr,
+		Model:             "  gpt-4.1  ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.RuntimeProfileID != runtimeProfileID {
+		t.Error("runtime_profile_id was not parsed")
+	}
+	if input.ProviderAccountID == nil || *input.ProviderAccountID != providerAccountID {
+		t.Error("provider_account_id was not parsed")
+	}
+	if input.Model != "gpt-4.1" {
+		t.Errorf("expected trimmed model, got %q", input.Model)
+	}
+
+	if _, err := decodeQuickCreateAgentInput(quickCreateAgentRequest{Name: "Agent", RuntimeProfileID: "not-a-uuid"}); err == nil {
+		t.Error("expected error for invalid runtime_profile_id")
+	}
+}
+
 func TestGetAgentBuildRequiresWorkspaceMembership(t *testing.T) {
 	userID := uuid.New()
 	buildWorkspaceID := uuid.New()

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -267,6 +267,10 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/agent-deployments", createAgentDeploymentHandler(logger, agentBuildService, authorizer))
 
+	// Quick-create collapses build + version + ready + deployment into one call.
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-builds/quick-create", quickCreateAgentHandler(logger, agentBuildService, authorizer))
+
 	// Workspace Secrets (admin-only via ActionManageSecrets)
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/secrets", listWorkspaceSecretsHandler(logger, workspaceSecretsService, authorizer))

--- a/backend/internal/api/test_helpers_test.go
+++ b/backend/internal/api/test_helpers_test.go
@@ -57,3 +57,6 @@ func (stubAgentBuildService) MarkVersionReady(_ context.Context, _ uuid.UUID) er
 func (stubAgentBuildService) CreateDeployment(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error) {
 	return repository.AgentDeploymentRow{}, errors.New("not implemented")
 }
+func (stubAgentBuildService) QuickCreate(_ context.Context, _ Caller, _ uuid.UUID, _ QuickCreateAgentInput) (QuickCreateAgentResult, error) {
+	return QuickCreateAgentResult{}, errors.New("not implemented")
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4995,6 +4995,43 @@ paths:
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
 
+  /v1/workspaces/{workspaceID}/agent-builds/quick-create:
+    post:
+      operationId: quickCreateAgent
+      tags: [AgentBuilds]
+      summary: Quick-create an agent
+      description: >
+        Collapses the build, first version, ready transition, and deployment
+        into a single call. Supply the agent's name and instructions (or a
+        template) plus a model on a provider account against a runtime profile;
+        the build, version, ready transition, and deployment are derived. The
+        advanced per-step endpoints remain available for power users.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuickCreateAgentRequest"
+      responses:
+        "201":
+          description: Agent created (build, version, and deployment)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuickCreateAgentResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+
   # ---------------------------------------------------------------------------
   # Playgrounds
   # ---------------------------------------------------------------------------
@@ -12899,6 +12936,53 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    QuickCreateAgentRequest:
+      type: object
+      required: [name, runtime_profile_id, provider_account_id, model]
+      description: >
+        Either instructions or template must be provided. An explicit
+        instructions string takes precedence; otherwise the template supplies
+        the agent's policy.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        instructions:
+          type: string
+          description: System prompt for the agent. Stored as the version policy.
+        agent_kind:
+          type: string
+          description: Defaults to llm_agent.
+        template:
+          type: string
+          description: Built-in build-version template key (e.g. honest-agent).
+        model_spec:
+          type: object
+          additionalProperties: true
+        runtime_profile_id:
+          type: string
+          format: uuid
+        provider_account_id:
+          type: string
+          format: uuid
+        model:
+          type: string
+        deployment_config:
+          type: object
+          additionalProperties: true
+
+    QuickCreateAgentResponse:
+      type: object
+      required: [build, version, deployment]
+      properties:
+        build:
+          $ref: "#/components/schemas/AgentBuild"
+        version:
+          $ref: "#/components/schemas/AgentBuildVersion"
+        deployment:
+          $ref: "#/components/schemas/AgentDeploymentCreateResponse"
 
     # --- Hosted Runs ---
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-client.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/table";
 import { Bot } from "lucide-react";
 import { CreateBuildDialog } from "./create-build-dialog";
+import { QuickCreateAgentDialog } from "./quick-create-agent-dialog";
 
 const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   active: "default",
@@ -36,7 +37,10 @@ export function BuildsClient({ workspaceId }: { workspaceId: string }) {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Agent Builds</h1>
-        <CreateBuildDialog workspaceId={workspaceId} />
+        <div className="flex items-center gap-2">
+          <CreateBuildDialog workspaceId={workspaceId} />
+          <QuickCreateAgentDialog workspaceId={workspaceId} />
+        </div>
       </div>
 
       {error ? (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
@@ -65,10 +65,10 @@ export function CreateBuildDialog({ workspaceId }: CreateBuildDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
-        render={<Button size="sm" />}
+        render={<Button size="sm" variant="outline" />}
       >
         <Plus data-icon="inline-start" className="size-4" />
-        New Agent Build
+        New build (advanced)
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
@@ -159,14 +159,17 @@ export function QuickCreateAgentDialog({
       toast.success(`Created and deployed "${result.build.name}"`);
       setOpen(false);
       resetForm();
-      await mutateMany(workspaceMutationKeys.quickCreateAgentDialog(workspaceId));
     } catch (err) {
       toast.error(
         err instanceof ApiError ? err.message : "Failed to create agent",
       );
+      return;
     } finally {
       setSubmitting(false);
     }
+    // Revalidate the lists in the background — a refresh failure must not
+    // surface as a create failure (the create already succeeded above).
+    void mutateMany(workspaceMutationKeys.quickCreateAgentDialog(workspaceId));
   }
 
   return (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { useApiMutator } from "@/lib/api/swr";
+import { ApiError } from "@/lib/api/errors";
+import { workspaceMutationKeys } from "@/lib/workspace-resource";
+import { quickCreateAgent } from "@/lib/api/quick-create-agent";
+import type {
+  RuntimeProfile,
+  ProviderAccount,
+  ProviderConnectionModel,
+} from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2, Sparkles } from "lucide-react";
+
+const inputClass =
+  "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
+const selectClass =
+  "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
+
+/**
+ * The one-step path to a runnable agent. It hides the build/version/ready/
+ * deployment plumbing: the user names the agent, writes its instructions, and
+ * picks a model — the backend's quick-create endpoint does the rest. The
+ * granular Builds and Deployments screens remain for power users.
+ */
+export function QuickCreateAgentDialog({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const { getAccessToken } = useAccessToken();
+  const { mutateMany } = useApiMutator();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [selectedProfileId, setSelectedProfileId] = useState("");
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [model, setModel] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const [profiles, setProfiles] = useState<RuntimeProfile[]>([]);
+  const [accounts, setAccounts] = useState<ProviderAccount[]>([]);
+  const [models, setModels] = useState<ProviderConnectionModel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const modelRequestRef = useRef(0);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const [profilesRes, accountsRes] = await Promise.all([
+        api.get<{ items: RuntimeProfile[] }>(
+          `/v1/workspaces/${workspaceId}/runtime-profiles`,
+        ),
+        api.get<{ items: ProviderAccount[] }>(
+          `/v1/workspaces/${workspaceId}/provider-accounts`,
+        ),
+      ]);
+      setProfiles(profilesRes.items);
+      setAccounts(accountsRes.items);
+      // The runtime profile is plumbing — default to the first one so the user
+      // never has to think about it. Power users can change it under Advanced.
+      if (profilesRes.items.length > 0) {
+        setSelectedProfileId((current) => current || profilesRes.items[0].id);
+      }
+    } catch {
+      toast.error("Failed to load workspace settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken, workspaceId]);
+
+  useEffect(() => {
+    if (open) loadData();
+  }, [open, loadData]);
+
+  const loadModels = useCallback(
+    async (accountId: string) => {
+      const requestId = ++modelRequestRef.current;
+      setLoadingModels(true);
+      setModels([]);
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await api.get<{ items: ProviderConnectionModel[] }>(
+          `/v1/provider-accounts/${accountId}/models`,
+        );
+        if (modelRequestRef.current === requestId) setModels(res.items);
+      } catch {
+        // Live model list is optional — fall back to free-form model entry.
+        if (modelRequestRef.current === requestId) setModels([]);
+      } finally {
+        if (modelRequestRef.current === requestId) setLoadingModels(false);
+      }
+    },
+    [getAccessToken],
+  );
+
+  function handleAccountChange(accountId: string) {
+    setSelectedAccountId(accountId);
+    setModel("");
+    setModels([]);
+    if (accountId) loadModels(accountId);
+    else {
+      modelRequestRef.current += 1;
+      setLoadingModels(false);
+    }
+  }
+
+  function resetForm() {
+    modelRequestRef.current += 1;
+    setName("");
+    setInstructions("");
+    setSelectedProfileId("");
+    setSelectedAccountId("");
+    setModel("");
+    setModels([]);
+    setLoadingModels(false);
+  }
+
+  const needsAccount = !loading && accounts.length === 0;
+  const needsProfile = !loading && profiles.length === 0;
+  const canSubmit =
+    name.trim() &&
+    instructions.trim() &&
+    selectedAccountId &&
+    selectedProfileId &&
+    model.trim();
+
+  async function handleCreate() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const result = await quickCreateAgent(api, workspaceId, {
+        name: name.trim(),
+        instructions: instructions.trim(),
+        runtime_profile_id: selectedProfileId,
+        provider_account_id: selectedAccountId,
+        model: model.trim(),
+      });
+      toast.success(`Created and deployed "${result.build.name}"`);
+      setOpen(false);
+      resetForm();
+      await mutateMany(workspaceMutationKeys.quickCreateAgentDialog(workspaceId));
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to create agent",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <Sparkles data-icon="inline-start" className="size-4" />
+        New agent
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New agent</DialogTitle>
+          <DialogDescription>
+            Name it, tell it what to do, and pick a model. We build, version, and
+            deploy it for you — ready to race.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2 max-h-[60vh] overflow-y-auto">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Refund resolver"
+              autoFocus
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Instructions
+            </label>
+            <textarea
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              placeholder="Describe how the agent should behave. This becomes its system prompt."
+              rows={5}
+              className={`${inputClass} resize-y`}
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Provider account
+            </label>
+            <select
+              value={selectedAccountId}
+              onChange={(e) => handleAccountChange(e.target.value)}
+              disabled={loading}
+              className={selectClass}
+            >
+              <option value="">
+                {loading
+                  ? "Loading..."
+                  : needsAccount
+                    ? "No accounts — create one first"
+                    : "Select a provider account"}
+              </option>
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.provider_key})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Model</label>
+            {models.length > 0 ? (
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                disabled={loadingModels}
+                className={selectClass}
+              >
+                <option value="">Select a model</option>
+                {models.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.display_name} ({m.id})
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="e.g. gpt-4.1, claude-sonnet-4-6"
+                disabled={loadingModels}
+                className={inputClass}
+              />
+            )}
+            <p className="mt-1 text-xs text-muted-foreground">
+              {loadingModels
+                ? "Loading available models…"
+                : !selectedAccountId
+                  ? "Select a provider account to load its models."
+                  : models.length > 0
+                    ? "Pick a model from this provider connection."
+                    : "Enter the provider model ID."}
+            </p>
+          </div>
+
+          <details className="rounded-lg border border-border/60 px-3 py-2">
+            <summary className="cursor-pointer text-sm font-medium text-muted-foreground">
+              Advanced
+            </summary>
+            <div className="mt-3">
+              <label className="mb-1.5 block text-sm font-medium">
+                Runtime profile
+              </label>
+              <select
+                value={selectedProfileId}
+                onChange={(e) => setSelectedProfileId(e.target.value)}
+                disabled={loading}
+                className={selectClass}
+              >
+                <option value="">
+                  {loading
+                    ? "Loading..."
+                    : needsProfile
+                      ? "No profiles — create one first"
+                      : "Select a profile"}
+                </option>
+                {profiles.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.execution_target})
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Controls iteration and timeout limits. Defaults to your first
+                profile.
+              </p>
+            </div>
+          </details>
+
+          {needsAccount || needsProfile ? (
+            <p className="text-xs text-destructive">
+              This workspace needs a{needsAccount ? " provider account" : ""}
+              {needsAccount && needsProfile ? " and a" : ""}
+              {needsProfile ? " runtime profile" : ""} before you can create an
+              agent.
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || submitting} onClick={handleCreate}>
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              "Create agent"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/lib/api/quick-create-agent.ts
+++ b/web/src/lib/api/quick-create-agent.ts
@@ -1,0 +1,44 @@
+import type { ApiClient } from "@/lib/api/client";
+import type {
+  AgentBuild,
+  AgentBuildVersion,
+  AgentDeploymentCreateResponse,
+} from "@/lib/api/types";
+
+/**
+ * Collapses the build -> version -> ready -> deployment chain into one request.
+ * The caller supplies what an agent fundamentally is (a name and instructions,
+ * or a template) and what it runs on (a model on a provider account against a
+ * runtime profile); the backend derives the rest.
+ *
+ * Either `instructions` or `template` must be set.
+ */
+export interface QuickCreateAgentInput {
+  name: string;
+  description?: string;
+  instructions?: string;
+  agent_kind?: string;
+  template?: string;
+  model_spec?: unknown;
+  runtime_profile_id: string;
+  provider_account_id: string;
+  model: string;
+  deployment_config?: unknown;
+}
+
+export interface QuickCreateAgentResponse {
+  build: AgentBuild;
+  version: AgentBuildVersion;
+  deployment: AgentDeploymentCreateResponse;
+}
+
+export function quickCreateAgent(
+  api: ApiClient,
+  workspaceId: string,
+  input: QuickCreateAgentInput,
+): Promise<QuickCreateAgentResponse> {
+  return api.post<QuickCreateAgentResponse>(
+    `/v1/workspaces/${workspaceId}/agent-builds/quick-create`,
+    input,
+  );
+}

--- a/web/src/lib/workspace-resource.ts
+++ b/web/src/lib/workspace-resource.ts
@@ -87,6 +87,12 @@ export const workspaceMutationKeys = {
       workspaceResourceKeys.providerAccounts(workspaceId),
     ];
   },
+  quickCreateAgentDialog(workspaceId: string): ApiQueryKey[] {
+    return [
+      workspaceResourceKeys.builds(workspaceId),
+      workspaceResourceKeys.deployments(workspaceId),
+    ];
+  },
   createRunDialog(workspaceId: string): ApiQueryKey[] {
     return [
       workspaceResourceKeys.challengePacks(workspaceId),


### PR DESCRIPTION
## Why

Getting an agent into a race today means understanding and stepping through **four** separate concepts — build → version → *mark ready* → deployment → run. The build/deployment split is architecturally correct (it's what makes benchmark records immutable and reproducible), but exposing all of its plumbing as first-class UI nouns makes the product hard to understand.

This PR adds the **Vercel-style collapse**: one action that produces a runnable agent, with the versioning, ready-gate, snapshots, and runtime profile handled automatically. It's **additive** — the granular Builds and Deployments screens are untouched and remain the advanced path for power users.

## What

**Backend** — new endpoint `POST /v1/workspaces/{workspaceID}/agent-builds/quick-create`:
- `AgentBuildManager.QuickCreate` orchestrates the existing `CreateBuild → CreateVersion → MarkVersionReady → CreateDeployment` methods in one call. No new persistence path, no data-model change — each step keeps its own validation and the deployment snapshot is created exactly as in the granular flow.
- Deployment-target inputs (model, provider account, runtime profile) are validated up front so a bad value can't leave an orphaned build behind.
- Authorizes all four underlying actions, not just the terminal deployment.
- OpenAPI spec updated (`QuickCreateAgentRequest` / `QuickCreateAgentResponse`).

**Frontend** — a `New agent` dialog on the Builds page:
- Asks only for **name + instructions + model** (provider account picks its models live, with free-text fallback).
- The runtime profile is treated as plumbing — defaults to the workspace's first profile, changeable under an **Advanced** disclosure.
- `New build (advanced)` (the old per-step flow) is kept as a secondary outline button.

## What this deliberately does NOT do

- Does not remove or rename the Builds/Deployments pages, the data model, versions, snapshots, or the per-step endpoints.
- Does not make quick-create atomic across all four writes (it's best-effort orchestration; failures are validated against up front). A single-transaction repository path is a reasonable follow-up if orphan-on-failure becomes a concern.

## Tests / checks

- `go build ./...`, `go vet ./...` clean.
- New tests: `TestQuickCreateAgentOrchestratesChain`, `TestQuickCreateAgentValidationRejectsBeforeWriting` (table), `TestDecodeQuickCreateAgentInput`; full `internal/api` suite passes with `-race`.
- `npx tsc --noEmit` and `eslint` clean on touched files.
- `redocly lint` introduces no new errors (the 5 pre-existing `ErrorResponse` errors in the `datasets` paths are unrelated and present on `main`).