### PR TITLE
feat(vibe-eval): confirmation engine, tool-invocation audit, draft tools

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -171,7 +171,7 @@ func main() {
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo).WithProviderClient(providerRouter)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)
-	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo)
+	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo).WithBundleValidator(challengePackAuthoringManager)
 	// Guide agent (Step 2) is optional: enabled only when VIBEEVAL_GUIDE_* is configured.
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -171,7 +171,9 @@ func main() {
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo).WithProviderClient(providerRouter)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)
-	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo).WithBundleValidator(challengePackAuthoringManager)
+	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo).
+		WithChallengePackAuthoring(challengePackAuthoringManager).
+		WithEntitlementGate(billingManager)
 	// Guide agent (Step 2) is optional: enabled only when VIBEEVAL_GUIDE_* is configured.
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -176,7 +176,7 @@ func main() {
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager
 	if guideCfg, ok := api.VibeEvalGuideConfigFromEnv(); ok {
-		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager)
+		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager)
 		if gerr != nil {
 			logger.Error("failed to initialize vibe eval guide agent", "error", gerr)
 			os.Exit(1)

--- a/backend/db/migrations/00059_vibe_eval_tool_invocations.sql
+++ b/backend/db/migrations/00059_vibe_eval_tool_invocations.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+-- Vibe Eval tool-invocation audit log (Step 3 of the guide agent, #875 §6). Generalizes the
+-- never-merged Phase 2 `vibe_eval_draft_events` (validate/publish only) into one append-only row
+-- per draft+ tool call, regardless of outcome. read-tier calls are audited only when they touch
+-- sensitive evidence (Phase 0 rule). Metadata and hashes only — NEVER secret values, raw
+-- artifact contents, or provider keys.
+CREATE TABLE vibe_eval_tool_invocations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    conversation_id uuid NOT NULL,
+    message_id uuid, -- the assistant tool-call message this records (nullable; SET NULL if pruned)
+    actor_user_id uuid NOT NULL, -- the authenticated Caller, NEVER the model
+    tool_name text NOT NULL,
+    action text NOT NULL, -- api.Action string, validated by the api adapter
+    risk_tier text NOT NULL CHECK (risk_tier IN ('read', 'draft', 'workspace_write', 'cost_incurring', 'admin_sensitive', 'destructive_external')),
+    payload_hash text NOT NULL DEFAULT '', -- sha256 of canonical-JSON(tool, normalized args)
+    -- Soft reference to vibe_eval_pending_confirmations.id (no FK): the audit log is append-only
+    -- and must outlive transient/expired confirmation rows, so it must not be nulled or cascaded
+    -- when a confirmation row is cleaned up.
+    confirmation_id uuid,
+    request_payload jsonb NOT NULL DEFAULT '{}'::jsonb, -- validated args, audit-scrubbed (metadata only)
+    result_payload jsonb NOT NULL DEFAULT '{}'::jsonb, -- outcome metadata, audit-scrubbed (ids/hashes/state/counts)
+    credit_reservation_id uuid, -- Step 4: set for cost_incurring tools (no FK yet; wallet tables land in Step 4)
+    outcome text NOT NULL CHECK (outcome IN ('ok', 'denied', 'error', 'confirmation_required')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE,
+    FOREIGN KEY (conversation_id, workspace_id) REFERENCES vibe_eval_conversations (id, workspace_id) ON DELETE CASCADE,
+    FOREIGN KEY (message_id) REFERENCES vibe_eval_messages (id) ON DELETE SET NULL,
+    FOREIGN KEY (actor_user_id) REFERENCES users (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX vibe_eval_tool_invocations_conversation_idx
+    ON vibe_eval_tool_invocations (conversation_id, created_at DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS vibe_eval_tool_invocations;

--- a/backend/db/migrations/00060_vibe_eval_pending_confirmations.sql
+++ b/backend/db/migrations/00060_vibe_eval_pending_confirmations.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+-- Vibe Eval pending confirmations (Step 3, #875 §5.3/§5.4). The propose→confirm half of the
+-- confirmation engine: a workspace_write+ tool proposes an action, the turn ends, and the user
+-- resolves it later via POST .../confirmations/{id}, which streams a continuation turn.
+--
+-- payload_hash binds the confirmation to EXACTLY the args shown to the user (sha256 of
+-- canonical-JSON); resolve echoes it, and a mismatch is rejected (anti bait-and-switch).
+-- bound_args is the verbatim validated args to execute on approve (internal state, not audit).
+--
+-- Crash-safe status machine (single-use): pending → executing → succeeded | failed (approve
+-- path), pending → denied (deny path), pending → expired (lapsed). The atomic resolve claims the
+-- row (pending → executing RETURNING) so two concurrent POSTs can't both execute; an `executing`
+-- row left by a crash lets a retry re-enter effect execution idempotently.
+CREATE TABLE vibe_eval_pending_confirmations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    conversation_id uuid NOT NULL,
+    message_id uuid, -- the assistant tool-call message that proposed this (for resume pairing)
+    proposed_by_user_id uuid NOT NULL, -- the authenticated Caller who proposed (provenance; NEVER the model)
+    tool_name text NOT NULL,
+    tool_call_id text NOT NULL DEFAULT '', -- provider tool_use id, to pair the resumed tool-result
+    action text NOT NULL, -- api.Action string, validated by the api adapter on resolve
+    risk_tier text NOT NULL CHECK (risk_tier IN ('workspace_write', 'cost_incurring', 'admin_sensitive', 'destructive_external')),
+    payload_hash text NOT NULL, -- sha256 of canonical-JSON(tool, normalized args); echoed on resolve
+    bound_args jsonb NOT NULL DEFAULT '{}'::jsonb, -- exact validated args to execute on approve
+    summary text NOT NULL DEFAULT '', -- human-readable confirmation card body
+    estimate jsonb, -- Step 4: CostEstimate for cost_incurring tools (nullable)
+    status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'executing', 'succeeded', 'failed', 'denied', 'expired')),
+    resolved_by_user_id uuid, -- who approved/denied (the authenticated Caller)
+    resolved_at timestamptz,
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE,
+    FOREIGN KEY (conversation_id, workspace_id) REFERENCES vibe_eval_conversations (id, workspace_id) ON DELETE CASCADE,
+    FOREIGN KEY (message_id) REFERENCES vibe_eval_messages (id) ON DELETE CASCADE,
+    FOREIGN KEY (proposed_by_user_id) REFERENCES users (id) ON DELETE RESTRICT,
+    FOREIGN KEY (resolved_by_user_id) REFERENCES users (id) ON DELETE RESTRICT
+);
+
+-- At most one ACTIVE confirmation per (conversation, tool, payload_hash): blocks duplicate
+-- proposals while one is in flight, but allows a fresh attempt after a terminal state. Expiry is
+-- an explicit status transition (pending -> expired), NOT a time predicate, precisely so a lapsed
+-- row leaves this partial index instead of blocking re-proposal forever (partial indexes can't
+-- use now()). The create path expires stale rows in-tx before inserting.
+CREATE UNIQUE INDEX vibe_eval_pending_confirmations_active_idx
+    ON vibe_eval_pending_confirmations (conversation_id, tool_name, payload_hash)
+    WHERE status IN ('pending', 'executing');
+
+CREATE INDEX vibe_eval_pending_confirmations_conversation_idx
+    ON vibe_eval_pending_confirmations (conversation_id, created_at DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS vibe_eval_pending_confirmations;

--- a/backend/db/queries/vibe_eval.sql
+++ b/backend/db/queries/vibe_eval.sql
@@ -68,6 +68,16 @@ FROM vibe_eval_drafts
 WHERE conversation_id = @conversation_id
 ORDER BY updated_at DESC;
 
+-- name: MarkVibeEvalDraftValidation :one
+-- Content-preserving validation update (validate_draft) — sets only validation state/errors.
+UPDATE vibe_eval_drafts
+SET
+    validation_state = @validation_state,
+    validation_errors = @validation_errors,
+    updated_by_user_id = @updated_by_user_id
+WHERE id = @id
+RETURNING *;
+
 -- name: GetVibeEvalDraftByID :one
 SELECT *
 FROM vibe_eval_drafts

--- a/backend/db/queries/vibe_eval.sql
+++ b/backend/db/queries/vibe_eval.sql
@@ -140,3 +140,134 @@ SELECT *
 FROM vibe_eval_messages
 WHERE conversation_id = @conversation_id
 ORDER BY seq ASC;
+
+-- name: AppendVibeEvalToolInvocation :one
+-- Append-only audit row for one draft+ tool call (#875 §6). request_payload/result_payload are
+-- audit-scrubbed metadata only. confirmation_id is a soft reference (no FK).
+INSERT INTO vibe_eval_tool_invocations (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    message_id,
+    actor_user_id,
+    tool_name,
+    action,
+    risk_tier,
+    payload_hash,
+    confirmation_id,
+    request_payload,
+    result_payload,
+    credit_reservation_id,
+    outcome
+)
+VALUES (
+    @organization_id,
+    @workspace_id,
+    @conversation_id,
+    sqlc.narg('message_id'),
+    @actor_user_id,
+    @tool_name,
+    @action,
+    @risk_tier,
+    @payload_hash,
+    sqlc.narg('confirmation_id'),
+    @request_payload,
+    @result_payload,
+    sqlc.narg('credit_reservation_id'),
+    @outcome
+)
+RETURNING *;
+
+-- name: ListVibeEvalToolInvocationsByConversationID :many
+SELECT *
+FROM vibe_eval_tool_invocations
+WHERE conversation_id = @conversation_id
+ORDER BY created_at DESC, id DESC;
+
+-- name: CreateVibeEvalPendingConfirmation :one
+-- Propose half of the confirmation engine (#875 §5.3). bound_args is the verbatim args to
+-- execute on approve; payload_hash binds the confirmation to exactly those args.
+INSERT INTO vibe_eval_pending_confirmations (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    message_id,
+    proposed_by_user_id,
+    tool_name,
+    tool_call_id,
+    action,
+    risk_tier,
+    payload_hash,
+    bound_args,
+    summary,
+    estimate,
+    expires_at
+)
+VALUES (
+    @organization_id,
+    @workspace_id,
+    @conversation_id,
+    sqlc.narg('message_id'),
+    @proposed_by_user_id,
+    @tool_name,
+    @tool_call_id,
+    @action,
+    @risk_tier,
+    @payload_hash,
+    @bound_args,
+    @summary,
+    sqlc.narg('estimate'),
+    @expires_at
+)
+RETURNING *;
+
+-- name: ExpireStaleVibeEvalPendingConfirmations :many
+-- Transition lapsed 'pending' rows for a conversation to 'expired' so they leave the active
+-- partial unique index and stop blocking re-proposal (#875 §5.3). The create path runs this in
+-- the same tx before inserting.
+UPDATE vibe_eval_pending_confirmations
+SET status = 'expired', resolved_at = now()
+WHERE conversation_id = @conversation_id
+  AND status = 'pending'
+  AND expires_at <= now()
+RETURNING *;
+
+-- name: GetVibeEvalPendingConfirmationForResume :one
+-- Crash-safe re-entry: returns the row only if it is still 'executing' and the presented hash
+-- matches, so a retried POST can resume effect execution exactly once. 0 rows => not resumable.
+SELECT *
+FROM vibe_eval_pending_confirmations
+WHERE id = @id
+  AND status = 'executing'
+  AND payload_hash = @payload_hash
+LIMIT 1;
+
+-- name: GetVibeEvalPendingConfirmationByID :one
+SELECT *
+FROM vibe_eval_pending_confirmations
+WHERE id = @id
+LIMIT 1;
+
+-- name: ResolveVibeEvalPendingConfirmation :one
+-- Atomic, single-use transition out of 'pending' (#875 §5.3). Only the request that matches a
+-- still-pending, unexpired row with the presented payload_hash wins (0 rows => already resolved,
+-- expired, or hash mismatch => reject). @new_status is 'executing' (approve) or 'denied' (deny).
+UPDATE vibe_eval_pending_confirmations
+SET
+    status = @new_status,
+    resolved_by_user_id = @resolved_by_user_id,
+    resolved_at = now()
+WHERE id = @id
+  AND status = 'pending'
+  AND expires_at > now()
+  AND payload_hash = @payload_hash
+RETURNING *;
+
+-- name: MarkVibeEvalPendingConfirmationResult :one
+-- Terminal transition after the bound effect runs: 'executing' -> 'succeeded' | 'failed'.
+-- Conditioned on status='executing' so a crashed/retried effect transitions exactly once.
+UPDATE vibe_eval_pending_confirmations
+SET status = @status
+WHERE id = @id
+  AND status = 'executing'
+RETURNING *;

--- a/backend/db/queries/vibe_eval.sql
+++ b/backend/db/queries/vibe_eval.sql
@@ -85,11 +85,26 @@ WHERE id = @id
 LIMIT 1;
 
 -- name: UpdateVibeEvalDraft :one
+-- Editing content unpublishes the draft: the published refs are cleared so a stale published
+-- version can never be reused as an idempotency signal for changed content (3c-3 effect identity).
 UPDATE vibe_eval_drafts
 SET
     content = @content,
     validation_state = @validation_state,
     validation_errors = @validation_errors,
+    published_challenge_pack_id = NULL,
+    published_challenge_pack_version_id = NULL,
+    updated_by_user_id = @updated_by_user_id
+WHERE id = @id
+RETURNING *;
+
+-- name: MarkVibeEvalDraftPublished :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = 'valid',
+    validation_errors = '[]'::jsonb,
+    published_challenge_pack_id = @published_challenge_pack_id,
+    published_challenge_pack_version_id = @published_challenge_pack_version_id,
     updated_by_user_id = @updated_by_user_id
 WHERE id = @id
 RETURNING *;

--- a/backend/db/queries/vibe_eval.sql
+++ b/backend/db/queries/vibe_eval.sql
@@ -184,6 +184,17 @@ FROM vibe_eval_tool_invocations
 WHERE conversation_id = @conversation_id
 ORDER BY created_at DESC, id DESC;
 
+-- name: GetVibeEvalConfirmedToolOutcome :one
+-- The durable, outcome-aware execution result for a confirmation: the latest ok/error audit row
+-- (the confirmation_required propose row is excluded). 0 rows ⇒ the confirmed effect never ran (or
+-- ran but its best-effort audit write was lost — the caller treats that ambiguity conservatively).
+SELECT outcome
+FROM vibe_eval_tool_invocations
+WHERE confirmation_id = @confirmation_id
+  AND outcome IN ('ok', 'error')
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
+
 -- name: CreateVibeEvalPendingConfirmation :one
 -- Propose half of the confirmation engine (#875 §5.3). bound_args is the verbatim args to
 -- execute on approve; payload_hash binds the confirmation to exactly those args.

--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -122,11 +122,15 @@ type ChallengePackAuthoringRepository interface {
 	GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (repository.Artifact, error)
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
 	PublishChallengePackBundle(ctx context.Context, params repository.PublishChallengePackBundleParams) (repository.PublishedChallengePack, error)
+	ResolvePublishedChallengePackBundle(ctx context.Context, workspaceID uuid.UUID, slug string, versionNumber int32) (repository.PublishedChallengePack, error)
 }
 
 type ChallengePackAuthoringService interface {
 	ValidateBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (ValidateChallengePackResponse, error)
 	PublishBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error)
+	// ResolvePublishedBundle returns the existing published identity for a bundle whose version is
+	// already published — used to recover a duplicate-version publish without republishing.
+	ResolvePublishedBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error)
 }
 
 type ChallengePackAuthoringManager struct {
@@ -234,6 +238,26 @@ func (m *ChallengePackAuthoringManager) PublishBundle(ctx context.Context, works
 	}
 	cleanupBundleArtifact = nil
 
+	return PublishChallengePackResponse{
+		ChallengePackID:        published.ChallengePackID,
+		ChallengePackVersionID: published.ChallengePackVersionID,
+		EvaluationSpecID:       published.EvaluationSpecID,
+		InputSetIDs:            published.InputSetIDs,
+		BundleArtifactID:       published.BundleArtifactID,
+	}, nil
+}
+
+// ResolvePublishedBundle parses the bundle to its (slug, version) identity and resolves the existing
+// published pack/version/spec/input-sets — the recovery path for a duplicate-version publish.
+func (m *ChallengePackAuthoringManager) ResolvePublishedBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error) {
+	bundle, err := challengepack.ParseYAML(bundleYAML)
+	if err != nil {
+		return PublishChallengePackResponse{}, err
+	}
+	published, err := m.repo.ResolvePublishedChallengePackBundle(ctx, workspaceID, bundle.Pack.Slug, bundle.Version.Number)
+	if err != nil {
+		return PublishChallengePackResponse{}, err
+	}
 	return PublishChallengePackResponse{
 		ChallengePackID:        published.ChallengePackID,
 		ChallengePackVersionID: published.ChallengePackVersionID,

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -103,6 +103,10 @@ func (f *fakeChallengePackAuthoringRepository) PublishChallengePackBundle(_ cont
 	return f.published, nil
 }
 
+func (f *fakeChallengePackAuthoringRepository) ResolvePublishedChallengePackBundle(_ context.Context, _ uuid.UUID, _ string, _ int32) (repository.PublishedChallengePack, error) {
+	return f.published, nil
+}
+
 type fakeChallengePackEntitlementGate struct {
 	err              error
 	checkedWorkspace uuid.UUID

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -248,6 +248,8 @@ func registerProtectedRoutes(
 		Patch("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}", updateVibeEvalDraftHandler(logger, vibeEvalService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate", validateVibeEvalDraftHandler(logger, vibeEvalService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish", publishVibeEvalDraftHandler(logger, vibeEvalService))
 	// Guide-agent endpoints (Step 2). Registered only when VIBEEVAL_GUIDE_* is configured;
 	// otherwise the feature stays dark (like other optional services). The handlers run their
 	// own action-tier authz (manage-drafts for turns, read for transcript) before streaming.

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -246,6 +246,8 @@ func registerProtectedRoutes(
 		Get("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}", getVibeEvalDraftHandler(logger, vibeEvalService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Patch("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}", updateVibeEvalDraftHandler(logger, vibeEvalService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate", validateVibeEvalDraftHandler(logger, vibeEvalService))
 	// Guide-agent endpoints (Step 2). Registered only when VIBEEVAL_GUIDE_* is configured;
 	// otherwise the feature stays dark (like other optional services). The handlers run their
 	// own action-tier authz (manage-drafts for turns, read for transcript) before streaming.

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -254,6 +254,8 @@ func registerProtectedRoutes(
 			Post("/workspaces/{workspaceID}/vibe-eval/conversations/{conversationID}/turns", createVibeEvalTurnHandler(logger, vibeEvalAgentManager))
 		router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 			Get("/workspaces/{workspaceID}/vibe-eval/conversations/{conversationID}/messages", listVibeEvalMessagesHandler(logger, vibeEvalAgentManager))
+		router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+			Post("/workspaces/{workspaceID}/vibe-eval/conversations/{conversationID}/confirmations/{confirmationID}", resolveVibeEvalConfirmationHandler(logger, vibeEvalAgentManager))
 	}
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/artifacts", listWorkspaceArtifactsHandler(logger, artifactService))

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -507,6 +507,9 @@ func (noopVibeEvalService) GetDraft(context.Context, Caller, GetVibeEvalDraftInp
 func (noopVibeEvalService) UpdateDraft(context.Context, Caller, UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
 	return repository.VibeEvalDraft{}, errors.New("vibe eval service is not configured")
 }
+func (noopVibeEvalService) ValidateDraft(context.Context, Caller, ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
+	return ValidateVibeEvalDraftResult{}, errors.New("vibe eval service is not configured")
+}
 
 type noopCompareReadService struct{}
 

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -510,6 +510,9 @@ func (noopVibeEvalService) UpdateDraft(context.Context, Caller, UpdateVibeEvalDr
 func (noopVibeEvalService) ValidateDraft(context.Context, Caller, ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
 	return ValidateVibeEvalDraftResult{}, errors.New("vibe eval service is not configured")
 }
+func (noopVibeEvalService) PublishDraftAndAudit(context.Context, Caller, PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	return PublishVibeEvalDraftResult{}, errors.New("vibe eval service is not configured")
+}
 
 type noopCompareReadService struct{}
 
@@ -638,5 +641,8 @@ func (noopChallengePackAuthoringService) ValidateBundle(_ context.Context, _ uui
 }
 
 func (noopChallengePackAuthoringService) PublishBundle(_ context.Context, _ uuid.UUID, _ []byte) (PublishChallengePackResponse, error) {
+	return PublishChallengePackResponse{}, errors.New("challenge pack authoring service is not configured")
+}
+func (noopChallengePackAuthoringService) ResolvePublishedBundle(_ context.Context, _ uuid.UUID, _ []byte) (PublishChallengePackResponse, error) {
 	return PublishChallengePackResponse{}, errors.New("challenge pack authoring service is not configured")
 }

--- a/backend/internal/api/test_helpers_test.go
+++ b/backend/internal/api/test_helpers_test.go
@@ -26,6 +26,9 @@ func (stubChallengePackAuthoringService) ValidateBundle(_ context.Context, _ uui
 func (stubChallengePackAuthoringService) PublishBundle(_ context.Context, _ uuid.UUID, _ []byte) (PublishChallengePackResponse, error) {
 	return PublishChallengePackResponse{}, errors.New("not implemented")
 }
+func (stubChallengePackAuthoringService) ResolvePublishedBundle(_ context.Context, _ uuid.UUID, _ []byte) (PublishChallengePackResponse, error) {
+	return PublishChallengePackResponse{}, errors.New("not implemented")
+}
 
 func (stubAgentBuildService) CreateBuild(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildInput) (repository.AgentBuild, error) {
 	return repository.AgentBuild{}, errors.New("not implemented")

--- a/backend/internal/api/vibe_eval.go
+++ b/backend/internal/api/vibe_eval.go
@@ -26,6 +26,7 @@ type VibeEvalRepository interface {
 	ListVibeEvalDraftsByConversationID(ctx context.Context, conversationID uuid.UUID) ([]repository.VibeEvalDraft, error)
 	GetVibeEvalDraftByID(ctx context.Context, id uuid.UUID) (repository.VibeEvalDraft, error)
 	UpdateVibeEvalDraft(ctx context.Context, params repository.UpdateVibeEvalDraftParams) (repository.VibeEvalDraft, error)
+	MarkVibeEvalDraftValidation(ctx context.Context, params repository.MarkVibeEvalDraftValidationParams) (repository.VibeEvalDraft, error)
 }
 
 type VibeEvalService interface {
@@ -36,15 +37,29 @@ type VibeEvalService interface {
 	ListDrafts(ctx context.Context, caller Caller, input ListVibeEvalDraftsInput) ([]repository.VibeEvalDraft, error)
 	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+	ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error)
+}
+
+// vibeEvalBundleValidator validates a challenge-pack bundle (the existing ChallengePackAuthoringService).
+type vibeEvalBundleValidator interface {
+	ValidateBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (ValidateChallengePackResponse, error)
 }
 
 type VibeEvalManager struct {
-	authorizer WorkspaceAuthorizer
-	repo       VibeEvalRepository
+	authorizer    WorkspaceAuthorizer
+	repo          VibeEvalRepository
+	bundleChecker vibeEvalBundleValidator // optional; required only for validate_draft (challenge_pack)
 }
 
 func NewVibeEvalManager(authorizer WorkspaceAuthorizer, repo VibeEvalRepository) *VibeEvalManager {
 	return &VibeEvalManager{authorizer: authorizer, repo: repo}
+}
+
+// WithBundleValidator wires the challenge-pack bundle validator (enables ValidateDraft). Kept as a
+// setter so NewVibeEvalManager and its existing callers/tests are unchanged.
+func (m *VibeEvalManager) WithBundleValidator(v vibeEvalBundleValidator) *VibeEvalManager {
+	m.bundleChecker = v
+	return m
 }
 
 type VibeEvalValidationError struct {
@@ -90,6 +105,17 @@ type UpdateVibeEvalDraftInput struct {
 	Content          json.RawMessage
 	ValidationState  string
 	ValidationErrors json.RawMessage
+}
+
+type ValidateVibeEvalDraftInput struct {
+	WorkspaceID uuid.UUID
+	DraftID     uuid.UUID
+}
+
+type ValidateVibeEvalDraftResult struct {
+	Draft  repository.VibeEvalDraft
+	Valid  bool
+	Errors []validationErrorDetail
 }
 
 func (m *VibeEvalManager) CreateConversation(ctx context.Context, caller Caller, input CreateVibeEvalConversationInput) (repository.VibeEvalConversation, error) {
@@ -218,6 +244,95 @@ func (m *VibeEvalManager) UpdateDraft(ctx context.Context, caller Caller, input 
 		ValidationErrors: normalizeArrayJSON(input.ValidationErrors),
 		UpdatedByUserID:  caller.UserID,
 	})
+}
+
+// ValidateDraft validates a challenge_pack draft's bundle and records its validation state/errors
+// (content-preserving). Draft tier — no confirmation. Shared by the REST endpoint and the
+// validate_draft guide tool (one manager path). It does NOT compute a publish payload hash or
+// publish anything (Step 3c-3).
+func (m *VibeEvalManager) ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
+	draft, err := m.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: input.WorkspaceID, DraftID: input.DraftID})
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, draft.WorkspaceID, ActionManageVibeEvalDrafts); err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	if draft.DraftKind != "challenge_pack" {
+		return ValidateVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be a challenge_pack draft to validate"}
+	}
+	if m.bundleChecker == nil {
+		return ValidateVibeEvalDraftResult{}, errors.New("vibe eval bundle validator is not configured")
+	}
+	bundleYAML, bundleErr := vibeEvalDraftBundleYAML(draft)
+	if bundleErr != nil {
+		// A missing/malformed bundle is a normal INVALID validation outcome (persist invalid +
+		// structured errors), not a request error — the agent should learn what to fix and retry.
+		return m.markVibeEvalDraftInvalid(ctx, caller, draft, bundleErr)
+	}
+	validation, err := m.bundleChecker.ValidateBundle(ctx, draft.WorkspaceID, bundleYAML)
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	state := "invalid"
+	validationErrors := []byte("[]")
+	if validation.Valid {
+		state = "valid"
+	} else {
+		validationErrors, err = json.Marshal(validation.Errors)
+		if err != nil {
+			return ValidateVibeEvalDraftResult{}, fmt.Errorf("marshal validation errors: %w", err)
+		}
+	}
+	updated, err := m.repo.MarkVibeEvalDraftValidation(ctx, repository.MarkVibeEvalDraftValidationParams{
+		ID:               draft.ID,
+		ValidationState:  state,
+		ValidationErrors: validationErrors,
+		UpdatedByUserID:  caller.UserID,
+	})
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	return ValidateVibeEvalDraftResult{Draft: updated, Valid: validation.Valid, Errors: validation.Errors}, nil
+}
+
+// vibeEvalDraftBundleYAML extracts the challenge-pack bundle YAML from a draft's content
+// (accepts bundle_yaml | yaml | manifest_yaml).
+func vibeEvalDraftBundleYAML(draft repository.VibeEvalDraft) ([]byte, error) {
+	var content struct {
+		BundleYAML   string `json:"bundle_yaml"`
+		YAML         string `json:"yaml"`
+		ManifestYAML string `json:"manifest_yaml"`
+	}
+	if err := json.Unmarshal(draft.Content, &content); err != nil {
+		return nil, VibeEvalValidationError{Code: "validation_error", Message: "draft content must be a JSON object"}
+	}
+	for _, candidate := range []string{content.BundleYAML, content.YAML, content.ManifestYAML} {
+		if y := strings.TrimSpace(candidate); y != "" {
+			return []byte(y), nil
+		}
+	}
+	return nil, VibeEvalValidationError{Code: "validation_error", Message: "challenge_pack draft content must include bundle_yaml"}
+}
+
+// markVibeEvalDraftInvalid records a draft as invalid with a single structured error (used when the
+// bundle is missing/malformed, which is a validation outcome rather than a request error).
+func (m *VibeEvalManager) markVibeEvalDraftInvalid(ctx context.Context, caller Caller, draft repository.VibeEvalDraft, cause error) (ValidateVibeEvalDraftResult, error) {
+	errs := []validationErrorDetail{{Field: "bundle_yaml", Message: cause.Error()}}
+	errsJSON, err := json.Marshal(errs)
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, fmt.Errorf("marshal validation errors: %w", err)
+	}
+	updated, err := m.repo.MarkVibeEvalDraftValidation(ctx, repository.MarkVibeEvalDraftValidationParams{
+		ID:               draft.ID,
+		ValidationState:  "invalid",
+		ValidationErrors: errsJSON,
+		UpdatedByUserID:  caller.UserID,
+	})
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	return ValidateVibeEvalDraftResult{Draft: updated, Valid: false, Errors: errs}, nil
 }
 
 func validVibeEvalPhase(phase string) bool {
@@ -487,6 +602,29 @@ func updateVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) ht
 			return
 		}
 		writeJSON(w, http.StatusOK, mapVibeEvalDraftResponse(result))
+	}
+}
+
+func validateVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, ok := vibeEvalCallerAndWorkspace(w, r)
+		if !ok {
+			return
+		}
+		draftID, ok := parseVibeEvalURLUUID(w, "draftID", "invalid_draft_id", r)
+		if !ok {
+			return
+		}
+		result, err := service.ValidateDraft(r.Context(), caller, ValidateVibeEvalDraftInput{WorkspaceID: workspaceID, DraftID: draftID})
+		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"draft":  mapVibeEvalDraftResponse(result.Draft),
+			"valid":  result.Valid,
+			"errors": result.Errors,
+		})
 	}
 }
 

--- a/backend/internal/api/vibe_eval.go
+++ b/backend/internal/api/vibe_eval.go
@@ -858,9 +858,13 @@ func decodeVibeEvalJSON(w http.ResponseWriter, r *http.Request, dest any) bool {
 
 func handleVibeEvalError(w http.ResponseWriter, logger *slog.Logger, err error) {
 	var validationErr VibeEvalValidationError
+	var gateErr billingpkg.GateError
 	switch {
 	case errors.As(err, &validationErr):
 		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+	case errors.As(err, &gateErr):
+		// Entitlement gate (e.g. publish_draft without private_challenge_packs) → 403, not 500.
+		writeBillingGateError(w, gateErr.Decision)
 	case errors.Is(err, repository.ErrVibeEvalConversationNotFound):
 		writeError(w, http.StatusNotFound, "conversation_not_found", "vibe eval conversation not found")
 	case errors.Is(err, repository.ErrVibeEvalDraftNotFound):

--- a/backend/internal/api/vibe_eval.go
+++ b/backend/internal/api/vibe_eval.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -27,6 +28,8 @@ type VibeEvalRepository interface {
 	GetVibeEvalDraftByID(ctx context.Context, id uuid.UUID) (repository.VibeEvalDraft, error)
 	UpdateVibeEvalDraft(ctx context.Context, params repository.UpdateVibeEvalDraftParams) (repository.VibeEvalDraft, error)
 	MarkVibeEvalDraftValidation(ctx context.Context, params repository.MarkVibeEvalDraftValidationParams) (repository.VibeEvalDraft, error)
+	MarkVibeEvalDraftPublished(ctx context.Context, params repository.MarkVibeEvalDraftPublishedParams) (repository.VibeEvalDraft, error)
+	AppendVibeEvalToolInvocation(ctx context.Context, params repository.AppendVibeEvalToolInvocationParams) (repository.VibeEvalToolInvocation, error)
 }
 
 type VibeEvalService interface {
@@ -38,27 +41,43 @@ type VibeEvalService interface {
 	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error)
+	PublishDraftAndAudit(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error)
 }
 
-// vibeEvalBundleValidator validates a challenge-pack bundle (the existing ChallengePackAuthoringService).
-type vibeEvalBundleValidator interface {
+// vibeEvalChallengePackAuthoring is the challenge-pack authoring surface VibeEval needs (the existing
+// ChallengePackAuthoringManager satisfies it): validate, publish, and resolve-already-published.
+type vibeEvalChallengePackAuthoring interface {
 	ValidateBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (ValidateChallengePackResponse, error)
+	PublishBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error)
+	ResolvePublishedBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error)
+}
+
+// vibeEvalEntitlementGate gates publishing new challenge-pack effects (private-pack entitlement).
+type vibeEvalEntitlementGate interface {
+	CheckWorkspaceFeature(ctx context.Context, workspaceID uuid.UUID, feature string) error
 }
 
 type VibeEvalManager struct {
-	authorizer    WorkspaceAuthorizer
-	repo          VibeEvalRepository
-	bundleChecker vibeEvalBundleValidator // optional; required only for validate_draft (challenge_pack)
+	authorizer  WorkspaceAuthorizer
+	repo        VibeEvalRepository
+	packs       vibeEvalChallengePackAuthoring // optional; required for validate_draft / publish_draft
+	entitlement vibeEvalEntitlementGate        // optional; gates new publish effects
 }
 
 func NewVibeEvalManager(authorizer WorkspaceAuthorizer, repo VibeEvalRepository) *VibeEvalManager {
 	return &VibeEvalManager{authorizer: authorizer, repo: repo}
 }
 
-// WithBundleValidator wires the challenge-pack bundle validator (enables ValidateDraft). Kept as a
-// setter so NewVibeEvalManager and its existing callers/tests are unchanged.
-func (m *VibeEvalManager) WithBundleValidator(v vibeEvalBundleValidator) *VibeEvalManager {
-	m.bundleChecker = v
+// WithChallengePackAuthoring wires the challenge-pack authoring service (enables validate_draft and
+// publish_draft). Setter-style so NewVibeEvalManager and its existing callers stay unchanged.
+func (m *VibeEvalManager) WithChallengePackAuthoring(p vibeEvalChallengePackAuthoring) *VibeEvalManager {
+	m.packs = p
+	return m
+}
+
+// WithEntitlementGate wires the entitlement gate consulted before a NEW publish effect.
+func (m *VibeEvalManager) WithEntitlementGate(g vibeEvalEntitlementGate) *VibeEvalManager {
+	m.entitlement = g
 	return m
 }
 
@@ -116,6 +135,21 @@ type ValidateVibeEvalDraftResult struct {
 	Draft  repository.VibeEvalDraft
 	Valid  bool
 	Errors []validationErrorDetail
+}
+
+type PublishVibeEvalDraftInput struct {
+	WorkspaceID uuid.UUID
+	DraftID     uuid.UUID
+}
+
+type PublishVibeEvalDraftResult struct {
+	Draft                  repository.VibeEvalDraft
+	ChallengePackID        uuid.UUID
+	ChallengePackVersionID uuid.UUID
+	EvaluationSpecID       uuid.UUID
+	InputSetIDs            []uuid.UUID
+	BundleArtifactID       *uuid.UUID
+	AlreadyPublished       bool // true when returned from the effect-identity idempotency short-circuit
 }
 
 func (m *VibeEvalManager) CreateConversation(ctx context.Context, caller Caller, input CreateVibeEvalConversationInput) (repository.VibeEvalConversation, error) {
@@ -261,8 +295,8 @@ func (m *VibeEvalManager) ValidateDraft(ctx context.Context, caller Caller, inpu
 	if draft.DraftKind != "challenge_pack" {
 		return ValidateVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be a challenge_pack draft to validate"}
 	}
-	if m.bundleChecker == nil {
-		return ValidateVibeEvalDraftResult{}, errors.New("vibe eval bundle validator is not configured")
+	if m.packs == nil {
+		return ValidateVibeEvalDraftResult{}, errors.New("vibe eval challenge-pack authoring is not configured")
 	}
 	bundleYAML, bundleErr := vibeEvalDraftBundleYAML(draft)
 	if bundleErr != nil {
@@ -270,7 +304,7 @@ func (m *VibeEvalManager) ValidateDraft(ctx context.Context, caller Caller, inpu
 		// structured errors), not a request error — the agent should learn what to fix and retry.
 		return m.markVibeEvalDraftInvalid(ctx, caller, draft, bundleErr)
 	}
-	validation, err := m.bundleChecker.ValidateBundle(ctx, draft.WorkspaceID, bundleYAML)
+	validation, err := m.packs.ValidateBundle(ctx, draft.WorkspaceID, bundleYAML)
 	if err != nil {
 		return ValidateVibeEvalDraftResult{}, err
 	}
@@ -333,6 +367,142 @@ func (m *VibeEvalManager) markVibeEvalDraftInvalid(ctx context.Context, caller C
 		return ValidateVibeEvalDraftResult{}, err
 	}
 	return ValidateVibeEvalDraftResult{Draft: updated, Valid: false, Errors: errs}, nil
+}
+
+// PublishDraft publishes a validated challenge_pack draft as a runnable challenge pack. Workspace-write
+// tier (the guide-tool confirmation is enforced by the loop; REST is a direct human action). The ONE
+// manager path shared by the publish_draft tool and the REST endpoint. Idempotent by EFFECT IDENTITY:
+// an already-published draft returns its existing pack/version without republishing or re-gating.
+func (m *VibeEvalManager) PublishDraft(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	draft, err := m.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: input.WorkspaceID, DraftID: input.DraftID})
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, draft.WorkspaceID, ActionPublishChallengePack); err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+
+	// Effect-identity idempotency: a draft that already records a published pack/version is published
+	// for its CURRENT content (UpdateDraft clears these on edit). Return it WITHOUT re-publishing or a
+	// new entitlement check — this is the retry/recovery path and must not fail on entitlement changes.
+	if draft.PublishedChallengePackID != nil && draft.PublishedChallengePackVersionID != nil {
+		return PublishVibeEvalDraftResult{
+			Draft:                  draft,
+			ChallengePackID:        *draft.PublishedChallengePackID,
+			ChallengePackVersionID: *draft.PublishedChallengePackVersionID,
+			AlreadyPublished:       true,
+		}, nil
+	}
+
+	if draft.DraftKind != "challenge_pack" {
+		return PublishVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be a challenge_pack draft to publish"}
+	}
+	if draft.ValidationState != "valid" {
+		return PublishVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be validated before publish"}
+	}
+	if m.packs == nil {
+		return PublishVibeEvalDraftResult{}, errors.New("vibe eval challenge-pack authoring is not configured")
+	}
+	bundleYAML, bundleErr := vibeEvalDraftBundleYAML(draft)
+	if bundleErr != nil {
+		_, _ = m.markVibeEvalDraftInvalid(ctx, caller, draft, bundleErr)
+		return PublishVibeEvalDraftResult{}, bundleErr
+	}
+
+	// Entitlement gate applies only to a NEW publish effect (after the already-published short-circuit).
+	if m.entitlement != nil {
+		if err := m.entitlement.CheckWorkspaceFeature(ctx, draft.WorkspaceID, billingpkg.FeaturePrivateChallengePacks); err != nil {
+			return PublishVibeEvalDraftResult{}, err
+		}
+	}
+
+	published, err := m.packs.PublishBundle(ctx, draft.WorkspaceID, bundleYAML)
+	if err != nil {
+		var validationErr ChallengePackAuthoringValidationError
+		if errors.As(err, &validationErr) {
+			validationErrors, marshalErr := json.Marshal(validationErr.Errors)
+			if marshalErr != nil {
+				return PublishVibeEvalDraftResult{}, fmt.Errorf("marshal validation errors: %w", marshalErr)
+			}
+			_, _ = m.repo.MarkVibeEvalDraftValidation(ctx, repository.MarkVibeEvalDraftValidationParams{
+				ID:               draft.ID,
+				ValidationState:  "invalid",
+				ValidationErrors: validationErrors,
+				UpdatedByUserID:  caller.UserID,
+			})
+			return PublishVibeEvalDraftResult{}, err
+		}
+		if errors.Is(err, repository.ErrChallengePackVersionExists) {
+			// Duplicate-version recovery (crash/race: the version was created but the draft was not
+			// marked published). Resolve the existing effect concretely instead of failing/republishing.
+			published, err = m.packs.ResolvePublishedBundle(ctx, draft.WorkspaceID, bundleYAML)
+			if err != nil {
+				return PublishVibeEvalDraftResult{}, err
+			}
+		} else {
+			return PublishVibeEvalDraftResult{}, err
+		}
+	}
+
+	updated, err := m.repo.MarkVibeEvalDraftPublished(ctx, repository.MarkVibeEvalDraftPublishedParams{
+		ID:                              draft.ID,
+		PublishedChallengePackID:        published.ChallengePackID,
+		PublishedChallengePackVersionID: published.ChallengePackVersionID,
+		UpdatedByUserID:                 caller.UserID,
+	})
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	return PublishVibeEvalDraftResult{
+		Draft:                  updated,
+		ChallengePackID:        published.ChallengePackID,
+		ChallengePackVersionID: published.ChallengePackVersionID,
+		EvaluationSpecID:       published.EvaluationSpecID,
+		InputSetIDs:            published.InputSetIDs,
+		BundleArtifactID:       published.BundleArtifactID,
+	}, nil
+}
+
+// PublishDraftAndAudit is the REST entrypoint: it runs PublishDraft and writes exactly ONE
+// metadata-only audit row for the REST path. The guide-tool path calls PublishDraft directly and is
+// audited by the loop — so neither path double-audits.
+func (m *VibeEvalManager) PublishDraftAndAudit(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	// Load the draft up front so the audit row has org/conversation identity even if publish fails.
+	draft, err := m.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: input.WorkspaceID, DraftID: input.DraftID})
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	result, pubErr := m.PublishDraft(ctx, caller, input)
+	m.auditRESTPublish(ctx, caller, draft, result, pubErr)
+	return result, pubErr
+}
+
+func (m *VibeEvalManager) auditRESTPublish(ctx context.Context, caller Caller, draft repository.VibeEvalDraft, result PublishVibeEvalDraftResult, pubErr error) {
+	outcome := "ok"
+	resultPayload := json.RawMessage(`{}`)
+	if pubErr != nil {
+		outcome = "error"
+	} else {
+		resultPayload, _ = json.Marshal(map[string]any{
+			"challenge_pack_id":         result.ChallengePackID,
+			"challenge_pack_version_id": result.ChallengePackVersionID,
+			"already_published":         result.AlreadyPublished,
+		})
+	}
+	requestPayload, _ := json.Marshal(map[string]any{"draft_id": draft.ID})
+	// Best-effort: audit must never fail the publish.
+	_, _ = m.repo.AppendVibeEvalToolInvocation(ctx, repository.AppendVibeEvalToolInvocationParams{
+		OrganizationID: draft.OrganizationID,
+		WorkspaceID:    draft.WorkspaceID,
+		ConversationID: draft.ConversationID,
+		ActorUserID:    caller.UserID,
+		ToolName:       "publish_draft",
+		Action:         string(ActionPublishChallengePack),
+		RiskTier:       "workspace_write",
+		RequestPayload: requestPayload,
+		ResultPayload:  resultPayload,
+		Outcome:        outcome,
+	})
 }
 
 func validVibeEvalPhase(phase string) bool {
@@ -624,6 +794,30 @@ func validateVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) 
 			"draft":  mapVibeEvalDraftResponse(result.Draft),
 			"valid":  result.Valid,
 			"errors": result.Errors,
+		})
+	}
+}
+
+func publishVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, ok := vibeEvalCallerAndWorkspace(w, r)
+		if !ok {
+			return
+		}
+		draftID, ok := parseVibeEvalURLUUID(w, "draftID", "invalid_draft_id", r)
+		if !ok {
+			return
+		}
+		result, err := service.PublishDraftAndAudit(r.Context(), caller, PublishVibeEvalDraftInput{WorkspaceID: workspaceID, DraftID: draftID})
+		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"draft":                     mapVibeEvalDraftResponse(result.Draft),
+			"challenge_pack_id":         result.ChallengePackID,
+			"challenge_pack_version_id": result.ChallengePackVersionID,
+			"already_published":         result.AlreadyPublished,
 		})
 	}
 }

--- a/backend/internal/api/vibe_eval.go
+++ b/backend/internal/api/vibe_eval.go
@@ -533,7 +533,9 @@ func handleVibeEvalError(w http.ResponseWriter, logger *slog.Logger, err error) 
 		writeError(w, http.StatusNotFound, "conversation_not_found", "vibe eval conversation not found")
 	case errors.Is(err, repository.ErrVibeEvalDraftNotFound):
 		writeError(w, http.StatusNotFound, "draft_not_found", "vibe eval draft not found")
-	case errors.Is(err, ErrForbidden):
+	case errors.Is(err, repository.ErrVibeEvalConfirmationNotFound):
+		writeError(w, http.StatusNotFound, "confirmation_not_found", "vibe eval pending confirmation not found")
+	case errors.Is(err, ErrForbidden), errors.Is(err, ErrUnauthenticated), errors.Is(err, ErrCallerMissing):
 		writeAuthzError(w, err)
 	default:
 		logger.Error("vibe eval request failed", "error", err)

--- a/backend/internal/api/vibe_eval_agent_confirmation.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/agentclash/agentclash/backend/internal/redaction"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+// vibeEvalConfirmationStore adapts the boundary-clean vibeeval.ConfirmationStore to the repository's
+// NAMED transition methods only (Approve/Deny/MarkSucceeded/MarkFailed) — never the generic sqlc
+// ones — so the engine path cannot move a confirmation to an illegal state.
+type vibeEvalConfirmationStore struct {
+	repo *repository.Repository
+}
+
+func (s vibeEvalConfirmationStore) Create(ctx context.Context, nc vibeeval.NewPendingConfirmation) (vibeeval.PendingConfirmation, error) {
+	row, err := s.repo.CreateVibeEvalPendingConfirmation(ctx, repository.CreateVibeEvalPendingConfirmationParams{
+		OrganizationID:   nc.OrganizationID,
+		WorkspaceID:      nc.WorkspaceID,
+		ConversationID:   nc.ConversationID,
+		MessageID:        nc.MessageID,
+		ProposedByUserID: nc.ProposedByUserID,
+		ToolName:         nc.ToolName,
+		ToolCallID:       nc.ToolCallID,
+		Action:           nc.Action,
+		RiskTier:         string(nc.RiskTier),
+		PayloadHash:      nc.PayloadHash,
+		BoundArgs:        nc.BoundArgs,
+		Summary:          nc.Summary,
+		ExpiresAt:        nc.ExpiresAt,
+	})
+	if err != nil {
+		return vibeeval.PendingConfirmation{}, err
+	}
+	return toVibeevalPendingConfirmation(row), nil
+}
+
+func (s vibeEvalConfirmationStore) Approve(ctx context.Context, id uuid.UUID, presentedHash string, by vibeeval.Actor) (vibeeval.PendingConfirmation, error) {
+	row, err := s.repo.ApproveVibeEvalPendingConfirmation(ctx, id, presentedHash, by.UserID)
+	if err != nil {
+		return vibeeval.PendingConfirmation{}, err
+	}
+	return toVibeevalPendingConfirmation(row), nil
+}
+
+func (s vibeEvalConfirmationStore) Deny(ctx context.Context, id uuid.UUID, presentedHash string, by vibeeval.Actor) (vibeeval.PendingConfirmation, error) {
+	row, err := s.repo.DenyVibeEvalPendingConfirmation(ctx, id, presentedHash, by.UserID)
+	if err != nil {
+		return vibeeval.PendingConfirmation{}, err
+	}
+	return toVibeevalPendingConfirmation(row), nil
+}
+
+func (s vibeEvalConfirmationStore) GetForResume(ctx context.Context, id uuid.UUID, presentedHash string) (vibeeval.PendingConfirmation, error) {
+	row, err := s.repo.GetVibeEvalPendingConfirmationForResume(ctx, id, presentedHash)
+	if err != nil {
+		return vibeeval.PendingConfirmation{}, err
+	}
+	return toVibeevalPendingConfirmation(row), nil
+}
+
+func (s vibeEvalConfirmationStore) MarkSucceeded(ctx context.Context, id uuid.UUID) error {
+	_, err := s.repo.MarkVibeEvalPendingConfirmationSucceeded(ctx, id)
+	return err
+}
+
+func (s vibeEvalConfirmationStore) MarkFailed(ctx context.Context, id uuid.UUID) error {
+	_, err := s.repo.MarkVibeEvalPendingConfirmationFailed(ctx, id)
+	return err
+}
+
+func toVibeevalPendingConfirmation(row repository.VibeEvalPendingConfirmation) vibeeval.PendingConfirmation {
+	return vibeeval.PendingConfirmation{
+		ID:             row.ID,
+		ConversationID: row.ConversationID,
+		MessageID:      row.MessageID,
+		ToolName:       row.ToolName,
+		ToolCallID:     row.ToolCallID,
+		Action:         row.Action,
+		RiskTier:       vibeeval.RiskTier(row.RiskTier),
+		PayloadHash:    row.PayloadHash,
+		BoundArgs:      row.BoundArgs,
+		Summary:        row.Summary,
+		Status:         row.Status,
+		ExpiresAt:      row.ExpiresAt,
+	}
+}
+
+// vibeEvalAuditWriter persists tool-invocation audit rows, structured-scrubbing the request/result
+// payloads (metadata only — never secrets/contents) before the repo write (#875 §6).
+type vibeEvalAuditWriter struct {
+	repo *repository.Repository
+}
+
+func (w vibeEvalAuditWriter) Append(ctx context.Context, a vibeeval.ToolInvocationAudit) error {
+	_, err := w.repo.AppendVibeEvalToolInvocation(ctx, repository.AppendVibeEvalToolInvocationParams{
+		OrganizationID: a.OrganizationID,
+		WorkspaceID:    a.WorkspaceID,
+		ConversationID: a.ConversationID,
+		MessageID:      a.MessageID,
+		ActorUserID:    a.Actor.UserID,
+		ToolName:       a.ToolName,
+		Action:         a.Action,
+		RiskTier:       string(a.RiskTier),
+		PayloadHash:    a.PayloadHash,
+		ConfirmationID: a.ConfirmationID,
+		RequestPayload: scrubStructuredJSON(a.RequestPayload),
+		ResultPayload:  scrubStructuredJSON(a.ResultPayload),
+		Outcome:        a.Outcome,
+	})
+	return err
+}
+
+// scrubStructuredJSON recursively scrubs known-secret-shaped strings out of a structured JSON value
+// using the shared Step-1 redactor, so audit payloads keep their shape (ids/keys/state) while never
+// persisting credentials or signed URLs.
+func scrubStructuredJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		b, _ := json.Marshal(redaction.ScrubHeaderSecrets(string(raw)))
+		return b
+	}
+	b, err := json.Marshal(scrubJSONValue(v))
+	if err != nil {
+		return raw
+	}
+	return b
+}
+
+func scrubJSONValue(v any) any {
+	switch t := v.(type) {
+	case string:
+		return redaction.ScrubHeaderSecrets(t)
+	case map[string]any:
+		for k, val := range t {
+			t[k] = scrubJSONValue(val)
+		}
+		return t
+	case []any:
+		for i, val := range t {
+			t[i] = scrubJSONValue(val)
+		}
+		return t
+	default:
+		return v
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_confirmation_handler_test.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation_handler_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// Finding 2: `approve` is required — a body omitting it must NOT silently deny. No DB needed: the
+// validation happens before any manager call.
+func TestResolveVibeEvalConfirmationRequiresApprove(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"payload_hash":"abc"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("workspaceID", uuid.NewString())
+	rctx.URLParams.Add("conversationID", uuid.NewString())
+	rctx.URLParams.Add("confirmationID", uuid.NewString())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	resolveVibeEvalConfirmationHandler(slog.Default(), &VibeEvalAgentManager{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "approve is required") {
+		t.Fatalf("body = %s, want approve-required validation error", rec.Body.String())
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_confirmation_handler_test.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation_handler_test.go
@@ -8,9 +8,37 @@ import (
 	"strings"
 	"testing"
 
+	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
+
+// gateErrVibeEvalService returns an entitlement GateError from the publish entrypoint.
+type gateErrVibeEvalService struct{ noopVibeEvalService }
+
+func (gateErrVibeEvalService) PublishDraftAndAudit(context.Context, Caller, PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	return PublishVibeEvalDraftResult{}, billingpkg.GateError{Decision: billingpkg.GateDecision{
+		Allowed: false, Code: billingpkg.GateCodeFeatureNotEntitled,
+		Message: "private_challenge_packs is not enabled on free", PlanKey: "free",
+	}}
+}
+
+// Follow-up to the live smoke: a blocked REST publish must return 403 (entitlement), not 500.
+func TestPublishVibeEvalDraftHandlerEntitlementReturns403(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("workspaceID", uuid.NewString())
+	rctx.URLParams.Add("draftID", uuid.NewString())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	publishVibeEvalDraftHandler(slog.Default(), gateErrVibeEvalService{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (entitlement gate); body=%s", rec.Code, rec.Body.String())
+	}
+}
 
 // Finding 2: `approve` is required — a body omitting it must NOT silently deny. No DB needed: the
 // validation happens before any manager call.

--- a/backend/internal/api/vibe_eval_agent_confirmation_integration_test.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation_integration_test.go
@@ -93,7 +93,9 @@ func TestVibeEvalManagerResolveConfirmationMatrix(t *testing.T) {
 		return pc
 	}
 	mgrWith := func(loop vibeEvalLoopRunner) *VibeEvalAgentManager {
-		return &VibeEvalAgentManager{repo: repo, loop: loop}
+		m := &VibeEvalAgentManager{repo: repo, loop: loop}
+		m.recoveryProbes = map[string]recoveryProbe{"publish_draft": m.publishEffectSucceeded}
+		return m
 	}
 
 	t.Run("approve fresh resumes with execute", func(t *testing.T) {
@@ -232,6 +234,110 @@ func TestVibeEvalManagerResolveConfirmationMatrix(t *testing.T) {
 			t.Fatalf("resolve: %v", err)
 		}
 		// Ran (message exists) but outcome unknown → conservative failed, never succeeded; no re-exec.
+		assertFinalizeNoReExecute(t, f, pc.ID, "failed")
+	})
+
+	// Publish recovery probe: ambiguous (executing, tool-result, no audit row) BUT the bound draft now
+	// records a published version → the effect succeeded; finalize succeeded, do NOT re-execute.
+	t.Run("publish recovery ambiguous with published effect marks succeeded", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		// Real pack + version rows (FK targets for the draft's published refs).
+		packID, versionID := uuid.New(), uuid.New()
+		if _, err := db.Exec(ctx, `INSERT INTO challenge_packs (id, workspace_id, slug, name, family) VALUES ($1,$2,$3,'n','f')`, packID, ws, "slug-"+packID.String()[:8]); err != nil {
+			t.Fatalf("seed pack: %v", err)
+		}
+		if _, err := db.Exec(ctx, `INSERT INTO challenge_pack_versions (id, challenge_pack_id, version_number, manifest_checksum) VALUES ($1,$2,1,'sum')`, versionID, packID); err != nil {
+			t.Fatalf("seed version: %v", err)
+		}
+		draft, err := repo.CreateVibeEvalDraft(ctx, repository.CreateVibeEvalDraftParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, DraftKind: "challenge_pack",
+			Content: []byte(`{"bundle_yaml":"name: x"}`), ValidationState: "valid", ValidationErrors: []byte("[]"),
+			CreatedByUserID: user, UpdatedByUserID: user,
+		})
+		if err != nil {
+			t.Fatalf("create draft: %v", err)
+		}
+		if _, err := repo.MarkVibeEvalDraftPublished(ctx, repository.MarkVibeEvalDraftPublishedParams{
+			ID: draft.ID, PublishedChallengePackID: packID, PublishedChallengePackVersionID: versionID, UpdatedByUserID: user,
+		}); err != nil {
+			t.Fatalf("mark published: %v", err)
+		}
+		pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, repository.CreateVibeEvalPendingConfirmationParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, ProposedByUserID: user,
+			ToolName: "publish_draft", ToolCallID: "tc-pub", Action: "publish_challenge_pack",
+			RiskTier: "workspace_write", PayloadHash: "h-pub", Summary: "s", ExpiresAt: time.Now().Add(time.Hour),
+			BoundArgs: []byte(`{"draft_id":"` + draft.ID.String() + `"}`),
+		})
+		if err != nil {
+			t.Fatalf("create confirmation: %v", err)
+		}
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-pub", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		// Tool-result message but NO audit row → ambiguous; the probe must consult the published effect.
+		if _, err := repo.AppendVibeEvalMessage(ctx, repository.AppendVibeEvalMessageParams{
+			ConversationID: conv.ID, Role: "tool", Content: "evidence", RedactionState: "applied", ToolCallID: "tc-pub", ToolName: "publish_draft",
+		}); err != nil {
+			t.Fatalf("append tool result: %v", err)
+		}
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-pub", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		assertFinalizeNoReExecute(t, f, pc.ID, "succeeded")
+	})
+
+	// Locality: a published draft that belongs to a DIFFERENT conversation must NOT be recovered as
+	// success for this confirmation — the probe enforces conversation/workspace locality.
+	t.Run("publish recovery rejects cross-conversation published draft", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		packID, versionID := uuid.New(), uuid.New()
+		if _, err := db.Exec(ctx, `INSERT INTO challenge_packs (id, workspace_id, slug, name, family) VALUES ($1,$2,$3,'n','f')`, packID, ws, "slugx-"+packID.String()[:8]); err != nil {
+			t.Fatalf("seed pack: %v", err)
+		}
+		if _, err := db.Exec(ctx, `INSERT INTO challenge_pack_versions (id, challenge_pack_id, version_number, manifest_checksum) VALUES ($1,$2,1,'sum')`, versionID, packID); err != nil {
+			t.Fatalf("seed version: %v", err)
+		}
+		otherConv, err := repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+			OrganizationID: org, WorkspaceID: ws, CreatedByUserID: user, Title: "other", Phase: "publish", Status: "active",
+		})
+		if err != nil {
+			t.Fatalf("create other conversation: %v", err)
+		}
+		draft, err := repo.CreateVibeEvalDraft(ctx, repository.CreateVibeEvalDraftParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: otherConv.ID, DraftKind: "challenge_pack",
+			Content: []byte(`{"bundle_yaml":"name: x"}`), ValidationState: "valid", ValidationErrors: []byte("[]"),
+			CreatedByUserID: user, UpdatedByUserID: user,
+		})
+		if err != nil {
+			t.Fatalf("create draft: %v", err)
+		}
+		if _, err := repo.MarkVibeEvalDraftPublished(ctx, repository.MarkVibeEvalDraftPublishedParams{
+			ID: draft.ID, PublishedChallengePackID: packID, PublishedChallengePackVersionID: versionID, UpdatedByUserID: user,
+		}); err != nil {
+			t.Fatalf("mark published: %v", err)
+		}
+		// Confirmation lives in THIS conv but is bound to the OTHER conversation's published draft.
+		pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, repository.CreateVibeEvalPendingConfirmationParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, ProposedByUserID: user,
+			ToolName: "publish_draft", ToolCallID: "tc-xconv", Action: "publish_challenge_pack",
+			RiskTier: "workspace_write", PayloadHash: "h-xconv", Summary: "s", ExpiresAt: time.Now().Add(time.Hour),
+			BoundArgs: []byte(`{"draft_id":"` + draft.ID.String() + `"}`),
+		})
+		if err != nil {
+			t.Fatalf("create confirmation: %v", err)
+		}
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-xconv", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		if _, err := repo.AppendVibeEvalMessage(ctx, repository.AppendVibeEvalMessageParams{
+			ConversationID: conv.ID, Role: "tool", Content: "evidence", RedactionState: "applied", ToolCallID: "tc-xconv", ToolName: "publish_draft",
+		}); err != nil {
+			t.Fatalf("append tool result: %v", err)
+		}
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-xconv", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		// Published, but cross-conversation → probe returns unknown → conservative failed.
 		assertFinalizeNoReExecute(t, f, pc.ID, "failed")
 	})
 }

--- a/backend/internal/api/vibe_eval_agent_confirmation_integration_test.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation_integration_test.go
@@ -1,0 +1,282 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Manager-level resolve matrix for Step 3b-2, incl. the no-double-execute guard (#875 §5.3/§5.4).
+//
+// WARNING — DESTRUCTIVE: seeds by TRUNCATEing organizations/users CASCADE. Point DATABASE_URL at a
+// DISPOSABLE database (throwaway container), never a dev/shared DB. Skips when DATABASE_URL unset.
+
+type fakeResolveLoop struct {
+	resumeApprovals []bool
+	continueCalls   int
+}
+
+func (f *fakeResolveLoop) RunTurn(context.Context, vibeeval.Actor, vibeeval.WorkspaceAuthorizer, vibeeval.Conversation, string, vibeeval.EventSink) (vibeeval.TurnResult, error) {
+	return vibeeval.TurnResult{}, nil
+}
+func (f *fakeResolveLoop) ResumeConfirmedTurn(_ context.Context, _ vibeeval.Actor, _ vibeeval.WorkspaceAuthorizer, _ vibeeval.Conversation, _ vibeeval.PendingConfirmation, approve bool, _ vibeeval.EventSink) (vibeeval.TurnResult, error) {
+	f.resumeApprovals = append(f.resumeApprovals, approve)
+	return vibeeval.TurnResult{StopReason: "completed"}, nil
+}
+func (f *fakeResolveLoop) ContinueTurn(context.Context, vibeeval.Actor, vibeeval.WorkspaceAuthorizer, vibeeval.Conversation, vibeeval.EventSink) (vibeeval.TurnResult, error) {
+	f.continueCalls++
+	return vibeeval.TurnResult{StopReason: "completed"}, nil
+}
+
+func openVibeEvalConfirmTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL is not set")
+	}
+	db, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(db.Close)
+	return db
+}
+
+func seedVibeEvalConfirmFixture(t *testing.T, ctx context.Context, db *pgxpool.Pool) (org, ws, user uuid.UUID) {
+	t.Helper()
+	if _, err := db.Exec(ctx, "TRUNCATE TABLE organizations, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	org, ws, user = uuid.New(), uuid.New(), uuid.New()
+	if _, err := db.Exec(ctx, `INSERT INTO organizations (id, name, slug) VALUES ($1,$2,$3)`, org, "Org", "org-"+org.String()[:8]); err != nil {
+		t.Fatalf("insert org: %v", err)
+	}
+	if _, err := db.Exec(ctx, `INSERT INTO workspaces (id, organization_id, name, slug) VALUES ($1,$2,$3,$4)`, ws, org, "WS", "ws-"+ws.String()[:8]); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	if _, err := db.Exec(ctx, `INSERT INTO users (id, workos_user_id, email, display_name) VALUES ($1,$2,$3,$4)`, user, "wu-"+user.String()[:8], user.String()[:8]+"@example.com", "U"); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return org, ws, user
+}
+
+func TestVibeEvalManagerResolveConfirmationMatrix(t *testing.T) {
+	ctx := context.Background()
+	db := openVibeEvalConfirmTestDB(t)
+	org, ws, user := seedVibeEvalConfirmFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	conv, err := repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+		OrganizationID: org, WorkspaceID: ws, CreatedByUserID: user, Title: "c", Phase: "author", Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateVibeEvalConversation: %v", err)
+	}
+	caller := Caller{UserID: user}
+
+	newPending := func(hash, toolCallID string) repository.VibeEvalPendingConfirmation {
+		pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, repository.CreateVibeEvalPendingConfirmationParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, ProposedByUserID: user,
+			ToolName: "publish_draft", ToolCallID: toolCallID, Action: "publish_challenge_pack",
+			RiskTier: "workspace_write", PayloadHash: hash, Summary: "s", ExpiresAt: time.Now().Add(time.Hour),
+		})
+		if err != nil {
+			t.Fatalf("CreateVibeEvalPendingConfirmation: %v", err)
+		}
+		return pc
+	}
+	mgrWith := func(loop vibeEvalLoopRunner) *VibeEvalAgentManager {
+		return &VibeEvalAgentManager{repo: repo, loop: loop}
+	}
+
+	t.Run("approve fresh resumes with execute", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-fresh", "tc-fresh")
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-fresh", nil); err != nil {
+			t.Fatalf("ResolveConfirmation: %v", err)
+		}
+		if len(f.resumeApprovals) != 1 || !f.resumeApprovals[0] || f.continueCalls != 0 {
+			t.Fatalf("want one ResumeConfirmedTurn(approve=true), got resume=%v continue=%d", f.resumeApprovals, f.continueCalls)
+		}
+	})
+
+	t.Run("deny resumes with deny", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-deny", "tc-deny")
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, false, "h-deny", nil); err != nil {
+			t.Fatalf("deny: %v", err)
+		}
+		if len(f.resumeApprovals) != 1 || f.resumeApprovals[0] {
+			t.Fatalf("want one ResumeConfirmedTurn(approve=false), got %v", f.resumeApprovals)
+		}
+	})
+
+	t.Run("hash mismatch rejects with no loop call", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-real", "tc-mismatch")
+		_, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-WRONG", nil)
+		if !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+			t.Fatalf("err = %v, want NotResolvable", err)
+		}
+		if len(f.resumeApprovals) != 0 || f.continueCalls != 0 {
+			t.Fatal("no loop call expected on hash mismatch")
+		}
+	})
+
+	t.Run("already denied rejects", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-2x", "tc-2x")
+		if _, err := repo.DenyVibeEvalPendingConfirmation(ctx, pc.ID, "h-2x", user); err != nil {
+			t.Fatalf("pre-deny: %v", err)
+		}
+		_, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-2x", nil)
+		if !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+			t.Fatalf("err = %v, want NotResolvable", err)
+		}
+	})
+
+	t.Run("claimed but effect not run re-executes", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-claim", "tc-claim")
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-claim", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		// No tool-result message exists → effect never ran → re-execute.
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-claim", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if len(f.resumeApprovals) != 1 || !f.resumeApprovals[0] || f.continueCalls != 0 {
+			t.Fatalf("want re-execute via ResumeConfirmedTurn, got resume=%v continue=%d", f.resumeApprovals, f.continueCalls)
+		}
+	})
+
+	// appendExecutionAudit records an ok/error audit row for the confirmed tool (the durable
+	// outcome evidence), plus its tool-result message — simulating a prior attempt that executed.
+	appendExecutionAudit := func(t *testing.T, pc repository.VibeEvalPendingConfirmation, outcome string) {
+		t.Helper()
+		if _, err := repo.AppendVibeEvalMessage(ctx, repository.AppendVibeEvalMessageParams{
+			ConversationID: conv.ID, Role: "tool", Content: "evidence", RedactionState: "applied", ToolCallID: pc.ToolCallID, ToolName: pc.ToolName,
+		}); err != nil {
+			t.Fatalf("append tool result: %v", err)
+		}
+		cid := pc.ID
+		if _, err := repo.AppendVibeEvalToolInvocation(ctx, repository.AppendVibeEvalToolInvocationParams{
+			OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, ActorUserID: user,
+			ToolName: pc.ToolName, Action: pc.Action, RiskTier: "workspace_write", PayloadHash: pc.PayloadHash,
+			ConfirmationID: &cid, Outcome: outcome,
+		}); err != nil {
+			t.Fatalf("append audit: %v", err)
+		}
+	}
+	assertFinalizeNoReExecute := func(t *testing.T, f *fakeResolveLoop, pcID uuid.UUID, wantStatus string) {
+		t.Helper()
+		if f.continueCalls != 1 || len(f.resumeApprovals) != 0 {
+			t.Fatalf("double-execute guard failed: continue=%d resume=%v (want continue=1, no resume)", f.continueCalls, f.resumeApprovals)
+		}
+		reloaded, err := repo.GetVibeEvalPendingConfirmationByID(ctx, pcID)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if reloaded.Status != wantStatus {
+			t.Fatalf("status = %q, want %q", reloaded.Status, wantStatus)
+		}
+	}
+
+	t.Run("no double execute, ok outcome finalizes succeeded", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-ok", "tc-ok")
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-ok", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		appendExecutionAudit(t, pc, "ok")
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-ok", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		assertFinalizeNoReExecute(t, f, pc.ID, "succeeded")
+	})
+
+	t.Run("no double execute, error outcome finalizes failed not succeeded", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-err", "tc-err")
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-err", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		appendExecutionAudit(t, pc, "error")
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-err", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		// A failed effect must NOT be promoted to succeeded.
+		assertFinalizeNoReExecute(t, f, pc.ID, "failed")
+	})
+
+	t.Run("ambiguous message-only evidence finalizes failed", func(t *testing.T) {
+		f := &fakeResolveLoop{}
+		pc := newPending("h-amb", "tc-amb")
+		if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "h-amb", user); err != nil {
+			t.Fatalf("pre-approve: %v", err)
+		}
+		// Tool-result message exists but NO audit outcome row (lost best-effort audit write).
+		if _, err := repo.AppendVibeEvalMessage(ctx, repository.AppendVibeEvalMessageParams{
+			ConversationID: conv.ID, Role: "tool", Content: "evidence", RedactionState: "applied", ToolCallID: "tc-amb", ToolName: "publish_draft",
+		}); err != nil {
+			t.Fatalf("append tool result: %v", err)
+		}
+		if _, err := mgrWith(f).ResolveConfirmation(ctx, caller, conv, pc, true, "h-amb", nil); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		// Ran (message exists) but outcome unknown → conservative failed, never succeeded; no re-exec.
+		assertFinalizeNoReExecute(t, f, pc.ID, "failed")
+	})
+}
+
+type allowAccessAuthorizer struct{}
+
+func (allowAccessAuthorizer) AuthorizeWorkspace(context.Context, Caller, uuid.UUID) error {
+	return nil
+}
+
+// Codex gate: a caller who can enter the workspace but lacks the bound action gets forbidden BEFORE
+// SSE and before any resolve transition.
+func TestVibeEvalManagerForbiddenResolve(t *testing.T) {
+	ctx := context.Background()
+	db := openVibeEvalConfirmTestDB(t)
+	org, ws, user := seedVibeEvalConfirmFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv, err := repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+		OrganizationID: org, WorkspaceID: ws, CreatedByUserID: user, Title: "c", Phase: "author", Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateVibeEvalConversation: %v", err)
+	}
+	pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, repository.CreateVibeEvalPendingConfirmationParams{
+		OrganizationID: org, WorkspaceID: ws, ConversationID: conv.ID, ProposedByUserID: user,
+		ToolName: "publish_draft", ToolCallID: "tc-f", Action: "publish_challenge_pack",
+		RiskTier: "workspace_write", PayloadHash: "h-f", Summary: "s", ExpiresAt: time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateVibeEvalPendingConfirmation: %v", err)
+	}
+
+	mgr := &VibeEvalAgentManager{authorizer: allowAccessAuthorizer{}, repo: repo}
+	// Viewer can enter the workspace but cannot publish_challenge_pack.
+	viewer := Caller{UserID: user, WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{ws: {WorkspaceID: ws, Role: RoleWorkspaceViewer}}}
+
+	if _, _, err := mgr.LoadConfirmationForResolve(ctx, viewer, ws, conv.ID, pc.ID); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+	// No resolve transition happened — the confirmation is untouched.
+	reloaded, err := repo.GetVibeEvalPendingConfirmationByID(ctx, pc.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Status != "pending" {
+		t.Fatalf("status = %q, want pending (no transition on forbidden)", reloaded.Status)
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_confirmation_scrub_test.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation_scrub_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// scrubStructuredJSON must recursively scrub header-shaped secrets out of structured audit payloads
+// while preserving shape (ids/keys/non-secret values). No DB needed.
+func TestScrubStructuredJSON(t *testing.T) {
+	in := json.RawMessage(`{"run_id":"abc-123","note":"Authorization: Bearer sk-supersecret-token","ok":true,"nested":["plain","x-api-key: leakvalue"]}`)
+	out := scrubStructuredJSON(in)
+
+	s := string(out)
+	if strings.Contains(s, "sk-supersecret-token") || strings.Contains(s, "leakvalue") {
+		t.Fatalf("secret survived scrubbing: %s", s)
+	}
+	if !strings.Contains(s, "[redacted]") {
+		t.Fatalf("expected redaction marker in scrubbed output: %s", s)
+	}
+	// Structure + non-secret values preserved.
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("scrubbed output is not valid JSON: %v", err)
+	}
+	if got["run_id"] != "abc-123" || got["ok"] != true {
+		t.Fatalf("non-secret fields changed: %+v", got)
+	}
+}
+
+// Empty / nil payloads round-trip unchanged.
+func TestScrubStructuredJSONEmpty(t *testing.T) {
+	if out := scrubStructuredJSON(nil); len(out) != 0 {
+		t.Fatalf("nil → %q, want empty", out)
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_draft_tools_test.go
+++ b/backend/internal/api/vibe_eval_agent_draft_tools_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type fakeDraftAuthor struct {
-	created  []CreateVibeEvalDraftInput
-	updated  []UpdateVibeEvalDraftInput
-	draft    repository.VibeEvalDraft // returned by Create/Update
-	getDraft repository.VibeEvalDraft // returned by GetDraft (the ownership pre-check)
+	created        []CreateVibeEvalDraftInput
+	updated        []UpdateVibeEvalDraftInput
+	validated      []ValidateVibeEvalDraftInput
+	draft          repository.VibeEvalDraft // returned by Create/Update
+	getDraft       repository.VibeEvalDraft // returned by GetDraft (the ownership pre-check)
+	validateResult ValidateVibeEvalDraftResult
 }
 
 func (f *fakeDraftAuthor) CreateDraft(_ context.Context, _ Caller, input CreateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
@@ -28,6 +30,10 @@ func (f *fakeDraftAuthor) GetDraft(_ context.Context, _ Caller, _ GetVibeEvalDra
 func (f *fakeDraftAuthor) UpdateDraft(_ context.Context, _ Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
 	f.updated = append(f.updated, input)
 	return f.draft, nil
+}
+func (f *fakeDraftAuthor) ValidateDraft(_ context.Context, _ Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
+	f.validated = append(f.validated, input)
+	return f.validateResult, nil
 }
 
 func TestCreateDraftTool(t *testing.T) {
@@ -109,5 +115,46 @@ func TestUpdateDraftToolRejectsCrossConversationDraft(t *testing.T) {
 	}
 	if len(fake.updated) != 0 {
 		t.Fatal("UpdateDraft must NOT be called for a cross-conversation draft")
+	}
+}
+
+func TestValidateDraftTool(t *testing.T) {
+	id := uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		getDraft:       repository.VibeEvalDraft{ID: id, ConversationID: conv.ID, WorkspaceID: conv.WorkspaceID, DraftKind: "challenge_pack"},
+		validateResult: ValidateVibeEvalDraftResult{Draft: repository.VibeEvalDraft{ID: id, ValidationState: "valid"}, Valid: true},
+	}
+	tool := validateDraftTool{drafts: fake}
+	if tool.RiskTier() != vibeeval.DraftTier {
+		t.Fatalf("risk tier = %q, want draft", tool.RiskTier())
+	}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	out, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fake.validated) != 1 || fake.validated[0].DraftID != id || fake.validated[0].WorkspaceID != conv.WorkspaceID {
+		t.Fatalf("ValidateDraft input mismatch: %+v", fake.validated)
+	}
+	if out.AuditResult["valid"] != true || out.AuditResult["draft_id"] != id.String() {
+		t.Fatalf("audit metadata = %+v, want valid + draft_id", out.AuditResult)
+	}
+}
+
+func TestValidateDraftToolRejectsCrossConversationDraft(t *testing.T) {
+	id := uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		getDraft: repository.VibeEvalDraft{ID: id, ConversationID: uuid.New(), WorkspaceID: conv.WorkspaceID, DraftKind: "challenge_pack"},
+	}
+	tool := validateDraftTool{drafts: fake}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	_, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`"}`))
+	if !errors.Is(err, repository.ErrVibeEvalDraftNotFound) {
+		t.Fatalf("err = %v, want ErrVibeEvalDraftNotFound", err)
+	}
+	if len(fake.validated) != 0 {
+		t.Fatal("ValidateDraft must NOT be called for a cross-conversation draft")
 	}
 }

--- a/backend/internal/api/vibe_eval_agent_draft_tools_test.go
+++ b/backend/internal/api/vibe_eval_agent_draft_tools_test.go
@@ -15,9 +15,11 @@ type fakeDraftAuthor struct {
 	created        []CreateVibeEvalDraftInput
 	updated        []UpdateVibeEvalDraftInput
 	validated      []ValidateVibeEvalDraftInput
+	published      []PublishVibeEvalDraftInput
 	draft          repository.VibeEvalDraft // returned by Create/Update
 	getDraft       repository.VibeEvalDraft // returned by GetDraft (the ownership pre-check)
 	validateResult ValidateVibeEvalDraftResult
+	publishResult  PublishVibeEvalDraftResult
 }
 
 func (f *fakeDraftAuthor) CreateDraft(_ context.Context, _ Caller, input CreateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
@@ -34,6 +36,10 @@ func (f *fakeDraftAuthor) UpdateDraft(_ context.Context, _ Caller, input UpdateV
 func (f *fakeDraftAuthor) ValidateDraft(_ context.Context, _ Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
 	f.validated = append(f.validated, input)
 	return f.validateResult, nil
+}
+func (f *fakeDraftAuthor) PublishDraft(_ context.Context, _ Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	f.published = append(f.published, input)
+	return f.publishResult, nil
 }
 
 func TestCreateDraftTool(t *testing.T) {
@@ -156,5 +162,55 @@ func TestValidateDraftToolRejectsCrossConversationDraft(t *testing.T) {
 	}
 	if len(fake.validated) != 0 {
 		t.Fatal("ValidateDraft must NOT be called for a cross-conversation draft")
+	}
+}
+
+func TestPublishDraftTool(t *testing.T) {
+	id, packID, versionID := uuid.New(), uuid.New(), uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		getDraft:      repository.VibeEvalDraft{ID: id, ConversationID: conv.ID, WorkspaceID: conv.WorkspaceID, DraftKind: "challenge_pack"},
+		publishResult: PublishVibeEvalDraftResult{Draft: repository.VibeEvalDraft{ID: id}, ChallengePackID: packID, ChallengePackVersionID: versionID},
+	}
+	tool := publishDraftTool{drafts: fake}
+	if tool.RiskTier() != vibeeval.WorkspaceWriteTier {
+		t.Fatalf("risk tier = %q, want workspace_write (confirmation-tier)", tool.RiskTier())
+	}
+	if tool.RequiredAction() != string(ActionPublishChallengePack) {
+		t.Fatalf("action = %q, want publish_challenge_pack", tool.RequiredAction())
+	}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	out, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fake.published) != 1 || fake.published[0].DraftID != id || fake.published[0].WorkspaceID != conv.WorkspaceID {
+		t.Fatalf("PublishDraft input mismatch: %+v", fake.published)
+	}
+	if out.AuditResult["challenge_pack_version_id"] != versionID.String() {
+		t.Fatalf("audit = %+v, want version id", out.AuditResult)
+	}
+	// Metadata must NOT carry bundle content.
+	for k := range out.Result.(map[string]any) {
+		if k == "bundle_yaml" || k == "content" {
+			t.Fatalf("result leaked bundle content key %q", k)
+		}
+	}
+}
+
+func TestPublishDraftToolRejectsCrossConversationDraft(t *testing.T) {
+	id := uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		getDraft: repository.VibeEvalDraft{ID: id, ConversationID: uuid.New(), WorkspaceID: conv.WorkspaceID, DraftKind: "challenge_pack"},
+	}
+	tool := publishDraftTool{drafts: fake}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	_, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`"}`))
+	if !errors.Is(err, repository.ErrVibeEvalDraftNotFound) {
+		t.Fatalf("err = %v, want ErrVibeEvalDraftNotFound", err)
+	}
+	if len(fake.published) != 0 {
+		t.Fatal("PublishDraft must NOT be called for a cross-conversation draft")
 	}
 }

--- a/backend/internal/api/vibe_eval_agent_draft_tools_test.go
+++ b/backend/internal/api/vibe_eval_agent_draft_tools_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+type fakeDraftAuthor struct {
+	created  []CreateVibeEvalDraftInput
+	updated  []UpdateVibeEvalDraftInput
+	draft    repository.VibeEvalDraft // returned by Create/Update
+	getDraft repository.VibeEvalDraft // returned by GetDraft (the ownership pre-check)
+}
+
+func (f *fakeDraftAuthor) CreateDraft(_ context.Context, _ Caller, input CreateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
+	f.created = append(f.created, input)
+	return f.draft, nil
+}
+func (f *fakeDraftAuthor) GetDraft(_ context.Context, _ Caller, _ GetVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
+	return f.getDraft, nil
+}
+func (f *fakeDraftAuthor) UpdateDraft(_ context.Context, _ Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
+	f.updated = append(f.updated, input)
+	return f.draft, nil
+}
+
+func TestCreateDraftTool(t *testing.T) {
+	id := uuid.New()
+	fake := &fakeDraftAuthor{draft: repository.VibeEvalDraft{ID: id, DraftKind: "eval_plan", ValidationState: "unknown"}}
+	tool := createDraftTool{drafts: fake}
+
+	if tool.RiskTier() != vibeeval.DraftTier {
+		t.Fatalf("risk tier = %q, want draft", tool.RiskTier())
+	}
+	if tool.RequiredAction() != string(ActionManageVibeEvalDrafts) {
+		t.Fatalf("action = %q, want manage_vibe_eval_drafts", tool.RequiredAction())
+	}
+
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New(), OrganizationID: uuid.New(), Phase: "author"}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	out, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_kind":"eval_plan","content":{"name":"p"}}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fake.created) != 1 {
+		t.Fatalf("CreateDraft calls = %d, want 1", len(fake.created))
+	}
+	got := fake.created[0]
+	if got.DraftKind != "eval_plan" || got.ConversationID != conv.ID || got.WorkspaceID != conv.WorkspaceID {
+		t.Fatalf("CreateDraft input mismatch: %+v (conv %s/%s)", got, conv.ID, conv.WorkspaceID)
+	}
+	if out.AuditResult["draft_id"] != id.String() {
+		t.Fatalf("audit draft_id = %v, want %s", out.AuditResult["draft_id"], id)
+	}
+}
+
+func TestCreateDraftToolMissingCaller(t *testing.T) {
+	tool := createDraftTool{drafts: &fakeDraftAuthor{}}
+	// No caller in context → error before any manager call.
+	_, err := tool.Execute(context.Background(), vibeeval.Actor{}, vibeeval.Conversation{ID: uuid.New()}, json.RawMessage(`{"draft_kind":"eval_plan","content":{}}`))
+	if err == nil {
+		t.Fatal("expected error when caller is missing from context")
+	}
+}
+
+func TestUpdateDraftTool(t *testing.T) {
+	id := uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		draft:    repository.VibeEvalDraft{ID: id, DraftKind: "scoring", ValidationState: "unknown"},
+		getDraft: repository.VibeEvalDraft{ID: id, ConversationID: conv.ID, WorkspaceID: conv.WorkspaceID, DraftKind: "scoring"},
+	}
+	tool := updateDraftTool{drafts: fake}
+
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	if _, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`","content":{"k":1}}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fake.updated) != 1 || fake.updated[0].DraftID != id || fake.updated[0].WorkspaceID != conv.WorkspaceID {
+		t.Fatalf("UpdateDraft input mismatch: %+v", fake.updated)
+	}
+
+	// Non-UUID draft_id is rejected before the manager call.
+	if _, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"nope","content":{}}`)); err == nil {
+		t.Fatal("expected error for non-UUID draft_id")
+	}
+}
+
+// The agent must not update a draft that belongs to a DIFFERENT conversation in the same workspace.
+func TestUpdateDraftToolRejectsCrossConversationDraft(t *testing.T) {
+	id := uuid.New()
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	fake := &fakeDraftAuthor{
+		// GetDraft returns a draft in the workspace but a DIFFERENT conversation.
+		getDraft: repository.VibeEvalDraft{ID: id, ConversationID: uuid.New(), WorkspaceID: conv.WorkspaceID, DraftKind: "scoring"},
+	}
+	tool := updateDraftTool{drafts: fake}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+
+	_, err := tool.Execute(ctx, vibeeval.Actor{}, conv, json.RawMessage(`{"draft_id":"`+id.String()+`","content":{"k":1}}`))
+	if !errors.Is(err, repository.ErrVibeEvalDraftNotFound) {
+		t.Fatalf("err = %v, want ErrVibeEvalDraftNotFound", err)
+	}
+	if len(fake.updated) != 0 {
+		t.Fatal("UpdateDraft must NOT be called for a cross-conversation draft")
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_handler.go
+++ b/backend/internal/api/vibe_eval_agent_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -68,6 +69,82 @@ func createVibeEvalTurnHandler(logger *slog.Logger, mgr *VibeEvalAgentManager) h
 				"type":  string(vibeeval.EventError),
 				"error": "turn failed",
 			})
+		}
+	}
+}
+
+// resolveVibeEvalConfirmationHandler approves or denies a pending confirmation and streams the
+// continuation turn over SSE. Ownership + bound-action authorization happen BEFORE the SSE switch
+// (so not-found/forbidden return as normal HTTP errors); the atomic resolve + execution stream.
+func resolveVibeEvalConfirmationHandler(logger *slog.Logger, mgr *VibeEvalAgentManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, ok := vibeEvalCallerAndWorkspace(w, r)
+		if !ok {
+			return
+		}
+		conversationID, ok := parseVibeEvalURLUUID(w, "conversationID", "invalid_conversation_id", r)
+		if !ok {
+			return
+		}
+		confirmationID, ok := parseVibeEvalURLUUID(w, "confirmationID", "invalid_confirmation_id", r)
+		if !ok {
+			return
+		}
+		var req struct {
+			Approve     *bool  `json:"approve"`
+			PayloadHash string `json:"payload_hash"`
+		}
+		if !decodeVibeEvalJSON(w, r, &req) {
+			return
+		}
+		// approve must be explicit — a missing field must NOT silently deny this high-impact action.
+		if req.Approve == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "approve is required")
+			return
+		}
+		if strings.TrimSpace(req.PayloadHash) == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "payload_hash is required")
+			return
+		}
+
+		conv, pc, err := mgr.LoadConfirmationForResolve(r.Context(), caller, workspaceID, conversationID, confirmationID)
+		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeError(w, http.StatusInternalServerError, "streaming_unsupported", "streaming is not supported")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		writeFrame := func(eventType string, payload any) {
+			data, err := json.Marshal(payload)
+			if err != nil {
+				return
+			}
+			fmt.Fprintf(w, "event: %s\n", eventType)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+		sink := func(e vibeeval.Event) { writeFrame(string(e.Type), e) }
+
+		if _, err := mgr.ResolveConfirmation(r.Context(), caller, conv, pc, *req.Approve, req.PayloadHash, sink); err != nil {
+			// Headers already sent — surface as an error event. The not-resolvable case (already
+			// resolved / expired / payload-hash mismatch) is a normal client outcome, not a 500.
+			msg := "resolve failed"
+			if errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+				msg = "confirmation not resolvable (already resolved, expired, or payload hash mismatch)"
+			} else {
+				logger.Error("vibe eval confirmation resolve failed", "error", err)
+			}
+			writeFrame(string(vibeeval.EventError), map[string]string{"type": string(vibeeval.EventError), "error": msg})
 		}
 	}
 }

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -25,9 +26,10 @@ type vibeEvalLoopRunner interface {
 }
 
 type VibeEvalAgentManager struct {
-	authorizer WorkspaceAuthorizer
-	repo       *repository.Repository
-	loop       vibeEvalLoopRunner
+	authorizer     WorkspaceAuthorizer
+	repo           *repository.Repository
+	loop           vibeEvalLoopRunner
+	recoveryProbes map[string]recoveryProbe // per-tool-name ambiguous-recovery effect probes
 }
 
 // NewVibeEvalAgentManager wires the read-only Step-2 agent. router is the api-server's
@@ -51,6 +53,7 @@ func NewVibeEvalAgentManager(
 		createDraftTool{drafts: drafts},
 		updateDraftTool{drafts: drafts},
 		validateDraftTool{drafts: drafts},
+		publishDraftTool{drafts: drafts},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {
@@ -70,7 +73,13 @@ func NewVibeEvalAgentManager(
 		WithConfirmationStore(vibeEvalConfirmationStore{repo: repo}).
 		WithAuditWriter(vibeEvalAuditWriter{repo: repo})
 
-	return &VibeEvalAgentManager{authorizer: authorizer, repo: repo, loop: loop}, nil
+	mgr := &VibeEvalAgentManager{authorizer: authorizer, repo: repo, loop: loop}
+	// publish_draft is idempotent by effect identity → its ambiguous-recovery probe consults the
+	// draft's published version rather than re-executing.
+	mgr.recoveryProbes = map[string]recoveryProbe{
+		"publish_draft": mgr.publishEffectSucceeded,
+	}
+	return mgr, nil
 }
 
 // AuthorizeTurn checks the caller may run a guide turn in the workspace (member+). The
@@ -187,13 +196,55 @@ func (m *VibeEvalAgentManager) ResolveConfirmation(ctx context.Context, caller C
 		return vibeeval.TurnResult{}, err
 	}
 	if ran {
-		if err := m.finalizeRanConfirmation(ctx, pc.ID, false); err != nil {
+		// Narrow per-tool recovery probe: an idempotent write tool (e.g. publish_draft) can confirm
+		// its effect succeeded from durable effect state — a stronger signal than the lost audit row.
+		// It never re-executes (re-entering ResumeConfirmedTurn would duplicate the tool_call_id in
+		// the transcript). Unknown → keep the conservative failed fallback.
+		succeeded := false
+		if probe, ok := m.recoveryProbes[executing.ToolName]; ok {
+			s, perr := probe(ctx, executing)
+			if perr != nil {
+				return vibeeval.TurnResult{}, perr
+			}
+			succeeded = s
+		}
+		if err := m.finalizeRanConfirmation(ctx, pc.ID, succeeded); err != nil {
 			return vibeeval.TurnResult{}, err
 		}
 		return m.loop.ContinueTurn(ctx, actor, authz, vconv, sink)
 	}
 	// Claimed but the effect never ran (crash before execution) → safe to execute now.
 	return m.loop.ResumeConfirmedTurn(ctx, actor, authz, vconv, toVibeevalPendingConfirmation(executing), true, sink)
+}
+
+// recoveryProbe reports whether an ambiguous (executing, no audit row) confirmation's effect actually
+// succeeded, by consulting the tool's durable effect state. (false, nil) means "unknown" → the caller
+// keeps the conservative failed fallback.
+type recoveryProbe func(ctx context.Context, pc repository.VibeEvalPendingConfirmation) (bool, error)
+
+// publishEffectSucceeded is the publish_draft recovery probe: the effect succeeded iff the bound
+// draft now records a published challenge-pack version (effect identity) AND belongs to THIS
+// confirmation's conversation+workspace — the same locality the live tool path enforces, so a bound
+// draft_id from another conversation/workspace can never be recovered as success here.
+func (m *VibeEvalAgentManager) publishEffectSucceeded(ctx context.Context, pc repository.VibeEvalPendingConfirmation) (bool, error) {
+	var args struct {
+		DraftID string `json:"draft_id"`
+	}
+	if err := json.Unmarshal(pc.BoundArgs, &args); err != nil {
+		return false, nil
+	}
+	draftID, err := uuid.Parse(args.DraftID)
+	if err != nil {
+		return false, nil
+	}
+	draft, err := m.repo.GetVibeEvalDraftByID(ctx, draftID)
+	if err != nil {
+		return false, nil
+	}
+	if draft.ConversationID != pc.ConversationID || draft.WorkspaceID != pc.WorkspaceID {
+		return false, nil
+	}
+	return draft.PublishedChallengePackVersionID != nil, nil
 }
 
 // finalizeRanConfirmation marks an already-executed confirmation succeeded or failed. A

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
@@ -14,10 +15,19 @@ import (
 // vibeeval loop with a repo-backed MessageStore, the read-only tool adapters, the shared
 // provider router, and the AgentClash-owned guide model — and bridges the authenticated
 // api.Caller into the loop per turn. The vibeeval core never imports api (§11.1).
+// vibeEvalLoopRunner is the slice of *vibeeval.AgentLoop the manager drives. Kept as an interface
+// so the resolve/no-double-execute decision logic is unit-testable with a fake loop + real repo
+// (provider.Router is a concrete struct, so the real loop can't run scripted models in a test).
+type vibeEvalLoopRunner interface {
+	RunTurn(ctx context.Context, actor vibeeval.Actor, authorizer vibeeval.WorkspaceAuthorizer, conv vibeeval.Conversation, userMessage string, sink vibeeval.EventSink) (vibeeval.TurnResult, error)
+	ResumeConfirmedTurn(ctx context.Context, actor vibeeval.Actor, authorizer vibeeval.WorkspaceAuthorizer, conv vibeeval.Conversation, pc vibeeval.PendingConfirmation, approve bool, sink vibeeval.EventSink) (vibeeval.TurnResult, error)
+	ContinueTurn(ctx context.Context, actor vibeeval.Actor, authorizer vibeeval.WorkspaceAuthorizer, conv vibeeval.Conversation, sink vibeeval.EventSink) (vibeeval.TurnResult, error)
+}
+
 type VibeEvalAgentManager struct {
 	authorizer WorkspaceAuthorizer
 	repo       *repository.Repository
-	loop       *vibeeval.AgentLoop
+	loop       vibeEvalLoopRunner
 }
 
 // NewVibeEvalAgentManager wires the read-only Step-2 agent. router is the api-server's
@@ -52,7 +62,9 @@ func NewVibeEvalAgentManager(
 		vibeeval.NewEvidenceRedactor(),
 		vibeeval.GuideModel{ProviderKey: cfg.ProviderKey, Model: cfg.Model, CredentialReference: cfg.CredentialReference},
 		vibeeval.DefaultLimits(),
-	)
+	).
+		WithConfirmationStore(vibeEvalConfirmationStore{repo: repo}).
+		WithAuditWriter(vibeEvalAuditWriter{repo: repo})
 
 	return &VibeEvalAgentManager{authorizer: authorizer, repo: repo, loop: loop}, nil
 }
@@ -90,6 +102,123 @@ func (m *VibeEvalAgentManager) RunTurn(ctx context.Context, caller Caller, works
 	authz := vibeEvalAuthorizer{authorizer: m.authorizer, caller: caller}
 	actor := vibeeval.Actor{UserID: caller.UserID}
 	return m.loop.RunTurn(ctx, actor, authz, vconv, userMessage, sink)
+}
+
+// LoadConfirmationForResolve loads the conversation + pending confirmation, verifies both belong to
+// the workspace, and authorizes the confirmation's BOUND action for the caller. The handler calls
+// this BEFORE switching to SSE, so a not-found/forbidden returns as a normal HTTP error.
+func (m *VibeEvalAgentManager) LoadConfirmationForResolve(ctx context.Context, caller Caller, workspaceID, conversationID, confirmationID uuid.UUID) (repository.VibeEvalConversation, repository.VibeEvalPendingConfirmation, error) {
+	conv, err := m.repo.GetVibeEvalConversationByID(ctx, conversationID)
+	if err != nil {
+		return repository.VibeEvalConversation{}, repository.VibeEvalPendingConfirmation{}, err
+	}
+	if conv.WorkspaceID != workspaceID {
+		return repository.VibeEvalConversation{}, repository.VibeEvalPendingConfirmation{}, repository.ErrVibeEvalConversationNotFound
+	}
+	pc, err := m.repo.GetVibeEvalPendingConfirmationByID(ctx, confirmationID)
+	if err != nil {
+		return repository.VibeEvalConversation{}, repository.VibeEvalPendingConfirmation{}, err
+	}
+	if pc.WorkspaceID != workspaceID || pc.ConversationID != conversationID {
+		return repository.VibeEvalConversation{}, repository.VibeEvalPendingConfirmation{}, repository.ErrVibeEvalConfirmationNotFound
+	}
+	// Authorize the action the confirmation will perform (e.g. publish_challenge_pack), not just the
+	// turn-level manage-drafts gate.
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, Action(pc.Action)); err != nil {
+		return repository.VibeEvalConversation{}, repository.VibeEvalPendingConfirmation{}, err
+	}
+	return conv, pc, nil
+}
+
+// ResolveConfirmation atomically approves or denies a pending confirmation and streams the
+// continuation turn. On approve it follows the crash-safe retry algorithm: claim (pending →
+// executing); if already claimed, re-enter ONLY if the effect has not already run (no double
+// execute) — otherwise finalize and continue. conv/pc come from LoadConfirmationForResolve.
+func (m *VibeEvalAgentManager) ResolveConfirmation(ctx context.Context, caller Caller, conv repository.VibeEvalConversation, pc repository.VibeEvalPendingConfirmation, approve bool, presentedHash string, sink vibeeval.EventSink) (vibeeval.TurnResult, error) {
+	vconv := vibeeval.Conversation{ID: conv.ID, WorkspaceID: conv.WorkspaceID, OrganizationID: conv.OrganizationID, Phase: conv.Phase}
+	authz := vibeEvalAuthorizer{authorizer: m.authorizer, caller: caller}
+	actor := vibeeval.Actor{UserID: caller.UserID}
+
+	if !approve {
+		denied, err := m.repo.DenyVibeEvalPendingConfirmation(ctx, pc.ID, presentedHash, caller.UserID)
+		if err != nil {
+			return vibeeval.TurnResult{}, err // ErrVibeEvalConfirmationNotResolvable → handler 409
+		}
+		return m.loop.ResumeConfirmedTurn(ctx, actor, authz, vconv, toVibeevalPendingConfirmation(denied), false, sink)
+	}
+
+	// Approve: atomic claim pending → executing.
+	approved, err := m.repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, presentedHash, caller.UserID)
+	if err == nil {
+		return m.loop.ResumeConfirmedTurn(ctx, actor, authz, vconv, toVibeevalPendingConfirmation(approved), true, sink)
+	}
+	if !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		return vibeeval.TurnResult{}, err
+	}
+
+	// Not freshly resolvable: a prior attempt may have claimed it. Re-enter ONLY if it is still
+	// executing for the same payload hash; otherwise it is denied/succeeded/expired/mismatch → reject.
+	executing, gerr := m.repo.GetVibeEvalPendingConfirmationForResume(ctx, pc.ID, presentedHash)
+	if gerr != nil {
+		return vibeeval.TurnResult{}, gerr
+	}
+	// No-double-execute guard: if the confirmed effect already ran, do NOT re-run it — finalize
+	// OUTCOME-AWARELY (never promote a failed/ambiguous effect to succeeded) and let the model
+	// respond over the existing history.
+	outcome, found, err := m.repo.GetVibeEvalConfirmedToolOutcome(ctx, pc.ID)
+	if err != nil {
+		return vibeeval.TurnResult{}, err
+	}
+	if found {
+		if err := m.finalizeRanConfirmation(ctx, pc.ID, outcome == "ok"); err != nil {
+			return vibeeval.TurnResult{}, err
+		}
+		return m.loop.ContinueTurn(ctx, actor, authz, vconv, sink)
+	}
+	// No durable audit outcome. Fall back to message-only evidence (weaker): if a tool-result for
+	// the confirmed call exists, the effect ran but the outcome is unknown (lost audit write) —
+	// treat as ambiguous: finalize as FAILED (never succeeded) and do NOT re-execute.
+	ran, err := m.confirmedToolResultExists(ctx, conv.ID, executing.ToolCallID)
+	if err != nil {
+		return vibeeval.TurnResult{}, err
+	}
+	if ran {
+		if err := m.finalizeRanConfirmation(ctx, pc.ID, false); err != nil {
+			return vibeeval.TurnResult{}, err
+		}
+		return m.loop.ContinueTurn(ctx, actor, authz, vconv, sink)
+	}
+	// Claimed but the effect never ran (crash before execution) → safe to execute now.
+	return m.loop.ResumeConfirmedTurn(ctx, actor, authz, vconv, toVibeevalPendingConfirmation(executing), true, sink)
+}
+
+// finalizeRanConfirmation marks an already-executed confirmation succeeded or failed. A
+// not-resolvable result is benign (a concurrent finalizer won the terminal transition).
+func (m *VibeEvalAgentManager) finalizeRanConfirmation(ctx context.Context, id uuid.UUID, succeeded bool) error {
+	var err error
+	if succeeded {
+		_, err = m.repo.MarkVibeEvalPendingConfirmationSucceeded(ctx, id)
+	} else {
+		_, err = m.repo.MarkVibeEvalPendingConfirmationFailed(ctx, id)
+	}
+	if err != nil && !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		return err
+	}
+	return nil
+}
+
+// confirmedToolResultExists reports whether a tool-result message exists for toolCallID.
+func (m *VibeEvalAgentManager) confirmedToolResultExists(ctx context.Context, conversationID uuid.UUID, toolCallID string) (bool, error) {
+	msgs, err := m.repo.ListVibeEvalMessagesByConversationID(ctx, conversationID)
+	if err != nil {
+		return false, err
+	}
+	for _, msg := range msgs {
+		if msg.Role == "tool" && msg.ToolCallID == toolCallID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // AuthorizeRead checks the caller may read the workspace (viewer+). Used for the

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -50,6 +50,7 @@ func NewVibeEvalAgentManager(
 		listChallengePacksTool{packs: packs},
 		createDraftTool{drafts: drafts},
 		updateDraftTool{drafts: drafts},
+		validateDraftTool{drafts: drafts},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -41,12 +41,15 @@ func NewVibeEvalAgentManager(
 	runs runStatusReader,
 	scorecards scorecardReader,
 	packs challengePackLister,
+	drafts vibeEvalDraftAuthor,
 ) (*VibeEvalAgentManager, error) {
 	registry := vibeeval.NewRegistry()
 	tools := []vibeeval.Tool{
 		getRunStatusTool{runs: runs},
 		readScorecardTool{scorecards: scorecards},
 		listChallengePacksTool{packs: packs},
+		createDraftTool{drafts: drafts},
+		updateDraftTool{drafts: drafts},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {

--- a/backend/internal/api/vibe_eval_agent_tools.go
+++ b/backend/internal/api/vibe_eval_agent_tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/vibeeval"
 	"github.com/google/uuid"
 )
@@ -30,6 +31,119 @@ type scorecardReader interface {
 // middleware populates — so the guide tool needs no explicit workspace argument.
 type challengePackLister interface {
 	ListChallengePacks(ctx context.Context) (ListChallengePacksResult, error)
+}
+
+// vibeEvalDraftAuthor is the manager surface the draft-authoring tools wrap. The guide tool and the
+// REST handlers call the SAME manager methods (Q2 — one source of truth for auth/validation/audit).
+type vibeEvalDraftAuthor interface {
+	CreateDraft(ctx context.Context, caller Caller, input CreateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+}
+
+const draftKindEnumJSON = `{"type":"string","enum":["eval_plan","challenge_pack","input_cases","scoring","runtime"]}`
+
+func draftToolOutput(draft repository.VibeEvalDraft) vibeeval.ToolOutput {
+	return vibeeval.ToolOutput{
+		Result: map[string]any{
+			"draft_id":         draft.ID.String(),
+			"draft_kind":       draft.DraftKind,
+			"validation_state": draft.ValidationState,
+		},
+		AuditResult: map[string]any{"draft_id": draft.ID.String(), "draft_kind": draft.DraftKind},
+	}
+}
+
+// --- create_draft (draft tier, no confirmation, audited) ---
+
+type createDraftTool struct{ drafts vibeEvalDraftAuthor }
+
+func (createDraftTool) Name() string                { return "create_draft" }
+func (createDraftTool) Phases() []string            { return []string{vibeeval.PhasePlan, vibeeval.PhaseAuthor} }
+func (createDraftTool) RiskTier() vibeeval.RiskTier { return vibeeval.DraftTier }
+func (createDraftTool) RequiredAction() string      { return string(ActionManageVibeEvalDrafts) }
+func (createDraftTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "create_draft",
+		Description: "Create a draft artifact in the current conversation and make it the active draft.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["draft_kind","content"],"properties":{"draft_kind":` + draftKindEnumJSON + `,"content":{"type":"object","description":"the draft body"}}}`),
+	}
+}
+
+func (t createDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in struct {
+		DraftKind string          `json:"draft_kind"`
+		Content   json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	draft, err := t.drafts.CreateDraft(ctx, caller, CreateVibeEvalDraftInput{
+		WorkspaceID:    conv.WorkspaceID,
+		ConversationID: conv.ID,
+		DraftKind:      in.DraftKind,
+		Content:        in.Content,
+	})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	return draftToolOutput(draft), nil
+}
+
+// --- update_draft (draft tier, no confirmation, audited) ---
+
+type updateDraftTool struct{ drafts vibeEvalDraftAuthor }
+
+func (updateDraftTool) Name() string                { return "update_draft" }
+func (updateDraftTool) Phases() []string            { return []string{vibeeval.PhasePlan, vibeeval.PhaseAuthor} }
+func (updateDraftTool) RiskTier() vibeeval.RiskTier { return vibeeval.DraftTier }
+func (updateDraftTool) RequiredAction() string      { return string(ActionManageVibeEvalDrafts) }
+func (updateDraftTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "update_draft",
+		Description: "Replace the content of an existing draft by its UUID.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["draft_id","content"],"properties":{"draft_id":{"type":"string","description":"draft UUID"},"content":{"type":"object","description":"the new draft body"}}}`),
+	}
+}
+
+func (t updateDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in struct {
+		DraftID string          `json:"draft_id"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	draftID, err := uuid.Parse(in.DraftID)
+	if err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("draft_id is not a UUID: %w", err)
+	}
+	// The shared manager UpdateDraft is workspace-scoped; confine the AGENT to drafts of THIS
+	// conversation, so it can't mutate another conversation's draft just by knowing the UUID.
+	current, err := t.drafts.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: conv.WorkspaceID, DraftID: draftID})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	if current.ConversationID != conv.ID {
+		return vibeeval.ToolOutput{}, repository.ErrVibeEvalDraftNotFound
+	}
+	draft, err := t.drafts.UpdateDraft(ctx, caller, UpdateVibeEvalDraftInput{
+		WorkspaceID: conv.WorkspaceID,
+		DraftID:     draftID,
+		Content:     in.Content,
+	})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	return draftToolOutput(draft), nil
 }
 
 // --- get_run_status ---
@@ -112,8 +226,10 @@ func (t readScorecardTool) Execute(ctx context.Context, _ vibeeval.Actor, _ vibe
 
 type listChallengePacksTool struct{ packs challengePackLister }
 
-func (listChallengePacksTool) Name() string                { return "list_challenge_packs" }
-func (listChallengePacksTool) Phases() []string            { return []string{vibeeval.PhasePlan, vibeeval.PhaseAuthor} }
+func (listChallengePacksTool) Name() string { return "list_challenge_packs" }
+func (listChallengePacksTool) Phases() []string {
+	return []string{vibeeval.PhasePlan, vibeeval.PhaseAuthor}
+}
 func (listChallengePacksTool) RiskTier() vibeeval.RiskTier { return vibeeval.ReadTier }
 func (listChallengePacksTool) RequiredAction() string      { return string(ActionReadWorkspace) }
 func (listChallengePacksTool) Definition() provider.ToolDefinition {

--- a/backend/internal/api/vibe_eval_agent_tools.go
+++ b/backend/internal/api/vibe_eval_agent_tools.go
@@ -39,6 +39,7 @@ type vibeEvalDraftAuthor interface {
 	CreateDraft(ctx context.Context, caller Caller, input CreateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+	ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error)
 }
 
 const draftKindEnumJSON = `{"type":"string","enum":["eval_plan","challenge_pack","input_cases","scoring","runtime"]}`
@@ -144,6 +145,58 @@ func (t updateDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vib
 		return vibeeval.ToolOutput{}, err
 	}
 	return draftToolOutput(draft), nil
+}
+
+// --- validate_draft (draft tier, no confirmation, audited) ---
+
+type validateDraftTool struct{ drafts vibeEvalDraftAuthor }
+
+func (validateDraftTool) Name() string { return "validate_draft" }
+func (validateDraftTool) Phases() []string {
+	return []string{vibeeval.PhaseAuthor, vibeeval.PhaseValidate}
+}
+func (validateDraftTool) RiskTier() vibeeval.RiskTier { return vibeeval.DraftTier }
+func (validateDraftTool) RequiredAction() string      { return string(ActionManageVibeEvalDrafts) }
+func (validateDraftTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "validate_draft",
+		Description: "Validate a challenge_pack draft's bundle and record its validation state and errors.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["draft_id"],"properties":{"draft_id":{"type":"string","description":"draft UUID"}}}`),
+	}
+}
+
+func (t validateDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in struct {
+		DraftID string `json:"draft_id"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	draftID, err := uuid.Parse(in.DraftID)
+	if err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("draft_id is not a UUID: %w", err)
+	}
+	// Conversation locality: the agent may only validate drafts of THIS conversation.
+	current, err := t.drafts.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: conv.WorkspaceID, DraftID: draftID})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	if current.ConversationID != conv.ID {
+		return vibeeval.ToolOutput{}, repository.ErrVibeEvalDraftNotFound
+	}
+	res, err := t.drafts.ValidateDraft(ctx, caller, ValidateVibeEvalDraftInput{WorkspaceID: conv.WorkspaceID, DraftID: draftID})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	return vibeeval.ToolOutput{
+		// Structured validation metadata only — never the bundle content.
+		Result:      map[string]any{"draft_id": res.Draft.ID.String(), "valid": res.Valid, "validation_state": res.Draft.ValidationState, "errors": res.Errors},
+		AuditResult: map[string]any{"draft_id": res.Draft.ID.String(), "valid": res.Valid, "error_count": len(res.Errors)},
+	}, nil
 }
 
 // --- get_run_status ---

--- a/backend/internal/api/vibe_eval_agent_tools.go
+++ b/backend/internal/api/vibe_eval_agent_tools.go
@@ -40,6 +40,7 @@ type vibeEvalDraftAuthor interface {
 	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error)
+	PublishDraft(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error)
 }
 
 const draftKindEnumJSON = `{"type":"string","enum":["eval_plan","challenge_pack","input_cases","scoring","runtime"]}`
@@ -197,6 +198,59 @@ func (t validateDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv v
 		Result:      map[string]any{"draft_id": res.Draft.ID.String(), "valid": res.Valid, "validation_state": res.Draft.ValidationState, "errors": res.Errors},
 		AuditResult: map[string]any{"draft_id": res.Draft.ID.String(), "valid": res.Valid, "error_count": len(res.Errors)},
 	}, nil
+}
+
+// --- publish_draft (workspace_write tier → confirmation required; loop audits) ---
+
+type publishDraftTool struct{ drafts vibeEvalDraftAuthor }
+
+func (publishDraftTool) Name() string                { return "publish_draft" }
+func (publishDraftTool) Phases() []string            { return []string{vibeeval.PhasePublish} }
+func (publishDraftTool) RiskTier() vibeeval.RiskTier { return vibeeval.WorkspaceWriteTier }
+func (publishDraftTool) RequiredAction() string      { return string(ActionPublishChallengePack) }
+func (publishDraftTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "publish_draft",
+		Description: "Publish a validated challenge_pack draft as a runnable challenge pack. Requires confirmation.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["draft_id"],"properties":{"draft_id":{"type":"string","description":"draft UUID"}}}`),
+	}
+}
+
+func (t publishDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in struct {
+		DraftID string `json:"draft_id"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	draftID, err := uuid.Parse(in.DraftID)
+	if err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("draft_id is not a UUID: %w", err)
+	}
+	// Conversation locality: the agent may only publish drafts of THIS conversation.
+	current, err := t.drafts.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: conv.WorkspaceID, DraftID: draftID})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	if current.ConversationID != conv.ID {
+		return vibeeval.ToolOutput{}, repository.ErrVibeEvalDraftNotFound
+	}
+	res, err := t.drafts.PublishDraft(ctx, caller, PublishVibeEvalDraftInput{WorkspaceID: conv.WorkspaceID, DraftID: draftID})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	// Metadata-only — IDs and state, never bundle content.
+	meta := map[string]any{
+		"draft_id":                  res.Draft.ID.String(),
+		"challenge_pack_id":         res.ChallengePackID.String(),
+		"challenge_pack_version_id": res.ChallengePackVersionID.String(),
+		"already_published":         res.AlreadyPublished,
+	}
+	return vibeeval.ToolOutput{Result: meta, AuditResult: meta}, nil
 }
 
 // --- get_run_status ---

--- a/backend/internal/api/vibe_eval_publish_draft_test.go
+++ b/backend/internal/api/vibe_eval_publish_draft_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeVibeEvalEntitlement struct {
+	err   error
+	calls int
+}
+
+func (f *fakeVibeEvalEntitlement) CheckWorkspaceFeature(context.Context, uuid.UUID, string) error {
+	f.calls++
+	return f.err
+}
+
+// seedValidChallengePackDraft seeds a challenge_pack draft already in validation_state=valid.
+func seedValidChallengePackDraft(repo *fakeVibeEvalRepo, ws, convID uuid.UUID) repository.VibeEvalDraft {
+	d := seedVibeEvalDraft(repo, ws, convID, "challenge_pack", `{"bundle_yaml":"name: x"}`)
+	d.ValidationState = "valid"
+	repo.drafts[d.ID] = d
+	return d
+}
+
+func newPublishMgr(repo *fakeVibeEvalRepo, packs *fakeVibeEvalPacks, gate *fakeVibeEvalEntitlement) *VibeEvalManager {
+	return NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(packs).WithEntitlementGate(gate)
+}
+
+func TestVibeEvalManager_PublishDraftSuccess(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	packID, versionID := uuid.New(), uuid.New()
+	packs := &fakeVibeEvalPacks{publishResp: PublishChallengePackResponse{ChallengePackID: packID, ChallengePackVersionID: versionID}}
+	gate := &fakeVibeEvalEntitlement{}
+	mgr := newPublishMgr(repo, packs, gate)
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	res, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("PublishDraft: %v", err)
+	}
+	if res.ChallengePackID != packID || res.ChallengePackVersionID != versionID || res.AlreadyPublished {
+		t.Fatalf("result = %+v, want new publish with IDs", res)
+	}
+	if packs.publishes != 1 || gate.calls != 1 {
+		t.Fatalf("publishes=%d gate=%d, want 1/1", packs.publishes, gate.calls)
+	}
+	got := repo.drafts[draft.ID]
+	if got.PublishedChallengePackVersionID == nil || *got.PublishedChallengePackVersionID != versionID {
+		t.Fatalf("draft not marked published: %+v", got.PublishedChallengePackVersionID)
+	}
+}
+
+func TestVibeEvalManager_PublishDraftInvalidBundle(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	packs := &fakeVibeEvalPacks{publishErr: ChallengePackAuthoringValidationError{Errors: []validationErrorDetail{{Field: "pack.slug", Message: "required"}}}}
+	mgr := newPublishMgr(repo, packs, &fakeVibeEvalEntitlement{})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	var verr ChallengePackAuthoringValidationError
+	if _, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); !errors.As(err, &verr) {
+		t.Fatalf("err = %v, want ChallengePackAuthoringValidationError", err)
+	}
+	if repo.drafts[draft.ID].ValidationState != "invalid" {
+		t.Fatalf("draft state = %q, want invalid after failed publish", repo.drafts[draft.ID].ValidationState)
+	}
+}
+
+func TestVibeEvalManager_PublishDraftForbidden(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := newPublishMgr(repo, &fakeVibeEvalPacks{}, &fakeVibeEvalEntitlement{})
+	viewer := vibeEvalCaller(user, ws, RoleWorkspaceViewer)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	if _, err := mgr.PublishDraft(context.Background(), viewer, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestVibeEvalManager_PublishDraftEntitlementBlocked(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	packs := &fakeVibeEvalPacks{}
+	gate := &fakeVibeEvalEntitlement{err: errors.New("entitlement denied")}
+	mgr := newPublishMgr(repo, packs, gate)
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	if _, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); err == nil {
+		t.Fatal("expected entitlement error")
+	}
+	if packs.publishes != 0 {
+		t.Fatalf("publishes=%d, want 0 (blocked before publish)", packs.publishes)
+	}
+}
+
+func TestVibeEvalManager_PublishDraftAlreadyPublishedIsIdempotent(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	packs := &fakeVibeEvalPacks{}
+	gate := &fakeVibeEvalEntitlement{}
+	mgr := newPublishMgr(repo, packs, gate)
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+	// Already published (effect identity recorded).
+	packID, versionID := uuid.New(), uuid.New()
+	d := repo.drafts[draft.ID]
+	d.PublishedChallengePackID = &packID
+	d.PublishedChallengePackVersionID = &versionID
+	repo.drafts[draft.ID] = d
+
+	res, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("PublishDraft: %v", err)
+	}
+	if !res.AlreadyPublished || res.ChallengePackVersionID != versionID {
+		t.Fatalf("result = %+v, want already-published with existing version", res)
+	}
+	if packs.publishes != 0 || gate.calls != 0 {
+		t.Fatalf("publishes=%d gate=%d, want 0/0 (no republish, no re-gate)", packs.publishes, gate.calls)
+	}
+}
+
+func TestVibeEvalManager_UpdateAfterPublishClearsRefs(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := newPublishMgr(repo, &fakeVibeEvalPacks{publishResp: PublishChallengePackResponse{ChallengePackID: uuid.New(), ChallengePackVersionID: uuid.New()}}, &fakeVibeEvalEntitlement{})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	if _, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); err != nil {
+		t.Fatalf("PublishDraft: %v", err)
+	}
+	if repo.drafts[draft.ID].PublishedChallengePackVersionID == nil {
+		t.Fatal("precondition: draft should be published")
+	}
+	// Editing content must clear the published refs (stale effect identity prevention).
+	if _, err := mgr.UpdateDraft(context.Background(), caller, UpdateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID, Content: []byte(`{"bundle_yaml":"name: y"}`)}); err != nil {
+		t.Fatalf("UpdateDraft: %v", err)
+	}
+	if repo.drafts[draft.ID].PublishedChallengePackVersionID != nil {
+		t.Fatal("update-after-publish must clear published refs")
+	}
+}
+
+func TestVibeEvalManager_PublishDraftDuplicateVersionRecovery(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	existingPack, existingVersion := uuid.New(), uuid.New()
+	packs := &fakeVibeEvalPacks{
+		publishErr:  repository.ErrChallengePackVersionExists,
+		resolveResp: PublishChallengePackResponse{ChallengePackID: existingPack, ChallengePackVersionID: existingVersion},
+	}
+	mgr := newPublishMgr(repo, packs, &fakeVibeEvalEntitlement{})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	res, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("duplicate-version recovery must resolve, not fail: %v", err)
+	}
+	if res.ChallengePackVersionID != existingVersion {
+		t.Fatalf("result version = %s, want existing %s", res.ChallengePackVersionID, existingVersion)
+	}
+	got := repo.drafts[draft.ID]
+	if got.PublishedChallengePackVersionID == nil || *got.PublishedChallengePackVersionID != existingVersion {
+		t.Fatalf("draft not marked published with existing version: %+v", got.PublishedChallengePackVersionID)
+	}
+}
+
+func TestVibeEvalManager_PublishDraftAndAuditExactlyOnce(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	packs := &fakeVibeEvalPacks{publishResp: PublishChallengePackResponse{ChallengePackID: uuid.New(), ChallengePackVersionID: uuid.New()}}
+	mgr := newPublishMgr(repo, packs, &fakeVibeEvalEntitlement{})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedValidChallengePackDraft(repo, ws, uuid.New())
+
+	// Plain PublishDraft (the tool path; the loop audits) must NOT write a manager audit row.
+	if _, err := mgr.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); err != nil {
+		t.Fatalf("PublishDraft: %v", err)
+	}
+	if len(repo.toolAudits) != 0 {
+		t.Fatalf("plain PublishDraft wrote %d audit rows, want 0 (loop audits the tool path)", len(repo.toolAudits))
+	}
+
+	// REST entrypoint writes exactly one metadata-only audit row.
+	draft2 := seedValidChallengePackDraft(repo, ws, uuid.New())
+	if _, err := mgr.PublishDraftAndAudit(context.Background(), caller, PublishVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft2.ID}); err != nil {
+		t.Fatalf("PublishDraftAndAudit: %v", err)
+	}
+	if len(repo.toolAudits) != 1 {
+		t.Fatalf("REST publish wrote %d audit rows, want exactly 1", len(repo.toolAudits))
+	}
+	row := repo.toolAudits[0]
+	if row.ToolName != "publish_draft" || row.Action != string(ActionPublishChallengePack) || row.RiskTier != "workspace_write" || row.Outcome != "ok" {
+		t.Fatalf("audit row = %+v, want publish_draft/publish_challenge_pack/workspace_write/ok", row)
+	}
+	if row.ConversationID != draft2.ConversationID || row.OrganizationID != org {
+		t.Fatalf("audit identity mismatch: %+v", row)
+	}
+}

--- a/backend/internal/api/vibe_eval_test.go
+++ b/backend/internal/api/vibe_eval_test.go
@@ -179,6 +179,12 @@ type fakeVibeEvalRepo struct {
 	now           time.Time
 	conversations map[uuid.UUID]repository.VibeEvalConversation
 	drafts        map[uuid.UUID]repository.VibeEvalDraft
+	toolAudits    []repository.AppendVibeEvalToolInvocationParams
+}
+
+func (r *fakeVibeEvalRepo) AppendVibeEvalToolInvocation(_ context.Context, params repository.AppendVibeEvalToolInvocationParams) (repository.VibeEvalToolInvocation, error) {
+	r.toolAudits = append(r.toolAudits, params)
+	return repository.VibeEvalToolInvocation{}, nil
 }
 
 func newFakeVibeEvalRepo(orgID, workspaceID uuid.UUID) *fakeVibeEvalRepo {
@@ -288,6 +294,26 @@ func (r *fakeVibeEvalRepo) UpdateVibeEvalDraft(_ context.Context, params reposit
 	item.Content = params.Content
 	item.ValidationState = params.ValidationState
 	item.ValidationErrors = params.ValidationErrors
+	// Editing content unpublishes the draft (matches the UpdateVibeEvalDraft query).
+	item.PublishedChallengePackID = nil
+	item.PublishedChallengePackVersionID = nil
+	item.UpdatedByUserID = params.UpdatedByUserID
+	item.UpdatedAt = r.now.Add(time.Second)
+	r.drafts[item.ID] = item
+	return item, nil
+}
+
+func (r *fakeVibeEvalRepo) MarkVibeEvalDraftPublished(_ context.Context, params repository.MarkVibeEvalDraftPublishedParams) (repository.VibeEvalDraft, error) {
+	item, ok := r.drafts[params.ID]
+	if !ok {
+		return repository.VibeEvalDraft{}, repository.ErrVibeEvalDraftNotFound
+	}
+	packID := params.PublishedChallengePackID
+	versionID := params.PublishedChallengePackVersionID
+	item.ValidationState = "valid"
+	item.ValidationErrors = []byte("[]")
+	item.PublishedChallengePackID = &packID
+	item.PublishedChallengePackVersionID = &versionID
 	item.UpdatedByUserID = params.UpdatedByUserID
 	item.UpdatedAt = r.now.Add(time.Second)
 	r.drafts[item.ID] = item

--- a/backend/internal/api/vibe_eval_test.go
+++ b/backend/internal/api/vibe_eval_test.go
@@ -293,3 +293,16 @@ func (r *fakeVibeEvalRepo) UpdateVibeEvalDraft(_ context.Context, params reposit
 	r.drafts[item.ID] = item
 	return item, nil
 }
+
+func (r *fakeVibeEvalRepo) MarkVibeEvalDraftValidation(_ context.Context, params repository.MarkVibeEvalDraftValidationParams) (repository.VibeEvalDraft, error) {
+	item, ok := r.drafts[params.ID]
+	if !ok {
+		return repository.VibeEvalDraft{}, repository.ErrVibeEvalDraftNotFound
+	}
+	item.ValidationState = params.ValidationState
+	item.ValidationErrors = params.ValidationErrors
+	item.UpdatedByUserID = params.UpdatedByUserID
+	item.UpdatedAt = r.now.Add(time.Second)
+	r.drafts[item.ID] = item
+	return item, nil
+}

--- a/backend/internal/api/vibe_eval_validate_draft_test.go
+++ b/backend/internal/api/vibe_eval_validate_draft_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeBundleValidator struct {
+	resp ValidateChallengePackResponse
+	err  error
+}
+
+func (f fakeBundleValidator) ValidateBundle(context.Context, uuid.UUID, []byte) (ValidateChallengePackResponse, error) {
+	return f.resp, f.err
+}
+
+func seedVibeEvalDraft(repo *fakeVibeEvalRepo, ws, convID uuid.UUID, kind, content string) repository.VibeEvalDraft {
+	id := uuid.New()
+	d := repository.VibeEvalDraft{
+		ID: id, OrganizationID: repo.orgID, WorkspaceID: ws, ConversationID: convID,
+		DraftKind: kind, Content: json.RawMessage(content), ValidationState: "unknown",
+	}
+	repo.drafts[id] = d
+	return d
+}
+
+func TestVibeEvalManager_ValidateDraftValid(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
+
+	res, err := mgr.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("ValidateDraft: %v", err)
+	}
+	if !res.Valid || res.Draft.ValidationState != "valid" || len(res.Errors) != 0 {
+		t.Fatalf("result = %+v, want valid", res)
+	}
+	if repo.drafts[draft.ID].ValidationState != "valid" {
+		t.Fatalf("persisted state = %q, want valid", repo.drafts[draft.ID].ValidationState)
+	}
+}
+
+func TestVibeEvalManager_ValidateDraftInvalid(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{
+		Valid:  false,
+		Errors: []validationErrorDetail{{Field: "pack.slug", Message: "required"}},
+	}})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"broken"}`)
+
+	res, err := mgr.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("ValidateDraft: %v", err)
+	}
+	if res.Valid || res.Draft.ValidationState != "invalid" || len(res.Errors) != 1 {
+		t.Fatalf("result = %+v, want invalid with one error", res)
+	}
+}
+
+func TestVibeEvalManager_ValidateDraftMissingBundleIsInvalid(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	// Bundle validator should NOT be consulted — the missing bundle is invalid before that.
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{err: errors.New("should not be called")})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"notes":"no bundle here"}`)
+
+	res, err := mgr.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID})
+	if err != nil {
+		t.Fatalf("missing bundle must be an invalid RESULT, not an error: %v", err)
+	}
+	if res.Valid || res.Draft.ValidationState != "invalid" || len(res.Errors) != 1 || res.Errors[0].Field != "bundle_yaml" {
+		t.Fatalf("result = %+v, want invalid with one bundle_yaml error", res)
+	}
+	if repo.drafts[draft.ID].ValidationState != "invalid" {
+		t.Fatalf("persisted state = %q, want invalid", repo.drafts[draft.ID].ValidationState)
+	}
+}
+
+func TestVibeEvalManager_ValidateDraftForbidden(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	// Viewer can read but cannot manage drafts.
+	viewer := vibeEvalCaller(user, ws, RoleWorkspaceViewer)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
+
+	if _, err := mgr.ValidateDraft(context.Background(), viewer, ValidateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestVibeEvalManager_ValidateDraftWrongWorkspace(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
+
+	// Ask under a different workspace → not found (ownership).
+	if _, err := mgr.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{WorkspaceID: uuid.New(), DraftID: draft.ID}); !errors.Is(err, repository.ErrVibeEvalDraftNotFound) {
+		t.Fatalf("err = %v, want ErrVibeEvalDraftNotFound", err)
+	}
+}
+
+func TestVibeEvalManager_ValidateDraftWrongKind(t *testing.T) {
+	ws, org, user := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeVibeEvalRepo(org, ws)
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
+	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "eval_plan", `{"bundle_yaml":"name: x"}`)
+
+	var verr VibeEvalValidationError
+	if _, err := mgr.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{WorkspaceID: ws, DraftID: draft.ID}); !errors.As(err, &verr) {
+		t.Fatalf("err = %v, want VibeEvalValidationError (non-challenge_pack)", err)
+	}
+}

--- a/backend/internal/api/vibe_eval_validate_draft_test.go
+++ b/backend/internal/api/vibe_eval_validate_draft_test.go
@@ -10,13 +10,28 @@ import (
 	"github.com/google/uuid"
 )
 
-type fakeBundleValidator struct {
+// fakeVibeEvalPacks fakes the challenge-pack authoring surface (validate/publish/resolve).
+type fakeVibeEvalPacks struct {
 	resp ValidateChallengePackResponse
 	err  error
+
+	publishResp PublishChallengePackResponse
+	publishErr  error
+	publishes   int
+
+	resolveResp PublishChallengePackResponse
+	resolveErr  error
 }
 
-func (f fakeBundleValidator) ValidateBundle(context.Context, uuid.UUID, []byte) (ValidateChallengePackResponse, error) {
+func (f *fakeVibeEvalPacks) ValidateBundle(context.Context, uuid.UUID, []byte) (ValidateChallengePackResponse, error) {
 	return f.resp, f.err
+}
+func (f *fakeVibeEvalPacks) PublishBundle(context.Context, uuid.UUID, []byte) (PublishChallengePackResponse, error) {
+	f.publishes++
+	return f.publishResp, f.publishErr
+}
+func (f *fakeVibeEvalPacks) ResolvePublishedBundle(context.Context, uuid.UUID, []byte) (PublishChallengePackResponse, error) {
+	return f.resolveResp, f.resolveErr
 }
 
 func seedVibeEvalDraft(repo *fakeVibeEvalRepo, ws, convID uuid.UUID, kind, content string) repository.VibeEvalDraft {
@@ -32,7 +47,7 @@ func seedVibeEvalDraft(repo *fakeVibeEvalRepo, ws, convID uuid.UUID, kind, conte
 func TestVibeEvalManager_ValidateDraftValid(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{resp: ValidateChallengePackResponse{Valid: true}})
 	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
 	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
 
@@ -51,7 +66,7 @@ func TestVibeEvalManager_ValidateDraftValid(t *testing.T) {
 func TestVibeEvalManager_ValidateDraftInvalid(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{resp: ValidateChallengePackResponse{
 		Valid:  false,
 		Errors: []validationErrorDetail{{Field: "pack.slug", Message: "required"}},
 	}})
@@ -71,7 +86,7 @@ func TestVibeEvalManager_ValidateDraftMissingBundleIsInvalid(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
 	// Bundle validator should NOT be consulted — the missing bundle is invalid before that.
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{err: errors.New("should not be called")})
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{err: errors.New("should not be called")})
 	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
 	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"notes":"no bundle here"}`)
 
@@ -90,7 +105,7 @@ func TestVibeEvalManager_ValidateDraftMissingBundleIsInvalid(t *testing.T) {
 func TestVibeEvalManager_ValidateDraftForbidden(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{resp: ValidateChallengePackResponse{Valid: true}})
 	// Viewer can read but cannot manage drafts.
 	viewer := vibeEvalCaller(user, ws, RoleWorkspaceViewer)
 	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
@@ -103,7 +118,7 @@ func TestVibeEvalManager_ValidateDraftForbidden(t *testing.T) {
 func TestVibeEvalManager_ValidateDraftWrongWorkspace(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{resp: ValidateChallengePackResponse{Valid: true}})
 	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
 	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "challenge_pack", `{"bundle_yaml":"name: x"}`)
 
@@ -116,7 +131,7 @@ func TestVibeEvalManager_ValidateDraftWrongWorkspace(t *testing.T) {
 func TestVibeEvalManager_ValidateDraftWrongKind(t *testing.T) {
 	ws, org, user := uuid.New(), uuid.New(), uuid.New()
 	repo := newFakeVibeEvalRepo(org, ws)
-	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithBundleValidator(fakeBundleValidator{resp: ValidateChallengePackResponse{Valid: true}})
+	mgr := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo).WithChallengePackAuthoring(&fakeVibeEvalPacks{resp: ValidateChallengePackResponse{Valid: true}})
 	caller := vibeEvalCaller(user, ws, RoleWorkspaceMember)
 	draft := seedVibeEvalDraft(repo, ws, uuid.New(), "eval_plan", `{"bundle_yaml":"name: x"}`)
 

--- a/backend/internal/repository/challenge_pack_authoring.go
+++ b/backend/internal/repository/challenge_pack_authoring.go
@@ -277,6 +277,53 @@ func (r *Repository) PublishChallengePackBundle(ctx context.Context, params Publ
 	return published, nil
 }
 
+// ResolvePublishedChallengePackBundle resolves the existing published identity (pack, version, spec,
+// input sets) for a bundle's (workspace, slug, version_number). It is used to recover the effect
+// after a duplicate-version publish (crash/race) — without republishing. The bundle artifact is not
+// part of the effect identity and is left nil. ErrChallengePackVersionExists is returned when no such
+// version is found (the caller should not have reached recovery in that case).
+func (r *Repository) ResolvePublishedChallengePackBundle(ctx context.Context, workspaceID uuid.UUID, slug string, versionNumber int32) (PublishedChallengePack, error) {
+	var packID, versionID, specID uuid.UUID
+	if err := r.db.QueryRow(ctx, `
+		SELECT
+			cpv.challenge_pack_id,
+			cpv.id,
+			(SELECT es.id FROM evaluation_specs es WHERE es.challenge_pack_version_id = cpv.id LIMIT 1)
+		FROM challenge_pack_versions cpv
+		JOIN challenge_packs cp ON cp.id = cpv.challenge_pack_id
+		WHERE cp.workspace_id = $1 AND cp.slug = $2 AND cpv.version_number = $3
+	`, workspaceID, slug, versionNumber).Scan(&packID, &versionID, &specID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PublishedChallengePack{}, ErrChallengePackVersionExists
+		}
+		return PublishedChallengePack{}, fmt.Errorf("resolve published challenge pack version: %w", err)
+	}
+
+	rows, err := r.db.Query(ctx, `SELECT id FROM challenge_input_sets WHERE challenge_pack_version_id = $1 ORDER BY input_key`, versionID)
+	if err != nil {
+		return PublishedChallengePack{}, fmt.Errorf("resolve published input sets: %w", err)
+	}
+	defer rows.Close()
+	inputSetIDs := make([]uuid.UUID, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return PublishedChallengePack{}, fmt.Errorf("scan published input set: %w", err)
+		}
+		inputSetIDs = append(inputSetIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return PublishedChallengePack{}, fmt.Errorf("iterate published input sets: %w", err)
+	}
+
+	return PublishedChallengePack{
+		ChallengePackID:        packID,
+		ChallengePackVersionID: versionID,
+		EvaluationSpecID:       specID,
+		InputSetIDs:            inputSetIDs,
+	}, nil
+}
+
 func resolveOrCreateChallengePack(ctx context.Context, tx pgx.Tx, workspaceID uuid.UUID, bundle challengepack.Bundle) (uuid.UUID, error) {
 	var (
 		packID         uuid.UUID

--- a/backend/internal/repository/sqlc/models.go
+++ b/backend/internal/repository/sqlc/models.go
@@ -681,6 +681,47 @@ type VibeEvalMessage struct {
 	CreatedAt      pgtype.Timestamptz
 }
 
+type VibeEvalPendingConfirmation struct {
+	ID               uuid.UUID
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
+	ConversationID   uuid.UUID
+	MessageID        *uuid.UUID
+	ProposedByUserID uuid.UUID
+	ToolName         string
+	ToolCallID       string
+	Action           string
+	RiskTier         string
+	PayloadHash      string
+	BoundArgs        []byte
+	Summary          string
+	Estimate         []byte
+	Status           string
+	ResolvedByUserID *uuid.UUID
+	ResolvedAt       pgtype.Timestamptz
+	ExpiresAt        pgtype.Timestamptz
+	CreatedAt        pgtype.Timestamptz
+}
+
+type VibeEvalToolInvocation struct {
+	ID                  uuid.UUID
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ConversationID      uuid.UUID
+	MessageID           *uuid.UUID
+	ActorUserID         uuid.UUID
+	ToolName            string
+	Action              string
+	RiskTier            string
+	PayloadHash         string
+	ConfirmationID      *uuid.UUID
+	RequestPayload      []byte
+	ResultPayload       []byte
+	CreditReservationID *uuid.UUID
+	Outcome             string
+	CreatedAt           pgtype.Timestamptz
+}
+
 type WorkspaceRegressionCase struct {
 	ID                           uuid.UUID
 	SuiteID                      uuid.UUID

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -115,6 +115,10 @@ type Querier interface {
 	GetRunComparisonByRunIDs(ctx context.Context, arg GetRunComparisonByRunIDsParams) (RunComparison, error)
 	GetRunScorecardByRunID(ctx context.Context, arg GetRunScorecardByRunIDParams) (RunScorecard, error)
 	GetRunnableChallengePackVersionByID(ctx context.Context, arg GetRunnableChallengePackVersionByIDParams) (ChallengePackVersion, error)
+	// The durable, outcome-aware execution result for a confirmation: the latest ok/error audit row
+	// (the confirmation_required propose row is excluded). 0 rows ⇒ the confirmed effect never ran (or
+	// ran but its best-effort audit write was lost — the caller treats that ambiguity conservatively).
+	GetVibeEvalConfirmedToolOutcome(ctx context.Context, arg GetVibeEvalConfirmedToolOutcomeParams) (string, error)
 	GetVibeEvalConversationByID(ctx context.Context, arg GetVibeEvalConversationByIDParams) (VibeEvalConversation, error)
 	GetVibeEvalDraftByID(ctx context.Context, arg GetVibeEvalDraftByIDParams) (VibeEvalDraft, error)
 	GetVibeEvalPendingConfirmationByID(ctx context.Context, arg GetVibeEvalPendingConfirmationByIDParams) (VibeEvalPendingConfirmation, error)

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -205,6 +205,8 @@ type Querier interface {
 	MarkHostedRunExecutionAccepted(ctx context.Context, arg MarkHostedRunExecutionAcceptedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionFailed(ctx context.Context, arg MarkHostedRunExecutionFailedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionTimedOut(ctx context.Context, arg MarkHostedRunExecutionTimedOutParams) (HostedRunExecution, error)
+	// Content-preserving validation update (validate_draft) — sets only validation state/errors.
+	MarkVibeEvalDraftValidation(ctx context.Context, arg MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error)
 	// Terminal transition after the bound effect runs: 'executing' -> 'succeeded' | 'failed'.
 	// Conditioned on status='executing' so a crashed/retried effect transitions exactly once.
 	MarkVibeEvalPendingConfirmationResult(ctx context.Context, arg MarkVibeEvalPendingConfirmationResultParams) (VibeEvalPendingConfirmation, error)

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -205,6 +205,7 @@ type Querier interface {
 	MarkHostedRunExecutionAccepted(ctx context.Context, arg MarkHostedRunExecutionAcceptedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionFailed(ctx context.Context, arg MarkHostedRunExecutionFailedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionTimedOut(ctx context.Context, arg MarkHostedRunExecutionTimedOutParams) (HostedRunExecution, error)
+	MarkVibeEvalDraftPublished(ctx context.Context, arg MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error)
 	// Content-preserving validation update (validate_draft) — sets only validation state/errors.
 	MarkVibeEvalDraftValidation(ctx context.Context, arg MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error)
 	// Terminal transition after the bound effect runs: 'executing' -> 'succeeded' | 'failed'.
@@ -238,6 +239,8 @@ type Querier interface {
 	UpdatePlaygroundTestCase(ctx context.Context, arg UpdatePlaygroundTestCaseParams) (PlaygroundTestCase, error)
 	UpdateRunAgentStatus(ctx context.Context, arg UpdateRunAgentStatusParams) (RunAgent, error)
 	UpdateRunStatus(ctx context.Context, arg UpdateRunStatusParams) (Run, error)
+	// Editing content unpublishes the draft: the published refs are cleared so a stale published
+	// version can never be reused as an idempotency signal for changed content (3c-3 effect identity).
 	UpdateVibeEvalDraft(ctx context.Context, arg UpdateVibeEvalDraftParams) (VibeEvalDraft, error)
 	UpsertBillingAccount(ctx context.Context, arg UpsertBillingAccountParams) error
 	UpsertBillingSubscription(ctx context.Context, arg UpsertBillingSubscriptionParams) (BillingSubscription, error)

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -11,6 +11,9 @@ import (
 )
 
 type Querier interface {
+	// Append-only audit row for one draft+ tool call (#875 §6). request_payload/result_payload are
+	// audit-scrubbed metadata only. confirmation_id is a soft reference (no FK).
+	AppendVibeEvalToolInvocation(ctx context.Context, arg AppendVibeEvalToolInvocationParams) (VibeEvalToolInvocation, error)
 	ApplyHostedRunEvent(ctx context.Context, arg ApplyHostedRunEventParams) (HostedRunExecution, error)
 	ArchiveDataset(ctx context.Context, arg ArchiveDatasetParams) (Dataset, error)
 	AttachRunToEvalSession(ctx context.Context, arg AttachRunToEvalSessionParams) (Run, error)
@@ -58,8 +61,15 @@ type Querier interface {
 	CreateRunCaseSelection(ctx context.Context, arg CreateRunCaseSelectionParams) (RunCaseSelection, error)
 	CreateVibeEvalConversation(ctx context.Context, arg CreateVibeEvalConversationParams) (VibeEvalConversation, error)
 	CreateVibeEvalDraft(ctx context.Context, arg CreateVibeEvalDraftParams) (VibeEvalDraft, error)
+	// Propose half of the confirmation engine (#875 §5.3). bound_args is the verbatim args to
+	// execute on approve; payload_hash binds the confirmation to exactly those args.
+	CreateVibeEvalPendingConfirmation(ctx context.Context, arg CreateVibeEvalPendingConfirmationParams) (VibeEvalPendingConfirmation, error)
 	DeletePlayground(ctx context.Context, arg DeletePlaygroundParams) error
 	DeletePlaygroundTestCase(ctx context.Context, arg DeletePlaygroundTestCaseParams) error
+	// Transition lapsed 'pending' rows for a conversation to 'expired' so they leave the active
+	// partial unique index and stop blocking re-proposal (#875 §5.3). The create path runs this in
+	// the same tx before inserting.
+	ExpireStaleVibeEvalPendingConfirmations(ctx context.Context, arg ExpireStaleVibeEvalPendingConfirmationsParams) ([]VibeEvalPendingConfirmation, error)
 	FindOrganizationByDodoSubscriptionOrCustomer(ctx context.Context, arg FindOrganizationByDodoSubscriptionOrCustomerParams) (uuid.UUID, error)
 	FinishBillingWebhookEvent(ctx context.Context, arg FinishBillingWebhookEventParams) (int64, error)
 	GetAgentBuildByID(ctx context.Context, arg GetAgentBuildByIDParams) (AgentBuild, error)
@@ -107,6 +117,10 @@ type Querier interface {
 	GetRunnableChallengePackVersionByID(ctx context.Context, arg GetRunnableChallengePackVersionByIDParams) (ChallengePackVersion, error)
 	GetVibeEvalConversationByID(ctx context.Context, arg GetVibeEvalConversationByIDParams) (VibeEvalConversation, error)
 	GetVibeEvalDraftByID(ctx context.Context, arg GetVibeEvalDraftByIDParams) (VibeEvalDraft, error)
+	GetVibeEvalPendingConfirmationByID(ctx context.Context, arg GetVibeEvalPendingConfirmationByIDParams) (VibeEvalPendingConfirmation, error)
+	// Crash-safe re-entry: returns the row only if it is still 'executing' and the presented hash
+	// matches, so a retried POST can resume effect execution exactly once. 0 rows => not resumable.
+	GetVibeEvalPendingConfirmationForResume(ctx context.Context, arg GetVibeEvalPendingConfirmationForResumeParams) (VibeEvalPendingConfirmation, error)
 	GetWorkspaceUsageWindowRaceCount(ctx context.Context, arg GetWorkspaceUsageWindowRaceCountParams) (int32, error)
 	InsertDatasetBaseline(ctx context.Context, arg InsertDatasetBaselineParams) (DatasetBaseline, error)
 	InsertDatasetExample(ctx context.Context, arg InsertDatasetExampleParams) (DatasetExample, error)
@@ -169,6 +183,7 @@ type Querier interface {
 	ListVibeEvalConversationsByWorkspaceID(ctx context.Context, arg ListVibeEvalConversationsByWorkspaceIDParams) ([]VibeEvalConversation, error)
 	ListVibeEvalDraftsByConversationID(ctx context.Context, arg ListVibeEvalDraftsByConversationIDParams) ([]VibeEvalDraft, error)
 	ListVibeEvalMessagesByConversationID(ctx context.Context, arg ListVibeEvalMessagesByConversationIDParams) ([]VibeEvalMessage, error)
+	ListVibeEvalToolInvocationsByConversationID(ctx context.Context, arg ListVibeEvalToolInvocationsByConversationIDParams) ([]VibeEvalToolInvocation, error)
 	LockActiveDatasetForVersion(ctx context.Context, arg LockActiveDatasetForVersionParams) (uuid.UUID, error)
 	// Step 1 of a two-statement append (run inside a repository transaction). Locks the
 	// conversation row FOR NO KEY UPDATE so concurrent appends to the same conversation serialize.
@@ -186,12 +201,19 @@ type Querier interface {
 	MarkHostedRunExecutionAccepted(ctx context.Context, arg MarkHostedRunExecutionAcceptedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionFailed(ctx context.Context, arg MarkHostedRunExecutionFailedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionTimedOut(ctx context.Context, arg MarkHostedRunExecutionTimedOutParams) (HostedRunExecution, error)
+	// Terminal transition after the bound effect runs: 'executing' -> 'succeeded' | 'failed'.
+	// Conditioned on status='executing' so a crashed/retried effect transitions exactly once.
+	MarkVibeEvalPendingConfirmationResult(ctx context.Context, arg MarkVibeEvalPendingConfirmationResultParams) (VibeEvalPendingConfirmation, error)
 	NextDatasetVersionNumber(ctx context.Context, arg NextDatasetVersionNumberParams) (int32, error)
 	PatchDataset(ctx context.Context, arg PatchDatasetParams) (Dataset, error)
 	PatchDatasetExample(ctx context.Context, arg PatchDatasetExampleParams) (DatasetExample, error)
 	PatchRegressionCase(ctx context.Context, arg PatchRegressionCaseParams) (WorkspaceRegressionCase, error)
 	PatchRegressionSuite(ctx context.Context, arg PatchRegressionSuiteParams) (WorkspaceRegressionSuite, error)
 	RecordDatasetEvalRun(ctx context.Context, arg RecordDatasetEvalRunParams) (DatasetEvalRun, error)
+	// Atomic, single-use transition out of 'pending' (#875 §5.3). Only the request that matches a
+	// still-pending, unexpired row with the presented payload_hash wins (0 rows => already resolved,
+	// expired, or hash mismatch => reject). @new_status is 'executing' (approve) or 'denied' (deny).
+	ResolveVibeEvalPendingConfirmation(ctx context.Context, arg ResolveVibeEvalPendingConfirmationParams) (VibeEvalPendingConfirmation, error)
 	ResolveWorkspaceOrganization(ctx context.Context, arg ResolveWorkspaceOrganizationParams) (uuid.UUID, error)
 	SetAgentTryoutRunID(ctx context.Context, arg SetAgentTryoutRunIDParams) (AgentTryout, error)
 	SetDatasetGenerationJobTemporalIDs(ctx context.Context, arg SetDatasetGenerationJobTemporalIDsParams) (DatasetGenerationJob, error)

--- a/backend/internal/repository/sqlc/vibe_eval.sql.go
+++ b/backend/internal/repository/sqlc/vibe_eval.sql.go
@@ -854,6 +854,51 @@ func (q *Queries) LockVibeEvalConversationForAppend(ctx context.Context, arg Loc
 	return i, err
 }
 
+const markVibeEvalDraftValidation = `-- name: MarkVibeEvalDraftValidation :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = $1,
+    validation_errors = $2,
+    updated_by_user_id = $3
+WHERE id = $4
+RETURNING id, organization_id, workspace_id, conversation_id, draft_kind, content, validation_state, validation_errors, published_challenge_pack_id, published_challenge_pack_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at
+`
+
+type MarkVibeEvalDraftValidationParams struct {
+	ValidationState  string
+	ValidationErrors []byte
+	UpdatedByUserID  uuid.UUID
+	ID               uuid.UUID
+}
+
+// Content-preserving validation update (validate_draft) — sets only validation state/errors.
+func (q *Queries) MarkVibeEvalDraftValidation(ctx context.Context, arg MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error) {
+	row := q.db.QueryRow(ctx, markVibeEvalDraftValidation,
+		arg.ValidationState,
+		arg.ValidationErrors,
+		arg.UpdatedByUserID,
+		arg.ID,
+	)
+	var i VibeEvalDraft
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.DraftKind,
+		&i.Content,
+		&i.ValidationState,
+		&i.ValidationErrors,
+		&i.PublishedChallengePackID,
+		&i.PublishedChallengePackVersionID,
+		&i.CreatedByUserID,
+		&i.UpdatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const markVibeEvalPendingConfirmationResult = `-- name: MarkVibeEvalPendingConfirmationResult :one
 UPDATE vibe_eval_pending_confirmations
 SET status = $1

--- a/backend/internal/repository/sqlc/vibe_eval.sql.go
+++ b/backend/internal/repository/sqlc/vibe_eval.sql.go
@@ -384,6 +384,29 @@ func (q *Queries) ExpireStaleVibeEvalPendingConfirmations(ctx context.Context, a
 	return items, nil
 }
 
+const getVibeEvalConfirmedToolOutcome = `-- name: GetVibeEvalConfirmedToolOutcome :one
+SELECT outcome
+FROM vibe_eval_tool_invocations
+WHERE confirmation_id = $1
+  AND outcome IN ('ok', 'error')
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+type GetVibeEvalConfirmedToolOutcomeParams struct {
+	ConfirmationID *uuid.UUID
+}
+
+// The durable, outcome-aware execution result for a confirmation: the latest ok/error audit row
+// (the confirmation_required propose row is excluded). 0 rows ⇒ the confirmed effect never ran (or
+// ran but its best-effort audit write was lost — the caller treats that ambiguity conservatively).
+func (q *Queries) GetVibeEvalConfirmedToolOutcome(ctx context.Context, arg GetVibeEvalConfirmedToolOutcomeParams) (string, error) {
+	row := q.db.QueryRow(ctx, getVibeEvalConfirmedToolOutcome, arg.ConfirmationID)
+	var outcome string
+	err := row.Scan(&outcome)
+	return outcome, err
+}
+
 const getVibeEvalConversationByID = `-- name: GetVibeEvalConversationByID :one
 SELECT id, organization_id, workspace_id, created_by_user_id, title, phase, status, active_draft_id, created_at, updated_at, archived_at
 FROM vibe_eval_conversations

--- a/backend/internal/repository/sqlc/vibe_eval.sql.go
+++ b/backend/internal/repository/sqlc/vibe_eval.sql.go
@@ -9,7 +9,102 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const appendVibeEvalToolInvocation = `-- name: AppendVibeEvalToolInvocation :one
+INSERT INTO vibe_eval_tool_invocations (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    message_id,
+    actor_user_id,
+    tool_name,
+    action,
+    risk_tier,
+    payload_hash,
+    confirmation_id,
+    request_payload,
+    result_payload,
+    credit_reservation_id,
+    outcome
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10,
+    $11,
+    $12,
+    $13,
+    $14
+)
+RETURNING id, organization_id, workspace_id, conversation_id, message_id, actor_user_id, tool_name, action, risk_tier, payload_hash, confirmation_id, request_payload, result_payload, credit_reservation_id, outcome, created_at
+`
+
+type AppendVibeEvalToolInvocationParams struct {
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ConversationID      uuid.UUID
+	MessageID           *uuid.UUID
+	ActorUserID         uuid.UUID
+	ToolName            string
+	Action              string
+	RiskTier            string
+	PayloadHash         string
+	ConfirmationID      *uuid.UUID
+	RequestPayload      []byte
+	ResultPayload       []byte
+	CreditReservationID *uuid.UUID
+	Outcome             string
+}
+
+// Append-only audit row for one draft+ tool call (#875 §6). request_payload/result_payload are
+// audit-scrubbed metadata only. confirmation_id is a soft reference (no FK).
+func (q *Queries) AppendVibeEvalToolInvocation(ctx context.Context, arg AppendVibeEvalToolInvocationParams) (VibeEvalToolInvocation, error) {
+	row := q.db.QueryRow(ctx, appendVibeEvalToolInvocation,
+		arg.OrganizationID,
+		arg.WorkspaceID,
+		arg.ConversationID,
+		arg.MessageID,
+		arg.ActorUserID,
+		arg.ToolName,
+		arg.Action,
+		arg.RiskTier,
+		arg.PayloadHash,
+		arg.ConfirmationID,
+		arg.RequestPayload,
+		arg.ResultPayload,
+		arg.CreditReservationID,
+		arg.Outcome,
+	)
+	var i VibeEvalToolInvocation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ActorUserID,
+		&i.ToolName,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.ConfirmationID,
+		&i.RequestPayload,
+		&i.ResultPayload,
+		&i.CreditReservationID,
+		&i.Outcome,
+		&i.CreatedAt,
+	)
+	return i, err
+}
 
 const createVibeEvalConversation = `-- name: CreateVibeEvalConversation :one
 INSERT INTO vibe_eval_conversations (
@@ -136,6 +231,159 @@ func (q *Queries) CreateVibeEvalDraft(ctx context.Context, arg CreateVibeEvalDra
 	return i, err
 }
 
+const createVibeEvalPendingConfirmation = `-- name: CreateVibeEvalPendingConfirmation :one
+INSERT INTO vibe_eval_pending_confirmations (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    message_id,
+    proposed_by_user_id,
+    tool_name,
+    tool_call_id,
+    action,
+    risk_tier,
+    payload_hash,
+    bound_args,
+    summary,
+    estimate,
+    expires_at
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10,
+    $11,
+    $12,
+    $13,
+    $14
+)
+RETURNING id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+`
+
+type CreateVibeEvalPendingConfirmationParams struct {
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
+	ConversationID   uuid.UUID
+	MessageID        *uuid.UUID
+	ProposedByUserID uuid.UUID
+	ToolName         string
+	ToolCallID       string
+	Action           string
+	RiskTier         string
+	PayloadHash      string
+	BoundArgs        []byte
+	Summary          string
+	Estimate         []byte
+	ExpiresAt        pgtype.Timestamptz
+}
+
+// Propose half of the confirmation engine (#875 §5.3). bound_args is the verbatim args to
+// execute on approve; payload_hash binds the confirmation to exactly those args.
+func (q *Queries) CreateVibeEvalPendingConfirmation(ctx context.Context, arg CreateVibeEvalPendingConfirmationParams) (VibeEvalPendingConfirmation, error) {
+	row := q.db.QueryRow(ctx, createVibeEvalPendingConfirmation,
+		arg.OrganizationID,
+		arg.WorkspaceID,
+		arg.ConversationID,
+		arg.MessageID,
+		arg.ProposedByUserID,
+		arg.ToolName,
+		arg.ToolCallID,
+		arg.Action,
+		arg.RiskTier,
+		arg.PayloadHash,
+		arg.BoundArgs,
+		arg.Summary,
+		arg.Estimate,
+		arg.ExpiresAt,
+	)
+	var i VibeEvalPendingConfirmation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ProposedByUserID,
+		&i.ToolName,
+		&i.ToolCallID,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.BoundArgs,
+		&i.Summary,
+		&i.Estimate,
+		&i.Status,
+		&i.ResolvedByUserID,
+		&i.ResolvedAt,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const expireStaleVibeEvalPendingConfirmations = `-- name: ExpireStaleVibeEvalPendingConfirmations :many
+UPDATE vibe_eval_pending_confirmations
+SET status = 'expired', resolved_at = now()
+WHERE conversation_id = $1
+  AND status = 'pending'
+  AND expires_at <= now()
+RETURNING id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+`
+
+type ExpireStaleVibeEvalPendingConfirmationsParams struct {
+	ConversationID uuid.UUID
+}
+
+// Transition lapsed 'pending' rows for a conversation to 'expired' so they leave the active
+// partial unique index and stop blocking re-proposal (#875 §5.3). The create path runs this in
+// the same tx before inserting.
+func (q *Queries) ExpireStaleVibeEvalPendingConfirmations(ctx context.Context, arg ExpireStaleVibeEvalPendingConfirmationsParams) ([]VibeEvalPendingConfirmation, error) {
+	rows, err := q.db.Query(ctx, expireStaleVibeEvalPendingConfirmations, arg.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []VibeEvalPendingConfirmation
+	for rows.Next() {
+		var i VibeEvalPendingConfirmation
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.WorkspaceID,
+			&i.ConversationID,
+			&i.MessageID,
+			&i.ProposedByUserID,
+			&i.ToolName,
+			&i.ToolCallID,
+			&i.Action,
+			&i.RiskTier,
+			&i.PayloadHash,
+			&i.BoundArgs,
+			&i.Summary,
+			&i.Estimate,
+			&i.Status,
+			&i.ResolvedByUserID,
+			&i.ResolvedAt,
+			&i.ExpiresAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getVibeEvalConversationByID = `-- name: GetVibeEvalConversationByID :one
 SELECT id, organization_id, workspace_id, created_by_user_id, title, phase, status, active_draft_id, created_at, updated_at, archived_at
 FROM vibe_eval_conversations
@@ -196,6 +444,87 @@ func (q *Queries) GetVibeEvalDraftByID(ctx context.Context, arg GetVibeEvalDraft
 		&i.UpdatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getVibeEvalPendingConfirmationByID = `-- name: GetVibeEvalPendingConfirmationByID :one
+SELECT id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+FROM vibe_eval_pending_confirmations
+WHERE id = $1
+LIMIT 1
+`
+
+type GetVibeEvalPendingConfirmationByIDParams struct {
+	ID uuid.UUID
+}
+
+func (q *Queries) GetVibeEvalPendingConfirmationByID(ctx context.Context, arg GetVibeEvalPendingConfirmationByIDParams) (VibeEvalPendingConfirmation, error) {
+	row := q.db.QueryRow(ctx, getVibeEvalPendingConfirmationByID, arg.ID)
+	var i VibeEvalPendingConfirmation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ProposedByUserID,
+		&i.ToolName,
+		&i.ToolCallID,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.BoundArgs,
+		&i.Summary,
+		&i.Estimate,
+		&i.Status,
+		&i.ResolvedByUserID,
+		&i.ResolvedAt,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getVibeEvalPendingConfirmationForResume = `-- name: GetVibeEvalPendingConfirmationForResume :one
+SELECT id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+FROM vibe_eval_pending_confirmations
+WHERE id = $1
+  AND status = 'executing'
+  AND payload_hash = $2
+LIMIT 1
+`
+
+type GetVibeEvalPendingConfirmationForResumeParams struct {
+	ID          uuid.UUID
+	PayloadHash string
+}
+
+// Crash-safe re-entry: returns the row only if it is still 'executing' and the presented hash
+// matches, so a retried POST can resume effect execution exactly once. 0 rows => not resumable.
+func (q *Queries) GetVibeEvalPendingConfirmationForResume(ctx context.Context, arg GetVibeEvalPendingConfirmationForResumeParams) (VibeEvalPendingConfirmation, error) {
+	row := q.db.QueryRow(ctx, getVibeEvalPendingConfirmationForResume, arg.ID, arg.PayloadHash)
+	var i VibeEvalPendingConfirmation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ProposedByUserID,
+		&i.ToolName,
+		&i.ToolCallID,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.BoundArgs,
+		&i.Summary,
+		&i.Estimate,
+		&i.Status,
+		&i.ResolvedByUserID,
+		&i.ResolvedAt,
+		&i.ExpiresAt,
+		&i.CreatedAt,
 	)
 	return i, err
 }
@@ -418,6 +747,54 @@ func (q *Queries) ListVibeEvalMessagesByConversationID(ctx context.Context, arg 
 	return items, nil
 }
 
+const listVibeEvalToolInvocationsByConversationID = `-- name: ListVibeEvalToolInvocationsByConversationID :many
+SELECT id, organization_id, workspace_id, conversation_id, message_id, actor_user_id, tool_name, action, risk_tier, payload_hash, confirmation_id, request_payload, result_payload, credit_reservation_id, outcome, created_at
+FROM vibe_eval_tool_invocations
+WHERE conversation_id = $1
+ORDER BY created_at DESC, id DESC
+`
+
+type ListVibeEvalToolInvocationsByConversationIDParams struct {
+	ConversationID uuid.UUID
+}
+
+func (q *Queries) ListVibeEvalToolInvocationsByConversationID(ctx context.Context, arg ListVibeEvalToolInvocationsByConversationIDParams) ([]VibeEvalToolInvocation, error) {
+	rows, err := q.db.Query(ctx, listVibeEvalToolInvocationsByConversationID, arg.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []VibeEvalToolInvocation
+	for rows.Next() {
+		var i VibeEvalToolInvocation
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.WorkspaceID,
+			&i.ConversationID,
+			&i.MessageID,
+			&i.ActorUserID,
+			&i.ToolName,
+			&i.Action,
+			&i.RiskTier,
+			&i.PayloadHash,
+			&i.ConfirmationID,
+			&i.RequestPayload,
+			&i.ResultPayload,
+			&i.CreditReservationID,
+			&i.Outcome,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockVibeEvalConversationForAppend = `-- name: LockVibeEvalConversationForAppend :one
 SELECT
     vibe_eval_conversations.id,
@@ -451,6 +828,103 @@ func (q *Queries) LockVibeEvalConversationForAppend(ctx context.Context, arg Loc
 	row := q.db.QueryRow(ctx, lockVibeEvalConversationForAppend, arg.ConversationID)
 	var i LockVibeEvalConversationForAppendRow
 	err := row.Scan(&i.ID, &i.OrganizationID, &i.WorkspaceID)
+	return i, err
+}
+
+const markVibeEvalPendingConfirmationResult = `-- name: MarkVibeEvalPendingConfirmationResult :one
+UPDATE vibe_eval_pending_confirmations
+SET status = $1
+WHERE id = $2
+  AND status = 'executing'
+RETURNING id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+`
+
+type MarkVibeEvalPendingConfirmationResultParams struct {
+	Status string
+	ID     uuid.UUID
+}
+
+// Terminal transition after the bound effect runs: 'executing' -> 'succeeded' | 'failed'.
+// Conditioned on status='executing' so a crashed/retried effect transitions exactly once.
+func (q *Queries) MarkVibeEvalPendingConfirmationResult(ctx context.Context, arg MarkVibeEvalPendingConfirmationResultParams) (VibeEvalPendingConfirmation, error) {
+	row := q.db.QueryRow(ctx, markVibeEvalPendingConfirmationResult, arg.Status, arg.ID)
+	var i VibeEvalPendingConfirmation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ProposedByUserID,
+		&i.ToolName,
+		&i.ToolCallID,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.BoundArgs,
+		&i.Summary,
+		&i.Estimate,
+		&i.Status,
+		&i.ResolvedByUserID,
+		&i.ResolvedAt,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const resolveVibeEvalPendingConfirmation = `-- name: ResolveVibeEvalPendingConfirmation :one
+UPDATE vibe_eval_pending_confirmations
+SET
+    status = $1,
+    resolved_by_user_id = $2,
+    resolved_at = now()
+WHERE id = $3
+  AND status = 'pending'
+  AND expires_at > now()
+  AND payload_hash = $4
+RETURNING id, organization_id, workspace_id, conversation_id, message_id, proposed_by_user_id, tool_name, tool_call_id, action, risk_tier, payload_hash, bound_args, summary, estimate, status, resolved_by_user_id, resolved_at, expires_at, created_at
+`
+
+type ResolveVibeEvalPendingConfirmationParams struct {
+	NewStatus        string
+	ResolvedByUserID *uuid.UUID
+	ID               uuid.UUID
+	PayloadHash      string
+}
+
+// Atomic, single-use transition out of 'pending' (#875 §5.3). Only the request that matches a
+// still-pending, unexpired row with the presented payload_hash wins (0 rows => already resolved,
+// expired, or hash mismatch => reject). @new_status is 'executing' (approve) or 'denied' (deny).
+func (q *Queries) ResolveVibeEvalPendingConfirmation(ctx context.Context, arg ResolveVibeEvalPendingConfirmationParams) (VibeEvalPendingConfirmation, error) {
+	row := q.db.QueryRow(ctx, resolveVibeEvalPendingConfirmation,
+		arg.NewStatus,
+		arg.ResolvedByUserID,
+		arg.ID,
+		arg.PayloadHash,
+	)
+	var i VibeEvalPendingConfirmation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.MessageID,
+		&i.ProposedByUserID,
+		&i.ToolName,
+		&i.ToolCallID,
+		&i.Action,
+		&i.RiskTier,
+		&i.PayloadHash,
+		&i.BoundArgs,
+		&i.Summary,
+		&i.Estimate,
+		&i.Status,
+		&i.ResolvedByUserID,
+		&i.ResolvedAt,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+	)
 	return i, err
 }
 

--- a/backend/internal/repository/sqlc/vibe_eval.sql.go
+++ b/backend/internal/repository/sqlc/vibe_eval.sql.go
@@ -854,6 +854,52 @@ func (q *Queries) LockVibeEvalConversationForAppend(ctx context.Context, arg Loc
 	return i, err
 }
 
+const markVibeEvalDraftPublished = `-- name: MarkVibeEvalDraftPublished :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = 'valid',
+    validation_errors = '[]'::jsonb,
+    published_challenge_pack_id = $1,
+    published_challenge_pack_version_id = $2,
+    updated_by_user_id = $3
+WHERE id = $4
+RETURNING id, organization_id, workspace_id, conversation_id, draft_kind, content, validation_state, validation_errors, published_challenge_pack_id, published_challenge_pack_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at
+`
+
+type MarkVibeEvalDraftPublishedParams struct {
+	PublishedChallengePackID        *uuid.UUID
+	PublishedChallengePackVersionID *uuid.UUID
+	UpdatedByUserID                 uuid.UUID
+	ID                              uuid.UUID
+}
+
+func (q *Queries) MarkVibeEvalDraftPublished(ctx context.Context, arg MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error) {
+	row := q.db.QueryRow(ctx, markVibeEvalDraftPublished,
+		arg.PublishedChallengePackID,
+		arg.PublishedChallengePackVersionID,
+		arg.UpdatedByUserID,
+		arg.ID,
+	)
+	var i VibeEvalDraft
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.DraftKind,
+		&i.Content,
+		&i.ValidationState,
+		&i.ValidationErrors,
+		&i.PublishedChallengePackID,
+		&i.PublishedChallengePackVersionID,
+		&i.CreatedByUserID,
+		&i.UpdatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const markVibeEvalDraftValidation = `-- name: MarkVibeEvalDraftValidation :one
 UPDATE vibe_eval_drafts
 SET
@@ -1033,6 +1079,8 @@ SET
     content = $1,
     validation_state = $2,
     validation_errors = $3,
+    published_challenge_pack_id = NULL,
+    published_challenge_pack_version_id = NULL,
     updated_by_user_id = $4
 WHERE id = $5
 RETURNING id, organization_id, workspace_id, conversation_id, draft_kind, content, validation_state, validation_errors, published_challenge_pack_id, published_challenge_pack_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at
@@ -1046,6 +1094,8 @@ type UpdateVibeEvalDraftParams struct {
 	ID               uuid.UUID
 }
 
+// Editing content unpublishes the draft: the published refs are cleared so a stale published
+// version can never be reused as an idempotency signal for changed content (3c-3 effect identity).
 func (q *Queries) UpdateVibeEvalDraft(ctx context.Context, arg UpdateVibeEvalDraftParams) (VibeEvalDraft, error) {
 	row := q.db.QueryRow(ctx, updateVibeEvalDraft,
 		arg.Content,

--- a/backend/internal/repository/vibe_eval.go
+++ b/backend/internal/repository/vibe_eval.go
@@ -474,6 +474,23 @@ func (r *Repository) ListVibeEvalToolInvocationsByConversationID(ctx context.Con
 	return out, nil
 }
 
+// GetVibeEvalConfirmedToolOutcome returns the latest ok/error audit outcome recorded for a
+// confirmation's executed tool. found=false when no execution audit row exists yet (the effect
+// never ran, or ran but its best-effort audit write was lost).
+func (r *Repository) GetVibeEvalConfirmedToolOutcome(ctx context.Context, confirmationID uuid.UUID) (outcome string, found bool, err error) {
+	cid := confirmationID
+	o, err := r.queries.GetVibeEvalConfirmedToolOutcome(ctx, repositorysqlc.GetVibeEvalConfirmedToolOutcomeParams{
+		ConfirmationID: &cid,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return o, true, nil
+}
+
 func mapVibeEvalToolInvocation(row repositorysqlc.VibeEvalToolInvocation) (VibeEvalToolInvocation, error) {
 	createdAt, err := requiredTime("vibe_eval_tool_invocations.created_at", row.CreatedAt)
 	if err != nil {

--- a/backend/internal/repository/vibe_eval.go
+++ b/backend/internal/repository/vibe_eval.go
@@ -201,6 +201,35 @@ type MarkVibeEvalDraftValidationParams struct {
 	UpdatedByUserID  uuid.UUID
 }
 
+// MarkVibeEvalDraftPublishedParams records the published challenge-pack/version on a draft (the
+// effect identity for publish idempotency).
+type MarkVibeEvalDraftPublishedParams struct {
+	ID                              uuid.UUID
+	PublishedChallengePackID        uuid.UUID
+	PublishedChallengePackVersionID uuid.UUID
+	UpdatedByUserID                 uuid.UUID
+}
+
+// MarkVibeEvalDraftPublished records the published pack/version on the draft and forces the draft
+// valid (a published draft is, by construction, a valid one).
+func (r *Repository) MarkVibeEvalDraftPublished(ctx context.Context, params MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error) {
+	packID := params.PublishedChallengePackID
+	versionID := params.PublishedChallengePackVersionID
+	row, err := r.queries.MarkVibeEvalDraftPublished(ctx, repositorysqlc.MarkVibeEvalDraftPublishedParams{
+		ID:                              params.ID,
+		PublishedChallengePackID:        &packID,
+		PublishedChallengePackVersionID: &versionID,
+		UpdatedByUserID:                 params.UpdatedByUserID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalDraft{}, ErrVibeEvalDraftNotFound
+		}
+		return VibeEvalDraft{}, err
+	}
+	return mapVibeEvalDraft(row)
+}
+
 // MarkVibeEvalDraftValidation records a draft's validation outcome without touching its content.
 func (r *Repository) MarkVibeEvalDraftValidation(ctx context.Context, params MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error) {
 	row, err := r.queries.MarkVibeEvalDraftValidation(ctx, repositorysqlc.MarkVibeEvalDraftValidationParams{

--- a/backend/internal/repository/vibe_eval.go
+++ b/backend/internal/repository/vibe_eval.go
@@ -193,6 +193,31 @@ func (r *Repository) UpdateVibeEvalDraft(ctx context.Context, params UpdateVibeE
 	return mapVibeEvalDraft(row)
 }
 
+// MarkVibeEvalDraftValidationParams updates only a draft's validation state/errors (content-preserving).
+type MarkVibeEvalDraftValidationParams struct {
+	ID               uuid.UUID
+	ValidationState  string
+	ValidationErrors json.RawMessage
+	UpdatedByUserID  uuid.UUID
+}
+
+// MarkVibeEvalDraftValidation records a draft's validation outcome without touching its content.
+func (r *Repository) MarkVibeEvalDraftValidation(ctx context.Context, params MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error) {
+	row, err := r.queries.MarkVibeEvalDraftValidation(ctx, repositorysqlc.MarkVibeEvalDraftValidationParams{
+		ID:               params.ID,
+		ValidationState:  params.ValidationState,
+		ValidationErrors: params.ValidationErrors,
+		UpdatedByUserID:  params.UpdatedByUserID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalDraft{}, ErrVibeEvalDraftNotFound
+		}
+		return VibeEvalDraft{}, err
+	}
+	return mapVibeEvalDraft(row)
+}
+
 func mapVibeEvalConversation(row repositorysqlc.VibeEvalConversation) (VibeEvalConversation, error) {
 	createdAt, err := requiredTime("vibe_eval_conversations.created_at", row.CreatedAt)
 	if err != nil {

--- a/backend/internal/repository/vibe_eval.go
+++ b/backend/internal/repository/vibe_eval.go
@@ -10,6 +10,7 @@ import (
 	repositorysqlc "github.com/agentclash/agentclash/backend/internal/repository/sqlc"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 var (
@@ -381,4 +382,342 @@ func mapVibeEvalMessage(row repositorysqlc.VibeEvalMessage) (VibeEvalMessage, er
 		Usage:          cloneRawMessage(row.Usage),
 		CreatedAt:      createdAt,
 	}, nil
+}
+
+// --- Tool-invocation audit log (Step 3, migration 00059, #875 §6) ---
+
+var (
+	// ErrVibeEvalConfirmationNotFound is returned when a pending confirmation id does not exist.
+	ErrVibeEvalConfirmationNotFound = errors.New("vibe eval pending confirmation not found")
+	// ErrVibeEvalConfirmationNotResolvable is returned when the atomic resolve matches no row:
+	// the confirmation was already resolved, has expired, or the presented payload hash differs.
+	ErrVibeEvalConfirmationNotResolvable = errors.New("vibe eval pending confirmation not resolvable")
+)
+
+// VibeEvalToolInvocation is one append-only audit row for a draft+ tool call.
+type VibeEvalToolInvocation struct {
+	ID                  uuid.UUID
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ConversationID      uuid.UUID
+	MessageID           *uuid.UUID
+	ActorUserID         uuid.UUID
+	ToolName            string
+	Action              string
+	RiskTier            string
+	PayloadHash         string
+	ConfirmationID      *uuid.UUID
+	RequestPayload      json.RawMessage
+	ResultPayload       json.RawMessage
+	CreditReservationID *uuid.UUID
+	Outcome             string
+	CreatedAt           time.Time
+}
+
+// AppendVibeEvalToolInvocationParams is the input for AppendVibeEvalToolInvocation.
+type AppendVibeEvalToolInvocationParams struct {
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ConversationID      uuid.UUID
+	MessageID           *uuid.UUID
+	ActorUserID         uuid.UUID
+	ToolName            string
+	Action              string
+	RiskTier            string
+	PayloadHash         string
+	ConfirmationID      *uuid.UUID
+	RequestPayload      json.RawMessage
+	ResultPayload       json.RawMessage
+	CreditReservationID *uuid.UUID
+	Outcome             string
+}
+
+// AppendVibeEvalToolInvocation writes one audit row. request/result payloads must already be
+// audit-scrubbed (metadata only) by the caller.
+func (r *Repository) AppendVibeEvalToolInvocation(ctx context.Context, params AppendVibeEvalToolInvocationParams) (VibeEvalToolInvocation, error) {
+	row, err := r.queries.AppendVibeEvalToolInvocation(ctx, repositorysqlc.AppendVibeEvalToolInvocationParams{
+		OrganizationID:      params.OrganizationID,
+		WorkspaceID:         params.WorkspaceID,
+		ConversationID:      params.ConversationID,
+		MessageID:           params.MessageID,
+		ActorUserID:         params.ActorUserID,
+		ToolName:            params.ToolName,
+		Action:              params.Action,
+		RiskTier:            params.RiskTier,
+		PayloadHash:         params.PayloadHash,
+		ConfirmationID:      params.ConfirmationID,
+		RequestPayload:      jsonOrEmptyObject(params.RequestPayload),
+		ResultPayload:       jsonOrEmptyObject(params.ResultPayload),
+		CreditReservationID: params.CreditReservationID,
+		Outcome:             params.Outcome,
+	})
+	if err != nil {
+		return VibeEvalToolInvocation{}, err
+	}
+	return mapVibeEvalToolInvocation(row)
+}
+
+// ListVibeEvalToolInvocationsByConversationID returns a conversation's audit trail, newest first.
+func (r *Repository) ListVibeEvalToolInvocationsByConversationID(ctx context.Context, conversationID uuid.UUID) ([]VibeEvalToolInvocation, error) {
+	rows, err := r.queries.ListVibeEvalToolInvocationsByConversationID(ctx, repositorysqlc.ListVibeEvalToolInvocationsByConversationIDParams{ConversationID: conversationID})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]VibeEvalToolInvocation, 0, len(rows))
+	for _, row := range rows {
+		item, err := mapVibeEvalToolInvocation(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func mapVibeEvalToolInvocation(row repositorysqlc.VibeEvalToolInvocation) (VibeEvalToolInvocation, error) {
+	createdAt, err := requiredTime("vibe_eval_tool_invocations.created_at", row.CreatedAt)
+	if err != nil {
+		return VibeEvalToolInvocation{}, err
+	}
+	return VibeEvalToolInvocation{
+		ID:                  row.ID,
+		OrganizationID:      row.OrganizationID,
+		WorkspaceID:         row.WorkspaceID,
+		ConversationID:      row.ConversationID,
+		MessageID:           row.MessageID,
+		ActorUserID:         row.ActorUserID,
+		ToolName:            row.ToolName,
+		Action:              row.Action,
+		RiskTier:            row.RiskTier,
+		PayloadHash:         row.PayloadHash,
+		ConfirmationID:      row.ConfirmationID,
+		RequestPayload:      cloneRawMessage(row.RequestPayload),
+		ResultPayload:       cloneRawMessage(row.ResultPayload),
+		CreditReservationID: row.CreditReservationID,
+		Outcome:             row.Outcome,
+		CreatedAt:           createdAt,
+	}, nil
+}
+
+// --- Pending confirmations (Step 3, migration 00060, #875 §5.3) ---
+
+// VibeEvalPendingConfirmation is one propose→confirm record for a workspace_write+ tool call.
+type VibeEvalPendingConfirmation struct {
+	ID               uuid.UUID
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
+	ConversationID   uuid.UUID
+	MessageID        *uuid.UUID
+	ProposedByUserID uuid.UUID
+	ToolName         string
+	ToolCallID       string
+	Action           string
+	RiskTier         string
+	PayloadHash      string
+	BoundArgs        json.RawMessage
+	Summary          string
+	Estimate         json.RawMessage
+	Status           string
+	ResolvedByUserID *uuid.UUID
+	ResolvedAt       *time.Time
+	ExpiresAt        time.Time
+	CreatedAt        time.Time
+}
+
+// CreateVibeEvalPendingConfirmationParams is the input for CreateVibeEvalPendingConfirmation.
+type CreateVibeEvalPendingConfirmationParams struct {
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
+	ConversationID   uuid.UUID
+	MessageID        *uuid.UUID
+	ProposedByUserID uuid.UUID
+	ToolName         string
+	ToolCallID       string
+	Action           string
+	RiskTier         string
+	PayloadHash      string
+	BoundArgs        json.RawMessage
+	Summary          string
+	Estimate         json.RawMessage
+	ExpiresAt        time.Time
+}
+
+// CreateVibeEvalPendingConfirmation records a proposed confirmation in 'pending' state. It runs
+// as a transaction that first transitions the conversation's lapsed 'pending' rows to 'expired'
+// (so a stale row no longer occupies the active partial unique index) and then inserts — a
+// duplicate ACTIVE proposal for the same (conversation, tool, payload_hash) still fails the
+// unique index.
+func (r *Repository) CreateVibeEvalPendingConfirmation(ctx context.Context, params CreateVibeEvalPendingConfirmationParams) (VibeEvalPendingConfirmation, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return VibeEvalPendingConfirmation{}, fmt.Errorf("begin pending confirmation create: %w", err)
+	}
+	defer rollback(ctx, tx)
+	q := r.queries.WithTx(tx)
+
+	if _, err := q.ExpireStaleVibeEvalPendingConfirmations(ctx, repositorysqlc.ExpireStaleVibeEvalPendingConfirmationsParams{
+		ConversationID: params.ConversationID,
+	}); err != nil {
+		return VibeEvalPendingConfirmation{}, err
+	}
+
+	row, err := q.CreateVibeEvalPendingConfirmation(ctx, repositorysqlc.CreateVibeEvalPendingConfirmationParams{
+		OrganizationID:   params.OrganizationID,
+		WorkspaceID:      params.WorkspaceID,
+		ConversationID:   params.ConversationID,
+		MessageID:        params.MessageID,
+		ProposedByUserID: params.ProposedByUserID,
+		ToolName:         params.ToolName,
+		ToolCallID:       params.ToolCallID,
+		Action:           params.Action,
+		RiskTier:         params.RiskTier,
+		PayloadHash:      params.PayloadHash,
+		BoundArgs:        jsonOrEmptyObject(params.BoundArgs),
+		Summary:          params.Summary,
+		Estimate:         nilIfEmpty(params.Estimate),
+		ExpiresAt:        pgtype.Timestamptz{Time: params.ExpiresAt.UTC(), Valid: true},
+	})
+	if err != nil {
+		return VibeEvalPendingConfirmation{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return VibeEvalPendingConfirmation{}, fmt.Errorf("commit pending confirmation create: %w", err)
+	}
+	return mapVibeEvalPendingConfirmation(row)
+}
+
+// GetVibeEvalPendingConfirmationByID fetches a confirmation by id.
+func (r *Repository) GetVibeEvalPendingConfirmationByID(ctx context.Context, id uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	row, err := r.queries.GetVibeEvalPendingConfirmationByID(ctx, repositorysqlc.GetVibeEvalPendingConfirmationByIDParams{ID: id})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalPendingConfirmation{}, ErrVibeEvalConfirmationNotFound
+		}
+		return VibeEvalPendingConfirmation{}, err
+	}
+	return mapVibeEvalPendingConfirmation(row)
+}
+
+// ApproveVibeEvalPendingConfirmation atomically claims a pending confirmation, transitioning it
+// 'pending' -> 'executing' (the bound effect then runs). DenyVibeEvalPendingConfirmation does
+// 'pending' -> 'denied'. Both return ErrVibeEvalConfirmationNotResolvable when no row matches
+// (already resolved, expired, or payload-hash mismatch) — the caller must reject. Named methods
+// (rather than a generic newStatus arg) keep callers from moving the row to an illegal state.
+func (r *Repository) ApproveVibeEvalPendingConfirmation(ctx context.Context, id uuid.UUID, presentedHash string, resolvedBy uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	return r.resolveVibeEvalPendingConfirmation(ctx, id, "executing", presentedHash, resolvedBy)
+}
+
+// DenyVibeEvalPendingConfirmation atomically transitions a pending confirmation to 'denied'.
+func (r *Repository) DenyVibeEvalPendingConfirmation(ctx context.Context, id uuid.UUID, presentedHash string, resolvedBy uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	return r.resolveVibeEvalPendingConfirmation(ctx, id, "denied", presentedHash, resolvedBy)
+}
+
+func (r *Repository) resolveVibeEvalPendingConfirmation(ctx context.Context, id uuid.UUID, newStatus, presentedHash string, resolvedBy uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	resolver := resolvedBy
+	row, err := r.queries.ResolveVibeEvalPendingConfirmation(ctx, repositorysqlc.ResolveVibeEvalPendingConfirmationParams{
+		NewStatus:        newStatus,
+		ResolvedByUserID: &resolver,
+		ID:               id,
+		PayloadHash:      presentedHash,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalPendingConfirmation{}, ErrVibeEvalConfirmationNotResolvable
+		}
+		return VibeEvalPendingConfirmation{}, err
+	}
+	return mapVibeEvalPendingConfirmation(row)
+}
+
+// GetVibeEvalPendingConfirmationForResume returns a confirmation only if it is still 'executing'
+// and the presented hash matches — the crash-safe re-entry primitive. A retried POST that lost
+// the Approve race uses this to decide "already executing, re-enter effect" vs reject. Returns
+// ErrVibeEvalConfirmationNotResolvable when not resumable.
+func (r *Repository) GetVibeEvalPendingConfirmationForResume(ctx context.Context, id uuid.UUID, presentedHash string) (VibeEvalPendingConfirmation, error) {
+	row, err := r.queries.GetVibeEvalPendingConfirmationForResume(ctx, repositorysqlc.GetVibeEvalPendingConfirmationForResumeParams{
+		ID:          id,
+		PayloadHash: presentedHash,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalPendingConfirmation{}, ErrVibeEvalConfirmationNotResolvable
+		}
+		return VibeEvalPendingConfirmation{}, err
+	}
+	return mapVibeEvalPendingConfirmation(row)
+}
+
+// MarkVibeEvalPendingConfirmationSucceeded / Failed transition a claimed ('executing')
+// confirmation to its terminal status. ErrVibeEvalConfirmationNotResolvable when the row is no
+// longer 'executing' (already finalized) so the effect is finalized exactly once.
+func (r *Repository) MarkVibeEvalPendingConfirmationSucceeded(ctx context.Context, id uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	return r.markVibeEvalPendingConfirmationResult(ctx, id, "succeeded")
+}
+
+// MarkVibeEvalPendingConfirmationFailed transitions a claimed confirmation to 'failed'.
+func (r *Repository) MarkVibeEvalPendingConfirmationFailed(ctx context.Context, id uuid.UUID) (VibeEvalPendingConfirmation, error) {
+	return r.markVibeEvalPendingConfirmationResult(ctx, id, "failed")
+}
+
+func (r *Repository) markVibeEvalPendingConfirmationResult(ctx context.Context, id uuid.UUID, status string) (VibeEvalPendingConfirmation, error) {
+	row, err := r.queries.MarkVibeEvalPendingConfirmationResult(ctx, repositorysqlc.MarkVibeEvalPendingConfirmationResultParams{
+		Status: status,
+		ID:     id,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalPendingConfirmation{}, ErrVibeEvalConfirmationNotResolvable
+		}
+		return VibeEvalPendingConfirmation{}, err
+	}
+	return mapVibeEvalPendingConfirmation(row)
+}
+
+func mapVibeEvalPendingConfirmation(row repositorysqlc.VibeEvalPendingConfirmation) (VibeEvalPendingConfirmation, error) {
+	createdAt, err := requiredTime("vibe_eval_pending_confirmations.created_at", row.CreatedAt)
+	if err != nil {
+		return VibeEvalPendingConfirmation{}, err
+	}
+	expiresAt, err := requiredTime("vibe_eval_pending_confirmations.expires_at", row.ExpiresAt)
+	if err != nil {
+		return VibeEvalPendingConfirmation{}, err
+	}
+	return VibeEvalPendingConfirmation{
+		ID:               row.ID,
+		OrganizationID:   row.OrganizationID,
+		WorkspaceID:      row.WorkspaceID,
+		ConversationID:   row.ConversationID,
+		MessageID:        row.MessageID,
+		ProposedByUserID: row.ProposedByUserID,
+		ToolName:         row.ToolName,
+		ToolCallID:       row.ToolCallID,
+		Action:           row.Action,
+		RiskTier:         row.RiskTier,
+		PayloadHash:      row.PayloadHash,
+		BoundArgs:        cloneRawMessage(row.BoundArgs),
+		Summary:          row.Summary,
+		Estimate:         cloneRawMessage(row.Estimate),
+		Status:           row.Status,
+		ResolvedByUserID: row.ResolvedByUserID,
+		ResolvedAt:       optionalTime(row.ResolvedAt),
+		ExpiresAt:        expiresAt,
+		CreatedAt:        createdAt,
+	}, nil
+}
+
+// jsonOrEmptyObject coerces an empty/nil RawMessage to a JSON "{}" so NOT NULL jsonb columns
+// keep their object default instead of attempting a NULL insert.
+func jsonOrEmptyObject(raw json.RawMessage) []byte {
+	if len(raw) == 0 {
+		return []byte("{}")
+	}
+	return raw
+}
+
+// nilIfEmpty returns nil for an empty RawMessage so a nullable jsonb column stores SQL NULL.
+func nilIfEmpty(raw json.RawMessage) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
 }

--- a/backend/internal/repository/vibe_eval_confirmation_integration_test.go
+++ b/backend/internal/repository/vibe_eval_confirmation_integration_test.go
@@ -1,0 +1,229 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+// Confirmation/audit repo round-trips for Step 3a (#875 §5.3/§6).
+//
+// WARNING — DESTRUCTIVE: calls seedFixture, which TRUNCATEs core tables CASCADE. Point
+// DATABASE_URL at a DISPOSABLE database (see vibe_eval_concurrency_integration_test.go for the
+// throwaway-container recipe), never a dev/shared DB. Skips when DATABASE_URL is unset.
+
+func seedVibeEvalConversation(t *testing.T, ctx context.Context, repo *repository.Repository, f testFixture) repository.VibeEvalConversation {
+	t.Helper()
+	conv, err := repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+		OrganizationID:  f.organizationID,
+		WorkspaceID:     f.workspaceID,
+		CreatedByUserID: f.userID,
+		Title:           "confirm",
+		Phase:           "author",
+		Status:          "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateVibeEvalConversation: %v", err)
+	}
+	return conv
+}
+
+func newPendingParams(f testFixture, convID uuid.UUID, hash string, expires time.Time) repository.CreateVibeEvalPendingConfirmationParams {
+	return repository.CreateVibeEvalPendingConfirmationParams{
+		OrganizationID:   f.organizationID,
+		WorkspaceID:      f.workspaceID,
+		ConversationID:   convID,
+		ProposedByUserID: f.userID,
+		ToolName:         "publish_draft",
+		ToolCallID:       "toolu_pub_1",
+		Action:           "publish_challenge_pack",
+		RiskTier:         "workspace_write",
+		PayloadHash:      hash,
+		Summary:          "Publish draft as challenge pack",
+		ExpiresAt:        expires,
+	}
+}
+
+func TestRepositoryVibeEvalToolInvocationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv := seedVibeEvalConversation(t, ctx, repo, fixture)
+
+	// Nullable confirmation_id / message_id and JSON payloads must round-trip.
+	got, err := repo.AppendVibeEvalToolInvocation(ctx, repository.AppendVibeEvalToolInvocationParams{
+		OrganizationID: fixture.organizationID,
+		WorkspaceID:    fixture.workspaceID,
+		ConversationID: conv.ID,
+		ActorUserID:    fixture.userID,
+		ToolName:       "get_run_status",
+		Action:         "read_workspace",
+		RiskTier:       "read",
+		PayloadHash:    "hash-abc",
+		RequestPayload: []byte(`{"run_id":"r1"}`),
+		ResultPayload:  []byte(`{"status":"draft"}`),
+		Outcome:        "ok",
+	})
+	if err != nil {
+		t.Fatalf("AppendVibeEvalToolInvocation: %v", err)
+	}
+	if got.MessageID != nil || got.ConfirmationID != nil || got.CreditReservationID != nil {
+		t.Fatalf("expected nil optional refs, got message=%v confirmation=%v credit=%v", got.MessageID, got.ConfirmationID, got.CreditReservationID)
+	}
+	if got.Outcome != "ok" || got.RiskTier != "read" {
+		t.Fatalf("unexpected row: %+v", got)
+	}
+
+	list, err := repo.ListVibeEvalToolInvocationsByConversationID(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("ListVibeEvalToolInvocationsByConversationID: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != got.ID {
+		t.Fatalf("list = %d rows, want the one appended row", len(list))
+	}
+}
+
+func TestRepositoryVibeEvalConfirmationApproveIsSingleUse(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv := seedVibeEvalConversation(t, ctx, repo, fixture)
+
+	pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, newPendingParams(fixture, conv.ID, "hash-1", time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("CreateVibeEvalPendingConfirmation: %v", err)
+	}
+	if pc.Status != "pending" {
+		t.Fatalf("status = %q, want pending", pc.Status)
+	}
+
+	approved, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "hash-1", fixture.userID)
+	if err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	if approved.Status != "executing" {
+		t.Fatalf("status = %q, want executing", approved.Status)
+	}
+	if approved.ResolvedByUserID == nil || *approved.ResolvedByUserID != fixture.userID {
+		t.Fatalf("resolved_by = %v, want %s", approved.ResolvedByUserID, fixture.userID)
+	}
+
+	// Second approve (e.g. a concurrent/retried POST) must not re-claim.
+	if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "hash-1", fixture.userID); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("second approve err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+}
+
+func TestRepositoryVibeEvalConfirmationHashMismatchAndDeny(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv := seedVibeEvalConversation(t, ctx, repo, fixture)
+
+	pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, newPendingParams(fixture, conv.ID, "hash-2", time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Presented hash mismatch (bait-and-switch) is rejected, row stays pending.
+	if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "wrong-hash", fixture.userID); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("mismatch approve err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+
+	denied, err := repo.DenyVibeEvalPendingConfirmation(ctx, pc.ID, "hash-2", fixture.userID)
+	if err != nil {
+		t.Fatalf("deny: %v", err)
+	}
+	if denied.Status != "denied" {
+		t.Fatalf("status = %q, want denied", denied.Status)
+	}
+	// Second resolve (approve or deny) after denied must fail.
+	if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "hash-2", fixture.userID); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("approve-after-deny err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+}
+
+func TestRepositoryVibeEvalConfirmationExpiryUnblocksReproposal(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv := seedVibeEvalConversation(t, ctx, repo, fixture)
+
+	// A lapsed pending row (already past expiry) must not block a fresh proposal with the same
+	// (conversation, tool, payload_hash): the create path expires it in-tx first.
+	stale, err := repo.CreateVibeEvalPendingConfirmation(ctx, newPendingParams(fixture, conv.ID, "hash-3", time.Now().Add(-time.Minute)))
+	if err != nil {
+		t.Fatalf("create stale: %v", err)
+	}
+
+	fresh, err := repo.CreateVibeEvalPendingConfirmation(ctx, newPendingParams(fixture, conv.ID, "hash-3", time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("re-propose after expiry should succeed, got: %v", err)
+	}
+	if fresh.ID == stale.ID {
+		t.Fatal("expected a new confirmation row")
+	}
+
+	staleReloaded, err := repo.GetVibeEvalPendingConfirmationByID(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("get stale: %v", err)
+	}
+	if staleReloaded.Status != "expired" {
+		t.Fatalf("stale status = %q, want expired", staleReloaded.Status)
+	}
+	if fresh.Status != "pending" {
+		t.Fatalf("fresh status = %q, want pending", fresh.Status)
+	}
+}
+
+func TestRepositoryVibeEvalConfirmationMarkResultAndResume(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	conv := seedVibeEvalConversation(t, ctx, repo, fixture)
+
+	pc, err := repo.CreateVibeEvalPendingConfirmation(ctx, newPendingParams(fixture, conv.ID, "hash-4", time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := repo.ApproveVibeEvalPendingConfirmation(ctx, pc.ID, "hash-4", fixture.userID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	// While executing, the crash-safe resume primitive returns the row for matching hash only.
+	if _, err := repo.GetVibeEvalPendingConfirmationForResume(ctx, pc.ID, "hash-4"); err != nil {
+		t.Fatalf("resume while executing: %v", err)
+	}
+	if _, err := repo.GetVibeEvalPendingConfirmationForResume(ctx, pc.ID, "wrong"); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("resume wrong-hash err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+
+	done, err := repo.MarkVibeEvalPendingConfirmationSucceeded(ctx, pc.ID)
+	if err != nil {
+		t.Fatalf("mark succeeded: %v", err)
+	}
+	if done.Status != "succeeded" {
+		t.Fatalf("status = %q, want succeeded", done.Status)
+	}
+
+	// Finalize exactly once: a second mark (or fail) must not re-transition a terminal row.
+	if _, err := repo.MarkVibeEvalPendingConfirmationSucceeded(ctx, pc.ID); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("double mark err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+	if _, err := repo.MarkVibeEvalPendingConfirmationFailed(ctx, pc.ID); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("mark-failed-after-succeeded err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+	// Resume after terminal must also reject.
+	if _, err := repo.GetVibeEvalPendingConfirmationForResume(ctx, pc.ID, "hash-4"); !errors.Is(err, repository.ErrVibeEvalConfirmationNotResolvable) {
+		t.Fatalf("resume after terminal err = %v, want ErrVibeEvalConfirmationNotResolvable", err)
+	}
+}

--- a/backend/internal/vibeeval/confirmation.go
+++ b/backend/internal/vibeeval/confirmation.go
@@ -29,6 +29,8 @@ type PendingConfirmation struct {
 
 // NewPendingConfirmation is the input to ConfirmationStore.Create.
 type NewPendingConfirmation struct {
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
 	ConversationID   uuid.UUID
 	MessageID        *uuid.UUID
 	ProposedByUserID uuid.UUID
@@ -66,6 +68,8 @@ const (
 // ToolInvocationAudit is one metadata-only audit record (#875 §6). It never carries secrets or raw
 // artifact contents; the backing AuditWriter scrubs request/result payloads to structured metadata.
 type ToolInvocationAudit struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
 	ConversationID uuid.UUID
 	MessageID      *uuid.UUID
 	Actor          Actor

--- a/backend/internal/vibeeval/confirmation.go
+++ b/backend/internal/vibeeval/confirmation.go
@@ -1,0 +1,127 @@
+package vibeeval
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PendingConfirmation is a proposed workspace_write+ action awaiting user approval (#875 §5.3).
+// Boundary-clean: no api types; identity flows via Actor, authorization via action string.
+type PendingConfirmation struct {
+	ID             uuid.UUID
+	ConversationID uuid.UUID
+	MessageID      *uuid.UUID // the assistant tool-call message that proposed this
+	ToolName       string
+	ToolCallID     string // provider tool_use id, for resume pairing
+	Action         string
+	RiskTier       RiskTier
+	PayloadHash    string
+	BoundArgs      json.RawMessage // exact args to execute on approve
+	Summary        string
+	Status         string
+	ExpiresAt      time.Time
+}
+
+// NewPendingConfirmation is the input to ConfirmationStore.Create.
+type NewPendingConfirmation struct {
+	ConversationID   uuid.UUID
+	MessageID        *uuid.UUID
+	ProposedByUserID uuid.UUID
+	ToolName         string
+	ToolCallID       string
+	Action           string
+	RiskTier         RiskTier
+	PayloadHash      string
+	BoundArgs        json.RawMessage
+	Summary          string
+	ExpiresAt        time.Time
+}
+
+// ConfirmationStore persists and transitions pending confirmations. The api layer backs this with
+// the repository's NAMED transition methods (Approve/Deny/MarkSucceeded/MarkFailed) — never the
+// generic ones. Resolve atomicity and crash-safe re-entry live in the repo (Step 3a).
+type ConfirmationStore interface {
+	Create(ctx context.Context, nc NewPendingConfirmation) (PendingConfirmation, error)
+	Approve(ctx context.Context, id uuid.UUID, presentedHash string, by Actor) (PendingConfirmation, error)
+	Deny(ctx context.Context, id uuid.UUID, presentedHash string, by Actor) (PendingConfirmation, error)
+	GetForResume(ctx context.Context, id uuid.UUID, presentedHash string) (PendingConfirmation, error)
+	MarkSucceeded(ctx context.Context, id uuid.UUID) error
+	MarkFailed(ctx context.Context, id uuid.UUID) error
+}
+
+// Audit outcomes (mirror vibe_eval_tool_invocations.outcome). Nuance (e.g. one_confirmation_per_turn)
+// goes in the result-payload metadata, not the outcome enum.
+const (
+	AuditOutcomeOK                   = "ok"
+	AuditOutcomeDenied               = "denied"
+	AuditOutcomeError                = "error"
+	AuditOutcomeConfirmationRequired = "confirmation_required"
+)
+
+// ToolInvocationAudit is one metadata-only audit record (#875 §6). It never carries secrets or raw
+// artifact contents; the backing AuditWriter scrubs request/result payloads to structured metadata.
+type ToolInvocationAudit struct {
+	ConversationID uuid.UUID
+	MessageID      *uuid.UUID
+	Actor          Actor
+	ToolName       string
+	Action         string
+	RiskTier       RiskTier
+	PayloadHash    string
+	ConfirmationID *uuid.UUID
+	RequestPayload json.RawMessage
+	ResultPayload  json.RawMessage
+	Outcome        string
+}
+
+// AuditWriter appends tool-invocation audit rows. The default is a no-op until the api adapter
+// wires the repo-backed, scrubbing writer (Step 3b-2).
+type AuditWriter interface {
+	Append(ctx context.Context, a ToolInvocationAudit) error
+}
+
+// NoopAuditWriter discards audit rows.
+type NoopAuditWriter struct{}
+
+// Append discards the record.
+func (NoopAuditWriter) Append(context.Context, ToolInvocationAudit) error { return nil }
+
+// requiresConfirmation reports whether a tool's risk tier needs a propose→confirm step
+// (workspace_write and above). read/draft execute inline (Phase 0 matrix).
+func requiresConfirmation(tier RiskTier) bool {
+	switch tier {
+	case WorkspaceWriteTier, CostIncurringTier, AdminSensitiveTier, DestructiveTier:
+		return true
+	default:
+		return false
+	}
+}
+
+// payloadHash binds a confirmation to exactly the tool + normalized args shown to the user: sha256
+// over canonical JSON, so re-ordered keys hash identically (anti bait-and-switch, #875 §5.3).
+func payloadHash(toolName string, args json.RawMessage) string {
+	h := sha256.Sum256(append([]byte(toolName+"\x00"), canonicalJSON(args)...))
+	return hex.EncodeToString(h[:])
+}
+
+// canonicalJSON normalizes JSON so semantically-equal payloads hash identically (Go's json.Marshal
+// emits object keys in sorted order). Non-JSON input is hashed verbatim.
+func canonicalJSON(raw json.RawMessage) []byte {
+	if len(raw) == 0 {
+		return []byte("null")
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return b
+}

--- a/backend/internal/vibeeval/loop.go
+++ b/backend/internal/vibeeval/loop.go
@@ -59,7 +59,8 @@ type Event struct {
 	ConfirmationID string    `json:"confirmation_id,omitempty"`
 	Action         string    `json:"action,omitempty"`
 	Summary        string    `json:"summary,omitempty"`
-	ExpiresAt      string    `json:"expires_at,omitempty"` // RFC3339, on confirmation.required
+	PayloadHash    string    `json:"payload_hash,omitempty"` // the client echoes this on resolve (hash of args, not the args)
+	ExpiresAt      string    `json:"expires_at,omitempty"`   // RFC3339, on confirmation.required
 	StopReason     string    `json:"stop_reason,omitempty"`
 }
 
@@ -257,7 +258,7 @@ func (l *AgentLoop) runLoop(ctx context.Context, actor Actor, authorizer Workspa
 			}
 			result.StopReason = "confirmation_required"
 			result.PendingConfirmation = &pc
-			sink(Event{Type: EventConfirmationRequired, ToolName: pc.ToolName, ToolCallID: pc.ToolCallID, ConfirmationID: pc.ID.String(), Action: pc.Action, Summary: pc.Summary, ExpiresAt: pc.ExpiresAt.UTC().Format(time.RFC3339)})
+			sink(Event{Type: EventConfirmationRequired, ToolName: pc.ToolName, ToolCallID: pc.ToolCallID, ConfirmationID: pc.ID.String(), Action: pc.Action, Summary: pc.Summary, PayloadHash: pc.PayloadHash, ExpiresAt: pc.ExpiresAt.UTC().Format(time.RFC3339)})
 			return l.finish(result, sink), nil
 		}
 
@@ -304,6 +305,8 @@ func (l *AgentLoop) requireConfirmation(ctx context.Context, actor Actor, conv C
 	mid := messageID
 	hash := payloadHash(tc.Name, tc.Arguments)
 	pc, err := l.confirmations.Create(ctx, NewPendingConfirmation{
+		OrganizationID:   conv.OrganizationID,
+		WorkspaceID:      conv.WorkspaceID,
 		ConversationID:   conv.ID,
 		MessageID:        &mid,
 		ProposedByUserID: actor.UserID,
@@ -397,6 +400,8 @@ func requiresAudit(tier RiskTier) bool {
 // turn). request is the raw tool args (the AuditWriter scrubs); result is metadata-only.
 func (l *AgentLoop) auditInvocation(ctx context.Context, conv Conversation, actor Actor, messageID, confirmationID *uuid.UUID, toolName, action string, tier RiskTier, hash string, request, result json.RawMessage, outcome string) {
 	_ = l.audit.Append(ctx, ToolInvocationAudit{
+		OrganizationID: conv.OrganizationID,
+		WorkspaceID:    conv.WorkspaceID,
 		ConversationID: conv.ID,
 		MessageID:      messageID,
 		Actor:          actor,
@@ -523,6 +528,30 @@ func assertConfirmedCallPresent(batch []provider.ToolCall, pc PendingConfirmatio
 		}
 	}
 	return fmt.Errorf("confirmation %s tool_call %q not found in deferred batch", pc.ID, pc.ToolCallID)
+}
+
+// ContinueTurn replays the conversation and continues the model loop WITHOUT appending a user
+// message or executing any deferred batch. The api manager uses it for the crash-safe finalize
+// path: a confirmed effect already executed (its tool-result is persisted) but finalization
+// failed; on retry we must NOT re-execute — just let the model respond over the existing history.
+func (l *AgentLoop) ContinueTurn(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, sink EventSink) (TurnResult, error) {
+	if sink == nil {
+		sink = func(Event) {}
+	}
+	var result TurnResult
+	pmsgs := []provider.Message{{Role: "system", Content: systemPrompt(conv.Phase)}}
+	history, err := l.messages.History(ctx, conv.ID)
+	if err != nil {
+		return result, err
+	}
+	for _, m := range history {
+		pm, err := toProviderMessage(m)
+		if err != nil {
+			return result, fmt.Errorf("rebuild history for conversation %s: %w", conv.ID, err)
+		}
+		pmsgs = append(pmsgs, pm)
+	}
+	return l.runLoop(ctx, actor, authorizer, conv, pmsgs, result, 0, sink)
 }
 
 // deferredBatch returns the tool-call array of the assistant message that proposed pc.

--- a/backend/internal/vibeeval/loop.go
+++ b/backend/internal/vibeeval/loop.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/google/uuid"
 )
 
 // modelInvoker is the slice of the provider Router the loop needs. provider.Router satisfies
@@ -25,34 +26,41 @@ type GuideModel struct {
 
 // AgentLimits bound a single turn.
 type AgentLimits struct {
-	MaxSteps     int
-	MaxToolCalls int
-	WallClock    time.Duration
+	MaxSteps        int
+	MaxToolCalls    int
+	WallClock       time.Duration
+	ConfirmationTTL time.Duration // how long a proposed confirmation stays resolvable
 }
 
-// DefaultLimits is a conservative bound for the read-only Step 2 loop.
+// DefaultLimits is a conservative bound for the guide loop.
 func DefaultLimits() AgentLimits {
-	return AgentLimits{MaxSteps: 8, MaxToolCalls: 16, WallClock: 2 * time.Minute}
+	return AgentLimits{MaxSteps: 8, MaxToolCalls: 16, WallClock: 2 * time.Minute, ConfirmationTTL: 15 * time.Minute}
 }
 
 // EventType identifies a streamed turn event (consumed by the api SSE handler).
 type EventType string
 
 const (
-	EventAssistantText EventType = "assistant.text"
-	EventToolCall      EventType = "tool.call"
-	EventToolResult    EventType = "tool.result"
-	EventTurnCompleted EventType = "turn.completed"
-	EventError         EventType = "error"
+	EventAssistantText        EventType = "assistant.text"
+	EventToolCall             EventType = "tool.call"
+	EventToolResult           EventType = "tool.result"
+	EventConfirmationRequired EventType = "confirmation.required"
+	EventTurnCompleted        EventType = "turn.completed"
+	EventError                EventType = "error"
 )
 
-// Event is a streamed turn event.
+// Event is a streamed turn event. The confirmation.required card carries metadata only (id, action,
+// summary) — never the bound args or any secret/content.
 type Event struct {
-	Type       EventType `json:"type"`
-	Text       string    `json:"text,omitempty"`
-	ToolName   string    `json:"tool_name,omitempty"`
-	ToolCallID string    `json:"tool_call_id,omitempty"`
-	StopReason string    `json:"stop_reason,omitempty"`
+	Type           EventType `json:"type"`
+	Text           string    `json:"text,omitempty"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	ToolCallID     string    `json:"tool_call_id,omitempty"`
+	ConfirmationID string    `json:"confirmation_id,omitempty"`
+	Action         string    `json:"action,omitempty"`
+	Summary        string    `json:"summary,omitempty"`
+	ExpiresAt      string    `json:"expires_at,omitempty"` // RFC3339, on confirmation.required
+	StopReason     string    `json:"stop_reason,omitempty"`
 }
 
 // EventSink receives turn events as they happen. nil is tolerated.
@@ -71,27 +79,61 @@ type ToolInvocationRecord struct {
 type TurnResult struct {
 	AssistantText   string
 	ToolInvocations []ToolInvocationRecord
-	StopReason      string // completed | limit | error
-	Usage           provider.Usage
+	StopReason      string // completed | limit | error | confirmation_required
+	// PendingConfirmation is set when StopReason == confirmation_required: the proposed action the
+	// caller must approve/deny via POST .../confirmations/{id} to resume the turn.
+	PendingConfirmation *PendingConfirmation
+	Usage               provider.Usage
 }
 
-// AgentLoop runs one bounded, tool-calling guide turn. Step 2 exercises read-only tools
-// only — confirmation (Step 3) and credit (Step 4) are not wired here.
+// AgentLoop runs one bounded, tool-calling guide turn. read/draft tools execute inline;
+// workspace_write+ tools propose a confirmation and end the turn (Step 3, end+resume). Credit
+// (Step 4) is not wired here.
 type AgentLoop struct {
-	invoker  modelInvoker
-	registry ToolRegistry
-	messages MessageStore
-	redactor EvidenceRedactor
-	model    GuideModel
-	limits   AgentLimits
+	invoker       modelInvoker
+	registry      ToolRegistry
+	messages      MessageStore
+	redactor      EvidenceRedactor
+	confirmations ConfirmationStore // nil until WithConfirmationStore; required for write tools
+	audit         AuditWriter
+	model         GuideModel
+	limits        AgentLimits
 }
 
-// NewAgentLoop constructs the loop. invoker is typically a provider.Router.
+// NewAgentLoop constructs the loop. invoker is typically a provider.Router. Audit defaults to a
+// no-op and confirmations to nil; the api layer injects repo-backed implementations via the
+// With* setters (Step 3b-2).
 func NewAgentLoop(invoker modelInvoker, reg ToolRegistry, store MessageStore, redactor EvidenceRedactor, model GuideModel, limits AgentLimits) *AgentLoop {
+	// Normalize each defaultable bound independently — a caller that sets only MaxSteps must still
+	// get a non-zero ConfirmationTTL, else a proposed confirmation would be expired at creation.
+	def := DefaultLimits()
 	if limits.MaxSteps == 0 {
-		limits = DefaultLimits()
+		limits.MaxSteps = def.MaxSteps
 	}
-	return &AgentLoop{invoker: invoker, registry: reg, messages: store, redactor: redactor, model: model, limits: limits}
+	if limits.MaxToolCalls == 0 {
+		limits.MaxToolCalls = def.MaxToolCalls
+	}
+	if limits.WallClock == 0 {
+		limits.WallClock = def.WallClock
+	}
+	if limits.ConfirmationTTL == 0 {
+		limits.ConfirmationTTL = def.ConfirmationTTL
+	}
+	return &AgentLoop{invoker: invoker, registry: reg, messages: store, redactor: redactor, audit: NoopAuditWriter{}, model: model, limits: limits}
+}
+
+// WithConfirmationStore injects the confirmation persistence (enables workspace_write+ tools).
+func (l *AgentLoop) WithConfirmationStore(s ConfirmationStore) *AgentLoop {
+	l.confirmations = s
+	return l
+}
+
+// WithAuditWriter injects the tool-invocation audit writer (defaults to no-op).
+func (l *AgentLoop) WithAuditWriter(a AuditWriter) *AgentLoop {
+	if a != nil {
+		l.audit = a
+	}
+	return l
 }
 
 // RunTurn runs one bounded turn for the given actor/conversation. actor is audit identity;
@@ -125,8 +167,15 @@ func (l *AgentLoop) RunTurn(ctx context.Context, actor Actor, authorizer Workspa
 		pmsgs = append(pmsgs, pm)
 	}
 
+	return l.runLoop(ctx, actor, authorizer, conv, pmsgs, result, 0, sink)
+}
+
+// runLoop drives the model/tool iteration over an already-built provider message list. Shared by
+// RunTurn (fresh user turn) and ResumeConfirmedTurn (after a confirmation resolves). toolCalls is
+// the running tool-call count carried across the resume boundary.
+func (l *AgentLoop) runLoop(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, pmsgs []provider.Message, result TurnResult, toolCalls int, sink EventSink) (TurnResult, error) {
 	defs := l.registry.Definitions(conv.Phase)
-	steps, toolCalls := 0, 0
+	steps := 0
 
 	for {
 		if steps >= l.limits.MaxSteps {
@@ -157,14 +206,15 @@ func (l *AgentLoop) RunTurn(ctx context.Context, actor Actor, authorizer Workspa
 		if err != nil {
 			return result, err
 		}
-		if _, err := l.messages.Append(ctx, Message{
+		assistantMsg, err := l.messages.Append(ctx, Message{
 			ConversationID: conv.ID,
 			Role:           RoleAssistant,
 			Content:        resp.OutputText,
 			RedactionState: RedactionNone,
 			ToolCalls:      toolCallsRaw,
 			Usage:          usageJSON(resp.Usage),
-		}); err != nil {
+		})
+		if err != nil {
 			return result, err
 		}
 		if resp.OutputText != "" {
@@ -177,13 +227,47 @@ func (l *AgentLoop) RunTurn(ctx context.Context, actor Actor, authorizer Workspa
 			break
 		}
 
+		// Confirmation gating (#875 §5.3): if the assistant batch contains any workspace_write+
+		// tool call, defer the WHOLE batch — execute none, propose one confirmation for the first
+		// such call, end the turn. The batch is executed atomically on resume so tool_use/
+		// tool_result pairing stays valid for siblings before and after the confirmed call.
+		if idx := l.firstConfirmationTierCall(resp.ToolCalls); idx >= 0 {
+			tc := resp.ToolCalls[idx]
+			tool, _ := l.registry.Resolve(tc.Name)
+			// Authorize the action BEFORE proposing — never show an approval card for an action the
+			// caller cannot perform. The api endpoint re-authorizes on resolve (defense in depth).
+			if err := authorizer.Authorize(ctx, conv.WorkspaceID, tool.RequiredAction()); err != nil {
+				// Forbidden: propose nothing; block the whole batch with synthetic results (history
+				// stays paired), then let the model react on the next step.
+				for _, btc := range resp.ToolCalls {
+					action, tier := l.actionAndTier(btc.Name)
+					content, reason := "not executed because a required confirmation is not authorized", "confirmation_forbidden"
+					if btc.ID == tc.ID {
+						content = "error: not authorized for " + btc.Name
+					}
+					pmsgs = append(pmsgs, l.appendSyntheticToolResult(ctx, conv, actor, &assistantMsg.ID, nil, btc, action, tier, content, AuditOutcomeError, reason, sink))
+				}
+				continue
+			}
+			pc, err := l.requireConfirmation(ctx, actor, conv, assistantMsg.ID, tc)
+			if err != nil {
+				sink(Event{Type: EventError, Text: err.Error()})
+				result.StopReason = "error"
+				return result, err
+			}
+			result.StopReason = "confirmation_required"
+			result.PendingConfirmation = &pc
+			sink(Event{Type: EventConfirmationRequired, ToolName: pc.ToolName, ToolCallID: pc.ToolCallID, ConfirmationID: pc.ID.String(), Action: pc.Action, Summary: pc.Summary, ExpiresAt: pc.ExpiresAt.UTC().Format(time.RFC3339)})
+			return l.finish(result, sink), nil
+		}
+
 		for _, tc := range resp.ToolCalls {
 			if toolCalls >= l.limits.MaxToolCalls {
 				result.StopReason = "limit"
 				return l.finish(result, sink), nil
 			}
 			toolCalls++
-			rec, toolMsg := l.executeTool(ctx, actor, authorizer, conv, tc, sink)
+			rec, toolMsg := l.executeTool(ctx, actor, authorizer, conv, tc, &assistantMsg.ID, nil, sink)
 			result.ToolInvocations = append(result.ToolInvocations, rec)
 			pmsgs = append(pmsgs, toolMsg)
 		}
@@ -197,11 +281,67 @@ func (l *AgentLoop) finish(result TurnResult, sink EventSink) TurnResult {
 	return result
 }
 
-// executeTool resolves, authorizes, runs, redacts, and persists one tool call. It returns
-// the audit record and the provider tool-result message to append to the conversation.
-func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, tc provider.ToolCall, sink EventSink) (ToolInvocationRecord, provider.Message) {
-	rec := ToolInvocationRecord{ToolName: tc.Name}
+// firstConfirmationTierCall returns the index of the first resolved, confirmation-tier tool call in
+// the batch, or -1. Unknown/unloaded tool names are not confirmation-tier (executeTool errors them).
+func (l *AgentLoop) firstConfirmationTierCall(calls []provider.ToolCall) int {
+	for i, tc := range calls {
+		if tool, ok := l.registry.Resolve(tc.Name); ok && requiresConfirmation(tool.RiskTier()) {
+			return i
+		}
+	}
+	return -1
+}
+
+// requireConfirmation persists a pending confirmation for one workspace_write+ tool call and audits
+// the propose as outcome=confirmation_required. The caller (runLoop) has already authorized the
+// action before reaching here, so a card is never shown for a forbidden action; the api endpoint
+// re-authorizes again on resolve (defense in depth).
+func (l *AgentLoop) requireConfirmation(ctx context.Context, actor Actor, conv Conversation, messageID uuid.UUID, tc provider.ToolCall) (PendingConfirmation, error) {
+	if l.confirmations == nil {
+		return PendingConfirmation{}, fmt.Errorf("confirmation store not configured for tool %s", tc.Name)
+	}
+	tool, _ := l.registry.Resolve(tc.Name)
+	mid := messageID
+	hash := payloadHash(tc.Name, tc.Arguments)
+	pc, err := l.confirmations.Create(ctx, NewPendingConfirmation{
+		ConversationID:   conv.ID,
+		MessageID:        &mid,
+		ProposedByUserID: actor.UserID,
+		ToolName:         tc.Name,
+		ToolCallID:       tc.ID,
+		Action:           tool.RequiredAction(),
+		RiskTier:         tool.RiskTier(),
+		PayloadHash:      hash,
+		BoundArgs:        append(json.RawMessage(nil), tc.Arguments...),
+		Summary:          confirmationSummary(tool),
+		ExpiresAt:        time.Now().Add(l.limits.ConfirmationTTL),
+	})
+	if err != nil {
+		return PendingConfirmation{}, err
+	}
+	l.auditInvocation(ctx, conv, actor, &mid, &pc.ID, tc.Name, tool.RequiredAction(), tool.RiskTier(), hash, tc.Arguments, nil, AuditOutcomeConfirmationRequired)
+	return pc, nil
+}
+
+func confirmationSummary(tool Tool) string {
+	return "Confirm " + tool.Name() + " (" + string(tool.RiskTier()) + ")"
+}
+
+// executeTool resolves, authorizes, runs, redacts, and persists one tool call. It returns the
+// audit record and the provider tool-result message to append. A draft+ tier call writes one
+// audit row (outcome ok/error) regardless of exit path; messageID links the assistant tool-call
+// row and confirmationID is set when this call was resolved from a confirmation.
+func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, tc provider.ToolCall, messageID, confirmationID *uuid.UUID, sink EventSink) (rec ToolInvocationRecord, msg provider.Message) {
+	rec = ToolInvocationRecord{ToolName: tc.Name}
 	sink(Event{Type: EventToolCall, ToolName: tc.Name, ToolCallID: tc.ID})
+
+	outcome := AuditOutcomeError
+	var resultMeta json.RawMessage
+	defer func() {
+		if requiresAudit(rec.RiskTier) {
+			l.auditInvocation(ctx, conv, actor, messageID, confirmationID, tc.Name, rec.Action, rec.RiskTier, payloadHash(tc.Name, tc.Arguments), tc.Arguments, resultMeta, outcome)
+		}
+	}()
 
 	fail := func(content string) provider.Message {
 		evidence, _ := l.redactor.Wrap(tc.Name, content)
@@ -242,7 +382,191 @@ func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer Wor
 	}
 	sink(Event{Type: EventToolResult, ToolName: tc.Name, ToolCallID: tc.ID})
 	rec.OK = true
+	outcome = AuditOutcomeOK
+	resultMeta = auditResultJSON(out.AuditResult)
 	return rec, provider.Message{Role: "tool", ToolCallID: tc.ID, Content: evidence}
+}
+
+// requiresAudit reports whether a tool call writes an audit row: every draft+ tier call. read-tier
+// calls are audited only when they touch sensitive evidence (Phase 0) — a later refinement.
+func requiresAudit(tier RiskTier) bool {
+	return tier == DraftTier || requiresConfirmation(tier)
+}
+
+// auditInvocation appends one metadata-only audit row, best-effort (audit failure never fails the
+// turn). request is the raw tool args (the AuditWriter scrubs); result is metadata-only.
+func (l *AgentLoop) auditInvocation(ctx context.Context, conv Conversation, actor Actor, messageID, confirmationID *uuid.UUID, toolName, action string, tier RiskTier, hash string, request, result json.RawMessage, outcome string) {
+	_ = l.audit.Append(ctx, ToolInvocationAudit{
+		ConversationID: conv.ID,
+		MessageID:      messageID,
+		Actor:          actor,
+		ToolName:       toolName,
+		Action:         action,
+		RiskTier:       tier,
+		PayloadHash:    hash,
+		ConfirmationID: confirmationID,
+		RequestPayload: request,
+		ResultPayload:  result,
+		Outcome:        outcome,
+	})
+}
+
+func auditResultJSON(meta map[string]any) json.RawMessage {
+	if len(meta) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// ResumeConfirmedTurn continues a turn that was suspended for a confirmation. pc is the ALREADY-
+// resolved confirmation (the api manager performed the atomic Approve/Deny + crash-safe re-entry
+// before calling this). The whole deferred assistant batch is resolved here so tool_use/
+// tool_result pairing stays valid, then the model loop continues (Step 3b, end+resume).
+func (l *AgentLoop) ResumeConfirmedTurn(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, pc PendingConfirmation, approve bool, sink EventSink) (TurnResult, error) {
+	if sink == nil {
+		sink = func(Event) {}
+	}
+	var result TurnResult
+
+	pmsgs := []provider.Message{{Role: "system", Content: systemPrompt(conv.Phase)}}
+	history, err := l.messages.History(ctx, conv.ID)
+	if err != nil {
+		return result, err
+	}
+	for _, m := range history {
+		pm, err := toProviderMessage(m)
+		if err != nil {
+			return result, fmt.Errorf("rebuild history for conversation %s: %w", conv.ID, err)
+		}
+		pmsgs = append(pmsgs, pm)
+	}
+
+	batch, ok := l.deferredBatch(history, pc)
+	if !ok {
+		return result, fmt.Errorf("deferred assistant batch for confirmation %s not found", pc.ID)
+	}
+
+	// Validate the confirmed call is present (and is the recorded tool) BEFORE executing anything,
+	// so a stale/corrupt confirmation never causes siblings to run without resolving the action.
+	if err := assertConfirmedCallPresent(batch, pc); err != nil {
+		return result, err
+	}
+
+	toolCalls := 0
+	for _, tc := range batch {
+		var toolMsg provider.Message
+		switch {
+		case tc.ID == pc.ToolCallID:
+			// The confirmed call: execute with the BOUND args (authoritative), or deny.
+			if approve {
+				bound := provider.ToolCall{ID: pc.ToolCallID, Name: pc.ToolName, Arguments: pc.BoundArgs}
+				var rec ToolInvocationRecord
+				rec, toolMsg = l.executeTool(ctx, actor, authorizer, conv, bound, pc.MessageID, &pc.ID, sink)
+				result.ToolInvocations = append(result.ToolInvocations, rec)
+				toolCalls++
+				// Surface finalization failures: a swallowed MarkSucceeded leaves the row 'executing',
+				// which the retry path would treat as resumable and could re-run the effect.
+				if rec.OK {
+					if merr := l.confirmations.MarkSucceeded(ctx, pc.ID); merr != nil {
+						return result, fmt.Errorf("finalize confirmation %s succeeded: %w", pc.ID, merr)
+					}
+				} else {
+					if merr := l.confirmations.MarkFailed(ctx, pc.ID); merr != nil {
+						return result, fmt.Errorf("finalize confirmation %s failed: %w", pc.ID, merr)
+					}
+				}
+			} else {
+				toolMsg = l.appendSyntheticToolResult(ctx, conv, actor, pc.MessageID, &pc.ID, tc, pc.Action, pc.RiskTier,
+					"confirmation denied by user", AuditOutcomeDenied, "denied_by_user", sink)
+			}
+		case l.isConfirmationTierName(tc.Name):
+			// An additional confirmation-tier sibling: never executed — one confirmation per turn.
+			action, tier := l.actionAndTier(tc.Name)
+			content, reason := "not executed: only one confirmation can be resolved per turn; please re-propose this action", "one_confirmation_per_turn"
+			if !approve {
+				content, reason = "not executed because the confirmation batch was denied", "batch_denied"
+			}
+			toolMsg = l.appendSyntheticToolResult(ctx, conv, actor, pc.MessageID, nil, tc, action, tier, content, AuditOutcomeError, reason, sink)
+		default:
+			// read/draft sibling: execute on approve, synthetic on deny.
+			if approve {
+				var rec ToolInvocationRecord
+				rec, toolMsg = l.executeTool(ctx, actor, authorizer, conv, tc, pc.MessageID, nil, sink)
+				result.ToolInvocations = append(result.ToolInvocations, rec)
+				toolCalls++
+			} else {
+				action, tier := l.actionAndTier(tc.Name)
+				toolMsg = l.appendSyntheticToolResult(ctx, conv, actor, pc.MessageID, nil, tc, action, tier,
+					"not executed because the confirmation batch was denied", AuditOutcomeError, "batch_denied", sink)
+			}
+		}
+		pmsgs = append(pmsgs, toolMsg)
+	}
+
+	return l.runLoop(ctx, actor, authorizer, conv, pmsgs, result, toolCalls, sink)
+}
+
+// assertConfirmedCallPresent verifies the deferred batch contains exactly the recorded confirmed
+// call (id + tool name), so a stale/corrupt confirmation never resolves against the wrong call or
+// silently runs siblings without resolving the action.
+func assertConfirmedCallPresent(batch []provider.ToolCall, pc PendingConfirmation) error {
+	for _, tc := range batch {
+		if tc.ID == pc.ToolCallID {
+			if tc.Name != pc.ToolName {
+				return fmt.Errorf("confirmation %s tool %q does not match batch call %q", pc.ID, pc.ToolName, tc.Name)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("confirmation %s tool_call %q not found in deferred batch", pc.ID, pc.ToolCallID)
+}
+
+// deferredBatch returns the tool-call array of the assistant message that proposed pc.
+func (l *AgentLoop) deferredBatch(history []Message, pc PendingConfirmation) ([]provider.ToolCall, bool) {
+	if pc.MessageID == nil {
+		return nil, false
+	}
+	for _, m := range history {
+		if m.Role == RoleAssistant && m.ID == *pc.MessageID {
+			var calls []provider.ToolCall
+			if len(m.ToolCalls) > 0 {
+				if err := json.Unmarshal(m.ToolCalls, &calls); err != nil {
+					return nil, false
+				}
+			}
+			return calls, true
+		}
+	}
+	return nil, false
+}
+
+func (l *AgentLoop) isConfirmationTierName(name string) bool {
+	tool, ok := l.registry.Resolve(name)
+	return ok && requiresConfirmation(tool.RiskTier())
+}
+
+func (l *AgentLoop) actionAndTier(name string) (string, RiskTier) {
+	if tool, ok := l.registry.Resolve(name); ok {
+		return tool.RequiredAction(), tool.RiskTier()
+	}
+	return "", RiskTier("")
+}
+
+// appendSyntheticToolResult appends a system-generated tool-result (not untrusted evidence) to keep
+// tool_use/tool_result pairing valid for a call that was deferred/denied/superseded, audits it for
+// draft+ tiers, and returns the provider message (marked as an error result).
+func (l *AgentLoop) appendSyntheticToolResult(ctx context.Context, conv Conversation, actor Actor, messageID, confirmationID *uuid.UUID, tc provider.ToolCall, action string, tier RiskTier, content, outcome, reason string, sink EventSink) provider.Message {
+	sink(Event{Type: EventToolResult, ToolName: tc.Name, ToolCallID: tc.ID})
+	_, _ = l.messages.Append(ctx, Message{ConversationID: conv.ID, Role: RoleTool, Content: content, RedactionState: RedactionNotApplicable, ToolCallID: tc.ID, ToolName: tc.Name})
+	if requiresAudit(tier) {
+		reasonMeta, _ := json.Marshal(map[string]string{"reason": reason})
+		l.auditInvocation(ctx, conv, actor, messageID, confirmationID, tc.Name, action, tier, payloadHash(tc.Name, tc.Arguments), tc.Arguments, reasonMeta, outcome)
+	}
+	return provider.Message{Role: "tool", ToolCallID: tc.ID, Content: content, IsError: true}
 }
 
 func toProviderMessage(m Message) (provider.Message, error) {

--- a/backend/internal/vibeeval/loop_confirmation_test.go
+++ b/backend/internal/vibeeval/loop_confirmation_test.go
@@ -1,0 +1,486 @@
+package vibeeval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/google/uuid"
+)
+
+var errTest = errors.New("test error")
+
+// --- confirmation/audit fakes ---
+
+type fakeWriteTool struct {
+	name    string
+	action  string
+	tier    RiskTier
+	called  *bool
+	result  any
+	execErr error
+}
+
+func (t fakeWriteTool) Name() string           { return t.name }
+func (t fakeWriteTool) Phases() []string       { return []string{PhasePlan} }
+func (t fakeWriteTool) RiskTier() RiskTier     { return t.tier }
+func (t fakeWriteTool) RequiredAction() string { return t.action }
+func (t fakeWriteTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{Name: t.name}
+}
+func (t fakeWriteTool) Execute(context.Context, Actor, Conversation, json.RawMessage) (ToolOutput, error) {
+	if t.called != nil {
+		*t.called = true
+	}
+	if t.execErr != nil {
+		return ToolOutput{}, t.execErr
+	}
+	return ToolOutput{Result: t.result, AuditResult: map[string]any{"ok": true}}, nil
+}
+
+type fakeConfirmationStore struct {
+	created   []NewPendingConfirmation
+	succeeded []uuid.UUID
+	failed    []uuid.UUID
+	markErr   error // when set, MarkSucceeded/MarkFailed return it (simulates a finalization failure)
+}
+
+func (s *fakeConfirmationStore) Create(_ context.Context, nc NewPendingConfirmation) (PendingConfirmation, error) {
+	s.created = append(s.created, nc)
+	return PendingConfirmation{
+		ID:             uuid.New(),
+		ConversationID: nc.ConversationID,
+		MessageID:      nc.MessageID,
+		ToolName:       nc.ToolName,
+		ToolCallID:     nc.ToolCallID,
+		Action:         nc.Action,
+		RiskTier:       nc.RiskTier,
+		PayloadHash:    nc.PayloadHash,
+		BoundArgs:      nc.BoundArgs,
+		Summary:        nc.Summary,
+		Status:         "pending",
+		ExpiresAt:      nc.ExpiresAt,
+	}, nil
+}
+
+// The loop never calls Approve/Deny/GetForResume (the api manager does); included for the interface.
+func (s *fakeConfirmationStore) Approve(context.Context, uuid.UUID, string, Actor) (PendingConfirmation, error) {
+	return PendingConfirmation{}, nil
+}
+func (s *fakeConfirmationStore) Deny(context.Context, uuid.UUID, string, Actor) (PendingConfirmation, error) {
+	return PendingConfirmation{}, nil
+}
+func (s *fakeConfirmationStore) GetForResume(context.Context, uuid.UUID, string) (PendingConfirmation, error) {
+	return PendingConfirmation{}, nil
+}
+func (s *fakeConfirmationStore) MarkSucceeded(_ context.Context, id uuid.UUID) error {
+	s.succeeded = append(s.succeeded, id)
+	return s.markErr
+}
+func (s *fakeConfirmationStore) MarkFailed(_ context.Context, id uuid.UUID) error {
+	s.failed = append(s.failed, id)
+	return s.markErr
+}
+
+type fakeAuditWriter struct{ rows []ToolInvocationAudit }
+
+func (a *fakeAuditWriter) Append(_ context.Context, r ToolInvocationAudit) error {
+	a.rows = append(a.rows, r)
+	return nil
+}
+
+func newConfirmLoop(inv modelInvoker, store MessageStore, reg ToolRegistry, cs ConfirmationStore, aw AuditWriter) *AgentLoop {
+	return newLoop(inv, store, reg).WithConfirmationStore(cs).WithAuditWriter(aw)
+}
+
+func toolMsgContents(msgs []Message) []string {
+	var out []string
+	for _, m := range msgs {
+		if m.Role == RoleTool {
+			out = append(out, m.Content)
+		}
+	}
+	return out
+}
+
+func auditOutcomes(rows []ToolInvocationAudit) map[string]int {
+	m := map[string]int{}
+	for _, r := range rows {
+		m[r.Outcome]++
+	}
+	return m
+}
+
+// --- tests ---
+
+func TestRunTurn_ConfirmationTierProposesAndStops(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &called, result: "published"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{"draft_id":"d1"}`)}}},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	aw := &fakeAuditWriter{}
+
+	var events []Event
+	res, err := newConfirmLoop(inv, store, reg, cs, aw).RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, conv(), "publish my draft", func(e Event) { events = append(events, e) })
+	if err != nil {
+		t.Fatalf("RunTurn error: %v", err)
+	}
+	if called {
+		t.Fatal("workspace_write tool must NOT execute before confirmation")
+	}
+	if res.StopReason != "confirmation_required" {
+		t.Fatalf("StopReason = %q, want confirmation_required", res.StopReason)
+	}
+	if res.PendingConfirmation == nil || res.PendingConfirmation.ToolName != "publish_draft" {
+		t.Fatalf("PendingConfirmation = %+v, want publish_draft", res.PendingConfirmation)
+	}
+	if len(cs.created) != 1 || cs.created[0].PayloadHash == "" {
+		t.Fatalf("expected one created confirmation with a payload hash, got %+v", cs.created)
+	}
+	// Only user + assistant persisted — NO tool-result yet.
+	if len(store.msgs) != 2 || store.msgs[1].Role != RoleAssistant {
+		t.Fatalf("persisted %v, want [user, assistant] only", roles(store.msgs))
+	}
+	if !hasEvent(events, EventConfirmationRequired) {
+		t.Fatalf("missing confirmation.required event: %v", events)
+	}
+	if got := auditOutcomes(aw.rows); got[AuditOutcomeConfirmationRequired] != 1 {
+		t.Fatalf("audit outcomes = %v, want one confirmation_required", got)
+	}
+}
+
+func TestResumeConfirmedTurn_ApproveExecutesAndContinues(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &called, result: "published"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{"draft_id":"d1"}`)}}},
+		{OutputText: "Published your draft."},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	aw := &fakeAuditWriter{}
+	loop := newConfirmLoop(inv, store, reg, cs, aw)
+	c := conv()
+
+	res, err := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "publish", nil)
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	pc := res.PendingConfirmation
+	if pc == nil {
+		t.Fatal("no pending confirmation")
+	}
+
+	res2, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *pc, true, nil)
+	if err != nil {
+		t.Fatalf("ResumeConfirmedTurn: %v", err)
+	}
+	if !called {
+		t.Fatal("confirmed tool must execute on approve")
+	}
+	if res2.StopReason != "completed" || res2.AssistantText != "Published your draft." {
+		t.Fatalf("resume result = %+v, want completed final text", res2)
+	}
+	if len(cs.succeeded) != 1 {
+		t.Fatalf("MarkSucceeded calls = %d, want 1", len(cs.succeeded))
+	}
+	if got := auditOutcomes(aw.rows); got[AuditOutcomeOK] != 1 {
+		t.Fatalf("audit outcomes = %v, want one ok for the executed publish", got)
+	}
+}
+
+func TestResumeConfirmedTurn_DenyAppendsSyntheticAndContinues(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &called, result: "x"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{"draft_id":"d1"}`)}}},
+		{OutputText: "Okay, I did not make any changes."},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	aw := &fakeAuditWriter{}
+	loop := newConfirmLoop(inv, store, reg, cs, aw)
+	c := conv()
+
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "publish", nil)
+	res2, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *res.PendingConfirmation, false, nil)
+	if err != nil {
+		t.Fatalf("ResumeConfirmedTurn deny: %v", err)
+	}
+	if called {
+		t.Fatal("confirmed tool must NOT execute on deny")
+	}
+	if res2.AssistantText != "Okay, I did not make any changes." {
+		t.Fatalf("AssistantText = %q", res2.AssistantText)
+	}
+	tools := toolMsgContents(store.msgs)
+	if len(tools) != 1 || tools[0] != "confirmation denied by user" {
+		t.Fatalf("tool messages = %v, want one synthetic denial", tools)
+	}
+	if got := auditOutcomes(aw.rows); got[AuditOutcomeDenied] != 1 {
+		t.Fatalf("audit outcomes = %v, want one denied", got)
+	}
+}
+
+// Codex-required: [read, publish, read] — initial turn creates one pending confirmation and NO tool
+// results; approve appends all three results in order and continues.
+func TestResumeConfirmedTurn_MixedBatchApproveExecutesAllInOrder(t *testing.T) {
+	read1, pub, read2 := false, false, false
+	reg := NewRegistry()
+	reg.Register(fakeReadTool{name: "read_a", called: &read1, result: "a"})
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &pub, result: "p"})
+	reg.Register(fakeReadTool{name: "read_b", called: &read2, result: "b"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{
+			{ID: "r1", Name: "read_a", Arguments: json.RawMessage(`{}`)},
+			{ID: "p1", Name: "publish_draft", Arguments: json.RawMessage(`{"draft_id":"d1"}`)},
+			{ID: "r2", Name: "read_b", Arguments: json.RawMessage(`{}`)},
+		}},
+		{OutputText: "Done."},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	aw := &fakeAuditWriter{}
+	loop := newConfirmLoop(inv, store, reg, cs, aw)
+	c := conv()
+
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "go", nil)
+	if read1 || pub || read2 {
+		t.Fatal("no tool in the batch may execute before confirmation")
+	}
+	if len(store.msgs) != 2 {
+		t.Fatalf("persisted %v, want [user, assistant] only", roles(store.msgs))
+	}
+	if res.PendingConfirmation == nil || res.PendingConfirmation.ToolCallID != "p1" {
+		t.Fatalf("pending confirmation = %+v, want for tool_call p1", res.PendingConfirmation)
+	}
+
+	if _, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *res.PendingConfirmation, true, nil); err != nil {
+		t.Fatalf("resume approve: %v", err)
+	}
+	if !read1 || !pub || !read2 {
+		t.Fatalf("approve must execute the whole batch: read_a=%v publish=%v read_b=%v", read1, pub, read2)
+	}
+	// tool-result order must match the original tool-call order r1, p1, r2.
+	var order []string
+	for _, m := range store.msgs {
+		if m.Role == RoleTool {
+			order = append(order, m.ToolCallID)
+		}
+	}
+	if len(order) != 3 || order[0] != "r1" || order[1] != "p1" || order[2] != "r2" {
+		t.Fatalf("tool-result order = %v, want [r1 p1 r2]", order)
+	}
+}
+
+// Codex-required: [publish_a, publish_b] — one pending confirmation; approve executes publish_a and
+// synthesizes a non-executed result for publish_b; deny synthesizes results for both.
+func TestResumeConfirmedTurn_TwoConfirmTierOnePerTurn(t *testing.T) {
+	a, b := false, false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_a", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &a, result: "a"})
+	reg.Register(fakeWriteTool{name: "publish_b", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &b, result: "b"})
+
+	batch := provider.Response{ToolCalls: []provider.ToolCall{
+		{ID: "pa", Name: "publish_a", Arguments: json.RawMessage(`{}`)},
+		{ID: "pb", Name: "publish_b", Arguments: json.RawMessage(`{}`)},
+	}}
+
+	// Approve path.
+	inv := &scriptedInvoker{responses: []provider.Response{batch, {OutputText: "done"}}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	loop := newConfirmLoop(inv, store, reg, cs, &fakeAuditWriter{})
+	c := conv()
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "go", nil)
+	if res.PendingConfirmation.ToolCallID != "pa" {
+		t.Fatalf("pending confirmation tool_call = %q, want pa (first confirm-tier)", res.PendingConfirmation.ToolCallID)
+	}
+	if _, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *res.PendingConfirmation, true, nil); err != nil {
+		t.Fatalf("resume approve: %v", err)
+	}
+	if !a || b {
+		t.Fatalf("approve must execute publish_a only: a=%v b=%v", a, b)
+	}
+
+	// Deny path: neither executes; both get synthetic results.
+	a, b = false, false
+	inv2 := &scriptedInvoker{responses: []provider.Response{batch, {OutputText: "no changes"}}}
+	store2 := &memStore{}
+	loop2 := newConfirmLoop(inv2, store2, reg, &fakeConfirmationStore{}, &fakeAuditWriter{})
+	c2 := conv()
+	res2, _ := loop2.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c2, "go", nil)
+	if _, err := loop2.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c2, *res2.PendingConfirmation, false, nil); err != nil {
+		t.Fatalf("resume deny: %v", err)
+	}
+	if a || b {
+		t.Fatalf("deny must execute nothing: a=%v b=%v", a, b)
+	}
+	if got := len(toolMsgContents(store2.msgs)); got != 2 {
+		t.Fatalf("deny synthetic tool messages = %d, want 2 (both calls paired)", got)
+	}
+}
+
+// Finding 1: a forbidden confirmation-tier proposal creates NO pending row and leaves history
+// paired (synthetic forbidden result), then the model continues.
+func TestRunTurn_ForbiddenConfirmationTierProposesNothing(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, called: &called, result: "x"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)}}},
+		{OutputText: "You are not allowed to publish here."},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	loop := newConfirmLoop(inv, store, reg, cs, &fakeAuditWriter{})
+
+	res, err := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, denyAll{}, conv(), "publish", nil)
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if called {
+		t.Fatal("forbidden tool must not execute")
+	}
+	if len(cs.created) != 0 {
+		t.Fatalf("forbidden action must not create a pending confirmation, got %d", len(cs.created))
+	}
+	if res.StopReason != "completed" {
+		t.Fatalf("StopReason = %q, want completed (model reacted after the block)", res.StopReason)
+	}
+	if got := toolMsgContents(store.msgs); len(got) != 1 {
+		t.Fatalf("want one synthetic tool result to keep history paired, got %v", got)
+	}
+}
+
+// Finding 2/asks: confirmed Execute errors on resume → MarkFailed (not MarkSucceeded).
+func TestResumeConfirmedTurn_ExecuteErrorMarksFailed(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, execErr: errTest})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)}}},
+		{OutputText: "That failed."},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{}
+	loop := newConfirmLoop(inv, store, reg, cs, &fakeAuditWriter{})
+	c := conv()
+
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "publish", nil)
+	if _, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *res.PendingConfirmation, true, nil); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if len(cs.failed) != 1 || len(cs.succeeded) != 0 {
+		t.Fatalf("want MarkFailed once and no MarkSucceeded, got failed=%d succeeded=%d", len(cs.failed), len(cs.succeeded))
+	}
+}
+
+// Finding 2: a MarkSucceeded error must be surfaced (not swallowed) so the api can retry rather
+// than leave an 'executing' row that the retry path would re-enter.
+func TestResumeConfirmedTurn_MarkErrorIsSurfaced(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, result: "ok"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)}}},
+		{OutputText: "done"},
+	}}
+	store := &memStore{}
+	cs := &fakeConfirmationStore{markErr: errTest}
+	loop := newConfirmLoop(inv, store, reg, cs, &fakeAuditWriter{})
+	c := conv()
+
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "publish", nil)
+	if _, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, *res.PendingConfirmation, true, nil); err == nil {
+		t.Fatal("expected MarkSucceeded failure to be surfaced as an error")
+	}
+}
+
+// Finding 3: a confirmation whose tool_call_id is absent from the deferred batch must error and
+// not execute siblings.
+func TestResumeConfirmedTurn_ConfirmedCallMissingErrors(t *testing.T) {
+	sib := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, result: "x"})
+	reg.Register(fakeReadTool{name: "read_a", called: &sib, result: "a"})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{
+			{ID: "p1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)},
+			{ID: "r1", Name: "read_a", Arguments: json.RawMessage(`{}`)},
+		}},
+	}}
+	store := &memStore{}
+	loop := newConfirmLoop(inv, store, reg, &fakeConfirmationStore{}, &fakeAuditWriter{})
+	c := conv()
+
+	res, _ := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, "go", nil)
+	stale := *res.PendingConfirmation
+	stale.ToolCallID = "does-not-exist"
+	if _, err := loop.ResumeConfirmedTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, c, stale, true, nil); err == nil {
+		t.Fatal("expected error when the confirmed tool_call_id is missing from the batch")
+	}
+	if sib {
+		t.Fatal("siblings must not execute when the confirmed call is absent")
+	}
+}
+
+// Finding 4: the confirmation.required event carries expiry metadata.
+func TestRunTurn_ConfirmationEventIncludesExpiry(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, result: "x"})
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)}}},
+	}}
+	var events []Event
+	_, _ = newConfirmLoop(inv, &memStore{}, reg, &fakeConfirmationStore{}, &fakeAuditWriter{}).
+		RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, conv(), "publish", func(e Event) { events = append(events, e) })
+	for _, e := range events {
+		if e.Type == EventConfirmationRequired {
+			if e.ExpiresAt == "" {
+				t.Fatal("confirmation.required event missing expires_at")
+			}
+			return
+		}
+	}
+	t.Fatal("no confirmation.required event emitted")
+}
+
+// Finding 5: partial AgentLimits must still yield a non-zero ConfirmationTTL (else a confirmation
+// is born expired). Verified via the proposed ExpiresAt being well in the future.
+func TestRunTurn_PartialLimitsStillGiveConfirmationTTL(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "publish_draft", action: "publish_challenge_pack", tier: WorkspaceWriteTier, result: "x"})
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "publish_draft", Arguments: json.RawMessage(`{}`)}}},
+	}}
+	cs := &fakeConfirmationStore{}
+	loop := NewAgentLoop(inv, reg, &memStore{}, NewEvidenceRedactor(),
+		GuideModel{ProviderKey: "anthropic", Model: "claude-sonnet-4-6", CredentialReference: "secret://anthropic"},
+		AgentLimits{MaxSteps: 3, MaxToolCalls: 5}).WithConfirmationStore(cs).WithAuditWriter(&fakeAuditWriter{})
+
+	if _, err := loop.RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, conv(), "publish", nil); err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if len(cs.created) != 1 {
+		t.Fatalf("want one created confirmation, got %d", len(cs.created))
+	}
+	if !cs.created[0].ExpiresAt.After(time.Now().Add(time.Minute)) {
+		t.Fatalf("ExpiresAt = %v, want a non-zero TTL well in the future (ConfirmationTTL defaulted)", cs.created[0].ExpiresAt)
+	}
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5080,6 +5080,52 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/vibe-eval/conversations/{conversationID}/confirmations/{confirmationID}:
+    post:
+      operationId: resolveVibeEvalConfirmation
+      summary: Approve or deny a Vibe Eval pending confirmation (Server-Sent Events stream)
+      description: >
+        Approves or denies a workspace_write+ action the guide agent proposed, then streams the
+        continuation turn as Server-Sent Events. The bound action is authorized and the
+        confirmation's payload_hash (echoed from the confirmation.required card) is matched before
+        the action runs; a mismatch or an already-resolved/expired confirmation yields an `error`
+        SSE event. Approving resumes and executes the bound action; denying records the denial and
+        continues. Only registered when the guide agent is configured on the server.
+      tags: [VibeEvals]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/VibeEvalConversationID"
+        - name: confirmationID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveVibeEvalConfirmationRequest"
+      responses:
+        "200":
+          description: Server-Sent Events stream of the continuation turn.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: "SSE frames: `event: <type>` then `data: <json>` per event."
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/workspaces/{workspaceID}/vibe-eval/conversations/{conversationID}/drafts:
     post:
       operationId: createVibeEvalDraft
@@ -12806,6 +12852,19 @@ components:
         message:
           type: string
           description: The user's message for this guide-agent turn.
+
+    ResolveVibeEvalConfirmationRequest:
+      type: object
+      required: [approve, payload_hash]
+      properties:
+        approve:
+          type: boolean
+          description: true to approve and execute the bound action, false to deny.
+        payload_hash:
+          type: string
+          description: >
+            The payload_hash echoed from the confirmation.required card. Binds the resolve to
+            exactly the proposed action's args (anti bait-and-switch); a mismatch is rejected.
 
     VibeEvalMessageResponse:
       type: object

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5234,6 +5234,36 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate:
+    post:
+      operationId: validateVibeEvalDraft
+      summary: Validate a Vibe Eval challenge_pack draft
+      description: >
+        Validates a challenge_pack draft's bundle and records its validation state and structured
+        errors (content-preserving). Draft tier — no confirmation. Same manager path as the
+        validate_draft guide tool.
+      tags: [VibeEvals]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/VibeEvalDraftID"
+      responses:
+        "200":
+          description: Validation result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateVibeEvalDraftResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/agent-tryout-templates:
     get:
       operationId: listAgentTryoutTemplates
@@ -13043,6 +13073,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VibeEvalDraftResponse"
+
+    ValidateVibeEvalDraftResponse:
+      type: object
+      required: [draft, valid, errors]
+      properties:
+        draft:
+          $ref: "#/components/schemas/VibeEvalDraftResponse"
+        valid:
+          type: boolean
+        errors:
+          type: array
+          description: Structured validation errors (empty when valid).
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
 
     # --- Agent Tryouts ---
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5264,6 +5264,37 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish:
+    post:
+      operationId: publishVibeEvalDraft
+      summary: Publish a validated Vibe Eval challenge_pack draft
+      description: >
+        Publishes a validated challenge_pack draft as a runnable challenge pack (requires the
+        private-pack entitlement). Idempotent by effect identity — an already-published draft returns
+        its existing pack/version without republishing. Shares the PublishDraft manager path with the
+        confirmation-gated publish_draft guide tool; this REST entrypoint is a direct human action.
+      tags: [VibeEvals]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/VibeEvalDraftID"
+      responses:
+        "200":
+          description: Publish result (IDs only).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishVibeEvalDraftResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/agent-tryout-templates:
     get:
       operationId: listAgentTryoutTemplates
@@ -13092,6 +13123,22 @@ components:
                 type: string
               message:
                 type: string
+
+    PublishVibeEvalDraftResponse:
+      type: object
+      required: [draft, challenge_pack_id, challenge_pack_version_id, already_published]
+      properties:
+        draft:
+          $ref: "#/components/schemas/VibeEvalDraftResponse"
+        challenge_pack_id:
+          type: string
+          format: uuid
+        challenge_pack_version_id:
+          type: string
+          format: uuid
+        already_published:
+          type: boolean
+          description: true when the result came from the effect-identity idempotency short-circuit.
 
     # --- Agent Tryouts ---
 


### PR DESCRIPTION
## What & why
Adds the write path for the Vibe Eval guide agent (epic #875): a confirmation engine, a generalized tool-invocation audit, and the draft author tools.

- **Confirmation engine (end+resume):** workspace-write+ tools defer the whole assistant batch and propose **one confirmation per turn**; payload-hash binding; outcome-aware crash-safe retry; per-tool-name recovery probes that finalize *succeeded* by effect identity (never re-execute).
- **Audit:** generalized `vibe_eval_tool_invocations` (metadata-only; secrets/contents scrubbed).
- **Draft tools:** `create_draft`/`update_draft` (conversation-local), `validate_draft`, `publish_draft` — the first confirmation-tier write. Publish idempotency is by **effect identity** (`PublishedChallengePackVersionID`), with duplicate-version recovery via concrete lookup. One manager path is shared by the guide tool + REST.
- Includes the entitlement `GateError` → **403** fix in `handleVibeEvalError`.

**Stack position:** PR 3 of 4. Base is `feat/vibe-eval-2-loop` (PR 2).

## Scope
31 files, +4,903/−49. Migrations **00059–00060** (`vibe_eval_tool_invocations`, `vibe_eval_pending_confirmations`).

## API
- `POST …/confirmations/{id}` resolve; `validate_draft` / `publish_draft` REST. OpenAPI updated.

## Test plan (proofs)
- **Live SSE smoke (PASS):** guide propose → `confirmation.required` card (metadata-only) → approve with payload_hash → continuation SSE → `publish_draft` succeeded against a real runnable pack; REST publish path + effect-identity idempotency + entitlement gate verified live (local-dev grant: org feature_flag `private_challenge_packs:true`).
- Unit tests: batch deferral, resume/retry, recovery probes, audit exactly-once.
- `go build/vet` clean.

## Out of scope
Eval-credit wallet, settlement, cost-incurring tools, allowance (PR 4).
