### PR TITLE
feat(challenge-packs): visual pack builder frontend

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/builder/[draftId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/builder/[draftId]/page.tsx
@@ -1,0 +1,10 @@
+import { PackBuilder } from "@/components/challenge-packs/pack-builder";
+
+export default async function ChallengePackBuilderPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; draftId: string }>;
+}) {
+  const { workspaceId, draftId } = await params;
+  return <PackBuilder workspaceId={workspaceId} draftId={draftId} />;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/table";
 import { Package } from "lucide-react";
 import { PublishPackDialog } from "./publish-pack-dialog";
+import { NewPackButton } from "./new-pack-button";
 
 const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {
   runnable: "default",
@@ -47,7 +48,10 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
             Benchmark definitions that agents are tested against.
           </p>
         </div>
-        <PublishPackDialog workspaceId={workspaceId} />
+        <div className="flex items-center gap-2">
+          <NewPackButton workspaceId={workspaceId} />
+          <PublishPackDialog workspaceId={workspaceId} />
+        </div>
       </div>
 
       {error ? (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/new-pack-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/new-pack-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Loader2, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { createDraft } from "@/components/challenge-packs/lib/api";
+import { emptyComposition } from "@/components/challenge-packs/lib/draft";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api/errors";
+
+export function NewPackButton({ workspaceId }: { workspaceId: string }) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [creating, setCreating] = useState(false);
+
+  const onClick = async () => {
+    setCreating(true);
+    try {
+      const token = await getAccessToken();
+      const draft = await createDraft(token, workspaceId, {
+        name: "Untitled pack",
+        execution_mode: "native",
+        composition: emptyComposition(),
+      });
+      router.push(`/workspaces/${workspaceId}/challenge-packs/builder/${draft.id}`);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't start a new pack");
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Button size="sm" onClick={onClick} disabled={creating}>
+      {creating ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+      New pack
+    </Button>
+  );
+}

--- a/web/src/components/challenge-packs/builder-shell.tsx
+++ b/web/src/components/challenge-packs/builder-shell.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { BuilderCenter } from "./editors/editor-registry";
+import { PackOutline } from "./outline/pack-outline";
+import { SpecCard } from "./pieces/spec-card";
+import { usePackDraft } from "./use-pack-draft";
+
+export function BuilderShell() {
+  const { state, publish } = usePackDraft();
+  const invalid = state.compile != null && !state.compile.valid;
+  const status = state.saving
+    ? "Saving…"
+    : state.compiling
+      ? "Updating preview…"
+      : state.savedAt
+        ? "Saved"
+        : "";
+
+  return (
+    <div className="flex h-[calc(100vh-7rem)] min-h-[560px] flex-col overflow-hidden rounded-xl border border-border bg-card">
+      <header className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold">
+            {state.composition.pack.name || "Untitled pack"}
+          </div>
+          <div className="text-xs text-muted-foreground">{status}</div>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => void publish()}
+          disabled={state.publishing || invalid}
+          title={invalid ? "Resolve the validation issues first" : undefined}
+        >
+          {state.publishing && <Loader2 className="size-4 animate-spin" />}
+          Publish
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <aside className="w-64 shrink-0 border-r border-border">
+          <PackOutline />
+        </aside>
+        <main className="min-w-0 flex-1 overflow-y-auto p-6">
+          <BuilderCenter />
+        </main>
+        <aside className="hidden w-80 shrink-0 border-l border-border lg:block">
+          <SpecCard />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/challenge-editor.tsx
+++ b/web/src/components/challenge-packs/editors/challenge-editor.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Field, controlClass } from "@/components/tools/field";
+import { updatePieceRef } from "../lib/draft";
+import type { ChallengeDefinition } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+const DIFFICULTIES = ["easy", "medium", "hard", "expert"];
+
+export function ChallengeEditor({ index }: { index: number }) {
+  const { state, update } = usePackDraft();
+  const def = (state.composition.challenges?.[index]?.inline ?? {}) as ChallengeDefinition;
+
+  const set = (patch: Partial<ChallengeDefinition>) =>
+    update((c) => updatePieceRef(c, "challenge", index, { inline: { ...def, ...patch } }));
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <h2 className="text-base font-semibold">Challenge</h2>
+      <Field label="Key" hint="unique within the pack; cases target it by key">
+        <input
+          className={controlClass}
+          value={def.key ?? ""}
+          onChange={(e) => set({ key: e.target.value })}
+          placeholder="refund-recovery"
+        />
+      </Field>
+      <Field label="Title">
+        <input
+          className={controlClass}
+          value={def.title ?? ""}
+          onChange={(e) => set({ title: e.target.value })}
+          placeholder="Recover a frustrated refund request"
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Category">
+          <input
+            className={controlClass}
+            value={def.category ?? ""}
+            onChange={(e) => set({ category: e.target.value })}
+            placeholder="support"
+          />
+        </Field>
+        <Field label="Difficulty">
+          <select
+            className={controlClass}
+            value={def.difficulty ?? "medium"}
+            onChange={(e) => set({ difficulty: e.target.value })}
+          >
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+      <Field
+        label="Instructions"
+        hint="The prompt the agent sees. Supports {{placeholder}} from case payloads."
+      >
+        <textarea
+          className={controlClass}
+          rows={8}
+          value={def.instructions ?? ""}
+          onChange={(e) => set({ instructions: e.target.value })}
+          placeholder="You are a support agent helping a customer refund order {{order_id}}..."
+        />
+      </Field>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/editor-registry.tsx
+++ b/web/src/components/challenge-packs/editors/editor-registry.tsx
@@ -1,25 +1,12 @@
 "use client";
 
-// Maps the current builder selection to its dedicated editor. Adding a future
-// piece kind is one entry here — no scattered switch statements.
+// Maps the current builder selection to its editor. Piece sections route
+// through PieceFrame, which handles library-referenced vs inline pieces.
 
-import type { ComponentType } from "react";
-
-import type { PieceKind } from "../lib/types";
+import { PieceFrame } from "../pieces/piece-frame";
 import { usePackDraft } from "../use-pack-draft";
-import { ChallengeEditor } from "./challenge-editor";
-import { InputSetEditor } from "./input-set-editor";
-import { JudgeEditor } from "./judge-editor";
 import { PackOverviewEditor } from "./pack-overview-editor";
 import { ScorecardEditor } from "./scorecard-editor";
-import { ValidatorEditor } from "./validator-editor";
-
-export const PIECE_EDITORS: Record<PieceKind, ComponentType<{ index: number }>> = {
-  challenge: ChallengeEditor,
-  input_set: InputSetEditor,
-  validator: ValidatorEditor,
-  judge: JudgeEditor,
-};
 
 export function BuilderCenter() {
   const { state } = usePackDraft();
@@ -27,7 +14,5 @@ export function BuilderCenter() {
 
   if (selection.section === "overview") return <PackOverviewEditor />;
   if (selection.section === "scorecard") return <ScorecardEditor />;
-
-  const Editor = PIECE_EDITORS[selection.kind];
-  return <Editor index={selection.index} />;
+  return <PieceFrame kind={selection.kind} index={selection.index} />;
 }

--- a/web/src/components/challenge-packs/editors/editor-registry.tsx
+++ b/web/src/components/challenge-packs/editors/editor-registry.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+// Maps the current builder selection to its dedicated editor. Adding a future
+// piece kind is one entry here — no scattered switch statements.
+
+import type { ComponentType } from "react";
+
+import type { PieceKind } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+import { ChallengeEditor } from "./challenge-editor";
+import { InputSetEditor } from "./input-set-editor";
+import { JudgeEditor } from "./judge-editor";
+import { PackOverviewEditor } from "./pack-overview-editor";
+import { ScorecardEditor } from "./scorecard-editor";
+import { ValidatorEditor } from "./validator-editor";
+
+export const PIECE_EDITORS: Record<PieceKind, ComponentType<{ index: number }>> = {
+  challenge: ChallengeEditor,
+  input_set: InputSetEditor,
+  validator: ValidatorEditor,
+  judge: JudgeEditor,
+};
+
+export function BuilderCenter() {
+  const { state } = usePackDraft();
+  const selection = state.selection;
+
+  if (selection.section === "overview") return <PackOverviewEditor />;
+  if (selection.section === "scorecard") return <ScorecardEditor />;
+
+  const Editor = PIECE_EDITORS[selection.kind];
+  return <Editor index={selection.index} />;
+}

--- a/web/src/components/challenge-packs/editors/flow-editor.tsx
+++ b/web/src/components/challenge-packs/editors/flow-editor.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+// Per-case multi-turn conversation flow editor. UserSimulatorSpec.phases is a
+// strictly ordered sequence (scripted -> llm -> human) with trigger/until
+// transitions, so this is an ordered list editor, not a free-form canvas.
+
+import { Plus, Trash2 } from "lucide-react";
+
+import { Field, controlClass } from "@/components/tools/field";
+import { Button } from "@/components/ui/button";
+import type {
+  UserSimulatorActor,
+  UserSimulatorPhase,
+  UserSimulatorSpec,
+  UserSimulatorTrigger,
+} from "../lib/types";
+
+const ACTORS: { value: UserSimulatorActor; label: string }[] = [
+  { value: "scripted", label: "Scripted — fixed messages" },
+  { value: "llm", label: "LLM — simulated persona" },
+  { value: "human", label: "Human — wait for a real reviewer" },
+];
+
+const TRIGGERS: UserSimulatorTrigger[] = [
+  "always",
+  "on_assistant_mismatch",
+  "on_validator_fail",
+  "on_judge_below",
+  "on_agent_loop",
+  "on_max_llm_turns",
+  "manual",
+  "never",
+];
+
+function defaultSimulator(): UserSimulatorSpec {
+  return {
+    schema_version: 1,
+    kind: "hybrid",
+    phases: [{ id: "open", actor: "scripted", turns: [{ message: "" }] }],
+  };
+}
+
+export function CaseFlowEditor({
+  value,
+  onChange,
+}: {
+  value?: UserSimulatorSpec;
+  onChange: (next: UserSimulatorSpec) => void;
+}) {
+  if (!value) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-3">
+        <p className="mb-2 text-xs text-muted-foreground">
+          Multi-turn mode: this case needs a conversation flow.
+        </p>
+        <Button size="xs" variant="outline" onClick={() => onChange(defaultSimulator())}>
+          <Plus className="size-3.5" /> Add conversation flow
+        </Button>
+      </div>
+    );
+  }
+
+  const phases = value.phases ?? [];
+  const setPhase = (i: number, patch: Partial<UserSimulatorPhase>) =>
+    onChange({ ...value, phases: phases.map((p, j) => (j === i ? { ...p, ...patch } : p)) });
+  const addPhase = () =>
+    onChange({
+      ...value,
+      phases: [...phases, { id: `phase-${phases.length + 1}`, actor: "scripted", turns: [{ message: "" }] }],
+    });
+  const removePhase = (i: number) =>
+    onChange({ ...value, phases: phases.filter((_, j) => j !== i) });
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Conversation ({phases.length} phase{phases.length === 1 ? "" : "s"})
+        </span>
+        <Button size="xs" variant="outline" onClick={addPhase}>
+          <Plus className="size-3.5" /> Add phase
+        </Button>
+      </div>
+
+      {phases.map((phase, i) => (
+        <div key={i} className="space-y-3 rounded-md border border-border bg-background p-3">
+          <div className="flex items-center gap-2">
+            <input
+              className={controlClass}
+              value={phase.id}
+              onChange={(e) => setPhase(i, { id: e.target.value })}
+              placeholder="phase id"
+            />
+            <select
+              className={controlClass}
+              value={phase.actor}
+              onChange={(e) => setPhase(i, { actor: e.target.value as UserSimulatorActor })}
+            >
+              {ACTORS.map((a) => (
+                <option key={a.value} value={a.value}>
+                  {a.label}
+                </option>
+              ))}
+            </select>
+            <Button size="icon-sm" variant="ghost" onClick={() => removePhase(i)} aria-label="Remove phase">
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+
+          {i > 0 && (
+            <Field label="Trigger" hint="when this phase activates">
+              <select
+                className={controlClass}
+                value={phase.trigger ?? "always"}
+                onChange={(e) => setPhase(i, { trigger: e.target.value as UserSimulatorTrigger })}
+              >
+                {TRIGGERS.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          )}
+
+          {phase.actor === "scripted" && (
+            <ScriptedTurns
+              turns={(phase.turns ?? []).map((t) => t.message)}
+              onChange={(messages) => setPhase(i, { turns: messages.map((message) => ({ message })) })}
+            />
+          )}
+
+          {phase.actor === "llm" && (
+            <div className="space-y-3">
+              <Field label="Persona">
+                <textarea
+                  className={controlClass}
+                  rows={2}
+                  value={phase.persona ?? ""}
+                  onChange={(e) => setPhase(i, { persona: e.target.value })}
+                  placeholder="Frustrated customer who accepts a clear timeline if treated with empathy"
+                />
+              </Field>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Max turns">
+                  <input
+                    className={controlClass}
+                    type="number"
+                    min="1"
+                    value={phase.max_turns ?? ""}
+                    onChange={(e) =>
+                      setPhase(i, {
+                        max_turns: e.target.value ? Number(e.target.value) : undefined,
+                      })
+                    }
+                    placeholder="3"
+                  />
+                </Field>
+                <Field label="Model" hint="optional override">
+                  <input
+                    className={controlClass}
+                    value={phase.model ?? ""}
+                    onChange={(e) => setPhase(i, { model: e.target.value })}
+                  />
+                </Field>
+              </div>
+              <Field label="Exit when" hint='comma-separated, e.g. assistant_emitted:timeline'>
+                <input
+                  className={controlClass}
+                  value={(phase.until ?? []).join(", ")}
+                  onChange={(e) =>
+                    setPhase(i, {
+                      until: e.target.value
+                        .split(",")
+                        .map((s) => s.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+              </Field>
+            </div>
+          )}
+
+          {phase.actor === "human" && (
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Timeout (ms)">
+                <input
+                  className={controlClass}
+                  type="number"
+                  min="0"
+                  value={phase.timeout_ms ?? ""}
+                  onChange={(e) =>
+                    setPhase(i, { timeout_ms: e.target.value ? Number(e.target.value) : undefined })
+                  }
+                  placeholder="900000"
+                />
+              </Field>
+              <Field label="On timeout">
+                <select
+                  className={controlClass}
+                  value={phase.on_timeout ?? "stop"}
+                  onChange={(e) => setPhase(i, { on_timeout: e.target.value })}
+                >
+                  <option value="stop">stop</option>
+                  <option value="fail">fail</option>
+                </select>
+              </Field>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ScriptedTurns({
+  turns,
+  onChange,
+}: {
+  turns: string[];
+  onChange: (turns: string[]) => void;
+}) {
+  return (
+    <Field label="User messages">
+      <div className="space-y-2">
+        {turns.map((message, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <textarea
+              className={controlClass}
+              rows={2}
+              value={message}
+              onChange={(e) => onChange(turns.map((t, j) => (j === i ? e.target.value : t)))}
+              placeholder="I need a refund for order {{order_id}} right now."
+            />
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              onClick={() => onChange(turns.filter((_, j) => j !== i))}
+              aria-label="Remove message"
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        ))}
+        <Button size="xs" variant="outline" onClick={() => onChange([...turns, ""])}>
+          <Plus className="size-3.5" /> Add message
+        </Button>
+      </div>
+    </Field>
+  );
+}

--- a/web/src/components/challenge-packs/editors/input-set-editor.tsx
+++ b/web/src/components/challenge-packs/editors/input-set-editor.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { pieceKeys, updatePieceRef } from "../lib/draft";
 import type { CaseDefinition, InputSetDefinition } from "../lib/types";
 import { usePackDraft } from "../use-pack-draft";
+import { CaseFlowEditor } from "./flow-editor";
 
 export function InputSetEditor({ index }: { index: number }) {
   const { state, update } = usePackDraft();
@@ -18,6 +19,7 @@ export function InputSetEditor({ index }: { index: number }) {
   }) as InputSetDefinition;
   const challengeKeys = pieceKeys(state.composition, "challenge");
   const cases = def.cases ?? [];
+  const executionMode = state.composition.version.execution_mode ?? "native";
 
   const set = (patch: Partial<InputSetDefinition>) =>
     update((c) => updatePieceRef(c, "input_set", index, { inline: { ...def, ...patch } }));
@@ -95,6 +97,12 @@ export function InputSetEditor({ index }: { index: number }) {
                 </Button>
               </div>
               <PayloadField value={cs.payload} onChange={(payload) => setCase(i, { payload })} />
+              {executionMode === "multi_turn" && (
+                <CaseFlowEditor
+                  value={cs.user_simulator}
+                  onChange={(user_simulator) => setCase(i, { user_simulator })}
+                />
+              )}
             </div>
           ))}
         </div>

--- a/web/src/components/challenge-packs/editors/input-set-editor.tsx
+++ b/web/src/components/challenge-packs/editors/input-set-editor.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Field, controlClass, monoControlClass } from "@/components/tools/field";
+import { Button } from "@/components/ui/button";
+import { pieceKeys, updatePieceRef } from "../lib/draft";
+import type { CaseDefinition, InputSetDefinition } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+export function InputSetEditor({ index }: { index: number }) {
+  const { state, update } = usePackDraft();
+  const def = (state.composition.input_sets?.[index]?.inline ?? {
+    key: "",
+    name: "",
+    cases: [],
+  }) as InputSetDefinition;
+  const challengeKeys = pieceKeys(state.composition, "challenge");
+  const cases = def.cases ?? [];
+
+  const set = (patch: Partial<InputSetDefinition>) =>
+    update((c) => updatePieceRef(c, "input_set", index, { inline: { ...def, ...patch } }));
+  const setCase = (i: number, patch: Partial<CaseDefinition>) =>
+    set({ cases: cases.map((cs, j) => (j === i ? { ...cs, ...patch } : cs)) });
+  const addCase = () =>
+    set({
+      cases: [
+        ...cases,
+        { challenge_key: challengeKeys[0] ?? "", case_key: `case-${cases.length + 1}`, payload: {} },
+      ],
+    });
+  const removeCase = (i: number) => set({ cases: cases.filter((_, j) => j !== i) });
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <h2 className="text-base font-semibold">Input set</h2>
+      <p className="text-sm text-muted-foreground">
+        The cases (test data) a challenge runs against.
+      </p>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Key">
+          <input
+            className={controlClass}
+            value={def.key ?? ""}
+            onChange={(e) => set({ key: e.target.value })}
+            placeholder="default"
+          />
+        </Field>
+        <Field label="Name">
+          <input
+            className={controlClass}
+            value={def.name ?? ""}
+            onChange={(e) => set({ name: e.target.value })}
+            placeholder="Default"
+          />
+        </Field>
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium">Cases ({cases.length})</span>
+          <Button size="xs" variant="outline" onClick={addCase} disabled={challengeKeys.length === 0}>
+            <Plus className="size-3.5" /> Add case
+          </Button>
+        </div>
+        {challengeKeys.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            Add a challenge first — each case targets a challenge by key.
+          </p>
+        )}
+        <div className="space-y-3">
+          {cases.map((cs, i) => (
+            <div key={i} className="space-y-3 rounded-lg border border-border p-3">
+              <div className="flex items-center gap-2">
+                <select
+                  className={controlClass}
+                  value={cs.challenge_key}
+                  onChange={(e) => setCase(i, { challenge_key: e.target.value })}
+                >
+                  {challengeKeys.map((k) => (
+                    <option key={k} value={k}>
+                      {k}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  className={controlClass}
+                  value={cs.case_key ?? ""}
+                  onChange={(e) => setCase(i, { case_key: e.target.value })}
+                  placeholder="case key"
+                />
+                <Button size="icon-sm" variant="ghost" onClick={() => removeCase(i)} aria-label="Remove case">
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+              <PayloadField value={cs.payload} onChange={(payload) => setCase(i, { payload })} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PayloadField({
+  value,
+  onChange,
+}: {
+  value?: Record<string, unknown>;
+  onChange: (value: Record<string, unknown>) => void;
+}) {
+  const [raw, setRaw] = useState(() => JSON.stringify(value ?? {}, null, 2));
+  const [error, setError] = useState("");
+
+  return (
+    <Field label="Payload" hint="JSON available to {{placeholders}} in the challenge instructions" error={error}>
+      <textarea
+        className={monoControlClass}
+        rows={4}
+        value={raw}
+        onChange={(e) => {
+          const next = e.target.value;
+          setRaw(next);
+          try {
+            const parsed = next.trim() ? JSON.parse(next) : {};
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+              setError("");
+              onChange(parsed as Record<string, unknown>);
+            } else {
+              setError("Payload must be a JSON object");
+            }
+          } catch {
+            setError("Invalid JSON");
+          }
+        }}
+      />
+    </Field>
+  );
+}

--- a/web/src/components/challenge-packs/editors/judge-editor.tsx
+++ b/web/src/components/challenge-packs/editors/judge-editor.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Field, controlClass } from "@/components/tools/field";
+import { updatePieceRef } from "../lib/draft";
+import type { JudgeMethodMode, LLMJudgeDeclaration } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+const MODES: { value: JudgeMethodMode; label: string }[] = [
+  { value: "rubric", label: "Rubric — score 1–5 against instructions" },
+  { value: "assertion", label: "Assertion — yes/no claim about the output" },
+];
+
+export function JudgeEditor({ index }: { index: number }) {
+  const { state, update } = usePackDraft();
+  const def = (state.composition.judges?.[index]?.inline ?? {}) as LLMJudgeDeclaration;
+
+  const set = (patch: Partial<LLMJudgeDeclaration>) =>
+    update((c) => updatePieceRef(c, "judge", index, { inline: { ...def, ...patch } }));
+
+  const mode = def.mode ?? "rubric";
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <h2 className="text-base font-semibold">LLM judge</h2>
+      <p className="text-sm text-muted-foreground">
+        An LLM-as-judge grader. Wire it into a scorecard dimension to make it count.
+      </p>
+      <Field label="Key" hint="unique; referenced by scorecard dimensions">
+        <input
+          className={controlClass}
+          value={def.key ?? ""}
+          onChange={(e) => set({ key: e.target.value })}
+          placeholder="empathy"
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Mode">
+          <select
+            className={controlClass}
+            value={mode}
+            onChange={(e) => set({ mode: e.target.value as JudgeMethodMode })}
+          >
+            {MODES.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Model">
+          <input
+            className={controlClass}
+            value={def.model ?? ""}
+            onChange={(e) => set({ model: e.target.value })}
+            placeholder="claude-haiku-4-5-20251001"
+          />
+        </Field>
+      </div>
+      {mode === "rubric" ? (
+        <Field label="Rubric" hint="how to score 1–5">
+          <textarea
+            className={controlClass}
+            rows={6}
+            value={def.rubric ?? ""}
+            onChange={(e) => set({ rubric: e.target.value })}
+            placeholder="Score 5 if the response is empathetic and gives a concrete next step..."
+          />
+        </Field>
+      ) : (
+        <Field label="Assertion" hint="a yes/no claim the output should satisfy">
+          <textarea
+            className={controlClass}
+            rows={4}
+            value={def.assertion ?? ""}
+            onChange={(e) => set({ assertion: e.target.value })}
+            placeholder="The assistant gives a concrete refund timeline instead of deflecting."
+          />
+        </Field>
+      )}
+      <Field
+        label="Evidence"
+        hint="comma-separated references the judge sees, e.g. final_output, case.payload.order_id"
+      >
+        <input
+          className={controlClass}
+          value={(def.context_from ?? []).join(", ")}
+          onChange={(e) =>
+            set({
+              context_from: e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            })
+          }
+          placeholder="final_output"
+        />
+      </Field>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/judge-editor.tsx
+++ b/web/src/components/challenge-packs/editors/judge-editor.tsx
@@ -6,8 +6,10 @@ import type { JudgeMethodMode, LLMJudgeDeclaration } from "../lib/types";
 import { usePackDraft } from "../use-pack-draft";
 
 const MODES: { value: JudgeMethodMode; label: string }[] = [
-  { value: "rubric", label: "Rubric — score 1–5 against instructions" },
-  { value: "assertion", label: "Assertion — yes/no claim about the output" },
+  { value: "rubric", label: "Rubric — score against instructions" },
+  { value: "assertion", label: "Assertion — yes/no claim" },
+  { value: "reference", label: "Reference — score vs a gold answer" },
+  { value: "n_wise", label: "N-wise — rank all agents together" },
 ];
 
 export function JudgeEditor({ index }: { index: number }) {
@@ -18,6 +20,9 @@ export function JudgeEditor({ index }: { index: number }) {
     update((c) => updatePieceRef(c, "judge", index, { inline: { ...def, ...patch } }));
 
   const mode = def.mode ?? "rubric";
+  const scale = def.score_scale ?? { min: 1, max: 5 };
+  const setScale = (patch: Partial<{ min: number; max: number }>) =>
+    set({ score_scale: { ...scale, ...patch } });
 
   return (
     <div className="max-w-2xl space-y-5">
@@ -33,7 +38,7 @@ export function JudgeEditor({ index }: { index: number }) {
           placeholder="empathy"
         />
       </Field>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-3 gap-4">
         <Field label="Mode">
           <select
             className={controlClass}
@@ -55,28 +60,112 @@ export function JudgeEditor({ index }: { index: number }) {
             placeholder="claude-haiku-4-5-20251001"
           />
         </Field>
-      </div>
-      {mode === "rubric" ? (
-        <Field label="Rubric" hint="how to score 1–5">
-          <textarea
+        <Field label="Samples" hint="median of N">
+          <input
             className={controlClass}
-            rows={6}
-            value={def.rubric ?? ""}
-            onChange={(e) => set({ rubric: e.target.value })}
-            placeholder="Score 5 if the response is empathetic and gives a concrete next step..."
+            type="number"
+            min="1"
+            max="10"
+            value={def.samples ?? ""}
+            onChange={(e) => set({ samples: e.target.value ? Number(e.target.value) : undefined })}
+            placeholder="3"
           />
         </Field>
-      ) : (
-        <Field label="Assertion" hint="a yes/no claim the output should satisfy">
-          <textarea
+      </div>
+
+      {(mode === "rubric" || mode === "reference") && (
+        <>
+          <Field label="Rubric" hint="how to score">
+            <textarea
+              className={controlClass}
+              rows={6}
+              value={def.rubric ?? ""}
+              onChange={(e) => set({ rubric: e.target.value })}
+              placeholder="Score 5 if the response is empathetic and gives a concrete next step..."
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Scale min">
+              <input
+                className={controlClass}
+                type="number"
+                value={scale.min}
+                onChange={(e) => setScale({ min: Number(e.target.value) })}
+              />
+            </Field>
+            <Field label="Scale max">
+              <input
+                className={controlClass}
+                type="number"
+                value={scale.max}
+                onChange={(e) => setScale({ max: Number(e.target.value) })}
+              />
+            </Field>
+          </div>
+        </>
+      )}
+
+      {mode === "reference" && (
+        <Field
+          label="Reference from"
+          hint="evidence reference to the gold answer, e.g. case.expectations.reference_response"
+        >
+          <input
             className={controlClass}
-            rows={4}
-            value={def.assertion ?? ""}
-            onChange={(e) => set({ assertion: e.target.value })}
-            placeholder="The assistant gives a concrete refund timeline instead of deflecting."
+            value={def.reference_from ?? ""}
+            onChange={(e) => set({ reference_from: e.target.value })}
           />
         </Field>
       )}
+
+      {mode === "assertion" && (
+        <>
+          <Field label="Assertion" hint="a yes/no claim about the output">
+            <textarea
+              className={controlClass}
+              rows={4}
+              value={def.assertion ?? ""}
+              onChange={(e) => set({ assertion: e.target.value })}
+              placeholder="The assistant gives a concrete refund timeline instead of deflecting."
+            />
+          </Field>
+          <Field label="Expectation">
+            <label className="flex h-9 items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={def.expect ?? true}
+                onChange={(e) => set({ expect: e.target.checked })}
+              />
+              Assertion should be true
+            </label>
+          </Field>
+        </>
+      )}
+
+      {mode === "n_wise" && (
+        <>
+          <Field label="Ranking prompt">
+            <textarea
+              className={controlClass}
+              rows={5}
+              value={def.prompt ?? ""}
+              onChange={(e) => set({ prompt: e.target.value })}
+              placeholder="Rank the responses from best to worst by how well they resolve the issue..."
+            />
+          </Field>
+          <Field label="Position debiasing">
+            <label className="flex h-9 items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={def.position_debiasing ?? false}
+                onChange={(e) => set({ position_debiasing: e.target.checked })}
+              />
+              Randomize agent order across samples
+            </label>
+          </Field>
+        </>
+      )}
+
       <Field
         label="Evidence"
         hint="comma-separated references the judge sees, e.g. final_output, case.payload.order_id"

--- a/web/src/components/challenge-packs/editors/pack-overview-editor.tsx
+++ b/web/src/components/challenge-packs/editors/pack-overview-editor.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Field, controlClass } from "@/components/tools/field";
+import { usePackDraft } from "../use-pack-draft";
+import type { ExecutionMode } from "../lib/types";
+
+const EXECUTION_MODES: { value: ExecutionMode; label: string }[] = [
+  { value: "native", label: "Native — single-turn tool loop" },
+  { value: "multi_turn", label: "Multi-turn — scripted/LLM/human conversation" },
+  { value: "prompt_eval", label: "Prompt eval — no tools, instruction following" },
+  { value: "responses", label: "Responses — structured output" },
+];
+
+export function PackOverviewEditor() {
+  const { state, update } = usePackDraft();
+  const { pack, version } = state.composition;
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <div>
+        <h2 className="text-base font-semibold">Pack overview</h2>
+        <p className="text-sm text-muted-foreground">Name, identity, and how the pack runs.</p>
+      </div>
+      <Field label="Name">
+        <input
+          className={controlClass}
+          value={pack.name}
+          onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, name: e.target.value } }))}
+          placeholder="Refund recovery"
+        />
+      </Field>
+      <Field label="Slug" hint="kebab-case identifier, unique in your workspace">
+        <input
+          className={controlClass}
+          value={pack.slug}
+          onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, slug: e.target.value } }))}
+          placeholder="refund-recovery"
+        />
+      </Field>
+      <Field label="Family" hint="Category, e.g. support, security, sre">
+        <input
+          className={controlClass}
+          value={pack.family}
+          onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, family: e.target.value } }))}
+          placeholder="support"
+        />
+      </Field>
+      <Field label="Description">
+        <textarea
+          className={controlClass}
+          rows={3}
+          value={pack.description ?? ""}
+          onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, description: e.target.value } }))}
+          placeholder="What this pack evaluates."
+        />
+      </Field>
+      <Field label="Execution mode">
+        <select
+          className={controlClass}
+          value={version.execution_mode ?? "native"}
+          onChange={(e) =>
+            update((c) => ({
+              ...c,
+              version: { ...c.version, execution_mode: e.target.value as ExecutionMode },
+            }))
+          }
+        >
+          {EXECUTION_MODES.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/piece-editors.ts
+++ b/web/src/components/challenge-packs/editors/piece-editors.ts
@@ -1,0 +1,17 @@
+// The piece-kind -> editor map, split out so both the center dispatcher
+// (editor-registry) and the piece frame can import it without a cycle.
+
+import type { ComponentType } from "react";
+
+import type { PieceKind } from "../lib/types";
+import { ChallengeEditor } from "./challenge-editor";
+import { InputSetEditor } from "./input-set-editor";
+import { JudgeEditor } from "./judge-editor";
+import { ValidatorEditor } from "./validator-editor";
+
+export const PIECE_EDITORS: Record<PieceKind, ComponentType<{ index: number }>> = {
+  challenge: ChallengeEditor,
+  input_set: InputSetEditor,
+  validator: ValidatorEditor,
+  judge: JudgeEditor,
+};

--- a/web/src/components/challenge-packs/editors/scorecard-editor.tsx
+++ b/web/src/components/challenge-packs/editors/scorecard-editor.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+
+import { Field, controlClass } from "@/components/tools/field";
+import { Button } from "@/components/ui/button";
+import { pieceKeys, setDimensions } from "../lib/draft";
+import type { DimensionDeclaration, DimensionSource, ScoringStrategy } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+const STRATEGIES: { value: ScoringStrategy; label: string }[] = [
+  { value: "weighted", label: "Weighted — weighted average of dimensions" },
+  { value: "binary", label: "Binary — pass only if every dimension passes" },
+  { value: "hybrid", label: "Hybrid — gates must pass + weighted score" },
+];
+
+const SOURCES: { value: DimensionSource; label: string }[] = [
+  { value: "validators", label: "Validators" },
+  { value: "llm_judge", label: "LLM judge" },
+];
+
+function numberOrUndefined(value: string): number | undefined {
+  if (value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function ScorecardEditor() {
+  const { state, update } = usePackDraft();
+  const scorecard = state.composition.scorecard;
+  const dims = scorecard.dimensions ?? [];
+  const validatorKeys = pieceKeys(state.composition, "validator");
+  const judgeKeys = pieceKeys(state.composition, "judge");
+
+  const setScorecard = (patch: Partial<typeof scorecard>) =>
+    update((c) => ({ ...c, scorecard: { ...c.scorecard, ...patch } }));
+  const setDim = (i: number, patch: Partial<DimensionDeclaration>) =>
+    update((c) => setDimensions(c, dims.map((d, j) => (j === i ? { ...d, ...patch } : d))));
+  const addDim = () =>
+    update((c) =>
+      setDimensions(c, [
+        ...dims,
+        { key: `dimension-${dims.length + 1}`, source: "validators", validators: [], weight: 1 },
+      ]),
+    );
+  const removeDim = (i: number) => update((c) => setDimensions(c, dims.filter((_, j) => j !== i)));
+
+  const strategy = scorecard.strategy ?? "weighted";
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <div>
+        <h2 className="text-base font-semibold">Scoring</h2>
+        <p className="text-sm text-muted-foreground">
+          Wire your validators and judges into scoring dimensions.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Strategy">
+          <select
+            className={controlClass}
+            value={strategy}
+            onChange={(e) => setScorecard({ strategy: e.target.value as ScoringStrategy })}
+          >
+            {STRATEGIES.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        {strategy !== "binary" && (
+          <Field label="Pass threshold" hint="overall score 0–1 to pass">
+            <input
+              className={controlClass}
+              type="number"
+              step="0.05"
+              min="0"
+              max="1"
+              value={scorecard.pass_threshold ?? ""}
+              onChange={(e) => setScorecard({ pass_threshold: numberOrUndefined(e.target.value) })}
+              placeholder="0.75"
+            />
+          </Field>
+        )}
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium">Dimensions ({dims.length})</span>
+          <Button size="xs" variant="outline" onClick={addDim}>
+            <Plus className="size-3.5" /> Add dimension
+          </Button>
+        </div>
+        <div className="space-y-3">
+          {dims.map((dim, i) => (
+            <div key={i} className="space-y-3 rounded-lg border border-border p-3">
+              <div className="flex items-center gap-2">
+                <input
+                  className={controlClass}
+                  value={dim.key}
+                  onChange={(e) => setDim(i, { key: e.target.value })}
+                  placeholder="correctness"
+                />
+                <select
+                  className={controlClass}
+                  value={dim.source}
+                  onChange={(e) => setDim(i, { source: e.target.value as DimensionSource })}
+                >
+                  {SOURCES.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+                <Button size="icon-sm" variant="ghost" onClick={() => removeDim(i)} aria-label="Remove dimension">
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+
+              {dim.source === "validators" ? (
+                <Field label="Validators" hint="which validators feed this dimension">
+                  {validatorKeys.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">Add a validator piece first.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {validatorKeys.map((key) => {
+                        const checked = (dim.validators ?? []).includes(key);
+                        return (
+                          <label
+                            key={key}
+                            className="flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(e) =>
+                                setDim(i, {
+                                  validators: e.target.checked
+                                    ? [...(dim.validators ?? []), key]
+                                    : (dim.validators ?? []).filter((k) => k !== key),
+                                })
+                              }
+                            />
+                            {key}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </Field>
+              ) : (
+                <Field label="Judge" hint="which judge feeds this dimension">
+                  {judgeKeys.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">Add a judge piece first.</p>
+                  ) : (
+                    <select
+                      className={controlClass}
+                      value={dim.judge_key ?? ""}
+                      onChange={(e) => setDim(i, { judge_key: e.target.value })}
+                    >
+                      <option value="">Select a judge…</option>
+                      {judgeKeys.map((key) => (
+                        <option key={key} value={key}>
+                          {key}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </Field>
+              )}
+
+              <div className="grid grid-cols-3 gap-3">
+                <Field label="Weight">
+                  <input
+                    className={controlClass}
+                    type="number"
+                    step="0.1"
+                    value={dim.weight ?? ""}
+                    onChange={(e) => setDim(i, { weight: numberOrUndefined(e.target.value) })}
+                    placeholder="1.0"
+                  />
+                </Field>
+                <Field label="Gate threshold" hint="0–1, optional">
+                  <input
+                    className={controlClass}
+                    type="number"
+                    step="0.05"
+                    min="0"
+                    max="1"
+                    value={dim.pass_threshold ?? ""}
+                    onChange={(e) => setDim(i, { pass_threshold: numberOrUndefined(e.target.value) })}
+                    placeholder="0.5"
+                  />
+                </Field>
+                <Field label="Gate">
+                  <label className="flex h-9 items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={dim.gate ?? false}
+                      onChange={(e) => setDim(i, { gate: e.target.checked })}
+                    />
+                    Must pass
+                  </label>
+                </Field>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/validator-editor.tsx
+++ b/web/src/components/challenge-packs/editors/validator-editor.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Field, controlClass, monoControlClass } from "@/components/tools/field";
+import { updatePieceRef } from "../lib/draft";
+import type { ValidatorDeclaration, ValidatorType } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+// v1 surfaces the common, output-targeting validator types. The full 21-type
+// registry (file/generation/tool-call/code) lands in a later phase.
+const COMMON_TYPES: { value: ValidatorType; label: string }[] = [
+  { value: "contains", label: "Output contains text" },
+  { value: "exact_match", label: "Output exactly equals" },
+  { value: "regex_match", label: "Output matches regex" },
+  { value: "fuzzy_match", label: "Fuzzy match (similarity)" },
+  { value: "numeric_match", label: "Numeric match" },
+  { value: "json_schema", label: "Output matches JSON schema" },
+];
+
+const EVIDENCE_TARGETS = ["final_output", "transcript.full", "transcript.from_mismatch"];
+
+export function ValidatorEditor({ index }: { index: number }) {
+  const { state, update } = usePackDraft();
+  const def = (state.composition.validators?.[index]?.inline ?? {}) as ValidatorDeclaration;
+
+  const set = (patch: Partial<ValidatorDeclaration>) =>
+    update((c) => updatePieceRef(c, "validator", index, { inline: { ...def, ...patch } }));
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <h2 className="text-base font-semibold">Validator</h2>
+      <p className="text-sm text-muted-foreground">
+        A deterministic check on the agent&apos;s output. Wire it into a scorecard dimension to make
+        it count toward the score.
+      </p>
+      <Field label="Key" hint="unique; referenced by scorecard dimensions">
+        <input
+          className={controlClass}
+          value={def.key ?? ""}
+          onChange={(e) => set({ key: e.target.value })}
+          placeholder="mentions_refund"
+        />
+      </Field>
+      <Field label="Check">
+        <select
+          className={controlClass}
+          value={def.type ?? "contains"}
+          onChange={(e) => set({ type: e.target.value as ValidatorType })}
+        >
+          {COMMON_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+      <Field label="Target" hint="what gets checked">
+        <select
+          className={controlClass}
+          value={def.target ?? "final_output"}
+          onChange={(e) => set({ target: e.target.value })}
+        >
+          {EVIDENCE_TARGETS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </Field>
+      <Field
+        label="Expected"
+        hint={'a literal (prefix "literal:") or an evidence reference like case.expectations.answer'}
+      >
+        <input
+          className={monoControlClass}
+          value={def.expected_from ?? ""}
+          onChange={(e) => set({ expected_from: e.target.value })}
+          placeholder="literal:refund"
+        />
+      </Field>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/editors/validator-editor.tsx
+++ b/web/src/components/challenge-packs/editors/validator-editor.tsx
@@ -1,37 +1,50 @@
 "use client";
 
+import { useState } from "react";
+
 import { Field, controlClass, monoControlClass } from "@/components/tools/field";
 import { updatePieceRef } from "../lib/draft";
 import type { ValidatorDeclaration, ValidatorType } from "../lib/types";
 import { usePackDraft } from "../use-pack-draft";
-
-// v1 surfaces the common, output-targeting validator types. The full 21-type
-// registry (file/generation/tool-call/code) lands in a later phase.
-const COMMON_TYPES: { value: ValidatorType; label: string }[] = [
-  { value: "contains", label: "Output contains text" },
-  { value: "exact_match", label: "Output exactly equals" },
-  { value: "regex_match", label: "Output matches regex" },
-  { value: "fuzzy_match", label: "Fuzzy match (similarity)" },
-  { value: "numeric_match", label: "Numeric match" },
-  { value: "json_schema", label: "Output matches JSON schema" },
-];
+import {
+  type ConfigField,
+  VALIDATOR_GROUPS,
+  VALIDATOR_TYPES,
+  defaultTargetForType,
+  validatorMeta,
+} from "./validator-types";
 
 const EVIDENCE_TARGETS = ["final_output", "transcript.full", "transcript.from_mismatch"];
 
 export function ValidatorEditor({ index }: { index: number }) {
   const { state, update } = usePackDraft();
   const def = (state.composition.validators?.[index]?.inline ?? {}) as ValidatorDeclaration;
+  const meta = validatorMeta(def.type);
+  const config = (def.config ?? {}) as Record<string, unknown>;
 
   const set = (patch: Partial<ValidatorDeclaration>) =>
     update((c) => updatePieceRef(c, "validator", index, { inline: { ...def, ...patch } }));
+
+  const changeType = (type: ValidatorType) => {
+    const next = validatorMeta(type);
+    set({
+      type,
+      target: defaultTargetForType(next),
+      config: {},
+      expected_from: next.needsExpected ? (def.expected_from ?? "") : undefined,
+    });
+  };
+
+  const setConfig = (key: string, value: unknown) => set({ config: { ...config, [key]: value } });
+  const filePath = (def.target ?? "").startsWith("file:") ? (def.target ?? "").slice(5) : "";
 
   return (
     <div className="max-w-2xl space-y-5">
       <h2 className="text-base font-semibold">Validator</h2>
       <p className="text-sm text-muted-foreground">
-        A deterministic check on the agent&apos;s output. Wire it into a scorecard dimension to make
-        it count toward the score.
+        A deterministic check. Wire it into a scorecard dimension to make it count.
       </p>
+
       <Field label="Key" hint="unique; referenced by scorecard dimensions">
         <input
           className={controlClass}
@@ -40,43 +53,160 @@ export function ValidatorEditor({ index }: { index: number }) {
           placeholder="mentions_refund"
         />
       </Field>
+
       <Field label="Check">
         <select
           className={controlClass}
           value={def.type ?? "contains"}
-          onChange={(e) => set({ type: e.target.value as ValidatorType })}
+          onChange={(e) => changeType(e.target.value as ValidatorType)}
         >
-          {COMMON_TYPES.map((t) => (
-            <option key={t.value} value={t.value}>
-              {t.label}
-            </option>
+          {VALIDATOR_GROUPS.map((group) => (
+            <optgroup key={group} label={group}>
+              {VALIDATOR_TYPES.filter((t) => t.group === group).map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </optgroup>
           ))}
         </select>
       </Field>
-      <Field label="Target" hint="what gets checked">
-        <select
-          className={controlClass}
-          value={def.target ?? "final_output"}
-          onChange={(e) => set({ target: e.target.value })}
+
+      {meta.forcesToolCalls ? (
+        <Field label="Target" hint="tool-call validators inspect the agent's tool calls">
+          <input className={controlClass} value="tool_calls" disabled />
+        </Field>
+      ) : meta.isFile ? (
+        <Field label="File path" hint="sandbox path to check">
+          <input
+            className={monoControlClass}
+            value={filePath}
+            onChange={(e) => set({ target: `file:${e.target.value}` })}
+            placeholder="/workspace/out.json"
+          />
+        </Field>
+      ) : (
+        <Field label="Target" hint="what gets checked">
+          <select
+            className={controlClass}
+            value={def.target ?? "final_output"}
+            onChange={(e) => set({ target: e.target.value })}
+          >
+            {EVIDENCE_TARGETS.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </Field>
+      )}
+
+      {meta.needsExpected && (
+        <Field
+          label="Expected"
+          hint={'a literal (prefix "literal:") or an evidence reference like case.expectations.answer'}
         >
-          {EVIDENCE_TARGETS.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
+          <input
+            className={monoControlClass}
+            value={def.expected_from ?? ""}
+            onChange={(e) => set({ expected_from: e.target.value })}
+            placeholder="literal:refund"
+          />
+        </Field>
+      )}
+
+      {meta.config?.map((field) => (
+        <ConfigFieldInput
+          key={field.key}
+          field={field}
+          value={config[field.key]}
+          onChange={(v) => setConfig(field.key, v)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ConfigFieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: ConfigField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  if (field.type === "boolean") {
+    return (
+      <Field label={field.label} hint={field.hint}>
+        <label className="flex h-9 items-center gap-2 text-sm">
+          <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} /> Enabled
+        </label>
       </Field>
-      <Field
-        label="Expected"
-        hint={'a literal (prefix "literal:") or an evidence reference like case.expectations.answer'}
-      >
+    );
+  }
+  if (field.type === "number") {
+    return (
+      <Field label={field.label} hint={field.hint}>
         <input
-          className={monoControlClass}
-          value={def.expected_from ?? ""}
-          onChange={(e) => set({ expected_from: e.target.value })}
-          placeholder="literal:refund"
+          className={controlClass}
+          type="number"
+          step="any"
+          value={typeof value === "number" ? value : ""}
+          onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+          placeholder={field.placeholder}
         />
       </Field>
-    </div>
+    );
+  }
+  if (field.type === "json") {
+    return <JsonConfigField field={field} value={value} onChange={onChange} />;
+  }
+  return (
+    <Field label={field.label} hint={field.hint}>
+      <input
+        className={controlClass}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder}
+      />
+    </Field>
+  );
+}
+
+function JsonConfigField({
+  field,
+  value,
+  onChange,
+}: {
+  field: ConfigField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const [raw, setRaw] = useState(() => (value === undefined ? "" : JSON.stringify(value, null, 2)));
+  const [error, setError] = useState("");
+  return (
+    <Field label={field.label} hint={field.hint} error={error}>
+      <textarea
+        className={monoControlClass}
+        rows={4}
+        value={raw}
+        onChange={(e) => {
+          const next = e.target.value;
+          setRaw(next);
+          if (!next.trim()) {
+            setError("");
+            onChange(undefined);
+            return;
+          }
+          try {
+            onChange(JSON.parse(next));
+            setError("");
+          } catch {
+            setError("Invalid JSON");
+          }
+        }}
+      />
+    </Field>
   );
 }

--- a/web/src/components/challenge-packs/editors/validator-types.ts
+++ b/web/src/components/challenge-packs/editors/validator-types.ts
@@ -1,0 +1,173 @@
+// Registry of all 21 validator types (mirror of backend/internal/scoring
+// ValidatorType + its IsFileValidator / RequiresExpectedFrom flags). Drives the
+// validator editor: the grouped type picker, whether a file path / expected
+// value / config sub-form is shown, and which config knobs each type exposes.
+
+import type { ValidatorType } from "../lib/types";
+
+export type ConfigFieldType = "number" | "text" | "boolean" | "json";
+
+export interface ConfigField {
+  key: string;
+  label: string;
+  type: ConfigFieldType;
+  hint?: string;
+  placeholder?: string;
+}
+
+export interface ValidatorTypeMeta {
+  value: ValidatorType;
+  label: string;
+  group: string;
+  /** Mirrors scoring.ValidatorType.RequiresExpectedFrom. */
+  needsExpected: boolean;
+  /** Mirrors scoring.ValidatorType.IsFileValidator — target is a file path. */
+  isFile: boolean;
+  /** tool_call_assertion forces target = tool_calls. */
+  forcesToolCalls?: boolean;
+  config?: ConfigField[];
+}
+
+export const VALIDATOR_TYPES: ValidatorTypeMeta[] = [
+  { value: "contains", label: "Output contains text", group: "String matching", needsExpected: true, isFile: false },
+  { value: "exact_match", label: "Output exactly equals", group: "String matching", needsExpected: true, isFile: false },
+  { value: "regex_match", label: "Output matches regex", group: "String matching", needsExpected: true, isFile: false },
+  {
+    value: "fuzzy_match",
+    label: "Fuzzy match (similarity)",
+    group: "String matching",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "threshold", label: "Similarity threshold (0–1)", type: "number", placeholder: "0.8" }],
+  },
+  {
+    value: "normalized_match",
+    label: "Normalized match",
+    group: "String matching",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "steps", label: "Normalization steps", type: "json", hint: '["lowercase","strip_punctuation"]' }],
+  },
+  { value: "boolean_assert", label: "Boolean assertion", group: "String matching", needsExpected: true, isFile: false },
+  {
+    value: "numeric_match",
+    label: "Numeric match",
+    group: "Numeric & math",
+    needsExpected: true,
+    isFile: false,
+    config: [
+      { key: "tolerance", label: "Tolerance", type: "number", placeholder: "0.01" },
+      { key: "extract_number", label: "Extract number from text", type: "boolean" },
+    ],
+  },
+  { value: "math_equivalence", label: "Math equivalence", group: "Numeric & math", needsExpected: true, isFile: false },
+  {
+    value: "json_schema",
+    label: "Matches JSON schema",
+    group: "JSON",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "schema", label: "JSON schema", type: "json" }],
+  },
+  {
+    value: "json_path_match",
+    label: "JSON path match",
+    group: "JSON",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "path", label: "JSON path", type: "text", placeholder: "$.status" }],
+  },
+  {
+    value: "token_f1",
+    label: "Token F1",
+    group: "Generation overlap",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "threshold", label: "Min F1 (0–1)", type: "number" }],
+  },
+  {
+    value: "bleu_score",
+    label: "BLEU score",
+    group: "Generation overlap",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "threshold", label: "Min BLEU (0–1)", type: "number" }],
+  },
+  {
+    value: "rouge_score",
+    label: "ROUGE score",
+    group: "Generation overlap",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "threshold", label: "Min ROUGE (0–1)", type: "number" }],
+  },
+  {
+    value: "chrf_score",
+    label: "chrF score",
+    group: "Generation overlap",
+    needsExpected: true,
+    isFile: false,
+    config: [{ key: "threshold", label: "Min chrF (0–1)", type: "number" }],
+  },
+  { value: "file_exists", label: "File exists", group: "Files & sandbox", needsExpected: false, isFile: true },
+  { value: "file_content_match", label: "File content matches", group: "Files & sandbox", needsExpected: true, isFile: true },
+  {
+    value: "file_json_schema",
+    label: "File matches JSON schema",
+    group: "Files & sandbox",
+    needsExpected: false,
+    isFile: true,
+    config: [{ key: "schema", label: "JSON schema", type: "json" }],
+  },
+  {
+    value: "directory_structure",
+    label: "Directory structure",
+    group: "Files & sandbox",
+    needsExpected: false,
+    isFile: true,
+    config: [
+      { key: "required_files", label: "Required files", type: "json", hint: '["src/main.go"]' },
+      { key: "forbidden_files", label: "Forbidden files", type: "json" },
+    ],
+  },
+  {
+    value: "code_execution",
+    label: "Code execution",
+    group: "Files & sandbox",
+    needsExpected: false,
+    isFile: false,
+    config: [{ key: "command", label: "Command", type: "text", placeholder: "pytest -q" }],
+  },
+  {
+    value: "postcondition",
+    label: "Postcondition",
+    group: "Files & sandbox",
+    needsExpected: false,
+    isFile: false,
+    config: [{ key: "check", label: "Check config", type: "json" }],
+  },
+  {
+    value: "tool_call_assertion",
+    label: "Tool call assertion",
+    group: "Tool calls",
+    needsExpected: false,
+    isFile: false,
+    forcesToolCalls: true,
+    config: [
+      { key: "tool_name", label: "Tool name", type: "text" },
+      { key: "min_calls", label: "Min calls", type: "number" },
+    ],
+  },
+];
+
+export const VALIDATOR_GROUPS: string[] = Array.from(new Set(VALIDATOR_TYPES.map((t) => t.group)));
+
+export function validatorMeta(type: ValidatorType | undefined): ValidatorTypeMeta {
+  return VALIDATOR_TYPES.find((t) => t.value === type) ?? VALIDATOR_TYPES[0];
+}
+
+export function defaultTargetForType(meta: ValidatorTypeMeta): string {
+  if (meta.forcesToolCalls) return "tool_calls";
+  if (meta.isFile) return "file:";
+  return "final_output";
+}

--- a/web/src/components/challenge-packs/lib/api.ts
+++ b/web/src/components/challenge-packs/lib/api.ts
@@ -34,6 +34,10 @@ export function piecesPath(workspaceId: string): string {
   return `/v1/workspaces/${workspaceId}/challenge-pieces`;
 }
 
+export function piecePath(workspaceId: string, pieceId: string): string {
+  return `${piecesPath(workspaceId)}/${pieceId}`;
+}
+
 export async function createDraft(
   token: Token,
   workspaceId: string,

--- a/web/src/components/challenge-packs/lib/api.ts
+++ b/web/src/components/challenge-packs/lib/api.ts
@@ -38,6 +38,10 @@ export function piecePath(workspaceId: string, pieceId: string): string {
   return `${piecesPath(workspaceId)}/${pieceId}`;
 }
 
+export function pieceLibraryPath(): string {
+  return "/v1/challenge-piece-library";
+}
+
 export async function createDraft(
   token: Token,
   workspaceId: string,

--- a/web/src/components/challenge-packs/lib/api.ts
+++ b/web/src/components/challenge-packs/lib/api.ts
@@ -1,0 +1,86 @@
+// Thin typed wrappers over the challenge-pack builder endpoints. Mutations go
+// through createApiClient (with a fresh access token); reads use the SWR hooks
+// in @/lib/api/swr against the same paths.
+
+import { createApiClient } from "@/lib/api/client";
+import type {
+  ChallengePackDraft,
+  ChallengePiece,
+  CompileDraftResponse,
+  Composition,
+  ExecutionMode,
+  PieceKind,
+} from "./types";
+
+type Token = string | null | undefined;
+
+export interface PublishDraftResponse {
+  challenge_pack_id: string;
+  challenge_pack_version_id: string;
+  evaluation_spec_id: string;
+  input_set_ids: string[];
+  bundle_artifact_id?: string;
+}
+
+export function draftCollectionPath(workspaceId: string): string {
+  return `/v1/workspaces/${workspaceId}/challenge-pack-drafts`;
+}
+
+export function draftPath(workspaceId: string, draftId: string): string {
+  return `${draftCollectionPath(workspaceId)}/${draftId}`;
+}
+
+export function piecesPath(workspaceId: string): string {
+  return `/v1/workspaces/${workspaceId}/challenge-pieces`;
+}
+
+export async function createDraft(
+  token: Token,
+  workspaceId: string,
+  body: { name: string; execution_mode?: ExecutionMode; composition?: Composition },
+): Promise<ChallengePackDraft> {
+  return createApiClient(token ?? undefined).post<ChallengePackDraft>(
+    draftCollectionPath(workspaceId),
+    body,
+  );
+}
+
+export async function patchDraft(
+  token: Token,
+  workspaceId: string,
+  draftId: string,
+  body: { name?: string; execution_mode?: ExecutionMode; composition?: Composition },
+): Promise<ChallengePackDraft> {
+  return createApiClient(token ?? undefined).patch<ChallengePackDraft>(
+    draftPath(workspaceId, draftId),
+    body,
+  );
+}
+
+export async function compileDraft(
+  token: Token,
+  workspaceId: string,
+  draftId: string,
+): Promise<CompileDraftResponse> {
+  return createApiClient(token ?? undefined).post<CompileDraftResponse>(
+    `${draftPath(workspaceId, draftId)}/compile`,
+  );
+}
+
+export async function publishDraft(
+  token: Token,
+  workspaceId: string,
+  draftId: string,
+): Promise<PublishDraftResponse> {
+  return createApiClient(token ?? undefined).post<PublishDraftResponse>(
+    `${draftPath(workspaceId, draftId)}/publish`,
+  );
+}
+
+export async function createPiece(
+  token: Token,
+  workspaceId: string,
+  body: { kind: PieceKind; slug: string; name: string; description?: string; definition: unknown },
+): Promise<ChallengePiece> {
+  return createApiClient(token ?? undefined).post<ChallengePiece>(piecesPath(workspaceId), body);
+}

--- a/web/src/components/challenge-packs/lib/draft.ts
+++ b/web/src/components/challenge-packs/lib/draft.ts
@@ -108,6 +108,18 @@ export function setDimensions(composition: Composition, dimensions: DimensionDec
 }
 
 /**
+ * The `key` of every inline piece of a kind — used to populate scorecard
+ * dimension references and case challenge-key selects. Library-referenced
+ * pieces (no inline definition) are resolved server-side, so they don't
+ * contribute keys to the client-side pickers yet.
+ */
+export function pieceKeys(composition: Composition, kind: PieceKind): string[] {
+  return pieceRefs(composition, kind)
+    .map((ref) => (ref.inline as { key?: string } | undefined)?.key)
+    .filter((key): key is string => typeof key === "string" && key.length > 0);
+}
+
+/**
  * Count of cases across inline input-set pieces. Library-referenced input sets
  * are counted server-side at compile time (their definitions aren't resolved
  * client-side), so this is a lower bound used only for the live preview.

--- a/web/src/components/challenge-packs/lib/draft.ts
+++ b/web/src/components/challenge-packs/lib/draft.ts
@@ -1,0 +1,122 @@
+// Pure helpers for the builder's working document (a Composition). The reducer
+// store (use-pack-draft) and the editors mutate a Composition through these
+// immutable helpers so state transitions stay in one testable place.
+
+import type {
+  Composition,
+  DimensionDeclaration,
+  PieceKind,
+  PieceRef,
+} from "./types";
+
+/** Sidebar/outline order for the piece groups. */
+export const PIECE_KINDS: PieceKind[] = ["challenge", "input_set", "validator", "judge"];
+
+export interface PieceKindMeta {
+  kind: PieceKind;
+  label: string;
+  pluralLabel: string;
+  description: string;
+}
+
+export const PIECE_KIND_META: Record<PieceKind, PieceKindMeta> = {
+  challenge: {
+    kind: "challenge",
+    label: "Challenge",
+    pluralLabel: "Challenges",
+    description: "The task an agent is asked to do.",
+  },
+  input_set: {
+    kind: "input_set",
+    label: "Input set",
+    pluralLabel: "Input sets",
+    description: "The cases (test data) a challenge runs against.",
+  },
+  validator: {
+    kind: "validator",
+    label: "Validator",
+    pluralLabel: "Validators",
+    description: "A deterministic check on the agent's output.",
+  },
+  judge: {
+    kind: "judge",
+    label: "LLM judge",
+    pluralLabel: "Judges",
+    description: "An LLM-as-judge grader scored against a rubric or assertion.",
+  },
+};
+
+type PieceField = "challenges" | "input_sets" | "validators" | "judges";
+
+const PIECE_FIELD: Record<PieceKind, PieceField> = {
+  challenge: "challenges",
+  input_set: "input_sets",
+  validator: "validators",
+  judge: "judges",
+};
+
+/** A fresh, empty composition for a new draft. */
+export function emptyComposition(): Composition {
+  return {
+    schema_version: 1,
+    pack: { slug: "", name: "", family: "general" },
+    version: { number: 1, execution_mode: "native" },
+    challenges: [],
+    input_sets: [],
+    validators: [],
+    judges: [],
+    scorecard: { strategy: "weighted", dimensions: [] },
+  };
+}
+
+/** Reads the piece refs of a kind, always returning an array. */
+export function pieceRefs(composition: Composition, kind: PieceKind): PieceRef[] {
+  return composition[PIECE_FIELD[kind]] ?? [];
+}
+
+/** Immutably append a piece reference of the given kind. */
+export function addPieceRef(composition: Composition, kind: PieceKind, ref: PieceRef): Composition {
+  const field = PIECE_FIELD[kind];
+  return { ...composition, [field]: [...(composition[field] ?? []), ref] };
+}
+
+/** Immutably replace the piece reference at index (no-op if out of range). */
+export function updatePieceRef(
+  composition: Composition,
+  kind: PieceKind,
+  index: number,
+  ref: PieceRef,
+): Composition {
+  const field = PIECE_FIELD[kind];
+  const current = composition[field] ?? [];
+  if (index < 0 || index >= current.length) return composition;
+  const next = [...current];
+  next[index] = ref;
+  return { ...composition, [field]: next };
+}
+
+/** Immutably remove the piece reference at index. */
+export function removePieceRef(composition: Composition, kind: PieceKind, index: number): Composition {
+  const field = PIECE_FIELD[kind];
+  const next = (composition[field] ?? []).filter((_, i) => i !== index);
+  return { ...composition, [field]: next };
+}
+
+/** Immutably replace the scorecard dimensions. */
+export function setDimensions(composition: Composition, dimensions: DimensionDeclaration[]): Composition {
+  return { ...composition, scorecard: { ...composition.scorecard, dimensions } };
+}
+
+/**
+ * Count of cases across inline input-set pieces. Library-referenced input sets
+ * are counted server-side at compile time (their definitions aren't resolved
+ * client-side), so this is a lower bound used only for the live preview.
+ */
+export function inlineCaseCount(composition: Composition): number {
+  let count = 0;
+  for (const ref of composition.input_sets ?? []) {
+    const inline = ref.inline as { cases?: unknown[] } | undefined;
+    if (Array.isArray(inline?.cases)) count += inline.cases.length;
+  }
+  return count;
+}

--- a/web/src/components/challenge-packs/lib/types.ts
+++ b/web/src/components/challenge-packs/lib/types.ts
@@ -135,14 +135,53 @@ export interface CaseExpectation {
   source?: string;
 }
 
+// --- multi-turn user simulator (mirror of challengepack.UserSimulatorSpec) ---
+
+export type UserSimulatorActor = "scripted" | "llm" | "human";
+
+export type UserSimulatorTrigger =
+  | "always"
+  | "on_assistant_mismatch"
+  | "on_validator_fail"
+  | "on_judge_below"
+  | "on_agent_loop"
+  | "on_max_llm_turns"
+  | "manual"
+  | "never";
+
+export interface UserSimulatorTurn {
+  message: string;
+  expects?: CaseExpectation[];
+}
+
+export interface UserSimulatorPhase {
+  id: string;
+  actor: UserSimulatorActor;
+  trigger?: UserSimulatorTrigger;
+  turns?: UserSimulatorTurn[];
+  persona?: string;
+  max_turns?: number;
+  until?: string[];
+  timeout_ms?: number;
+  on_timeout?: string;
+  model?: string;
+}
+
+export interface UserSimulatorSpec {
+  schema_version?: number;
+  kind?: string;
+  max_turns?: number;
+  phases: UserSimulatorPhase[];
+}
+
 export interface CaseDefinition {
   challenge_key: string;
   case_key?: string;
   payload?: Record<string, unknown>;
   inputs?: CaseInput[];
   expectations?: CaseExpectation[];
-  // user_simulator is the multi-turn phase flow; typed in the multi-turn phase.
-  user_simulator?: unknown;
+  // Required for multi_turn execution mode; ignored otherwise.
+  user_simulator?: UserSimulatorSpec;
 }
 
 export interface InputSetDefinition {

--- a/web/src/components/challenge-packs/lib/types.ts
+++ b/web/src/components/challenge-packs/lib/types.ts
@@ -257,6 +257,15 @@ export interface ChallengePiece {
   updated_at: string;
 }
 
+/** A built-in starter piece from GET /v1/challenge-piece-library. */
+export interface StarterPiece {
+  kind: PieceKind;
+  slug: string;
+  name: string;
+  description: string;
+  definition: Record<string, unknown>;
+}
+
 export type ChallengePackDraftStatus = "draft" | "published" | "discarded";
 
 export interface ChallengePackDraft {

--- a/web/src/components/challenge-packs/lib/types.ts
+++ b/web/src/components/challenge-packs/lib/types.ts
@@ -1,0 +1,274 @@
+// Canonical client-side mirror of backend/internal/challengepack (Composition +
+// Bundle pieces) and backend/internal/scoring (validators, judges, scorecard).
+// The visual pack builder edits a Composition directly; it is persisted as the
+// draft `composition` and compiled server-side into a runnable pack version.
+//
+// Field names are snake_case to match the Go JSON tags so these types
+// deserialize API payloads verbatim.
+
+export type PieceKind = "validator" | "judge" | "input_set" | "challenge";
+
+export type ExecutionMode = "native" | "prompt_eval" | "responses" | "multi_turn";
+
+// --- validators (backend/internal/scoring) ---
+
+export type ValidatorType =
+  | "exact_match"
+  | "contains"
+  | "regex_match"
+  | "json_schema"
+  | "json_path_match"
+  | "boolean_assert"
+  | "fuzzy_match"
+  | "numeric_match"
+  | "normalized_match"
+  | "token_f1"
+  | "math_equivalence"
+  | "bleu_score"
+  | "rouge_score"
+  | "chrf_score"
+  | "file_content_match"
+  | "file_exists"
+  | "file_json_schema"
+  | "directory_structure"
+  | "code_execution"
+  | "tool_call_assertion"
+  | "postcondition";
+
+export interface ValidatorDeclaration {
+  key: string;
+  type: ValidatorType;
+  target: string;
+  expected_from?: string;
+  config?: unknown;
+}
+
+// --- LLM judges ---
+
+export type JudgeMethodMode = "rubric" | "assertion" | "n_wise" | "reference";
+
+export interface ScoreScale {
+  min: number;
+  max: number;
+}
+
+export type ConsensusAggregation = "median" | "mean" | "majority_vote" | "unanimous";
+
+export interface ConsensusConfig {
+  aggregation: ConsensusAggregation;
+  min_agreement_threshold?: number;
+  flag_on_disagreement?: boolean;
+}
+
+export interface LLMJudgeDeclaration {
+  mode: JudgeMethodMode;
+  key: string;
+  model?: string;
+  models?: string[];
+  samples?: number;
+  context_from?: string[];
+  output_schema?: unknown;
+  score_scale?: ScoreScale;
+  rubric?: string;
+  assertion?: string;
+  expect?: boolean;
+  prompt?: string;
+  position_debiasing?: boolean;
+  reference_from?: string;
+  consensus?: ConsensusConfig;
+  anti_gaming_clauses?: string[];
+  timeout_ms?: number;
+}
+
+// --- scorecard ---
+
+export type DimensionSource =
+  | "validators"
+  | "metric"
+  | "reliability"
+  | "latency"
+  | "cost"
+  | "behavioral"
+  | "llm_judge"
+  | "human_preference";
+
+export type ScoringStrategy = "weighted" | "binary" | "hybrid";
+
+export type JudgeMode = "deterministic" | "llm_judge" | "hybrid";
+
+export interface DimensionDeclaration {
+  key: string;
+  source: DimensionSource;
+  validators?: string[];
+  metric?: string;
+  better_direction?: string;
+  weight?: number;
+  judge_key?: string;
+  gate?: boolean;
+  pass_threshold?: number;
+}
+
+// --- challenges + input sets (backend/internal/challengepack) ---
+
+export interface ChallengeDefinition {
+  key: string;
+  title: string;
+  category: string;
+  difficulty: string;
+  instructions?: string;
+  definition?: Record<string, unknown>;
+}
+
+export interface CaseInput {
+  key: string;
+  kind: string;
+  value?: unknown;
+  artifact_key?: string;
+  path?: string;
+}
+
+export interface CaseExpectation {
+  key: string;
+  kind: string;
+  value?: unknown;
+  artifact_key?: string;
+  source?: string;
+}
+
+export interface CaseDefinition {
+  challenge_key: string;
+  case_key?: string;
+  payload?: Record<string, unknown>;
+  inputs?: CaseInput[];
+  expectations?: CaseExpectation[];
+  // user_simulator is the multi-turn phase flow; typed in the multi-turn phase.
+  user_simulator?: unknown;
+}
+
+export interface InputSetDefinition {
+  key: string;
+  name: string;
+  description?: string;
+  cases?: CaseDefinition[];
+}
+
+/** The concrete definition shape stored in a piece of each kind. */
+export type PieceDefinition =
+  | ValidatorDeclaration
+  | LLMJudgeDeclaration
+  | ChallengeDefinition
+  | InputSetDefinition;
+
+// --- composition (the builder's working document) ---
+
+/**
+ * A reference to a reusable library piece (by id) OR an inline, not-yet-promoted
+ * definition. Exactly one of ref_id / inline is set.
+ */
+export interface PieceRef {
+  ref_id?: string;
+  inline?: PieceDefinition | Record<string, unknown>;
+}
+
+export interface PackMetadata {
+  slug: string;
+  name: string;
+  family: string;
+  description?: string;
+}
+
+export interface CompositionVersion {
+  number?: number;
+  execution_mode?: ExecutionMode;
+  tool_policy?: Record<string, unknown>;
+  sandbox?: Record<string, unknown>;
+}
+
+export interface CompositionScorecard {
+  name?: string;
+  version_number?: number;
+  judge_mode?: JudgeMode;
+  strategy?: ScoringStrategy;
+  pass_threshold?: number;
+  dimensions?: DimensionDeclaration[];
+}
+
+export interface Composition {
+  schema_version?: number;
+  pack: PackMetadata;
+  version: CompositionVersion;
+  challenges?: PieceRef[];
+  input_sets?: PieceRef[];
+  validators?: PieceRef[];
+  judges?: PieceRef[];
+  scorecard: CompositionScorecard;
+}
+
+// --- API resources ---
+
+export interface ChallengePiece {
+  id: string;
+  workspace_id: string;
+  kind: PieceKind;
+  slug: string;
+  name: string;
+  description: string;
+  definition: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export type ChallengePackDraftStatus = "draft" | "published" | "discarded";
+
+export interface ChallengePackDraft {
+  id: string;
+  workspace_id: string;
+  name: string;
+  execution_mode: ExecutionMode;
+  challenge_pack_id?: string;
+  composition: Composition | Record<string, unknown>;
+  status: ChallengePackDraftStatus;
+  last_published_version_id?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SpecCardDimension {
+  key: string;
+  source: string;
+  weight?: number;
+  gate: boolean;
+  pass_threshold?: number;
+  references?: string[];
+  summary: string;
+}
+
+/** The readable "rubric" preview (mirror of challengepack.SpecCard). */
+export interface SpecCard {
+  pack_name: string;
+  slug: string;
+  family: string;
+  description?: string;
+  execution_mode: string;
+  challenge_count: number;
+  case_count: number;
+  validator_count: number;
+  judge_count: number;
+  strategy: string;
+  dimensions: SpecCardDimension[];
+  pass_criteria: string;
+}
+
+/** A validation problem surfaced to the user, scoped to a field. */
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}
+
+/** Response of POST .../challenge-pack-drafts/{id}/compile. */
+export interface CompileDraftResponse {
+  valid: boolean;
+  errors: ValidationIssue[];
+  spec_card: SpecCard;
+  yaml: string;
+}

--- a/web/src/components/challenge-packs/outline/pack-outline.tsx
+++ b/web/src/components/challenge-packs/outline/pack-outline.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { LayoutGrid, Plus, SlidersHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { addPieceRef, PIECE_KINDS, PIECE_KIND_META, pieceRefs } from "../lib/draft";
+import type { PieceDefinition, PieceKind, PieceRef } from "../lib/types";
+import { type BuilderSelection, usePackDraft } from "../use-pack-draft";
+
+function defaultPieceInline(kind: PieceKind, n: number): PieceDefinition {
+  switch (kind) {
+    case "challenge":
+      return { key: `challenge-${n}`, title: "", category: "", difficulty: "medium" };
+    case "input_set":
+      return { key: n === 1 ? "default" : `set-${n}`, name: n === 1 ? "Default" : `Set ${n}`, cases: [] };
+    case "validator":
+      return { key: `validator-${n}`, type: "contains", target: "final_output", expected_from: "" };
+    case "judge":
+      return { key: `judge-${n}`, mode: "rubric", model: "claude-haiku-4-5-20251001" };
+  }
+}
+
+function pieceLabel(kind: PieceKind, ref: PieceRef, index: number): string {
+  const inline = ref.inline as Record<string, unknown> | undefined;
+  if (ref.ref_id && !inline) return `Library piece ${index + 1}`;
+  const title = (inline?.title as string) || (inline?.name as string) || (inline?.key as string);
+  return title || `${PIECE_KIND_META[kind].label} ${index + 1}`;
+}
+
+function isSelected(selection: BuilderSelection, target: BuilderSelection): boolean {
+  if (selection.section !== target.section) return false;
+  if (selection.section === "piece" && target.section === "piece") {
+    return selection.kind === target.kind && selection.index === target.index;
+  }
+  return true;
+}
+
+export function PackOutline() {
+  const { state, select, update } = usePackDraft();
+  const { composition, selection } = state;
+
+  const addPiece = (kind: PieceKind) => {
+    const count = pieceRefs(composition, kind).length;
+    const inline = defaultPieceInline(kind, count + 1);
+    update((c) => addPieceRef(c, kind, { inline }));
+    select({ section: "piece", kind, index: count });
+  };
+
+  return (
+    <nav className="flex h-full flex-col gap-1 overflow-y-auto p-3 text-sm">
+      <OutlineRow
+        icon={<LayoutGrid className="size-4" />}
+        label="Overview"
+        active={isSelected(selection, { section: "overview" })}
+        onClick={() => select({ section: "overview" })}
+      />
+
+      {PIECE_KINDS.map((kind) => {
+        const meta = PIECE_KIND_META[kind];
+        const refs = pieceRefs(composition, kind);
+        return (
+          <div key={kind} className="mt-3">
+            <div className="mb-1 flex items-center justify-between px-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {meta.pluralLabel}
+              </span>
+              <button
+                type="button"
+                onClick={() => addPiece(kind)}
+                className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label={`Add ${meta.label}`}
+                title={`Add ${meta.label}`}
+              >
+                <Plus className="size-3.5" />
+              </button>
+            </div>
+            {refs.length === 0 ? (
+              <p className="px-2 py-1 text-xs text-muted-foreground/70">{meta.description}</p>
+            ) : (
+              refs.map((ref, index) => (
+                <OutlineRow
+                  key={index}
+                  label={pieceLabel(kind, ref, index)}
+                  indented
+                  active={isSelected(selection, { section: "piece", kind, index })}
+                  onClick={() => select({ section: "piece", kind, index })}
+                />
+              ))
+            )}
+          </div>
+        );
+      })}
+
+      <div className="mt-3">
+        <OutlineRow
+          icon={<SlidersHorizontal className="size-4" />}
+          label="Scoring"
+          active={isSelected(selection, { section: "scorecard" })}
+          onClick={() => select({ section: "scorecard" })}
+        />
+      </div>
+    </nav>
+  );
+}
+
+function OutlineRow({
+  icon,
+  label,
+  active,
+  indented,
+  onClick,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  active: boolean;
+  indented?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 truncate rounded-md px-2 py-1.5 text-left transition-colors",
+        indented && "pl-7",
+        active ? "bg-foreground text-background" : "hover:bg-muted",
+      )}
+    >
+      {icon}
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}

--- a/web/src/components/challenge-packs/outline/pack-outline.tsx
+++ b/web/src/components/challenge-packs/outline/pack-outline.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { LayoutGrid, Plus, SlidersHorizontal } from "lucide-react";
+import { LayoutGrid, Library, Plus, SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { addPieceRef, PIECE_KINDS, PIECE_KIND_META, pieceRefs } from "../lib/draft";
-import type { PieceDefinition, PieceKind, PieceRef } from "../lib/types";
+import type { ChallengePiece, PieceDefinition, PieceKind, PieceRef } from "../lib/types";
+import { LibraryPicker } from "../pieces/library-picker";
 import { type BuilderSelection, usePackDraft } from "../use-pack-draft";
 
 function defaultPieceInline(kind: PieceKind, n: number): PieceDefinition {
@@ -36,14 +38,22 @@ function isSelected(selection: BuilderSelection, target: BuilderSelection): bool
 }
 
 export function PackOutline() {
-  const { state, select, update } = usePackDraft();
+  const { state, workspaceId, select, update } = usePackDraft();
   const { composition, selection } = state;
+  const [pickerKind, setPickerKind] = useState<PieceKind | null>(null);
 
   const addPiece = (kind: PieceKind) => {
     const count = pieceRefs(composition, kind).length;
     const inline = defaultPieceInline(kind, count + 1);
     update((c) => addPieceRef(c, kind, { inline }));
     select({ section: "piece", kind, index: count });
+  };
+
+  const addFromLibrary = (kind: PieceKind, piece: ChallengePiece) => {
+    const count = pieceRefs(composition, kind).length;
+    update((c) => addPieceRef(c, kind, { ref_id: piece.id }));
+    select({ section: "piece", kind, index: count });
+    setPickerKind(null);
   };
 
   return (
@@ -64,15 +74,26 @@ export function PackOutline() {
               <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                 {meta.pluralLabel}
               </span>
-              <button
-                type="button"
-                onClick={() => addPiece(kind)}
-                className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                aria-label={`Add ${meta.label}`}
-                title={`Add ${meta.label}`}
-              >
-                <Plus className="size-3.5" />
-              </button>
+              <div className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => setPickerKind(kind)}
+                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label={`Add ${meta.label} from library`}
+                  title="Add from library"
+                >
+                  <Library className="size-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => addPiece(kind)}
+                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label={`Add ${meta.label}`}
+                  title={`New ${meta.label.toLowerCase()}`}
+                >
+                  <Plus className="size-3.5" />
+                </button>
+              </div>
             </div>
             {refs.length === 0 ? (
               <p className="px-2 py-1 text-xs text-muted-foreground/70">{meta.description}</p>
@@ -99,6 +120,15 @@ export function PackOutline() {
           onClick={() => select({ section: "scorecard" })}
         />
       </div>
+
+      {pickerKind && (
+        <LibraryPicker
+          workspaceId={workspaceId}
+          kind={pickerKind}
+          onPick={(piece) => addFromLibrary(pickerKind, piece)}
+          onClose={() => setPickerKind(null)}
+        />
+      )}
     </nav>
   );
 }

--- a/web/src/components/challenge-packs/outline/pack-outline.tsx
+++ b/web/src/components/challenge-packs/outline/pack-outline.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { addPieceRef, PIECE_KINDS, PIECE_KIND_META, pieceRefs } from "../lib/draft";
-import type { ChallengePiece, PieceDefinition, PieceKind, PieceRef } from "../lib/types";
+import type { PieceDefinition, PieceKind, PieceRef } from "../lib/types";
 import { LibraryPicker } from "../pieces/library-picker";
 import { type BuilderSelection, usePackDraft } from "../use-pack-draft";
 
@@ -49,9 +49,9 @@ export function PackOutline() {
     select({ section: "piece", kind, index: count });
   };
 
-  const addFromLibrary = (kind: PieceKind, piece: ChallengePiece) => {
+  const addFromLibrary = (kind: PieceKind, ref: PieceRef) => {
     const count = pieceRefs(composition, kind).length;
-    update((c) => addPieceRef(c, kind, { ref_id: piece.id }));
+    update((c) => addPieceRef(c, kind, ref));
     select({ section: "piece", kind, index: count });
     setPickerKind(null);
   };
@@ -125,7 +125,7 @@ export function PackOutline() {
         <LibraryPicker
           workspaceId={workspaceId}
           kind={pickerKind}
-          onPick={(piece) => addFromLibrary(pickerKind, piece)}
+          onAdd={(ref) => addFromLibrary(pickerKind, ref)}
           onClose={() => setPickerKind(null)}
         />
       )}

--- a/web/src/components/challenge-packs/pack-builder.tsx
+++ b/web/src/components/challenge-packs/pack-builder.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { useApiQuery } from "@/lib/api/swr";
+import { BuilderShell } from "./builder-shell";
+import { draftPath } from "./lib/api";
+import { emptyComposition } from "./lib/draft";
+import type { ChallengePackDraft, Composition } from "./lib/types";
+import { PackDraftProvider } from "./use-pack-draft";
+
+/** Normalize a possibly-empty stored composition onto a complete shape. */
+function toComposition(raw: unknown): Composition {
+  const base = emptyComposition();
+  if (!raw || typeof raw !== "object") return base;
+  const r = raw as Partial<Composition>;
+  return {
+    ...base,
+    ...r,
+    pack: { ...base.pack, ...(r.pack ?? {}) },
+    version: { ...base.version, ...(r.version ?? {}) },
+    scorecard: { ...base.scorecard, ...(r.scorecard ?? {}) },
+  };
+}
+
+export function PackBuilder({ workspaceId, draftId }: { workspaceId: string; draftId: string }) {
+  const { data, error, isLoading } = useApiQuery<ChallengePackDraft>(draftPath(workspaceId, draftId));
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center text-muted-foreground">
+        <Loader2 className="size-5 animate-spin" />
+      </div>
+    );
+  }
+  if (error || !data) {
+    return <div className="p-8 text-sm text-destructive">Couldn&apos;t load this draft.</div>;
+  }
+
+  return (
+    <PackDraftProvider
+      workspaceId={workspaceId}
+      draftId={draftId}
+      initialComposition={toComposition(data.composition)}
+    >
+      <BuilderShell />
+    </PackDraftProvider>
+  );
+}

--- a/web/src/components/challenge-packs/pieces/library-picker.tsx
+++ b/web/src/components/challenge-packs/pieces/library-picker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-// A lightweight modal that lists the workspace's reusable pieces of a kind so
-// the builder can reference one into the current pack ("add from library").
+// "Add from library" modal. Lists two sources for the chosen kind: the
+// workspace's own reusable pieces (added as a reference by id) and the built-in
+// starter catalog (cloned inline). Returns the chosen PieceRef to the caller.
 
 import { Loader2, Search, X } from "lucide-react";
 import { useState } from "react";
@@ -9,28 +10,30 @@ import { useState } from "react";
 import { controlClass } from "@/components/tools/field";
 import { useApiListQuery } from "@/lib/api/swr";
 import { cn } from "@/lib/utils";
-import { piecesPath } from "../lib/api";
+import { pieceLibraryPath, piecesPath } from "../lib/api";
 import { PIECE_KIND_META } from "../lib/draft";
-import type { ChallengePiece, PieceKind } from "../lib/types";
+import type { ChallengePiece, PieceKind, PieceRef, StarterPiece } from "../lib/types";
 
 export function LibraryPicker({
   workspaceId,
   kind,
-  onPick,
+  onAdd,
   onClose,
 }: {
   workspaceId: string;
   kind: PieceKind;
-  onPick: (piece: ChallengePiece) => void;
+  onAdd: (ref: PieceRef) => void;
   onClose: () => void;
 }) {
-  const { data, isLoading } = useApiListQuery<ChallengePiece>(piecesPath(workspaceId), { kind });
+  const { data: wsData, isLoading: wsLoading } = useApiListQuery<ChallengePiece>(piecesPath(workspaceId), { kind });
+  const { data: starterData, isLoading: starterLoading } = useApiListQuery<StarterPiece>(pieceLibraryPath(), { kind });
   const [query, setQuery] = useState("");
   const meta = PIECE_KIND_META[kind];
   const needle = query.trim().toLowerCase();
-  const pieces = (data?.items ?? []).filter(
-    (p) => !needle || p.name.toLowerCase().includes(needle) || p.slug.toLowerCase().includes(needle),
-  );
+  const match = (name: string, slug: string) =>
+    !needle || name.toLowerCase().includes(needle) || slug.toLowerCase().includes(needle);
+  const workspacePieces = (wsData?.items ?? []).filter((p) => match(p.name, p.slug));
+  const starters = (starterData?.items ?? []).filter((p) => match(p.name, p.slug));
 
   return (
     <div
@@ -65,33 +68,71 @@ export function LibraryPicker({
           </div>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto p-2">
-          {isLoading ? (
+          {wsLoading || starterLoading ? (
             <div className="flex justify-center p-6">
               <Loader2 className="size-5 animate-spin text-muted-foreground" />
             </div>
-          ) : pieces.length === 0 ? (
-            <p className="p-6 text-center text-sm text-muted-foreground">
-              No saved {meta.pluralLabel.toLowerCase()} yet. Build one and use &ldquo;Save to
-              library&rdquo; to reuse it across packs.
-            </p>
           ) : (
-            pieces.map((piece) => (
-              <button
-                key={piece.id}
-                type="button"
-                onClick={() => onPick(piece)}
-                className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-muted"
-              >
-                <span className="text-sm font-medium">{piece.name}</span>
-                <span className="text-xs text-muted-foreground">
-                  {piece.slug}
-                  {piece.description ? ` — ${piece.description}` : ""}
-                </span>
-              </button>
-            ))
+            <>
+              <div className="mb-2">
+                <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Your library
+                </div>
+                {workspacePieces.length === 0 ? (
+                  <p className="px-2 py-1 text-xs text-muted-foreground/70">
+                    Nothing saved yet — build a piece and use &ldquo;Save to library&rdquo;.
+                  </p>
+                ) : (
+                  workspacePieces.map((p) => (
+                    <PickerRow
+                      key={p.id}
+                      name={p.name}
+                      subtitle={p.slug + (p.description ? ` — ${p.description}` : "")}
+                      onClick={() => onAdd({ ref_id: p.id })}
+                    />
+                  ))
+                )}
+              </div>
+              {starters.length > 0 && (
+                <div className="mb-2">
+                  <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Starters
+                  </div>
+                  {starters.map((s) => (
+                    <PickerRow
+                      key={s.slug}
+                      name={s.name}
+                      subtitle={s.description}
+                      onClick={() => onAdd({ inline: s.definition })}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
     </div>
+  );
+}
+
+function PickerRow({
+  name,
+  subtitle,
+  onClick,
+}: {
+  name: string;
+  subtitle?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-muted"
+    >
+      <span className="text-sm font-medium">{name}</span>
+      {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+    </button>
   );
 }

--- a/web/src/components/challenge-packs/pieces/library-picker.tsx
+++ b/web/src/components/challenge-packs/pieces/library-picker.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+// A lightweight modal that lists the workspace's reusable pieces of a kind so
+// the builder can reference one into the current pack ("add from library").
+
+import { Loader2, Search, X } from "lucide-react";
+import { useState } from "react";
+
+import { controlClass } from "@/components/tools/field";
+import { useApiListQuery } from "@/lib/api/swr";
+import { cn } from "@/lib/utils";
+import { piecesPath } from "../lib/api";
+import { PIECE_KIND_META } from "../lib/draft";
+import type { ChallengePiece, PieceKind } from "../lib/types";
+
+export function LibraryPicker({
+  workspaceId,
+  kind,
+  onPick,
+  onClose,
+}: {
+  workspaceId: string;
+  kind: PieceKind;
+  onPick: (piece: ChallengePiece) => void;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = useApiListQuery<ChallengePiece>(piecesPath(workspaceId), { kind });
+  const [query, setQuery] = useState("");
+  const meta = PIECE_KIND_META[kind];
+  const needle = query.trim().toLowerCase();
+  const pieces = (data?.items ?? []).filter(
+    (p) => !needle || p.name.toLowerCase().includes(needle) || p.slug.toLowerCase().includes(needle),
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[70vh] w-full max-w-lg flex-col rounded-xl border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <span className="text-sm font-semibold">Add {meta.label.toLowerCase()} from library</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="border-b border-border p-3">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              className={cn(controlClass, "pl-8")}
+              placeholder={`Search ${meta.pluralLabel.toLowerCase()}…`}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          {isLoading ? (
+            <div className="flex justify-center p-6">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : pieces.length === 0 ? (
+            <p className="p-6 text-center text-sm text-muted-foreground">
+              No saved {meta.pluralLabel.toLowerCase()} yet. Build one and use &ldquo;Save to
+              library&rdquo; to reuse it across packs.
+            </p>
+          ) : (
+            pieces.map((piece) => (
+              <button
+                key={piece.id}
+                type="button"
+                onClick={() => onPick(piece)}
+                className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-muted"
+              >
+                <span className="text-sm font-medium">{piece.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {piece.slug}
+                  {piece.description ? ` — ${piece.description}` : ""}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/pieces/piece-frame.tsx
+++ b/web/src/components/challenge-packs/pieces/piece-frame.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// Wraps a selected piece: a library-referenced piece renders read-only (with
+// "edit a copy" to detach it into an editable inline piece); an inline piece
+// renders its dedicated editor plus a "Save to library" action to promote it
+// into the reusable workspace library.
+
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Library, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api/errors";
+import { useApiQuery } from "@/lib/api/swr";
+import { PIECE_EDITORS } from "../editors/piece-editors";
+import { createPiece, piecePath } from "../lib/api";
+import { pieceRefs, updatePieceRef } from "../lib/draft";
+import type { ChallengePiece, PieceKind } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+export function PieceFrame({ kind, index }: { kind: PieceKind; index: number }) {
+  const { state } = usePackDraft();
+  const ref = pieceRefs(state.composition, kind)[index];
+
+  if (ref?.ref_id && !ref.inline) {
+    return <ReferencedPieceView kind={kind} index={index} pieceId={ref.ref_id} />;
+  }
+
+  const Editor = PIECE_EDITORS[kind];
+  return (
+    <div>
+      <PieceToolbar kind={kind} index={index} />
+      <Editor index={index} />
+    </div>
+  );
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "piece"
+  );
+}
+
+function PieceToolbar({ kind, index }: { kind: PieceKind; index: number }) {
+  const { state, workspaceId } = usePackDraft();
+  const { getAccessToken } = useAccessToken();
+  const [saving, setSaving] = useState(false);
+  const def = (pieceRefs(state.composition, kind)[index]?.inline ?? {}) as Record<string, unknown>;
+
+  const save = async () => {
+    const key = (def.key as string) || (def.name as string) || `${kind}-${index + 1}`;
+    setSaving(true);
+    try {
+      const token = await getAccessToken();
+      await createPiece(token, workspaceId, {
+        kind,
+        slug: slugify(key),
+        name: (def.title as string) || (def.name as string) || key,
+        definition: def,
+      });
+      toast.success("Saved to library — reuse it from the library picker");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't save to library");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mb-4 flex justify-end">
+      <Button size="xs" variant="outline" onClick={save} disabled={saving}>
+        {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Library className="size-3.5" />}
+        Save to library
+      </Button>
+    </div>
+  );
+}
+
+function ReferencedPieceView({
+  kind,
+  index,
+  pieceId,
+}: {
+  kind: PieceKind;
+  index: number;
+  pieceId: string;
+}) {
+  const { workspaceId, update } = usePackDraft();
+  const { data, isLoading } = useApiQuery<ChallengePiece>(piecePath(workspaceId, pieceId));
+
+  const detach = () =>
+    update((c) =>
+      updatePieceRef(c, kind, index, { inline: (data?.definition ?? {}) as Record<string, unknown> }),
+    );
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <div className="flex items-center gap-2">
+        <Library className="size-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">{data?.name ?? "Library piece"}</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Referenced from your workspace library. Edit it in the library to update every pack that uses
+        it, or edit a copy to customize it just for this pack.
+      </p>
+      {isLoading ? (
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      ) : (
+        <pre className="overflow-auto rounded-lg border border-border bg-muted/40 p-3 text-xs">
+          {JSON.stringify(data?.definition ?? {}, null, 2)}
+        </pre>
+      )}
+      <Button size="sm" variant="outline" onClick={detach} disabled={isLoading}>
+        Edit a copy
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/pieces/spec-card.tsx
+++ b/web/src/components/challenge-packs/pieces/spec-card.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Editor from "@monaco-editor/react";
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { usePackDraft } from "../use-pack-draft";
+
+type View = "readable" | "yaml";
+
+export function SpecCard() {
+  const { state } = usePackDraft();
+  const [view, setView] = useState<View>("readable");
+  const compile = state.compile;
+  const card = compile?.spec_card;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <span className="text-sm font-medium">Preview</span>
+        <div className="flex rounded-md border border-border p-0.5 text-xs">
+          {(["readable", "yaml"] as View[]).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              className={cn(
+                "rounded px-2 py-0.5 capitalize transition-colors",
+                view === v ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {v === "yaml" ? "YAML" : "Readable"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {state.compiling && !card && (
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          <Loader2 className="mr-2 size-4 animate-spin" /> Building preview…
+        </div>
+      )}
+
+      {view === "yaml" ? (
+        <div className="min-h-0 flex-1">
+          <Editor
+            height="100%"
+            defaultLanguage="yaml"
+            theme="vs-dark"
+            value={compile?.yaml ?? ""}
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              fontSize: 12,
+              wordWrap: "on",
+              scrollBeyondLastLine: false,
+            }}
+            loading={
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                <Loader2 className="size-5 animate-spin" />
+              </div>
+            }
+          />
+        </div>
+      ) : (
+        card && (
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+            <div>
+              <div className="text-sm font-semibold">{card.pack_name || "Untitled pack"}</div>
+              <div className="mt-1 flex flex-wrap gap-1.5">
+                {card.family && <Badge variant="outline">{card.family}</Badge>}
+                <Badge variant="outline">{card.execution_mode}</Badge>
+                <Badge variant="outline">{card.strategy}</Badge>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <Stat label="Challenges" value={card.challenge_count} />
+              <Stat label="Cases" value={card.case_count} />
+              <Stat label="Validators" value={card.validator_count} />
+              <Stat label="Judges" value={card.judge_count} />
+            </div>
+
+            <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
+              {card.pass_criteria}
+            </div>
+
+            {card.dimensions.length > 0 && (
+              <div className="space-y-1.5">
+                <div className="text-xs font-medium text-muted-foreground">Dimensions</div>
+                {card.dimensions.map((d) => (
+                  <div key={d.key} className="rounded-md border border-border px-2.5 py-1.5 text-xs">
+                    {d.summary}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <ValidationPanel valid={compile?.valid ?? false} errors={compile?.errors ?? []} />
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-border px-2.5 py-1.5">
+      <div className="text-base font-semibold tabular-nums">{value}</div>
+      <div className="text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function ValidationPanel({
+  valid,
+  errors,
+}: {
+  valid: boolean;
+  errors: { field: string; message: string }[];
+}) {
+  if (valid) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="size-4" /> Ready to publish
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-1.5 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+      <div className="flex items-center gap-2 text-sm font-medium text-amber-600 dark:text-amber-400">
+        <AlertCircle className="size-4" /> {errors.length} issue{errors.length === 1 ? "" : "s"} to resolve
+      </div>
+      <ul className="space-y-1 text-xs text-muted-foreground">
+        {errors.map((e, i) => (
+          <li key={i}>
+            <span className="font-mono text-foreground">{e.field}</span> — {e.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/use-pack-draft.tsx
+++ b/web/src/components/challenge-packs/use-pack-draft.tsx
@@ -180,6 +180,9 @@ export function PackDraftProvider({
       await patchDraft(token, workspaceId, draftId, { composition: compositionRef.current });
       const result = await publishDraft(token, workspaceId, draftId);
       toast.success("Challenge pack published");
+      // Re-enable the button before navigating so an intercepted navigation
+      // (redirect, route guard) can't leave Publish permanently disabled.
+      dispatch({ type: "publishingDone" });
       router.push(`/workspaces/${workspaceId}/challenge-packs/${result.challenge_pack_id}`);
     } catch (err) {
       if (err instanceof ApiError) {

--- a/web/src/components/challenge-packs/use-pack-draft.tsx
+++ b/web/src/components/challenge-packs/use-pack-draft.tsx
@@ -78,6 +78,7 @@ function reducer(state: State, action: Action): State {
 
 interface PackDraftContextValue {
   state: State;
+  workspaceId: string;
   select: (selection: BuilderSelection) => void;
   update: (updater: (composition: Composition) => Composition) => void;
   publish: () => Promise<void>;
@@ -191,8 +192,8 @@ export function PackDraftProvider({
   }, [getAccessToken, workspaceId, draftId, router]);
 
   const value = useMemo<PackDraftContextValue>(
-    () => ({ state, select, update, publish }),
-    [state, select, update, publish],
+    () => ({ state, workspaceId, select, update, publish }),
+    [state, workspaceId, select, update, publish],
   );
 
   return <PackDraftContext.Provider value={value}>{children}</PackDraftContext.Provider>;

--- a/web/src/components/challenge-packs/use-pack-draft.tsx
+++ b/web/src/components/challenge-packs/use-pack-draft.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+// The pack builder's single source of truth: one cohesive draft document
+// (a Composition) edited through a reducer, with debounced server-side autosave
+// + compile. Cross-piece references (a scorecard dimension pointing at a
+// validator/judge) need the whole draft in scope, so it lives in Context.
+
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/lib/api/errors";
+import { compileDraft, patchDraft, publishDraft } from "./lib/api";
+import type { CompileDraftResponse, Composition, PieceKind } from "./lib/types";
+
+const AUTOSAVE_DELAY_MS = 700;
+
+export type BuilderSelection =
+  | { section: "overview" }
+  | { section: "scorecard" }
+  | { section: "piece"; kind: PieceKind; index: number };
+
+interface State {
+  composition: Composition;
+  selection: BuilderSelection;
+  saving: boolean;
+  savedAt: number | null;
+  compiling: boolean;
+  compile: CompileDraftResponse | null;
+  publishing: boolean;
+}
+
+type Action =
+  | { type: "update"; updater: (composition: Composition) => Composition }
+  | { type: "select"; selection: BuilderSelection }
+  | { type: "savingStart" }
+  | { type: "savingDone" }
+  | { type: "compileStart" }
+  | { type: "compileDone"; result: CompileDraftResponse }
+  | { type: "compileFailed" }
+  | { type: "publishingStart" }
+  | { type: "publishingDone" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "update":
+      return { ...state, composition: action.updater(state.composition) };
+    case "select":
+      return { ...state, selection: action.selection };
+    case "savingStart":
+      return { ...state, saving: true };
+    case "savingDone":
+      return { ...state, saving: false, savedAt: Date.now() };
+    case "compileStart":
+      return { ...state, compiling: true };
+    case "compileDone":
+      return { ...state, compiling: false, compile: action.result };
+    case "compileFailed":
+      return { ...state, compiling: false };
+    case "publishingStart":
+      return { ...state, publishing: true };
+    case "publishingDone":
+      return { ...state, publishing: false };
+    default:
+      return state;
+  }
+}
+
+interface PackDraftContextValue {
+  state: State;
+  select: (selection: BuilderSelection) => void;
+  update: (updater: (composition: Composition) => Composition) => void;
+  publish: () => Promise<void>;
+}
+
+const PackDraftContext = createContext<PackDraftContextValue | null>(null);
+
+export function usePackDraft(): PackDraftContextValue {
+  const ctx = useContext(PackDraftContext);
+  if (!ctx) {
+    throw new Error("usePackDraft must be used within a PackDraftProvider");
+  }
+  return ctx;
+}
+
+export function PackDraftProvider({
+  workspaceId,
+  draftId,
+  initialComposition,
+  children,
+}: {
+  workspaceId: string;
+  draftId: string;
+  initialComposition: Composition;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+
+  const [state, dispatch] = useReducer(reducer, {
+    composition: initialComposition,
+    selection: { section: "overview" },
+    saving: false,
+    savedAt: null,
+    compiling: false,
+    compile: null,
+    publishing: false,
+  });
+
+  // Latest composition for the user-triggered publish callback. Synced via an
+  // effect — never written during render.
+  const compositionRef = useRef(state.composition);
+  const dirtyRef = useRef(false);
+
+  useEffect(() => {
+    compositionRef.current = state.composition;
+  }, [state.composition]);
+
+  const runCompile = useCallback(async () => {
+    dispatch({ type: "compileStart" });
+    try {
+      const token = await getAccessToken();
+      const result = await compileDraft(token, workspaceId, draftId);
+      dispatch({ type: "compileDone", result });
+    } catch {
+      dispatch({ type: "compileFailed" });
+    }
+  }, [getAccessToken, workspaceId, draftId]);
+
+  // Compile once on mount so the spec card reflects the loaded draft.
+  useEffect(() => {
+    void runCompile();
+  }, [runCompile]);
+
+  // Debounced save + recompile whenever the composition changes (after mount).
+  useEffect(() => {
+    if (!dirtyRef.current) {
+      dirtyRef.current = true;
+      return;
+    }
+    const handle = setTimeout(async () => {
+      dispatch({ type: "savingStart" });
+      try {
+        const token = await getAccessToken();
+        await patchDraft(token, workspaceId, draftId, { composition: state.composition });
+        dispatch({ type: "savingDone" });
+        await runCompile();
+      } catch (err) {
+        dispatch({ type: "savingDone" });
+        toast.error(err instanceof ApiError ? err.message : "Failed to save draft");
+      }
+    }, AUTOSAVE_DELAY_MS);
+    return () => clearTimeout(handle);
+  }, [state.composition, getAccessToken, workspaceId, draftId, runCompile]);
+
+  const select = useCallback((selection: BuilderSelection) => {
+    dispatch({ type: "select", selection });
+  }, []);
+
+  const update = useCallback((updater: (composition: Composition) => Composition) => {
+    dispatch({ type: "update", updater });
+  }, []);
+
+  const publish = useCallback(async () => {
+    dispatch({ type: "publishingStart" });
+    try {
+      const token = await getAccessToken();
+      // Persist the latest edits before publishing so the snapshot is current.
+      await patchDraft(token, workspaceId, draftId, { composition: compositionRef.current });
+      const result = await publishDraft(token, workspaceId, draftId);
+      toast.success("Challenge pack published");
+      router.push(`/workspaces/${workspaceId}/challenge-packs/${result.challenge_pack_id}`);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        toast.error(err.message || "Publish failed — resolve the validation issues first");
+      } else {
+        toast.error("Publish failed");
+      }
+      dispatch({ type: "publishingDone" });
+    }
+  }, [getAccessToken, workspaceId, draftId, router]);
+
+  const value = useMemo<PackDraftContextValue>(
+    () => ({ state, select, update, publish }),
+    [state, select, update, publish],
+  );
+
+  return <PackDraftContext.Provider value={value}>{children}</PackDraftContext.Provider>;
+}


### PR DESCRIPTION
## What

The visual, piece-based challenge-pack builder. Compose a pack from typed **pieces** (challenges, input sets, validators, judges) wired by a per-pack scorecard; each piece kind has its own purpose-built editor; a live readable **spec card** replaces raw YAML in the preview, with YAML behind a toggle as the escape hatch.

**Stacked on [#1071](https://github.com/agentclash/agentclash/pull/1071)** (backend). Base is `feat/challenge-pack-builder` — review/merge #1071 first.

## What's in

- **Store** — `use-pack-draft` reducer + Context; debounced autosave → authoritative server `compile` (spec card + validation + YAML).
- **Shell** — 3-pane: outline *collector* │ dedicated per-piece editor │ live spec card + YAML toggle. Publish gated on a valid compile.
- **Editors**: Pack overview, Challenge, Input-set grid (cases + JSON payloads), Validator (**all 21 types** via a grouped registry with file targets + per-type config), LLM Judge (**all 4 modes** — rubric / assertion / reference / n_wise), Scorecard wiring, and a **multi-turn conversation flow editor** (scripted → LLM → human phases) shown per-case in multi-turn mode.
- **Library reuse** — "Save to library" promotes an inline piece to a reusable workspace piece; "Add from library" picker references workspace pieces by id **and** clones built-in **starters** (`GET /v1/challenge-piece-library`); referenced pieces render read-only with "edit a copy".
- **Entry** — "New pack" on the challenge-packs page → creates a draft → opens `challenge-packs/builder/[draftId]`. The YAML dialog stays as the advanced escape hatch.

## Verification
- `tsc --noEmit` clean · `eslint` clean · `pnpm build` green.

## Intentionally in the YAML escape hatch (your v1 choice)
- Security/red-team & advanced-scoring (consensus, behavioral) piece editors.