### PR TITLE
feat(vibe-eval): eval-credit wallet, settlement, cost-incurring tools & allowance

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -178,7 +178,7 @@ func main() {
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager
 	if guideCfg, ok := api.VibeEvalGuideConfigFromEnv(); ok {
-		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager, runCreationManager, runCreationManager)
+		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager, runCreationManager, runCreationManager, billingManager)
 		if gerr != nil {
 			logger.Error("failed to initialize vibe eval guide agent", "error", gerr)
 			os.Exit(1)

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -178,7 +178,7 @@ func main() {
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager
 	if guideCfg, ok := api.VibeEvalGuideConfigFromEnv(); ok {
-		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager)
+		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager, runCreationManager)
 		if gerr != nil {
 			logger.Error("failed to initialize vibe eval guide agent", "error", gerr)
 			os.Exit(1)

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -178,7 +178,7 @@ func main() {
 	// It reuses the shared providerRouter and the run/scorecard read managers as read-only tools.
 	var vibeEvalAgentManager *api.VibeEvalAgentManager
 	if guideCfg, ok := api.VibeEvalGuideConfigFromEnv(); ok {
-		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager, runCreationManager)
+		m, gerr := api.NewVibeEvalAgentManager(authorizer, repo, providerRouter, guideCfg, runReadManager, replayReadManager, challengePackReadManager, vibeEvalManager, runCreationManager, runCreationManager)
 		if gerr != nil {
 			logger.Error("failed to initialize vibe eval guide agent", "error", gerr)
 			os.Exit(1)

--- a/backend/db/migrations/00061_org_eval_credit_wallet.sql
+++ b/backend/db/migrations/00061_org_eval_credit_wallet.sql
@@ -1,0 +1,72 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Prepaid, reserve-then-settle eval-execution credit (AgentClash-managed). Integer micros only
+-- (1 USD = 1_000_000 micros) — never floats/numeric for balances. Distinct from the budget package /
+-- workspace_spend_ledger (which is spend-policy reporting, not prepaid reserved credit).
+CREATE TABLE org_eval_credit_wallets (
+    organization_id  uuid PRIMARY KEY REFERENCES organizations (id) ON DELETE CASCADE,
+    currency_code    text NOT NULL DEFAULT 'USD',
+    available_micros bigint NOT NULL DEFAULT 0,
+    reserved_micros  bigint NOT NULL DEFAULT 0,
+    spent_micros     bigint NOT NULL DEFAULT 0,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+    -- Invariant 1 at the DB level: a balance can never go negative.
+    CONSTRAINT org_eval_credit_wallets_available_nonneg CHECK (available_micros >= 0),
+    CONSTRAINT org_eval_credit_wallets_reserved_nonneg CHECK (reserved_micros >= 0),
+    CONSTRAINT org_eval_credit_wallets_spent_nonneg CHECK (spent_micros >= 0)
+);
+
+-- Reservation lifecycle (open -> settled | released). One reservation per run (key `run:<run_id>`).
+-- The (organization_id, reservation_key) unique index makes Reserve idempotent.
+CREATE TABLE org_eval_credit_reservations (
+    id              uuid PRIMARY KEY,
+    organization_id uuid NOT NULL REFERENCES org_eval_credit_wallets (organization_id) ON DELETE CASCADE,
+    reservation_key text NOT NULL,
+    amount_micros   bigint NOT NULL CHECK (amount_micros > 0),
+    status          text NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'settled', 'released')),
+    run_id          uuid,
+    eval_session_id uuid,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    resolved_at     timestamptz,
+    UNIQUE (organization_id, reservation_key)
+);
+
+-- Immutable, append-only audit of every wallet mutation. Delta columns let the ledger reconstruct the
+-- wallet totals exactly (Invariant 6: sum of deltas == wallet columns).
+CREATE TABLE org_eval_credit_ledger (
+    id                     uuid PRIMARY KEY,
+    organization_id        uuid NOT NULL REFERENCES org_eval_credit_wallets (organization_id) ON DELETE CASCADE,
+    entry_type             text NOT NULL CHECK (entry_type IN ('grant', 'reserve', 'settle', 'release', 'adjust')),
+    amount_micros          bigint NOT NULL,
+    available_delta_micros bigint NOT NULL,
+    reserved_delta_micros  bigint NOT NULL,
+    spent_delta_micros     bigint NOT NULL,
+    idempotency_key        text,
+    reservation_id         uuid REFERENCES org_eval_credit_reservations (id) ON DELETE SET NULL,
+    run_id                 uuid,
+    eval_session_id        uuid,
+    tool_invocation_id     uuid,
+    confirmation_id        uuid,
+    actor_user_id          uuid,
+    reason                 text,
+    metadata               jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at             timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_org_eval_credit_ledger_org_created ON org_eval_credit_ledger (organization_id, created_at);
+
+-- Grant idempotency: at most one grant per (organization, grant key).
+CREATE UNIQUE INDEX uq_org_eval_credit_ledger_grant_key
+    ON org_eval_credit_ledger (organization_id, idempotency_key)
+    WHERE entry_type = 'grant';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS org_eval_credit_ledger;
+DROP TABLE IF EXISTS org_eval_credit_reservations;
+DROP TABLE IF EXISTS org_eval_credit_wallets;
+-- +goose StatementEnd

--- a/backend/db/migrations/00062_backfill_eval_credit_seed.sql
+++ b/backend/db/migrations/00062_backfill_eval_credit_seed.sql
@@ -1,0 +1,62 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Backfill the $3.00 signup eval credit for orgs that predate the wallet (idempotent on the stable
+-- grant key — re-runs and the live SeedOrgEvalCreditTx never double-grant). Wallet + ledger stay
+-- consistent: only orgs missing the signup grant are credited, and the ledger delta matches.
+INSERT INTO org_eval_credit_wallets (organization_id)
+SELECT id FROM organizations
+ON CONFLICT (organization_id) DO NOTHING;
+
+WITH missing AS (
+    SELECT o.id AS org_id
+    FROM organizations o
+    WHERE NOT EXISTS (
+        SELECT 1 FROM org_eval_credit_ledger l
+        WHERE l.organization_id = o.id
+          AND l.entry_type = 'grant'
+          AND l.idempotency_key = 'signup-eval-credit:v1'
+    )
+),
+credited AS (
+    UPDATE org_eval_credit_wallets w
+    SET available_micros = available_micros + 3000000, updated_at = now()
+    FROM missing m
+    WHERE w.organization_id = m.org_id
+    RETURNING w.organization_id
+)
+INSERT INTO org_eval_credit_ledger (
+    id, organization_id, entry_type, amount_micros,
+    available_delta_micros, reserved_delta_micros, spent_delta_micros,
+    idempotency_key, reason
+)
+SELECT gen_random_uuid(), organization_id, 'grant', 3000000, 3000000, 0, 0,
+       'signup-eval-credit:v1', 'backfill signup eval credit'
+FROM credited;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Reverse the backfill while keeping wallet+ledger reconciled: decrement available by the granted
+-- amount AND delete the matching grant row ONLY for orgs where the decrement succeeded. An org that
+-- has since reserved/spent the credit (available < 3000000) is left fully intact — both its wallet
+-- and its ledger row — so the ledger always reconciles to the wallet.
+WITH backfilled AS (
+    SELECT organization_id FROM org_eval_credit_ledger
+    WHERE entry_type = 'grant' AND idempotency_key = 'signup-eval-credit:v1'
+      AND reason = 'backfill signup eval credit'
+),
+decremented AS (
+    UPDATE org_eval_credit_wallets w
+    SET available_micros = available_micros - 3000000, updated_at = now()
+    FROM backfilled b
+    WHERE w.organization_id = b.organization_id AND w.available_micros >= 3000000
+    RETURNING w.organization_id
+)
+DELETE FROM org_eval_credit_ledger l
+USING decremented d
+WHERE l.organization_id = d.organization_id
+  AND l.entry_type = 'grant' AND l.idempotency_key = 'signup-eval-credit:v1'
+  AND l.reason = 'backfill signup eval credit';
+-- +goose StatementEnd

--- a/backend/db/migrations/00063_guide_agent_turn_allowance.sql
+++ b/backend/db/migrations/00063_guide_agent_turn_allowance.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- 4e: guide-agent turn allowance — a monthly per-workspace QUOTA COUNTER, distinct from the $3 eval
+-- credit wallet. The counter lives on the existing usage window (alongside race_count); the LIMIT is a
+-- stored entitlement column (mirroring races_per_workspace_month, NULL ⇒ unlimited/custom).
+ALTER TABLE workspace_usage_windows
+    ADD COLUMN guide_agent_turn_count integer NOT NULL DEFAULT 0 CHECK (guide_agent_turn_count >= 0);
+
+ALTER TABLE organization_entitlements
+    ADD COLUMN guide_agent_turns_per_workspace_month integer;
+
+-- Backfill existing entitlement rows from their plan, mirroring billing.materializeLimit / the §C numbers:
+-- free → 50 (flat), pro → 1000·seats, team → 4000·seats, enterprise → NULL (custom/unlimited). New and
+-- re-upserted rows get the materialized value through UpsertOrganizationEntitlements.
+UPDATE organization_entitlements
+SET guide_agent_turns_per_workspace_month = CASE plan_key
+    WHEN 'free' THEN 50
+    WHEN 'pro' THEN 1000 * seat_quantity
+    WHEN 'team' THEN 4000 * seat_quantity
+    ELSE NULL
+END
+WHERE guide_agent_turns_per_workspace_month IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE organization_entitlements DROP COLUMN guide_agent_turns_per_workspace_month;
+ALTER TABLE workspace_usage_windows DROP COLUMN guide_agent_turn_count;
+
+-- +goose StatementEnd

--- a/backend/db/queries/billing.sql
+++ b/backend/db/queries/billing.sql
@@ -16,6 +16,7 @@ SELECT
     max_models_per_race,
     replay_retention_days,
     concurrency_limit,
+    guide_agent_turns_per_workspace_month,
     feature_flags,
     source_subscription_id,
     effective_at,
@@ -37,6 +38,7 @@ INSERT INTO organization_entitlements (
     max_models_per_race,
     replay_retention_days,
     concurrency_limit,
+    guide_agent_turns_per_workspace_month,
     feature_flags,
     source_subscription_id,
     effective_at,
@@ -54,6 +56,7 @@ VALUES (
     @max_models_per_race,
     @replay_retention_days,
     @concurrency_limit,
+    @guide_agent_turns_per_workspace_month,
     @feature_flags::jsonb,
     sqlc.narg('source_subscription_id'),
     now(),
@@ -70,6 +73,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
     max_models_per_race = EXCLUDED.max_models_per_race,
     replay_retention_days = EXCLUDED.replay_retention_days,
     concurrency_limit = EXCLUDED.concurrency_limit,
+    guide_agent_turns_per_workspace_month = EXCLUDED.guide_agent_turns_per_workspace_month,
     feature_flags = EXCLUDED.feature_flags,
     source_subscription_id = EXCLUDED.source_subscription_id,
     effective_at = EXCLUDED.effective_at,
@@ -93,8 +97,8 @@ FROM runs
 WHERE workspace_id = @workspace_id
   AND status IN ('queued', 'provisioning', 'running', 'scoring');
 
--- name: GetWorkspaceUsageWindowRaceCount :one
-SELECT race_count
+-- name: GetWorkspaceUsageWindowCounts :one
+SELECT race_count, guide_agent_turn_count
 FROM workspace_usage_windows
 WHERE workspace_id = @workspace_id
   AND window_start = @window_start;

--- a/backend/db/queries/eval_sessions.sql
+++ b/backend/db/queries/eval_sessions.sql
@@ -1,5 +1,6 @@
 -- name: CreateEvalSession :one
 INSERT INTO eval_sessions (
+    id,
     status,
     repetitions,
     aggregation_config,
@@ -9,6 +10,7 @@ INSERT INTO eval_sessions (
     started_at,
     finished_at
 ) VALUES (
+    @id,
     @status,
     @repetitions,
     @aggregation_config,

--- a/backend/db/queries/run_creation.sql
+++ b/backend/db/queries/run_creation.sql
@@ -27,6 +27,10 @@ WHERE challenge_pack_version_id = @challenge_pack_version_id
 ORDER BY execution_order ASC, id ASC;
 
 -- name: ListRunnableDeploymentsWithLatestSnapshot :many
+-- The frozen billing identity for each lane comes from the SNAPSHOT path (4d-1):
+-- source_provider_account_id is the BYOK signal; the model identity (provider_key/provider_model_id)
+-- and the FROZEN output rate (model_aliases.output_cost_per_million_tokens) drive the eval-credit
+-- estimate. LEFT JOINs so a deployment with no managed alias still returns one row.
 SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.id,
     agent_deployments.organization_id,
@@ -34,12 +38,20 @@ SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.name,
     agent_deployment_snapshots.id AS agent_deployment_snapshot_id,
     agent_deployments.spend_policy_id,
-    agent_deployments.routing_policy_id
+    agent_deployments.routing_policy_id,
+    agent_deployment_snapshots.source_provider_account_id,
+    model_catalog_entries.provider_key,
+    model_catalog_entries.provider_model_id,
+    model_aliases.output_cost_per_million_tokens
 FROM agent_deployments
 JOIN agent_deployment_snapshots
   ON agent_deployment_snapshots.agent_deployment_id = agent_deployments.id
  AND agent_deployment_snapshots.organization_id = agent_deployments.organization_id
  AND agent_deployment_snapshots.workspace_id = agent_deployments.workspace_id
+LEFT JOIN model_aliases
+  ON model_aliases.id = agent_deployment_snapshots.source_model_alias_id
+LEFT JOIN model_catalog_entries
+  ON model_catalog_entries.id = model_aliases.model_catalog_entry_id
 WHERE agent_deployments.workspace_id = @workspace_id
   AND agent_deployments.id = ANY(@deployment_ids::uuid[])
   AND agent_deployments.status = 'active'

--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -1,5 +1,6 @@
 -- name: CreateRun :one
 INSERT INTO runs (
+    id,
     organization_id,
     workspace_id,
     challenge_pack_version_id,
@@ -21,6 +22,7 @@ INSERT INTO runs (
     race_context,
     race_context_min_step_gap
 ) VALUES (
+    @id,
     @organization_id,
     @workspace_id,
     @challenge_pack_version_id,

--- a/backend/internal/api/billing.go
+++ b/backend/internal/api/billing.go
@@ -49,6 +49,7 @@ type BillingRepository interface {
 	CountActiveWorkspaces(ctx context.Context, orgID uuid.UUID) (int, error)
 	CountActiveWorkspaceRuns(ctx context.Context, workspaceID uuid.UUID) (int, error)
 	GetWorkspaceUsageSnapshot(ctx context.Context, workspaceID uuid.UUID, windowStart, windowEnd time.Time) (repository.WorkspaceUsageSnapshot, error)
+	ConsumeGuideAgentTurn(ctx context.Context, workspaceID uuid.UUID, entitlements billingpkg.EffectiveEntitlements, windowStart, windowEnd time.Time) error
 	CreateBillingCheckoutIntent(ctx context.Context, input repository.BillingCheckoutIntentInput) (repository.BillingCheckoutIntent, error)
 	UpsertBillingAccount(ctx context.Context, orgID uuid.UUID, dodoCustomerID string, billingEmail string, status string) error
 	GetBillingAccount(ctx context.Context, orgID uuid.UUID) (repository.BillingAccount, error)
@@ -143,16 +144,17 @@ type WorkspaceGateSummary struct {
 }
 
 type WorkspaceQuotaResult struct {
-	OrganizationID  uuid.UUID    `json:"organization_id"`
-	WorkspaceID     uuid.UUID    `json:"workspace_id"`
-	PlanKey         string       `json:"plan_key"`
-	BillingPeriod   string       `json:"billing_period"`
-	Status          string       `json:"status"`
-	MonthlyRaces    QuotaCounter `json:"monthly_races"`
-	ConcurrentRaces QuotaCounter `json:"concurrent_races"`
-	Seats           QuotaCounter `json:"seats"`
-	WindowStart     time.Time    `json:"window_start"`
-	WindowEnd       time.Time    `json:"window_end"`
+	OrganizationID         uuid.UUID    `json:"organization_id"`
+	WorkspaceID            uuid.UUID    `json:"workspace_id"`
+	PlanKey                string       `json:"plan_key"`
+	BillingPeriod          string       `json:"billing_period"`
+	Status                 string       `json:"status"`
+	MonthlyRaces           QuotaCounter `json:"monthly_races"`
+	MonthlyGuideAgentTurns QuotaCounter `json:"monthly_guide_agent_turns"`
+	ConcurrentRaces        QuotaCounter `json:"concurrent_races"`
+	Seats                  QuotaCounter `json:"seats"`
+	WindowStart            time.Time    `json:"window_start"`
+	WindowEnd              time.Time    `json:"window_end"`
 }
 
 type QuotaCounter struct {
@@ -376,6 +378,11 @@ func (m *BillingManager) GetWorkspaceQuota(ctx context.Context, caller Caller, w
 			result.Entitlements.RacesPerWorkspaceMonth,
 			&result.Usage.WindowEnd,
 		),
+		MonthlyGuideAgentTurns: quotaCounter(
+			result.Usage.GuideAgentTurnCount,
+			result.Entitlements.GuideAgentTurnsPerWorkspaceMonth,
+			&result.Usage.WindowEnd,
+		),
 		ConcurrentRaces: quotaCounter(
 			result.Usage.ActiveRuns,
 			result.Entitlements.ConcurrentRaces,
@@ -420,6 +427,23 @@ func (m *BillingManager) BuildRunGate(ctx context.Context, workspaceID uuid.UUID
 		WindowStart:     windowStart,
 		WindowEnd:       windowEnd,
 	}, nil
+}
+
+// ConsumeGuideAgentTurn atomically meters one guide-agent turn against the workspace's monthly allowance
+// (4e). It resolves the org entitlements, rejects an inactive entitlement, and delegates to the
+// repository's atomic window increment, which returns billingpkg.GateError (no increment) when the
+// allowance is exhausted. Distinct from the eval-credit wallet — platform guide-agent usage only.
+func (m *BillingManager) ConsumeGuideAgentTurn(ctx context.Context, workspaceID uuid.UUID) error {
+	_, entitlements, err := m.repo.ResolveWorkspaceEntitlements(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	now := m.now().UTC()
+	if decision := billingpkg.CheckEntitlementActive(entitlements, now); !decision.Allowed {
+		return billingpkg.GateError{Decision: decision}
+	}
+	windowStart, windowEnd := usageWindow(now)
+	return m.repo.ConsumeGuideAgentTurn(ctx, workspaceID, entitlements, windowStart, windowEnd)
 }
 
 func (m *BillingManager) BuildWorkspaceCreationGate(ctx context.Context, orgID uuid.UUID) (*repository.OrganizationEntitlementGate, error) {

--- a/backend/internal/api/billing_test.go
+++ b/backend/internal/api/billing_test.go
@@ -109,6 +109,7 @@ func TestBillingManagerGetWorkspaceQuotaSeparatesRaceAndConcurrencyUsage(t *test
 		billingpkg.EntitlementStatusActive,
 	)
 	repo.usage.RaceCount = 47
+	repo.usage.GuideAgentTurnCount = 1200
 	repo.usage.ActiveRuns = 2
 	repo.activeMembers = 3
 	now := time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC)
@@ -131,6 +132,9 @@ func TestBillingManagerGetWorkspaceQuotaSeparatesRaceAndConcurrencyUsage(t *test
 		t.Fatalf("plan key = %q, want pro", result.PlanKey)
 	}
 	assertQuotaCounter(t, "monthly races", result.MonthlyRaces, 47, 2500, 2453)
+	// Pro @ 5 seats → guide-agent allowance 1000*5 = 5000; used 1200 → remaining 3800.
+	assertQuotaCounter(t, "monthly guide-agent turns", result.MonthlyGuideAgentTurns, 1200, 5000, 3800)
+	assertTimePtr(t, "guide turns reset_at", result.MonthlyGuideAgentTurns.ResetAt, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	assertQuotaCounter(t, "concurrent races", result.ConcurrentRaces, 2, 3, 1)
 	assertQuotaCounter(t, "seats", result.Seats, 3, 25, 22)
 	assertTimePtr(t, "monthly races reset_at", result.MonthlyRaces.ResetAt, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
@@ -862,6 +866,11 @@ type fakeBillingRepository struct {
 	account       repository.BillingAccount
 	checkoutInput repository.BillingCheckoutIntentInput
 	trialUsed     bool
+
+	// 4e guide-agent turn allowance: configurable behaviour + observed call args.
+	guideTurnErr      error
+	guideTurnConsumed int
+	guideTurnUsed     int
 }
 
 func newFakeBillingRepository(workspaceID uuid.UUID) *fakeBillingRepository {
@@ -922,6 +931,14 @@ func (f *fakeBillingRepository) GetWorkspaceUsageSnapshot(_ context.Context, _ u
 	usage.WindowStart = windowStart
 	usage.WindowEnd = windowEnd
 	return usage, nil
+}
+
+func (f *fakeBillingRepository) ConsumeGuideAgentTurn(_ context.Context, _ uuid.UUID, _ billingpkg.EffectiveEntitlements, _, _ time.Time) error {
+	if f.guideTurnErr != nil {
+		return f.guideTurnErr
+	}
+	f.guideTurnConsumed++
+	return nil
 }
 
 func (f *fakeBillingRepository) CreateBillingCheckoutIntent(_ context.Context, input repository.BillingCheckoutIntentInput) (repository.BillingCheckoutIntent, error) {

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 )
 
@@ -67,6 +68,35 @@ type CreateEvalSessionInput struct {
 	Name                   string
 	MaxIterations          *int32
 	EvalSession            CreateEvalSessionConfigInput
+	// EvalSessionID + ChildReservations are the guide confirmed path (4d-3): a preallocated session id
+	// and one binding per expanded child (IN PLAN ORDER) carrying its preallocated run id + approved
+	// eval-credit amount. Empty ⇒ REST/manual create (auto-minted ids, no reservation, no wallet).
+	EvalSessionID     uuid.UUID
+	ChildReservations []EvalSessionChildReservation
+}
+
+// EvalSessionWorkflowStartError means the eval session + its child runs + reservations were created and
+// committed, but starting the session workflow failed. The effect happened (the reservations back real
+// runs), so the guide confirmed path treats this as success-with-warning, never a terminal failure.
+type EvalSessionWorkflowStartError struct {
+	Session domain.EvalSession
+	RunIDs  []uuid.UUID
+	Cause   error
+}
+
+func (e EvalSessionWorkflowStartError) Error() string {
+	return fmt.Sprintf("start eval session workflow for session %s: %v", e.Session.ID, e.Cause)
+}
+
+func (e EvalSessionWorkflowStartError) Unwrap() error {
+	return e.Cause
+}
+
+func int64PtrEqual(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 type EvalSessionRunMatrixEntryInput struct {
@@ -95,26 +125,282 @@ type CreateEvalSessionResult struct {
 	SeriesRuns []EvalSessionSeriesRun
 }
 
+// EvalSessionChildReservation binds one expanded child run to a preallocated run id, the eval credit
+// approved for it, and the lane identity (matrix key / seed) that the estimate enumerated. The guide
+// confirmed path supplies one per child IN PLAN ORDER; an empty slice is the REST/no-wallet path
+// (auto-minted ids, no reservations). AmountMicros == 0 means a BYOK child: its run id is still bound
+// (for idempotency) but no credit is reserved.
+type EvalSessionChildReservation struct {
+	RunID        uuid.UUID
+	AmountMicros int64
+	MatrixKey    string
+	Seed         *int64
+	// Lanes is the FROZEN lane identity the estimate priced/classified for this child, in deployment
+	// order. Confirmed execution compares it against the freshly-expanded child deployments so a changed
+	// deployment/snapshot/model or flipped managed↔BYOK lane can never bind the approved amount.
+	Lanes []EvalSessionChildLane
+}
+
+// EvalSessionChildLane is one lane's billing identity carried from estimate to confirmed execution.
+type EvalSessionChildLane struct {
+	DeploymentID              uuid.UUID
+	AgentDeploymentSnapshotID uuid.UUID
+	Managed                   bool
+}
+
+// EvalSessionChildCostEstimate is the per-child cost breakdown the confirmation card and estimate
+// envelope carry. Non-secret only (provider/model identity + rates via Lanes); the lane/seed identity
+// lets the confirmed execution bind the approved plan positionally.
+type EvalSessionChildCostEstimate struct {
+	MatrixKey    string                 `json:"matrix_key,omitempty"`
+	Seed         *int64                 `json:"seed,omitempty"`
+	AmountMicros int64                  `json:"amount_micros"`
+	BillingMode  string                 `json:"billing_mode"` // managed | byok
+	Lanes        []EvalCostLaneEstimate `json:"lanes"`
+}
+
+// EvalSessionCostEstimate aggregates the per-child managed-credit estimates for a prospective eval
+// session. AggregateMicros == Σ child AmountMicros; reservations stay per child (4d-3).
+type EvalSessionCostEstimate struct {
+	AggregateMicros int64                          `json:"aggregate_micros"`
+	Children        []EvalSessionChildCostEstimate `json:"children"`
+}
+
+// evalSessionChildPlan is one expanded child run plus the resolved deployments needed to price its
+// lanes. Run carries no preallocated RunID/reservation yet — CreateEvalSession overlays those from the
+// approved EvalSessionChildReservation bindings.
+type evalSessionChildPlan struct {
+	Run         repository.CreateQueuedRunParams
+	Deployments []repository.RunnableDeployment
+	MatrixKey   string
+	Seed        *int64
+}
+
+// evalSessionPlan is the deterministic expansion of an eval-session request: the session config, the
+// ordered child runs (with their deployments for pricing), the entitlement gate, and the pack's runtime
+// limits. Shared by EstimateEvalSessionCost (price each child) and CreateEvalSession (reserve+create),
+// so the estimate enumerates EXACTLY the children execution creates (4d-3 binding fork: option A).
+type evalSessionPlan struct {
+	Session         repository.CreateEvalSessionParams
+	Children        []evalSessionChildPlan
+	EntitlementGate *repository.RunEntitlementGate
+	RuntimeLimits   scoring.RuntimeLimits
+}
+
+// EstimateEvalSessionCost prices each expanded child run independently from the same plan execution
+// uses: all-managed child → its managed ceiling; all-BYOK child → 0; intra-child mixed → blocked
+// (ErrVibeEvalMixedBilling, the 4d-1 rule). Read-only (no ids, no reservation, no session). A session
+// MAY mix managed and BYOK children.
+func (m *RunCreationManager) EstimateEvalSessionCost(ctx context.Context, caller Caller, input CreateEvalSessionInput) (EvalSessionCostEstimate, error) {
+	plan, err := m.buildEvalSessionPlan(ctx, caller, input)
+	if err != nil {
+		return EvalSessionCostEstimate{}, err
+	}
+	estimate := EvalSessionCostEstimate{Children: make([]EvalSessionChildCostEstimate, 0, len(plan.Children))}
+	for _, child := range plan.Children {
+		childEstimate, err := estimateEvalCost(deploymentLanes(child.Deployments), plan.RuntimeLimits)
+		if err != nil {
+			return EvalSessionCostEstimate{}, err
+		}
+		estimate.AggregateMicros += childEstimate.TotalMicros
+		estimate.Children = append(estimate.Children, EvalSessionChildCostEstimate{
+			MatrixKey:    child.MatrixKey,
+			Seed:         cloneInt64Ptr(child.Seed),
+			AmountMicros: childEstimate.TotalMicros,
+			BillingMode:  billingModeForLanes(child.Deployments),
+			Lanes:        childEstimate.Lanes,
+		})
+	}
+	return estimate, nil
+}
+
+// deploymentLanes classifies resolved deployments into billing lanes (a frozen source provider account
+// ⇒ BYOK), reusing the frozen-snapshot pricing fields the estimate path reads.
+func deploymentLanes(deployments []repository.RunnableDeployment) []evalCostLane {
+	lanes := make([]evalCostLane, 0, len(deployments))
+	for _, d := range deployments {
+		lanes = append(lanes, evalCostLane{
+			DeploymentID:              d.ID,
+			AgentDeploymentSnapshotID: d.AgentDeploymentSnapshotID,
+			Managed:                   d.SourceProviderAccountID == nil,
+			ProviderKey:               d.ProviderKey,
+			ProviderModelID:           d.ProviderModelID,
+			OutputRatePerMillion:      d.OutputCostPerMillionTokens,
+		})
+	}
+	return lanes
+}
+
+// billingModeForLanes reports the child's billing mode from its deployments: "byok" only when EVERY
+// lane is BYOK, else "managed". (Intra-child mixed lanes are blocked earlier by estimateEvalCost, so a
+// child reaching here is uniformly one mode.)
+func billingModeForLanes(deployments []repository.RunnableDeployment) string {
+	for _, d := range deployments {
+		if d.SourceProviderAccountID == nil {
+			return "managed"
+		}
+	}
+	return "byok"
+}
+
+// CreateEvalSession expands the request into its deterministic child-run plan, overlays the approved
+// preallocated ids + per-child reservations (the guide confirmed path; empty ⇒ REST no-wallet), and
+// creates the session + child runs + reservations atomically, then starts the session workflow.
 func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Caller, input CreateEvalSessionInput) (CreateEvalSessionResult, error) {
-	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionCreateRun); err != nil {
+	plan, err := m.buildEvalSessionPlan(ctx, caller, input)
+	if err != nil {
 		return CreateEvalSessionResult{}, err
+	}
+
+	childRuns, err := bindEvalSessionChildReservations(plan.Children, input.ChildReservations)
+	if err != nil {
+		return CreateEvalSessionResult{}, err
+	}
+
+	createResult, err := m.repo.CreateEvalSessionWithQueuedRuns(ctx, repository.CreateEvalSessionWithQueuedRunsParams{
+		SessionID:       input.EvalSessionID,
+		Session:         plan.Session,
+		Runs:            childRuns,
+		EntitlementGate: plan.EntitlementGate,
+	})
+	if err != nil {
+		return CreateEvalSessionResult{}, fmt.Errorf("create eval session with queued runs: %w", err)
+	}
+	if err := m.evalSessionWorkflowStarter.StartEvalSessionWorkflow(ctx, createResult.Session.ID); err != nil {
+		return CreateEvalSessionResult{}, EvalSessionWorkflowStartError{
+			Session: createResult.Session,
+			RunIDs:  evalSessionRunIDs(createResult.Runs),
+			Cause:   err,
+		}
+	}
+
+	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
+	seededRuns := make([]EvalSessionSeededRun, 0, len(input.EvalSession.SeedFanout))
+	seriesRuns := make([]EvalSessionSeriesRun, 0, len(input.EvalSession.RunMatrix))
+	for _, run := range createResult.Runs {
+		runIDs = append(runIDs, run.ID)
+		if seed := evalSessionChildRunSeed(run.ExecutionPlan); seed != nil {
+			seededRuns = append(seededRuns, EvalSessionSeededRun{RunID: run.ID, Seed: *seed})
+		}
+	}
+	if len(input.EvalSession.RunMatrix) > 0 {
+		for _, run := range createResult.Runs {
+			series := evalSessionChildRunSeries(run.ExecutionPlan)
+			seriesRuns = append(seriesRuns, EvalSessionSeriesRun{
+				RunID:            run.ID,
+				MatrixKey:        series.MatrixKey,
+				DeploymentLineup: series.DeploymentLineup,
+				Seed:             evalSessionChildRunSeed(run.ExecutionPlan),
+			})
+		}
+	}
+
+	return CreateEvalSessionResult{
+		Session:    createResult.Session,
+		RunIDs:     runIDs,
+		SeededRuns: seededRuns,
+		SeriesRuns: seriesRuns,
+	}, nil
+}
+
+// bindEvalSessionChildReservations overlays the approved per-child bindings (preallocated run id +
+// reservation, in PLAN ORDER) onto the expanded child runs. An empty bindings slice is the REST path
+// (no preallocation, no reservation). A size or lane-identity (matrix key / seed) mismatch means the
+// expansion drifted from the approved estimate → fail before any side effect (no run, no reservation).
+func bindEvalSessionChildReservations(children []evalSessionChildPlan, bindings []EvalSessionChildReservation) ([]repository.CreateQueuedRunParams, error) {
+	childRuns := make([]repository.CreateQueuedRunParams, 0, len(children))
+	if len(bindings) == 0 {
+		for _, child := range children {
+			childRuns = append(childRuns, child.Run)
+		}
+		return childRuns, nil
+	}
+	if len(bindings) != len(children) {
+		return nil, RunCreationValidationError{
+			Code:    "stale_estimate",
+			Message: "approved child plan no longer matches the expanded eval session; re-estimate is required",
+		}
+	}
+	for i, child := range children {
+		binding := bindings[i]
+		if binding.AmountMicros < 0 {
+			return nil, RunCreationValidationError{Code: "invalid_reservation", Message: "reservation amount must not be negative"}
+		}
+		if binding.RunID == uuid.Nil {
+			return nil, RunCreationValidationError{Code: "invalid_reservation", Message: "each managed eval-session child requires a preallocated run id"}
+		}
+		// Positional binding must match the lane identity the estimate enumerated; otherwise the
+		// preallocated id/amount could attach to a different child than the user approved.
+		if binding.MatrixKey != child.MatrixKey || !int64PtrEqual(binding.Seed, child.Seed) {
+			return nil, RunCreationValidationError{
+				Code:    "stale_estimate",
+				Message: "approved child plan no longer matches the expanded eval session; re-estimate is required",
+			}
+		}
+		// The frozen lane identity (deployment + snapshot + managed/BYOK class) must match the freshly
+		// expanded child's deployments, so a changed snapshot/model/BYOK lane can never bind the approved
+		// amount. Caught BEFORE any reservation/run side effect.
+		if !evalSessionChildLanesMatch(binding.Lanes, child.Deployments) {
+			return nil, RunCreationValidationError{
+				Code:    "stale_estimate",
+				Message: "approved child lanes no longer match the expanded eval session deployments; re-estimate is required",
+			}
+		}
+		runParams := child.Run
+		runParams.RunID = binding.RunID
+		runParams.EvalCreditReservation = evalCreditReservationFor(binding.RunID, binding.AmountMicros)
+		childRuns = append(childRuns, runParams)
+	}
+	return childRuns, nil
+}
+
+// evalSessionChildLanesMatch reports whether the approved frozen lane identity equals the freshly
+// expanded child's deployments, positionally: same deployment id, same snapshot id, and same
+// managed/BYOK classification (a frozen source provider account ⇒ BYOK). Any divergence means the lane
+// drifted between propose and approve and the approved amount must not be bound.
+func evalSessionChildLanesMatch(approved []EvalSessionChildLane, deployments []repository.RunnableDeployment) bool {
+	if len(approved) != len(deployments) {
+		return false
+	}
+	for i, lane := range approved {
+		d := deployments[i]
+		if lane.DeploymentID != d.ID ||
+			lane.AgentDeploymentSnapshotID != d.AgentDeploymentSnapshotID ||
+			lane.Managed != (d.SourceProviderAccountID == nil) {
+			return false
+		}
+	}
+	return true
+}
+
+func evalSessionRunIDs(runs []domain.Run) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(runs))
+	for _, run := range runs {
+		ids = append(ids, run.ID)
+	}
+	return ids
+}
+
+func (m *RunCreationManager) buildEvalSessionPlan(ctx context.Context, caller Caller, input CreateEvalSessionInput) (evalSessionPlan, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionCreateRun); err != nil {
+		return evalSessionPlan{}, err
 	}
 
 	hasRunMatrix := len(input.EvalSession.RunMatrix) > 0
 	if input.EvalSession.Repetitions < 1 {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
+		return evalSessionPlan{}, RunCreationValidationError{
 			Code:    "invalid_eval_session",
 			Message: "eval_session.repetitions must be at least 1",
 		}
 	}
 	if hasRunMatrix && int32(len(input.EvalSession.RunMatrix)) != input.EvalSession.Repetitions {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
+		return evalSessionPlan{}, RunCreationValidationError{
 			Code:    "invalid_eval_session",
 			Message: "eval_session.run_matrix length must match repetitions",
 		}
 	}
 	if len(input.Participants) == 0 && !hasRunMatrix {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
+		return evalSessionPlan{}, RunCreationValidationError{
 			Code:    "invalid_participants",
 			Message: "at least one participant is required",
 		}
@@ -122,7 +408,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	executionMode := strings.TrimSpace(input.ExecutionMode)
 	if executionMode != "" && executionMode != "single_agent" && executionMode != "comparison" {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
+		return evalSessionPlan{}, RunCreationValidationError{
 			Code:    "invalid_execution_mode",
 			Message: "execution_mode must be either single_agent or comparison",
 		}
@@ -131,15 +417,15 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	challengePackVersion, err := m.repo.GetRunnableChallengePackVersionByID(ctx, input.ChallengePackVersionID)
 	if err != nil {
 		if err == repository.ErrChallengePackVersionNotFound {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_challenge_pack_version_id",
 				Message: "challenge_pack_version_id must reference a runnable challenge pack version",
 			}
 		}
-		return CreateEvalSessionResult{}, fmt.Errorf("load runnable challenge pack version: %w", err)
+		return evalSessionPlan{}, fmt.Errorf("load runnable challenge pack version: %w", err)
 	}
 	if challengePackVersion.WorkspaceID != nil && *challengePackVersion.WorkspaceID != input.WorkspaceID {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
+		return evalSessionPlan{}, RunCreationValidationError{
 			Code:    "invalid_challenge_pack_version_id",
 			Message: "challenge_pack_version_id must be visible to the selected workspace",
 		}
@@ -147,10 +433,10 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	if challengePackVersion.WorkspaceID == nil {
 		publicPacks, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, input.WorkspaceID)
 		if accessErr != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("load workspace public pack access: %w", accessErr)
+			return evalSessionPlan{}, fmt.Errorf("load workspace public pack access: %w", accessErr)
 		}
 		if !publicPacks {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_challenge_pack_version_id",
 				Message: "challenge_pack_version_id must be visible to the selected workspace",
 			}
@@ -164,15 +450,15 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		challengeInputSet, err := m.repo.GetChallengeInputSetByID(ctx, *input.ChallengeInputSetID)
 		if err != nil {
 			if err == repository.ErrChallengeInputSetNotFound {
-				return CreateEvalSessionResult{}, RunCreationValidationError{
+				return evalSessionPlan{}, RunCreationValidationError{
 					Code:    "invalid_challenge_input_set_id",
 					Message: "challenge_input_set_id must reference an active challenge input set",
 				}
 			}
-			return CreateEvalSessionResult{}, fmt.Errorf("load challenge input set: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("load challenge input set: %w", err)
 		}
 		if challengeInputSet.ChallengePackVersionID != input.ChallengePackVersionID {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_challenge_input_set_id",
 				Message: "challenge_input_set_id must belong to the selected challenge pack version",
 			}
@@ -180,14 +466,14 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	} else {
 		inputSets, err := m.repo.ListChallengeInputSetsByVersionID(ctx, input.ChallengePackVersionID)
 		if err != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("list challenge input sets: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("list challenge input sets: %w", err)
 		}
 		switch len(inputSets) {
 		case 0:
 		case 1:
 			input.ChallengeInputSetID = &inputSets[0].ID
 		default:
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "missing_challenge_input_set_id",
 				Message: "challenge pack has multiple input sets; challenge_input_set_id is required",
 			}
@@ -224,7 +510,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	if len(uniqueDeploymentIDs) > 0 {
 		deployments, err := m.repo.ListRunnableDeploymentsWithLatestSnapshot(ctx, input.WorkspaceID, uniqueDeploymentIDs)
 		if err != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("list runnable deployments with latest snapshot: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("list runnable deployments with latest snapshot: %w", err)
 		}
 		for _, deployment := range deployments {
 			deploymentsByID[deployment.ID] = deployment
@@ -235,7 +521,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	if len(uniqueBuildVersionIDs) > 0 {
 		deploymentsByBuildVersion, err := m.repo.ListRunnableDeploymentsByBuildVersionID(ctx, input.WorkspaceID, uniqueBuildVersionIDs)
 		if err != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("list runnable deployments by build version id: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("list runnable deployments by build version id: %w", err)
 		}
 		for _, item := range deploymentsByBuildVersion {
 			groupedDeployments[item.AgentBuildVersionID] = append(groupedDeployments[item.AgentBuildVersionID], item.Deployment)
@@ -329,7 +615,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		}
 	}
 	if len(participantDetails) > 0 {
-		return CreateEvalSessionResult{}, evalSessionValidationError{Errors: participantDetails}
+		return evalSessionPlan{}, evalSessionValidationError{Errors: participantDetails}
 	}
 
 	if executionMode == "" {
@@ -342,19 +628,19 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	}
 	for _, spec := range childSpecs {
 		if len(spec.Deployments) == 0 {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_participants",
 				Message: "each eval session child run requires at least one participant",
 			}
 		}
 		if len(spec.Participants) == 1 && executionMode != "single_agent" {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_execution_mode",
 				Message: "single-participant eval sessions must use execution_mode single_agent",
 			}
 		}
 		if len(spec.Participants) > 1 && executionMode != "comparison" {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "invalid_execution_mode",
 				Message: "multi-participant eval sessions must use execution_mode comparison",
 			}
@@ -369,7 +655,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	}
 	for _, deployment := range allResolvedDeployments {
 		if deployment.OrganizationID != organizationID {
-			return CreateEvalSessionResult{}, fmt.Errorf("participant deployments in workspace %s resolved to multiple organizations", input.WorkspaceID)
+			return evalSessionPlan{}, fmt.Errorf("participant deployments in workspace %s resolved to multiple organizations", input.WorkspaceID)
 		}
 	}
 
@@ -385,7 +671,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 		result, err := m.budgetChecker.CheckPreRunBudget(ctx, input.WorkspaceID, *deployment.SpendPolicyID)
 		if err != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("check spend policy budget: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("check spend policy budget: %w", err)
 		}
 		if result.SoftLimitHit {
 			slog.Default().Warn("spend policy soft limit reached",
@@ -395,7 +681,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			)
 		}
 		if !result.Allowed {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
+			return evalSessionPlan{}, RunCreationValidationError{
 				Code:    "budget_exceeded",
 				Message: fmt.Sprintf("workspace spend limit exceeded (current: $%.2f, limit: $%.2f)", result.CurrentSpend, *result.HardLimit),
 			}
@@ -432,7 +718,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	challengeIdentityIDs, err := m.repo.ListChallengeIdentityIDsByPackVersionID(ctx, input.ChallengePackVersionID)
 	if err != nil {
-		return CreateEvalSessionResult{}, fmt.Errorf("list official challenge identities: %w", err)
+		return evalSessionPlan{}, fmt.Errorf("list official challenge identities: %w", err)
 	}
 
 	caseSelections := make([]repository.CreateQueuedRunCaseSelectionParams, 0, len(challengeIdentityIDs))
@@ -449,7 +735,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		baseName = defaultEvalSessionRunName(m.now().UTC())
 	}
 
-	childRuns := make([]repository.CreateQueuedRunParams, 0, len(childSpecs))
+	children := make([]evalSessionChildPlan, 0, len(childSpecs))
 	for repetition, spec := range childSpecs {
 		specRunAgents := baseRunAgents
 		if hasRunMatrix {
@@ -467,32 +753,37 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		runInput.Seed = cloneInt64Ptr(spec.Seed)
 		executionPlan, err := buildExecutionPlan(runInput, specRunAgents, nil)
 		if err != nil {
-			return CreateEvalSessionResult{}, fmt.Errorf("build execution plan: %w", err)
+			return evalSessionPlan{}, fmt.Errorf("build execution plan: %w", err)
 		}
-		childRuns = append(childRuns, repository.CreateQueuedRunParams{
-			OrganizationID:         organizationID,
-			WorkspaceID:            input.WorkspaceID,
-			ChallengePackVersionID: input.ChallengePackVersionID,
-			ChallengeInputSetID:    input.ChallengeInputSetID,
-			OfficialPackMode:       domain.OfficialPackModeFull,
-			CreatedByUserID:        &caller.UserID,
-			Name:                   evalSessionRunName(baseName, int32(repetition), input.EvalSession.Repetitions),
-			ExecutionMode:          executionMode,
-			ExecutionPlan:          executionPlan,
-			RunAgents:              specRunAgents,
-			CaseSelections:         caseSelections,
+		children = append(children, evalSessionChildPlan{
+			Run: repository.CreateQueuedRunParams{
+				OrganizationID:         organizationID,
+				WorkspaceID:            input.WorkspaceID,
+				ChallengePackVersionID: input.ChallengePackVersionID,
+				ChallengeInputSetID:    input.ChallengeInputSetID,
+				OfficialPackMode:       domain.OfficialPackModeFull,
+				CreatedByUserID:        &caller.UserID,
+				Name:                   evalSessionRunName(baseName, int32(repetition), input.EvalSession.Repetitions),
+				ExecutionMode:          executionMode,
+				ExecutionPlan:          executionPlan,
+				RunAgents:              specRunAgents,
+				CaseSelections:         caseSelections,
+			},
+			Deployments: spec.Deployments,
+			MatrixKey:   spec.MatrixKey,
+			Seed:        cloneInt64Ptr(spec.Seed),
 		})
 	}
 
 	var entitlementGate *repository.RunEntitlementGate
 	if m.entitlementGate != nil {
-		entitlementGate, err = m.entitlementGate.BuildRunGate(ctx, input.WorkspaceID, maxParticipantCount, len(childRuns))
+		entitlementGate, err = m.entitlementGate.BuildRunGate(ctx, input.WorkspaceID, maxParticipantCount, len(children))
 		if err != nil {
-			return CreateEvalSessionResult{}, err
+			return evalSessionPlan{}, err
 		}
 	}
 
-	createResult, err := m.repo.CreateEvalSessionWithQueuedRuns(ctx, repository.CreateEvalSessionWithQueuedRunsParams{
+	return evalSessionPlan{
 		Session: repository.CreateEvalSessionParams{
 			Repetitions:            input.EvalSession.Repetitions,
 			AggregationConfig:      buildAggregationSnapshot(input.EvalSession),
@@ -500,45 +791,9 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			RoutingTaskSnapshot:    buildRoutingTaskSnapshot(input.EvalSession),
 			SchemaVersion:          input.EvalSession.SchemaVersion,
 		},
-		Runs:            childRuns,
+		Children:        children,
 		EntitlementGate: entitlementGate,
-	})
-	if err != nil {
-		return CreateEvalSessionResult{}, fmt.Errorf("create eval session with queued runs: %w", err)
-	}
-	if err := m.evalSessionWorkflowStarter.StartEvalSessionWorkflow(ctx, createResult.Session.ID); err != nil {
-		return CreateEvalSessionResult{}, fmt.Errorf("start eval session workflow for session %s: %w", createResult.Session.ID, err)
-	}
-
-	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
-	seededRuns := make([]EvalSessionSeededRun, 0, len(input.EvalSession.SeedFanout))
-	seriesRuns := make([]EvalSessionSeriesRun, 0, len(input.EvalSession.RunMatrix))
-	for _, run := range createResult.Runs {
-		runIDs = append(runIDs, run.ID)
-		if seed := evalSessionChildRunSeed(run.ExecutionPlan); seed != nil {
-			seededRuns = append(seededRuns, EvalSessionSeededRun{
-				RunID: run.ID,
-				Seed:  *seed,
-			})
-		}
-	}
-	if hasRunMatrix {
-		for _, run := range createResult.Runs {
-			series := evalSessionChildRunSeries(run.ExecutionPlan)
-			seriesRuns = append(seriesRuns, EvalSessionSeriesRun{
-				RunID:            run.ID,
-				MatrixKey:        series.MatrixKey,
-				DeploymentLineup: series.DeploymentLineup,
-				Seed:             evalSessionChildRunSeed(run.ExecutionPlan),
-			})
-		}
-	}
-
-	return CreateEvalSessionResult{
-		Session:    createResult.Session,
-		RunIDs:     runIDs,
-		SeededRuns: seededRuns,
-		SeriesRuns: seriesRuns,
+		RuntimeLimits:   challengePackRuntimeLimits(challengePackVersion.Manifest),
 	}, nil
 }
 

--- a/backend/internal/api/eval_sessions.go
+++ b/backend/internal/api/eval_sessions.go
@@ -244,6 +244,13 @@ func decodeCreateEvalSessionRequest(_ context.Context, r *http.Request) (CreateE
 	if err != nil {
 		return CreateEvalSessionInput{}, err
 	}
+	return buildCreateEvalSessionInput(body, workspaceID)
+}
+
+// buildCreateEvalSessionInput maps a decoded request body to a CreateEvalSessionInput for a given
+// workspace. Shared by the REST decoder (workspace from body) and the create_eval_session guide tool
+// (workspace from the conversation), so both go through one validation/parse path.
+func buildCreateEvalSessionInput(body createEvalSessionRequest, workspaceID uuid.UUID) (CreateEvalSessionInput, error) {
 	challengePackVersionID, err := parseRequiredUUID(body.ChallengePackVersionID, "challenge_pack_version_id", "invalid_challenge_pack_version_id")
 	if err != nil {
 		return CreateEvalSessionInput{}, err

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -92,6 +92,21 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 		return CreateRunResult{}, err
 	}
 
+	// Fail closed on any malformed reservation request — never silently drop it. A negative amount is
+	// invalid; a positive amount needs a stable preallocated run id (the reservation is keyed "run:<id>").
+	if input.ReservationMicros < 0 {
+		return CreateRunResult{}, RunCreationValidationError{
+			Code:    "invalid_reservation",
+			Message: "reservation amount must not be negative",
+		}
+	}
+	if input.ReservationMicros > 0 && input.RunID == uuid.Nil {
+		return CreateRunResult{}, RunCreationValidationError{
+			Code:    "invalid_reservation",
+			Message: "a managed eval-credit reservation requires a preallocated run id",
+		}
+	}
+
 	if len(input.AgentDeploymentIDs) == 0 {
 		return CreateRunResult{}, RunCreationValidationError{
 			Code:    "invalid_agent_deployment_ids",
@@ -306,6 +321,8 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 	}
 
 	result, err := m.repo.CreateQueuedRun(ctx, repository.CreateQueuedRunParams{
+		RunID:                  input.RunID,
+		EvalCreditReservation:  evalCreditReservationFor(input.RunID, input.ReservationMicros),
 		OrganizationID:         organizationID,
 		WorkspaceID:            input.WorkspaceID,
 		ChallengePackVersionID: input.ChallengePackVersionID,

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -70,7 +70,13 @@ type CreateRunInput struct {
 	SeriesMatrixKey            string
 	SeriesDeploymentLineup     string
 	CIMetadata                 *domain.RunCIMetadata
-	DatasetEvalRun            *repository.RecordDatasetEvalRunParams
+	DatasetEvalRun             *repository.RecordDatasetEvalRunParams
+	// RunID, when set, preallocates the run id (the guide confirmed path supplies it so the eval-credit
+	// reservation and the run share a stable, idempotent id). Zero ⇒ a fresh id is minted.
+	RunID uuid.UUID
+	// ReservationMicros, when > 0, reserves that much managed eval credit atomically with run creation
+	// (keyed "run:<RunID>"). 0 ⇒ no reservation (BYOK / REST). Requires RunID to be set.
+	ReservationMicros int64
 }
 
 type CreateRunResult struct {

--- a/backend/internal/api/vibe_eval_agent_allowance_integration_test.go
+++ b/backend/internal/api/vibe_eval_agent_allowance_integration_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// DB-backed create-turn handler tests for the 4e allowance: the conversation guard runs BEFORE metering,
+// so an invalid conversation never burns a turn, and a valid conversation with an exhausted allowance
+// returns a clean pre-SSE 402. Skips when DATABASE_URL is unset (seeds via TRUNCATE — throwaway DB only).
+
+func postTurn(mgr *VibeEvalAgentManager, caller Caller, workspaceID, conversationID uuid.UUID) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"message":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, caller))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("workspaceID", workspaceID.String())
+	rctx.URLParams.Add("conversationID", conversationID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	createVibeEvalTurnHandler(slog.Default(), mgr).ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCreateTurnHandler_AllowanceAndConversationGuard(t *testing.T) {
+	ctx := context.Background()
+	db := openVibeEvalConfirmTestDB(t)
+	org, ws, user := seedVibeEvalConfirmFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	conv, err := repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+		OrganizationID: org, WorkspaceID: ws, CreatedByUserID: user, Title: "c", Phase: "author", Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateVibeEvalConversation: %v", err)
+	}
+	caller := vibeEvalCaller(user, ws, "workspace_admin")
+	mgrWith := func(meter *fakeGuideMeter) *VibeEvalAgentManager {
+		return &VibeEvalAgentManager{authorizer: fakeVibeEvalAuthorizer{}, repo: repo, meter: meter, now: time.Now}
+	}
+
+	t.Run("exhausted allowance on a valid conversation returns pre-SSE 402", func(t *testing.T) {
+		meter := &fakeGuideMeter{err: quotaGateError()}
+		rec := postTurn(mgrWith(meter), caller, ws, conv.ID)
+		if rec.Code != http.StatusPaymentRequired {
+			t.Fatalf("status = %d, want 402; body=%s", rec.Code, rec.Body.String())
+		}
+		if strings.HasPrefix(rec.Header().Get("Content-Type"), "text/event-stream") {
+			t.Fatalf("content-type = %q, want a normal JSON error (no SSE switch)", rec.Header().Get("Content-Type"))
+		}
+		if meter.calls != 1 {
+			t.Fatalf("meter calls = %d, want 1 (valid conversation meters once)", meter.calls)
+		}
+	})
+
+	t.Run("missing conversation does not meter", func(t *testing.T) {
+		meter := &fakeGuideMeter{}
+		rec := postTurn(mgrWith(meter), caller, ws, uuid.New()) // conversation that does not exist
+		if rec.Code == http.StatusOK || rec.Code == http.StatusPaymentRequired {
+			t.Fatalf("status = %d, want a normal error (not 200/402)", rec.Code)
+		}
+		if meter.calls != 0 {
+			t.Fatalf("meter calls = %d, want 0 (a missing conversation must not burn a turn)", meter.calls)
+		}
+	})
+
+	t.Run("cross-workspace conversation does not meter", func(t *testing.T) {
+		otherWS := uuid.New()
+		otherCaller := vibeEvalCaller(user, otherWS, "workspace_admin") // authorized for otherWS, not ws
+		meter := &fakeGuideMeter{}
+		// conv belongs to ws; the request targets otherWS — RequireConversation rejects the locality.
+		rec := postTurn(mgrWith(meter), otherCaller, otherWS, conv.ID)
+		if rec.Code == http.StatusOK || rec.Code == http.StatusPaymentRequired {
+			t.Fatalf("status = %d, want a normal error (not 200/402)", rec.Code)
+		}
+		if meter.calls != 0 {
+			t.Fatalf("meter calls = %d, want 0 (a cross-workspace conversation must not burn a turn)", meter.calls)
+		}
+	})
+}

--- a/backend/internal/api/vibe_eval_agent_allowance_test.go
+++ b/backend/internal/api/vibe_eval_agent_allowance_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeGuideMeter struct {
+	calls int
+	err   error
+}
+
+func (f *fakeGuideMeter) ConsumeGuideAgentTurn(_ context.Context, _ uuid.UUID) error {
+	f.calls++
+	return f.err
+}
+
+func allowanceManager(meter guideTurnMeter, now time.Time) *VibeEvalAgentManager {
+	return &VibeEvalAgentManager{meter: meter, now: func() time.Time { return now }}
+}
+
+func quotaGateError() error {
+	return billingpkg.GateError{Decision: billingpkg.GateDecision{Allowed: false, Code: billingpkg.GateCodeQuotaExceeded, Message: "exhausted"}}
+}
+
+func TestMeterFreshTurn_BlockSurfacesGateError(t *testing.T) {
+	meter := &fakeGuideMeter{err: quotaGateError()}
+	err := allowanceManager(meter, time.Now()).MeterFreshTurn(context.Background(), uuid.New())
+	var gateErr billingpkg.GateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("err = %v, want billing GateError (handler maps it to a pre-SSE 402)", err)
+	}
+	if meter.calls != 1 {
+		t.Fatalf("consume called %d times, want 1 (a fresh turn always meters)", meter.calls)
+	}
+}
+
+func TestMeterFreshTurn_AllowedConsumesOnce(t *testing.T) {
+	meter := &fakeGuideMeter{}
+	if err := allowanceManager(meter, time.Now()).MeterFreshTurn(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("MeterFreshTurn: %v", err)
+	}
+	if meter.calls != 1 {
+		t.Fatalf("consume called %d times, want 1", meter.calls)
+	}
+}
+
+func TestMeterConfirmationResolve_GenuineApproveCounts(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	meter := &fakeGuideMeter{}
+	pc := repository.VibeEvalPendingConfirmation{Status: "pending", PayloadHash: "h", ExpiresAt: now.Add(time.Hour)}
+	if err := allowanceManager(meter, now).MeterConfirmationResolve(context.Background(), uuid.New(), pc, "h", true); err != nil {
+		t.Fatalf("MeterConfirmationResolve: %v", err)
+	}
+	if meter.calls != 1 {
+		t.Fatalf("consume called %d times, want 1 (genuine approve counts)", meter.calls)
+	}
+}
+
+func TestMeterConfirmationResolve_DenyNeverCounts(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	meter := &fakeGuideMeter{}
+	pc := repository.VibeEvalPendingConfirmation{Status: "pending", PayloadHash: "h", ExpiresAt: now.Add(time.Hour)}
+	if err := allowanceManager(meter, now).MeterConfirmationResolve(context.Background(), uuid.New(), pc, "h", false); err != nil {
+		t.Fatalf("deny meter: %v", err)
+	}
+	if meter.calls != 0 {
+		t.Fatalf("consume called %d times on deny, want 0 (deny is always allowed and uncounted)", meter.calls)
+	}
+}
+
+func TestMeterConfirmationResolve_InvalidApproveUncounted(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	cases := map[string]repository.VibeEvalPendingConfirmation{
+		"wrong_hash":       {Status: "pending", PayloadHash: "real", ExpiresAt: now.Add(time.Hour)},
+		"expired":          {Status: "pending", PayloadHash: "h", ExpiresAt: now.Add(-time.Minute)},
+		"already_resolved": {Status: "succeeded", PayloadHash: "h", ExpiresAt: now.Add(time.Hour)},
+		"executing":        {Status: "executing", PayloadHash: "h", ExpiresAt: now.Add(time.Hour)},
+	}
+	for name, pc := range cases {
+		t.Run(name, func(t *testing.T) {
+			meter := &fakeGuideMeter{}
+			// approve=true with the presented hash "h"; only "wrong_hash" presents a non-matching pc hash.
+			if err := allowanceManager(meter, now).MeterConfirmationResolve(context.Background(), uuid.New(), pc, "h", true); err != nil {
+				t.Fatalf("invalid-resolve meter: %v", err)
+			}
+			if meter.calls != 0 {
+				t.Fatalf("consume called %d times for %s, want 0 (invalid resolves never burn quota)", meter.calls, name)
+			}
+		})
+	}
+}

--- a/backend/internal/api/vibe_eval_agent_confirmation.go
+++ b/backend/internal/api/vibe_eval_agent_confirmation.go
@@ -31,6 +31,7 @@ func (s vibeEvalConfirmationStore) Create(ctx context.Context, nc vibeeval.NewPe
 		PayloadHash:      nc.PayloadHash,
 		BoundArgs:        nc.BoundArgs,
 		Summary:          nc.Summary,
+		Estimate:         nc.Estimate,
 		ExpiresAt:        nc.ExpiresAt,
 	})
 	if err != nil {
@@ -85,6 +86,7 @@ func toVibeevalPendingConfirmation(row repository.VibeEvalPendingConfirmation) v
 		PayloadHash:    row.PayloadHash,
 		BoundArgs:      row.BoundArgs,
 		Summary:        row.Summary,
+		Estimate:       row.Estimate,
 		Status:         row.Status,
 		ExpiresAt:      row.ExpiresAt,
 	}

--- a/backend/internal/api/vibe_eval_agent_handler.go
+++ b/backend/internal/api/vibe_eval_agent_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/vibeeval"
 	"github.com/google/uuid"
@@ -37,6 +38,23 @@ func createVibeEvalTurnHandler(logger *slog.Logger, mgr *VibeEvalAgentManager) h
 		}
 		if err := mgr.AuthorizeTurn(r.Context(), caller, workspaceID); err != nil {
 			writeAuthzError(w, err)
+			return
+		}
+		// Validate the conversation BEFORE metering (4e): a missing or cross-workspace conversation must
+		// NOT burn a guide-agent turn — it is not a genuine turn and makes no model call.
+		if err := mgr.RequireConversation(r.Context(), workspaceID, conversationID); err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		// Meter the guide-agent turn allowance BEFORE the SSE switch (4e): an exhausted allowance is a
+		// clean 402 with no model call. A fresh user turn always consumes one.
+		if err := mgr.MeterFreshTurn(r.Context(), workspaceID); err != nil {
+			var gateErr billingpkg.GateError
+			if errors.As(err, &gateErr) {
+				writeBillingGateError(w, gateErr.Decision)
+				return
+			}
+			handleVibeEvalError(w, logger, err)
 			return
 		}
 
@@ -109,6 +127,18 @@ func resolveVibeEvalConfirmationHandler(logger *slog.Logger, mgr *VibeEvalAgentM
 
 		conv, pc, err := mgr.LoadConfirmationForResolve(r.Context(), caller, workspaceID, conversationID, confirmationID)
 		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		// Meter the guide-agent turn allowance BEFORE the SSE switch (4e): only a genuine fresh APPROVE
+		// resume consumes a turn. Deny is always allowed and uncounted; an approve for a non-resolvable
+		// confirmation is uncounted (no model call). An exhausted allowance is a clean 402.
+		if err := mgr.MeterConfirmationResolve(r.Context(), workspaceID, pc, req.PayloadHash, *req.Approve); err != nil {
+			var gateErr billingpkg.GateError
+			if errors.As(err, &gateErr) {
+				writeBillingGateError(w, gateErr.Decision)
+				return
+			}
 			handleVibeEvalError(w, logger, err)
 			return
 		}

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -44,6 +44,7 @@ func NewVibeEvalAgentManager(
 	scorecards scorecardReader,
 	packs challengePackLister,
 	drafts vibeEvalDraftAuthor,
+	estimator vibeEvalCostEstimator,
 ) (*VibeEvalAgentManager, error) {
 	registry := vibeeval.NewRegistry()
 	tools := []vibeeval.Tool{
@@ -54,6 +55,7 @@ func NewVibeEvalAgentManager(
 		updateDraftTool{drafts: drafts},
 		validateDraftTool{drafts: drafts},
 		publishDraftTool{drafts: drafts},
+		estimateEvalCostTool{estimator: estimator},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -44,7 +44,7 @@ func NewVibeEvalAgentManager(
 	scorecards scorecardReader,
 	packs challengePackLister,
 	drafts vibeEvalDraftAuthor,
-	estimator vibeEvalCostEstimator,
+	runCreator vibeEvalRunCreator,
 ) (*VibeEvalAgentManager, error) {
 	registry := vibeeval.NewRegistry()
 	tools := []vibeeval.Tool{
@@ -55,7 +55,8 @@ func NewVibeEvalAgentManager(
 		updateDraftTool{drafts: drafts},
 		validateDraftTool{drafts: drafts},
 		publishDraftTool{drafts: drafts},
-		estimateEvalCostTool{estimator: estimator},
+		estimateEvalCostTool{estimator: runCreator},
+		createRunTool{runs: runCreator},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -45,6 +45,7 @@ func NewVibeEvalAgentManager(
 	packs challengePackLister,
 	drafts vibeEvalDraftAuthor,
 	runCreator vibeEvalRunCreator,
+	sessionCreator vibeEvalSessionCreator,
 ) (*VibeEvalAgentManager, error) {
 	registry := vibeeval.NewRegistry()
 	tools := []vibeeval.Tool{
@@ -57,6 +58,7 @@ func NewVibeEvalAgentManager(
 		publishDraftTool{drafts: drafts},
 		estimateEvalCostTool{estimator: runCreator},
 		createRunTool{runs: runCreator},
+		createEvalSessionTool{sessions: sessionCreator},
 	}
 	for _, t := range tools {
 		if !roleAllows(RoleWorkspaceAdmin, Action(t.RequiredAction())) {

--- a/backend/internal/api/vibe_eval_agent_manager.go
+++ b/backend/internal/api/vibe_eval_agent_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -25,10 +26,19 @@ type vibeEvalLoopRunner interface {
 	ContinueTurn(ctx context.Context, actor vibeeval.Actor, authorizer vibeeval.WorkspaceAuthorizer, conv vibeeval.Conversation, sink vibeeval.EventSink) (vibeeval.TurnResult, error)
 }
 
+// guideTurnMeter atomically consumes one guide-agent turn against the workspace's monthly allowance (4e),
+// returning billingpkg.GateError when exhausted. BillingManager satisfies it. Kept narrow so the vibeeval
+// manager depends only on the metering capability, not the whole billing surface.
+type guideTurnMeter interface {
+	ConsumeGuideAgentTurn(ctx context.Context, workspaceID uuid.UUID) error
+}
+
 type VibeEvalAgentManager struct {
 	authorizer     WorkspaceAuthorizer
 	repo           *repository.Repository
 	loop           vibeEvalLoopRunner
+	meter          guideTurnMeter
+	now            func() time.Time
 	recoveryProbes map[string]recoveryProbe // per-tool-name ambiguous-recovery effect probes
 }
 
@@ -46,7 +56,13 @@ func NewVibeEvalAgentManager(
 	drafts vibeEvalDraftAuthor,
 	runCreator vibeEvalRunCreator,
 	sessionCreator vibeEvalSessionCreator,
+	meter guideTurnMeter,
 ) (*VibeEvalAgentManager, error) {
+	// The guide-turn allowance meter is required in production (every fresh turn / approve is metered).
+	// Fail fast rather than risk a nil-pointer at the first turn.
+	if meter == nil {
+		return nil, fmt.Errorf("vibe-eval guide-turn meter is required")
+	}
 	registry := vibeeval.NewRegistry()
 	tools := []vibeeval.Tool{
 		getRunStatusTool{runs: runs},
@@ -78,7 +94,7 @@ func NewVibeEvalAgentManager(
 		WithConfirmationStore(vibeEvalConfirmationStore{repo: repo}).
 		WithAuditWriter(vibeEvalAuditWriter{repo: repo})
 
-	mgr := &VibeEvalAgentManager{authorizer: authorizer, repo: repo, loop: loop}
+	mgr := &VibeEvalAgentManager{authorizer: authorizer, repo: repo, loop: loop, meter: meter, now: time.Now}
 	// publish_draft is idempotent by effect identity → its ambiguous-recovery probe consults the
 	// draft's published version rather than re-executing.
 	mgr.recoveryProbes = map[string]recoveryProbe{
@@ -91,6 +107,44 @@ func NewVibeEvalAgentManager(
 // handler calls this BEFORE switching to SSE so a 403 returns as a normal HTTP error.
 func (m *VibeEvalAgentManager) AuthorizeTurn(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
 	return AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionManageVibeEvalDrafts)
+}
+
+// RequireConversation verifies the conversation exists and belongs to the workspace. The create-turn
+// handler calls this BEFORE metering (4e blocker): otherwise a caller authorized for the workspace could
+// POST to a missing or cross-workspace conversation and burn a guide-agent turn for a non-genuine turn.
+// RunTurn re-checks the same locality (a cheap duplicate read) before it runs the model.
+func (m *VibeEvalAgentManager) RequireConversation(ctx context.Context, workspaceID, conversationID uuid.UUID) error {
+	conv, err := m.repo.GetVibeEvalConversationByID(ctx, conversationID)
+	if err != nil {
+		return err
+	}
+	if conv.WorkspaceID != workspaceID {
+		return repository.ErrVibeEvalConversationNotFound
+	}
+	return nil
+}
+
+// MeterFreshTurn consumes one guide-agent turn allowance for a fresh user turn (4e). The handler calls
+// this BEFORE the SSE switch (and AFTER RequireConversation), so an exhausted allowance returns a clean
+// 402 (billingpkg.GateError) with no model call. A turn that passes is counted even if it later errors
+// mid-stream (consumed at accept-time).
+func (m *VibeEvalAgentManager) MeterFreshTurn(ctx context.Context, workspaceID uuid.UUID) error {
+	return m.meter.ConsumeGuideAgentTurn(ctx, workspaceID)
+}
+
+// MeterConfirmationResolve consumes one guide-agent turn allowance ONLY for a genuine fresh APPROVE
+// resume (4e, B1-adjusted + D): deny is always allowed and never counted; an approve for a non-resolvable
+// confirmation (wrong payload hash, expired, or already resolved/executing) is never counted, since it
+// will not drive a model call. The genuineness predicate is the pre-SSE check; the atomic consume
+// provides the 402. A rare resolve-retry that races the claim may over-count by one (accepted).
+func (m *VibeEvalAgentManager) MeterConfirmationResolve(ctx context.Context, workspaceID uuid.UUID, pc repository.VibeEvalPendingConfirmation, presentedHash string, approve bool) error {
+	if !approve {
+		return nil
+	}
+	if pc.Status != "pending" || pc.PayloadHash != presentedHash || !m.now().UTC().Before(pc.ExpiresAt.UTC()) {
+		return nil
+	}
+	return m.meter.ConsumeGuideAgentTurn(ctx, workspaceID)
 }
 
 // RunTurn loads the conversation, bridges the caller, and runs one bounded turn. The handler

--- a/backend/internal/api/vibe_eval_agent_tools.go
+++ b/backend/internal/api/vibe_eval_agent_tools.go
@@ -253,6 +253,63 @@ func (t publishDraftTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vi
 	return vibeeval.ToolOutput{Result: meta, AuditResult: meta}, nil
 }
 
+// --- estimate_eval_cost (read tier, no confirmation) ---
+
+// vibeEvalCostEstimator is the manager surface the estimate tool wraps (RunCreationManager satisfies it).
+type vibeEvalCostEstimator interface {
+	EstimateEvalCost(ctx context.Context, caller Caller, input EstimateEvalCostInput) (CostEstimate, error)
+}
+
+type estimateEvalCostTool struct{ estimator vibeEvalCostEstimator }
+
+func (estimateEvalCostTool) Name() string                { return "estimate_eval_cost" }
+func (estimateEvalCostTool) Phases() []string            { return []string{vibeeval.PhaseRun} }
+func (estimateEvalCostTool) RiskTier() vibeeval.RiskTier { return vibeeval.ReadTier }
+func (estimateEvalCostTool) RequiredAction() string      { return string(ActionReadWorkspace) }
+func (estimateEvalCostTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "estimate_eval_cost",
+		Description: "Estimate the managed eval credit a run would reserve, for a challenge_pack_version and agent deployments.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["challenge_pack_version_id","agent_deployment_ids"],"properties":{"challenge_pack_version_id":{"type":"string","description":"challenge pack version UUID"},"agent_deployment_ids":{"type":"array","items":{"type":"string"},"description":"agent deployment UUIDs"}}}`),
+	}
+}
+
+func (t estimateEvalCostTool) Execute(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in struct {
+		ChallengePackVersionID string   `json:"challenge_pack_version_id"`
+		AgentDeploymentIDs     []string `json:"agent_deployment_ids"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	versionID, err := uuid.Parse(in.ChallengePackVersionID)
+	if err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("challenge_pack_version_id is not a UUID: %w", err)
+	}
+	deploymentIDs := make([]uuid.UUID, 0, len(in.AgentDeploymentIDs))
+	for _, raw := range in.AgentDeploymentIDs {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			return vibeeval.ToolOutput{}, fmt.Errorf("agent_deployment_id %q is not a UUID: %w", raw, err)
+		}
+		deploymentIDs = append(deploymentIDs, id)
+	}
+	est, err := t.estimator.EstimateEvalCost(ctx, caller, EstimateEvalCostInput{
+		WorkspaceID: conv.WorkspaceID, ChallengePackVersionID: versionID, AgentDeploymentIDs: deploymentIDs,
+	})
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	return vibeeval.ToolOutput{
+		Result:      est,
+		AuditResult: map[string]any{"total_micros": est.TotalMicros, "lanes": len(est.Lanes)},
+	}, nil
+}
+
 // --- get_run_status ---
 
 type getRunStatusTool struct{ runs runStatusReader }

--- a/backend/internal/api/vibe_eval_cost.go
+++ b/backend/internal/api/vibe_eval_cost.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 )
@@ -39,6 +40,10 @@ func (m *RunCreationManager) EstimateEvalCost(ctx context.Context, caller Caller
 	// Visibility: the challenge-pack version must be visible to the workspace (same rule as CreateRun).
 	version, err := m.repo.GetRunnableChallengePackVersionByID(ctx, input.ChallengePackVersionID)
 	if err != nil {
+		// Normalize not-found to a client validation error (the id isn't a runnable version for them).
+		if errors.Is(err, repository.ErrChallengePackVersionNotFound) {
+			return CostEstimate{}, RunCreationValidationError{Code: "invalid_challenge_pack_version_id", Message: "challenge_pack_version_id must be a runnable version visible to the selected workspace"}
+		}
 		return CostEstimate{}, err
 	}
 	if version.WorkspaceID != nil && *version.WorkspaceID != input.WorkspaceID {

--- a/backend/internal/api/vibe_eval_cost.go
+++ b/backend/internal/api/vibe_eval_cost.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/google/uuid"
+)
+
+// EstimateEvalCostInput estimates the managed eval-credit reservation for a prospective run.
+type EstimateEvalCostInput struct {
+	WorkspaceID            uuid.UUID
+	ChallengePackVersionID uuid.UUID
+	AgentDeploymentIDs     []uuid.UUID
+}
+
+// EstimateEvalCost computes the conservative managed-spend ceiling for a prospective run from the
+// frozen deployment snapshots + the challenge pack's runtime limits. Read-only (no reservation, no run).
+func (m *RunCreationManager) EstimateEvalCost(ctx context.Context, caller Caller, input EstimateEvalCostInput) (CostEstimate, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionReadWorkspace); err != nil {
+		return CostEstimate{}, err
+	}
+	if len(input.AgentDeploymentIDs) == 0 {
+		return CostEstimate{}, RunCreationValidationError{Code: "validation_error", Message: "at least one agent deployment is required"}
+	}
+	// Reject duplicate deployment ids (mirrors CreateRun) — otherwise a dup would double-count a lane.
+	seen := make(map[uuid.UUID]struct{}, len(input.AgentDeploymentIDs))
+	for _, id := range input.AgentDeploymentIDs {
+		if _, ok := seen[id]; ok {
+			return CostEstimate{}, RunCreationValidationError{Code: "invalid_agent_deployment_ids", Message: "agent_deployment_ids must not contain duplicates"}
+		}
+		seen[id] = struct{}{}
+	}
+
+	// Visibility: the challenge-pack version must be visible to the workspace (same rule as CreateRun).
+	version, err := m.repo.GetRunnableChallengePackVersionByID(ctx, input.ChallengePackVersionID)
+	if err != nil {
+		return CostEstimate{}, err
+	}
+	if version.WorkspaceID != nil && *version.WorkspaceID != input.WorkspaceID {
+		return CostEstimate{}, RunCreationValidationError{Code: "invalid_challenge_pack_version_id", Message: "challenge_pack_version_id must be visible to the selected workspace"}
+	}
+	if version.WorkspaceID == nil {
+		publicPacks, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, input.WorkspaceID)
+		if accessErr != nil {
+			return CostEstimate{}, fmt.Errorf("load workspace public pack access: %w", accessErr)
+		}
+		if !publicPacks {
+			return CostEstimate{}, RunCreationValidationError{Code: "invalid_challenge_pack_version_id", Message: "challenge_pack_version_id must be visible to the selected workspace"}
+		}
+	}
+	limits := challengePackRuntimeLimits(version.Manifest)
+
+	// The query is workspace-scoped; a short result means some ids are not visible to this workspace.
+	deployments, err := m.repo.ListRunnableDeploymentsWithLatestSnapshot(ctx, input.WorkspaceID, input.AgentDeploymentIDs)
+	if err != nil {
+		return CostEstimate{}, err
+	}
+	if len(deployments) != len(input.AgentDeploymentIDs) {
+		return CostEstimate{}, RunCreationValidationError{Code: "invalid_agent_deployment_ids", Message: "one or more agent_deployment_ids are not visible to the selected workspace"}
+	}
+
+	lanes := make([]evalCostLane, 0, len(deployments))
+	for _, d := range deployments {
+		lanes = append(lanes, evalCostLane{
+			DeploymentID:         d.ID,
+			Managed:              d.SourceProviderAccountID == nil, // a frozen source provider account ⇒ BYOK
+			ProviderKey:          d.ProviderKey,
+			ProviderModelID:      d.ProviderModelID,
+			OutputRatePerMillion: d.OutputCostPerMillionTokens,
+		})
+	}
+	return estimateEvalCost(lanes, limits)
+}
+
+// challengePackRuntimeLimits extracts max_cost_usd / max_total_tokens from a challenge-pack version
+// manifest, preferring evaluation_spec.runtime_limits over a top-level runtime_limits block.
+func challengePackRuntimeLimits(manifest json.RawMessage) scoring.RuntimeLimits {
+	var document struct {
+		RuntimeLimits  scoring.RuntimeLimits `json:"runtime_limits"`
+		EvaluationSpec struct {
+			RuntimeLimits scoring.RuntimeLimits `json:"runtime_limits"`
+		} `json:"evaluation_spec"`
+	}
+	if len(manifest) == 0 {
+		return scoring.RuntimeLimits{}
+	}
+	if err := json.Unmarshal(manifest, &document); err != nil {
+		return scoring.RuntimeLimits{}
+	}
+	limits := document.EvaluationSpec.RuntimeLimits
+	if limits.MaxCostUSD == nil {
+		limits.MaxCostUSD = document.RuntimeLimits.MaxCostUSD
+	}
+	if limits.MaxTotalTokens == nil {
+		limits.MaxTotalTokens = document.RuntimeLimits.MaxTotalTokens
+	}
+	return limits
+}
+
+// Eval-cost estimation errors (4d-1). Both map to a 400-style validation failure for the guide/REST.
+var (
+	// ErrVibeEvalMixedBilling blocks a run whose lanes mix managed + BYOK billing (unsupported for now).
+	ErrVibeEvalMixedBilling = errors.New("mixed_billing_unsupported")
+	// ErrVibeEvalCostEstimateUnavailable blocks a managed cost-incurring run with no bounded estimate.
+	ErrVibeEvalCostEstimateUnavailable = errors.New("cost_estimate_unavailable")
+)
+
+// evalCostLane is one deployment lane classified for billing. Managed=false means BYOK (the lane has a
+// frozen source provider account), which never consumes eval credit. OutputRatePerMillion is the rate
+// FROZEN on the snapshot's model alias (model_aliases.output_cost_per_million_tokens) — never a live
+// catalog read — so reservation pricing cannot drift after deployment.
+type evalCostLane struct {
+	DeploymentID         uuid.UUID
+	Managed              bool
+	ProviderKey          string
+	ProviderModelID      string
+	OutputRatePerMillion float64
+}
+
+// EvalCostLaneEstimate is the per-lane breakdown shown on the confirmation card and recorded in the
+// estimate/audit metadata. Non-secret only: provider/model, the runtime limit applied, the output rate
+// used, and the lane micros — never provider-account IDs or credential references.
+type EvalCostLaneEstimate struct {
+	DeploymentID         uuid.UUID `json:"deployment_id"`
+	Managed              bool      `json:"managed"`
+	ProviderKey          string    `json:"provider_key,omitempty"`
+	ProviderModelID      string    `json:"provider_model_id,omitempty"`
+	Basis                string    `json:"basis"`                             // byok | max_cost_usd | max_total_tokens_output_rate
+	RuntimeLimit         string    `json:"runtime_limit,omitempty"`           // e.g. "max_cost_usd=2.5" | "max_total_tokens=1000000"
+	OutputRatePerMillion *float64  `json:"output_rate_per_million,omitempty"` // only for the token-rate basis
+	Micros               int64     `json:"micros"`
+}
+
+// CostEstimate is the conservative managed-spend ceiling for a run (the reservation amount).
+type CostEstimate struct {
+	TotalMicros int64                  `json:"total_micros"`
+	Lanes       []EvalCostLaneEstimate `json:"lanes"`
+}
+
+// estimateEvalCost computes the conservative managed-spend ceiling (#875 §8, 4d-1, option A):
+//   - mixed managed+BYOK lanes → ErrVibeEvalMixedBilling (blocked for now);
+//   - all-BYOK → 0 (BYOK never consumes credit);
+//   - per managed lane: max_cost_usd wins; else max_total_tokens priced ENTIRELY at the model's output
+//     rate (worst-case ceiling); else block. A managed model with no catalog price blocks (never free).
+//
+// USD → integer micros, always rounded UP (never under-reserve).
+func estimateEvalCost(lanes []evalCostLane, limits scoring.RuntimeLimits) (CostEstimate, error) {
+	var managed, byok int
+	for _, l := range lanes {
+		if l.Managed {
+			managed++
+		} else {
+			byok++
+		}
+	}
+	if managed > 0 && byok > 0 {
+		return CostEstimate{}, fmt.Errorf("%w: a run must be all-managed or all-BYOK", ErrVibeEvalMixedBilling)
+	}
+
+	estimate := CostEstimate{Lanes: make([]EvalCostLaneEstimate, 0, len(lanes))}
+	for _, l := range lanes {
+		if !l.Managed {
+			estimate.Lanes = append(estimate.Lanes, EvalCostLaneEstimate{
+				DeploymentID: l.DeploymentID, Managed: false, ProviderKey: l.ProviderKey,
+				ProviderModelID: l.ProviderModelID, Micros: 0, Basis: "byok",
+			})
+			continue
+		}
+		laneEst, err := laneManagedEstimate(l, limits)
+		if err != nil {
+			return CostEstimate{}, err
+		}
+		estimate.TotalMicros += laneEst.Micros
+		estimate.Lanes = append(estimate.Lanes, laneEst)
+	}
+	return estimate, nil
+}
+
+func laneManagedEstimate(l evalCostLane, limits scoring.RuntimeLimits) (EvalCostLaneEstimate, error) {
+	est := EvalCostLaneEstimate{DeploymentID: l.DeploymentID, Managed: true, ProviderKey: l.ProviderKey, ProviderModelID: l.ProviderModelID}
+	if limits.MaxCostUSD != nil {
+		est.Basis = "max_cost_usd"
+		est.RuntimeLimit = fmt.Sprintf("max_cost_usd=%g", *limits.MaxCostUSD)
+		est.Micros = usdToMicrosCeil(*limits.MaxCostUSD)
+		return est, nil
+	}
+	if limits.MaxTotalTokens != nil {
+		// A non-positive FROZEN alias rate blocks: model_aliases defaults pricing to 0, which would make
+		// a managed run free by accident. Never treat a zero/negative frozen rate as $0.
+		if l.OutputRatePerMillion <= 0 {
+			return EvalCostLaneEstimate{}, fmt.Errorf("%w: no positive frozen output rate for managed model %s/%s", ErrVibeEvalCostEstimateUnavailable, l.ProviderKey, l.ProviderModelID)
+		}
+		rate := l.OutputRatePerMillion
+		est.Basis = "max_total_tokens_output_rate"
+		est.RuntimeLimit = fmt.Sprintf("max_total_tokens=%d", *limits.MaxTotalTokens)
+		est.OutputRatePerMillion = &rate
+		// Conservative: every token at the frozen output rate (the priciest), per-million.
+		usd := float64(*limits.MaxTotalTokens) * rate / 1_000_000.0
+		est.Micros = usdToMicrosCeil(usd)
+		return est, nil
+	}
+	return EvalCostLaneEstimate{}, fmt.Errorf("%w: spec declares neither max_cost_usd nor max_total_tokens", ErrVibeEvalCostEstimateUnavailable)
+}
+
+// usdToMicrosCeil converts USD to integer micros, rounding UP so the reservation never under-covers.
+func usdToMicrosCeil(usd float64) int64 {
+	if usd <= 0 {
+		return 0
+	}
+	return int64(math.Ceil(usd * 1_000_000.0))
+}

--- a/backend/internal/api/vibe_eval_cost.go
+++ b/backend/internal/api/vibe_eval_cost.go
@@ -72,11 +72,12 @@ func (m *RunCreationManager) EstimateEvalCost(ctx context.Context, caller Caller
 	lanes := make([]evalCostLane, 0, len(deployments))
 	for _, d := range deployments {
 		lanes = append(lanes, evalCostLane{
-			DeploymentID:         d.ID,
-			Managed:              d.SourceProviderAccountID == nil, // a frozen source provider account ⇒ BYOK
-			ProviderKey:          d.ProviderKey,
-			ProviderModelID:      d.ProviderModelID,
-			OutputRatePerMillion: d.OutputCostPerMillionTokens,
+			DeploymentID:              d.ID,
+			AgentDeploymentSnapshotID: d.AgentDeploymentSnapshotID,
+			Managed:                   d.SourceProviderAccountID == nil, // a frozen source provider account ⇒ BYOK
+			ProviderKey:               d.ProviderKey,
+			ProviderModelID:           d.ProviderModelID,
+			OutputRatePerMillion:      d.OutputCostPerMillionTokens,
 		})
 	}
 	return estimateEvalCost(lanes, limits)
@@ -120,25 +121,30 @@ var (
 // FROZEN on the snapshot's model alias (model_aliases.output_cost_per_million_tokens) — never a live
 // catalog read — so reservation pricing cannot drift after deployment.
 type evalCostLane struct {
-	DeploymentID         uuid.UUID
-	Managed              bool
-	ProviderKey          string
-	ProviderModelID      string
-	OutputRatePerMillion float64
+	DeploymentID              uuid.UUID
+	AgentDeploymentSnapshotID uuid.UUID
+	Managed                   bool
+	ProviderKey               string
+	ProviderModelID           string
+	OutputRatePerMillion      float64
 }
 
 // EvalCostLaneEstimate is the per-lane breakdown shown on the confirmation card and recorded in the
 // estimate/audit metadata. Non-secret only: provider/model, the runtime limit applied, the output rate
 // used, and the lane micros — never provider-account IDs or credential references.
 type EvalCostLaneEstimate struct {
-	DeploymentID         uuid.UUID `json:"deployment_id"`
-	Managed              bool      `json:"managed"`
-	ProviderKey          string    `json:"provider_key,omitempty"`
-	ProviderModelID      string    `json:"provider_model_id,omitempty"`
-	Basis                string    `json:"basis"`                             // byok | max_cost_usd | max_total_tokens_output_rate
-	RuntimeLimit         string    `json:"runtime_limit,omitempty"`           // e.g. "max_cost_usd=2.5" | "max_total_tokens=1000000"
-	OutputRatePerMillion *float64  `json:"output_rate_per_million,omitempty"` // only for the token-rate basis
-	Micros               int64     `json:"micros"`
+	DeploymentID uuid.UUID `json:"deployment_id"`
+	// AgentDeploymentSnapshotID pins the FROZEN snapshot the estimate priced/classified. Confirmed
+	// execution compares it against the freshly-expanded lane so a changed snapshot/model/BYOK lane can
+	// never bind an approved amount (non-secret — a frozen snapshot id, not a provider account).
+	AgentDeploymentSnapshotID uuid.UUID `json:"agent_deployment_snapshot_id"`
+	Managed                   bool      `json:"managed"`
+	ProviderKey               string    `json:"provider_key,omitempty"`
+	ProviderModelID           string    `json:"provider_model_id,omitempty"`
+	Basis                     string    `json:"basis"`                             // byok | max_cost_usd | max_total_tokens_output_rate
+	RuntimeLimit              string    `json:"runtime_limit,omitempty"`           // e.g. "max_cost_usd=2.5" | "max_total_tokens=1000000"
+	OutputRatePerMillion      *float64  `json:"output_rate_per_million,omitempty"` // only for the token-rate basis
+	Micros                    int64     `json:"micros"`
 }
 
 // CostEstimate is the conservative managed-spend ceiling for a run (the reservation amount).
@@ -171,7 +177,8 @@ func estimateEvalCost(lanes []evalCostLane, limits scoring.RuntimeLimits) (CostE
 	for _, l := range lanes {
 		if !l.Managed {
 			estimate.Lanes = append(estimate.Lanes, EvalCostLaneEstimate{
-				DeploymentID: l.DeploymentID, Managed: false, ProviderKey: l.ProviderKey,
+				DeploymentID: l.DeploymentID, AgentDeploymentSnapshotID: l.AgentDeploymentSnapshotID,
+				Managed: false, ProviderKey: l.ProviderKey,
 				ProviderModelID: l.ProviderModelID, Micros: 0, Basis: "byok",
 			})
 			continue
@@ -187,7 +194,7 @@ func estimateEvalCost(lanes []evalCostLane, limits scoring.RuntimeLimits) (CostE
 }
 
 func laneManagedEstimate(l evalCostLane, limits scoring.RuntimeLimits) (EvalCostLaneEstimate, error) {
-	est := EvalCostLaneEstimate{DeploymentID: l.DeploymentID, Managed: true, ProviderKey: l.ProviderKey, ProviderModelID: l.ProviderModelID}
+	est := EvalCostLaneEstimate{DeploymentID: l.DeploymentID, AgentDeploymentSnapshotID: l.AgentDeploymentSnapshotID, Managed: true, ProviderKey: l.ProviderKey, ProviderModelID: l.ProviderModelID}
 	if limits.MaxCostUSD != nil {
 		est.Basis = "max_cost_usd"
 		est.RuntimeLimit = fmt.Sprintf("max_cost_usd=%g", *limits.MaxCostUSD)

--- a/backend/internal/api/vibe_eval_cost_manager_test.go
+++ b/backend/internal/api/vibe_eval_cost_manager_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func estimateCaller(workspaceID uuid.UUID) Caller {
+	return Caller{
+		UserID:               uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"}},
+	}
+}
+
+func estimateManager(repo *fakeRunCreationRepository) *RunCreationManager {
+	return NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+}
+
+func managedDeployment(workspaceID uuid.UUID, rate float64) repository.RunnableDeployment {
+	return repository.RunnableDeployment{
+		ID: uuid.New(), WorkspaceID: workspaceID, ProviderKey: "openai", ProviderModelID: "gpt",
+		OutputCostPerMillionTokens: rate, // SourceProviderAccountID nil ⇒ managed
+	}
+}
+
+func TestEstimateEvalCost_Manager_Success(t *testing.T) {
+	ws := uuid.New()
+	versionID := uuid.New()
+	d := managedDeployment(ws, 3.0)
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID: versionID, WorkspaceID: &ws,
+			Manifest: []byte(`{"evaluation_spec":{"runtime_limits":{"max_cost_usd":1.5}}}`),
+		},
+		deployments: []repository.RunnableDeployment{d},
+	}
+	est, err := estimateManager(repo).EstimateEvalCost(context.Background(), estimateCaller(ws), EstimateEvalCostInput{
+		WorkspaceID: ws, ChallengePackVersionID: versionID, AgentDeploymentIDs: []uuid.UUID{d.ID},
+	})
+	if err != nil {
+		t.Fatalf("EstimateEvalCost: %v", err)
+	}
+	if est.TotalMicros != 1_500_000 || est.Lanes[0].Basis != "max_cost_usd" {
+		t.Fatalf("est = %+v, want 1.5M via max_cost_usd", est)
+	}
+}
+
+func TestEstimateEvalCost_Manager_RejectsDuplicateDeployments(t *testing.T) {
+	ws := uuid.New()
+	versionID := uuid.New()
+	dup := uuid.New()
+	repo := &fakeRunCreationRepository{challengePackVersion: repository.RunnableChallengePackVersion{ID: versionID, WorkspaceID: &ws}}
+	_, err := estimateManager(repo).EstimateEvalCost(context.Background(), estimateCaller(ws), EstimateEvalCostInput{
+		WorkspaceID: ws, ChallengePackVersionID: versionID, AgentDeploymentIDs: []uuid.UUID{dup, dup},
+	})
+	var verr RunCreationValidationError
+	if !errors.As(err, &verr) || verr.Code != "invalid_agent_deployment_ids" {
+		t.Fatalf("err = %v, want duplicate rejection", err)
+	}
+}
+
+func TestEstimateEvalCost_Manager_RejectsPartialDeployments(t *testing.T) {
+	ws := uuid.New()
+	versionID := uuid.New()
+	d := managedDeployment(ws, 3.0)
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: versionID, WorkspaceID: &ws},
+		deployments:          []repository.RunnableDeployment{d}, // only one resolves
+	}
+	_, err := estimateManager(repo).EstimateEvalCost(context.Background(), estimateCaller(ws), EstimateEvalCostInput{
+		WorkspaceID: ws, ChallengePackVersionID: versionID, AgentDeploymentIDs: []uuid.UUID{d.ID, uuid.New()},
+	})
+	var verr RunCreationValidationError
+	if !errors.As(err, &verr) || verr.Code != "invalid_agent_deployment_ids" {
+		t.Fatalf("err = %v, want partial (not-visible) rejection", err)
+	}
+}
+
+func TestEstimateEvalCost_Manager_RejectsVersionNotVisible(t *testing.T) {
+	ws := uuid.New()
+	otherWS := uuid.New()
+	versionID := uuid.New()
+	d := managedDeployment(ws, 3.0)
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: versionID, WorkspaceID: &otherWS}, // different workspace
+		deployments:          []repository.RunnableDeployment{d},
+	}
+	_, err := estimateManager(repo).EstimateEvalCost(context.Background(), estimateCaller(ws), EstimateEvalCostInput{
+		WorkspaceID: ws, ChallengePackVersionID: versionID, AgentDeploymentIDs: []uuid.UUID{d.ID},
+	})
+	var verr RunCreationValidationError
+	if !errors.As(err, &verr) || verr.Code != "invalid_challenge_pack_version_id" {
+		t.Fatalf("err = %v, want version-visibility rejection", err)
+	}
+}

--- a/backend/internal/api/vibe_eval_cost_manager_test.go
+++ b/backend/internal/api/vibe_eval_cost_manager_test.go
@@ -97,3 +97,28 @@ func TestEstimateEvalCost_Manager_RejectsVersionNotVisible(t *testing.T) {
 		t.Fatalf("err = %v, want version-visibility rejection", err)
 	}
 }
+
+func TestCreateRun_Manager_FailsClosedReservationWithoutRunID(t *testing.T) {
+	ws := uuid.New()
+	repo := &fakeRunCreationRepository{}
+	_, err := estimateManager(repo).CreateRun(context.Background(), estimateCaller(ws), CreateRunInput{
+		WorkspaceID: ws, ChallengePackVersionID: uuid.New(), AgentDeploymentIDs: []uuid.UUID{uuid.New()},
+		ReservationMicros: 1_000_000, // > 0 but RunID is zero
+	})
+	var verr RunCreationValidationError
+	if !errors.As(err, &verr) || verr.Code != "invalid_reservation" {
+		t.Fatalf("err = %v, want invalid_reservation (fail closed)", err)
+	}
+}
+
+func TestCreateRun_Manager_FailsClosedNegativeReservation(t *testing.T) {
+	ws := uuid.New()
+	_, err := estimateManager(&fakeRunCreationRepository{}).CreateRun(context.Background(), estimateCaller(ws), CreateRunInput{
+		WorkspaceID: ws, ChallengePackVersionID: uuid.New(), AgentDeploymentIDs: []uuid.UUID{uuid.New()},
+		RunID: uuid.New(), ReservationMicros: -5, // negative must fail closed, not become "no reservation"
+	})
+	var verr RunCreationValidationError
+	if !errors.As(err, &verr) || verr.Code != "invalid_reservation" {
+		t.Fatalf("err = %v, want invalid_reservation for negative amount", err)
+	}
+}

--- a/backend/internal/api/vibe_eval_cost_test.go
+++ b/backend/internal/api/vibe_eval_cost_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/google/uuid"
+)
+
+func f64p(v float64) *float64 { return &v }
+func i64p(v int64) *int64     { return &v }
+
+// managedLaneAt is a managed lane carrying the frozen alias output rate (per million).
+func managedLaneAt(outputRatePerMillion float64) evalCostLane {
+	return evalCostLane{DeploymentID: uuid.New(), Managed: true, ProviderKey: "anthropic", ProviderModelID: "claude", OutputRatePerMillion: outputRatePerMillion}
+}
+func managedLane() evalCostLane { return managedLaneAt(3.0) }
+func byokLane() evalCostLane    { return evalCostLane{DeploymentID: uuid.New(), Managed: false} }
+
+func TestEstimateEvalCost_MaxCostUSDWinsFirst(t *testing.T) {
+	// max_cost_usd present → used even though a (huge) frozen rate is available; tokens ignored.
+	est, err := estimateEvalCost([]evalCostLane{managedLaneAt(9_999.0)},
+		scoring.RuntimeLimits{MaxCostUSD: f64p(2.50), MaxTotalTokens: i64p(1_000_000)})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if est.TotalMicros != 2_500_000 || est.Lanes[0].Basis != "max_cost_usd" {
+		t.Fatalf("est = %+v, want 2.5M via max_cost_usd", est)
+	}
+}
+
+func TestEstimateEvalCost_OutputRatePricing(t *testing.T) {
+	// 1,000,000 tokens × $3/M (frozen output) = $3.00 = 3_000_000 micros.
+	est, err := estimateEvalCost([]evalCostLane{managedLaneAt(3.0)}, scoring.RuntimeLimits{MaxTotalTokens: i64p(1_000_000)})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if est.TotalMicros != 3_000_000 || est.Lanes[0].Basis != "max_total_tokens_output_rate" {
+		t.Fatalf("est = %+v, want 3M via output rate", est)
+	}
+}
+
+func TestEstimateEvalCost_RoundsUp(t *testing.T) {
+	// $0.0000005 → 0.5 micros → ceil to 1 (never under-reserve).
+	est, err := estimateEvalCost([]evalCostLane{managedLane()}, scoring.RuntimeLimits{MaxCostUSD: f64p(0.0000005)})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if est.TotalMicros != 1 {
+		t.Fatalf("total = %d, want 1 (rounded up)", est.TotalMicros)
+	}
+}
+
+func TestEstimateEvalCost_ZeroFrozenRateBlocks(t *testing.T) {
+	// Frozen alias rate 0 (model_aliases default) on a token-derived estimate → block, never free.
+	_, err := estimateEvalCost([]evalCostLane{managedLaneAt(0)}, scoring.RuntimeLimits{MaxTotalTokens: i64p(1_000_000)})
+	if !errors.Is(err, ErrVibeEvalCostEstimateUnavailable) {
+		t.Fatalf("err = %v, want ErrVibeEvalCostEstimateUnavailable for zero frozen rate", err)
+	}
+}
+
+func TestEstimateEvalCost_AllBYOKIsZero(t *testing.T) {
+	est, err := estimateEvalCost([]evalCostLane{byokLane(), byokLane()}, scoring.RuntimeLimits{})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if est.TotalMicros != 0 || est.Lanes[0].Basis != "byok" || est.Lanes[1].Basis != "byok" {
+		t.Fatalf("est = %+v, want zero, all byok", est)
+	}
+}
+
+func TestEstimateEvalCost_MixedBillingBlocks(t *testing.T) {
+	_, err := estimateEvalCost([]evalCostLane{managedLane(), byokLane()}, scoring.RuntimeLimits{MaxCostUSD: f64p(1)})
+	if !errors.Is(err, ErrVibeEvalMixedBilling) {
+		t.Fatalf("err = %v, want ErrVibeEvalMixedBilling", err)
+	}
+}
+
+func TestEstimateEvalCost_NoBoundBlocks(t *testing.T) {
+	// managed lane, neither max_cost_usd nor max_total_tokens → block.
+	_, err := estimateEvalCost([]evalCostLane{managedLane()}, scoring.RuntimeLimits{})
+	if !errors.Is(err, ErrVibeEvalCostEstimateUnavailable) {
+		t.Fatalf("err = %v, want ErrVibeEvalCostEstimateUnavailable", err)
+	}
+}
+
+func TestEstimateEvalCost_SumsManagedLanes(t *testing.T) {
+	// Two managed lanes, max_cost_usd applies per lane → 2 × $1.50 = $3.00.
+	est, err := estimateEvalCost([]evalCostLane{managedLane(), managedLane()}, scoring.RuntimeLimits{MaxCostUSD: f64p(1.50)})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	if est.TotalMicros != 3_000_000 || len(est.Lanes) != 2 {
+		t.Fatalf("est = %+v, want 3M across 2 lanes", est)
+	}
+}
+
+func TestEstimateEvalCost_AuditMetadata(t *testing.T) {
+	// token-rate basis carries provider/model, runtime limit, and the frozen output rate.
+	est, err := estimateEvalCost([]evalCostLane{managedLaneAt(3.0)}, scoring.RuntimeLimits{MaxTotalTokens: i64p(2_000_000)})
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	l := est.Lanes[0]
+	if l.ProviderKey != "anthropic" || l.ProviderModelID != "claude" {
+		t.Fatalf("lane provider/model = %s/%s", l.ProviderKey, l.ProviderModelID)
+	}
+	if l.RuntimeLimit != "max_total_tokens=2000000" {
+		t.Fatalf("runtime_limit = %q", l.RuntimeLimit)
+	}
+	if l.OutputRatePerMillion == nil || *l.OutputRatePerMillion != 3.0 {
+		t.Fatalf("output rate = %v, want 3.0", l.OutputRatePerMillion)
+	}
+	if l.Micros != 6_000_000 || est.TotalMicros != 6_000_000 {
+		t.Fatalf("micros = %d / total %d, want 6M", l.Micros, est.TotalMicros)
+	}
+	// max_cost_usd basis records the limit and no output rate.
+	est2, _ := estimateEvalCost([]evalCostLane{managedLaneAt(0)}, scoring.RuntimeLimits{MaxCostUSD: f64p(2.5)})
+	if est2.Lanes[0].RuntimeLimit != "max_cost_usd=2.5" || est2.Lanes[0].OutputRatePerMillion != nil {
+		t.Fatalf("max_cost_usd lane metadata = %+v", est2.Lanes[0])
+	}
+}

--- a/backend/internal/api/vibe_eval_cost_tool_test.go
+++ b/backend/internal/api/vibe_eval_cost_tool_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+type fakeCostEstimator struct {
+	got EstimateEvalCostInput
+	est CostEstimate
+	err error
+}
+
+func (f *fakeCostEstimator) EstimateEvalCost(_ context.Context, _ Caller, input EstimateEvalCostInput) (CostEstimate, error) {
+	f.got = input
+	return f.est, f.err
+}
+
+func TestEstimateEvalCostTool(t *testing.T) {
+	fake := &fakeCostEstimator{est: CostEstimate{TotalMicros: 1_500_000, Lanes: []EvalCostLaneEstimate{{Micros: 1_500_000}}}}
+	tool := estimateEvalCostTool{estimator: fake}
+
+	if tool.RiskTier() != vibeeval.ReadTier {
+		t.Fatalf("risk tier = %q, want read (no confirmation)", tool.RiskTier())
+	}
+	if tool.RequiredAction() != string(ActionReadWorkspace) {
+		t.Fatalf("action = %q, want read_workspace", tool.RequiredAction())
+	}
+
+	conv := vibeeval.Conversation{ID: uuid.New(), WorkspaceID: uuid.New()}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	vid, did := uuid.New(), uuid.New()
+	out, err := tool.Execute(ctx, vibeeval.Actor{}, conv,
+		json.RawMessage(`{"challenge_pack_version_id":"`+vid.String()+`","agent_deployment_ids":["`+did.String()+`"]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fake.got.WorkspaceID != conv.WorkspaceID || fake.got.ChallengePackVersionID != vid ||
+		len(fake.got.AgentDeploymentIDs) != 1 || fake.got.AgentDeploymentIDs[0] != did {
+		t.Fatalf("estimator input mismatch: %+v", fake.got)
+	}
+	if out.AuditResult["total_micros"] != int64(1_500_000) {
+		t.Fatalf("audit total_micros = %v, want 1.5M", out.AuditResult["total_micros"])
+	}
+}
+
+func TestEstimateEvalCostTool_RejectsBadUUID(t *testing.T) {
+	tool := estimateEvalCostTool{estimator: &fakeCostEstimator{}}
+	ctx := context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+	_, err := tool.Execute(ctx, vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()},
+		json.RawMessage(`{"challenge_pack_version_id":"nope","agent_deployment_ids":[]}`))
+	if err == nil {
+		t.Fatal("expected error for non-UUID challenge_pack_version_id")
+	}
+}

--- a/backend/internal/api/vibe_eval_create_eval_session.go
+++ b/backend/internal/api/vibe_eval_create_eval_session.go
@@ -1,0 +1,252 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+// createEvalSessionEstimateSchemaVersion is the version of the typed cost envelope stored on the
+// confirmation (pc.Estimate) and bound at confirmed execution. Bump it on any breaking envelope change.
+const createEvalSessionEstimateSchemaVersion = 1
+
+// createEvalSessionEnvelope is the server-generated, versioned, non-secret cost envelope for a
+// prospective eval session (4d-3, binding fork: option A — the materialized child plan). It carries the
+// preallocated session id plus, IN PLAN ORDER, one child per expanded run with its preallocated run id,
+// approved amount, billing mode, and the lane identity (matrix key / seed) the estimate enumerated. The
+// confirmed execution binds these positionally onto a freshly-expanded plan and reserves exactly these
+// amounts — never recomputed.
+type createEvalSessionEnvelope struct {
+	SchemaVersion   int                              `json:"schema_version"`
+	Kind            string                           `json:"kind"` // "create_eval_session"
+	EvalSessionID   uuid.UUID                        `json:"eval_session_id"`
+	AggregateMicros int64                            `json:"aggregate_micros"`
+	Children        []createEvalSessionChildEnvelope `json:"children"`
+}
+
+// createEvalSessionChildEnvelope is one child run's frozen plan entry. Non-secret: ids, amount, billing
+// mode, lane identity, and the per-lane provider/model estimate metadata — never provider-account ids,
+// credentials, prompts, or bundle content.
+type createEvalSessionChildEnvelope struct {
+	RunID        uuid.UUID              `json:"run_id"`
+	AmountMicros int64                  `json:"amount_micros"`
+	BillingMode  string                 `json:"billing_mode"` // managed | byok
+	MatrixKey    string                 `json:"matrix_key,omitempty"`
+	Seed         *int64                 `json:"seed,omitempty"`
+	Lanes        []EvalCostLaneEstimate `json:"lanes,omitempty"`
+}
+
+// vibeEvalSessionCreator is the manager surface create_eval_session wraps (RunCreationManager satisfies
+// it). Estimate prices every expanded child; CreateEvalSession reserves+creates them atomically.
+type vibeEvalSessionCreator interface {
+	EstimateEvalSessionCost(ctx context.Context, caller Caller, input CreateEvalSessionInput) (EvalSessionCostEstimate, error)
+	CreateEvalSession(ctx context.Context, caller Caller, input CreateEvalSessionInput) (CreateEvalSessionResult, error)
+}
+
+// createEvalSessionTool is the cost-incurring guide tool that estimates a whole eval session at propose
+// time (one aggregate card, per-child reservations), refuses unconfirmed execution, and reserves+creates
+// the session + N child runs atomically on approval.
+type createEvalSessionTool struct{ sessions vibeEvalSessionCreator }
+
+var (
+	_ vibeeval.Tool          = createEvalSessionTool{}
+	_ vibeeval.CostEstimator = createEvalSessionTool{}
+	_ vibeeval.ConfirmedTool = createEvalSessionTool{}
+)
+
+func (createEvalSessionTool) Name() string                { return "create_eval_session" }
+func (createEvalSessionTool) Phases() []string            { return []string{vibeeval.PhaseRun} }
+func (createEvalSessionTool) RiskTier() vibeeval.RiskTier { return vibeeval.CostIncurringTier }
+func (createEvalSessionTool) RequiredAction() string      { return string(ActionCreateRun) }
+func (createEvalSessionTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "create_eval_session",
+		Description: "Create and start an eval session (repeated/matrixed runs) for a challenge_pack_version. Requires confirmation; reserves managed eval credit per child run for the approved cost.",
+		// The arg shape mirrors the REST create-eval-session body (workspace comes from the conversation).
+		Parameters: json.RawMessage(`{"type":"object","required":["challenge_pack_version_id","eval_session"],"properties":{"challenge_pack_version_id":{"type":"string"},"challenge_input_set_id":{"type":"string"},"participants":{"type":"array","items":{"type":"object"}},"execution_mode":{"type":"string"},"name":{"type":"string"},"max_iterations":{"type":"integer"},"eval_session":{"type":"object"}}}`),
+	}
+}
+
+// parseCreateEvalSessionArgs decodes the tool args into a CreateEvalSessionInput for the conversation's
+// workspace, reusing the shared REST builder so estimate and confirmed execution validate identically.
+func parseCreateEvalSessionArgs(args json.RawMessage, workspaceID uuid.UUID) (CreateEvalSessionInput, error) {
+	var body createEvalSessionRequest
+	decoder := json.NewDecoder(bytes.NewReader(args))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return CreateEvalSessionInput{}, fmt.Errorf("invalid args: %w", err)
+	}
+	if decoder.More() {
+		return CreateEvalSessionInput{}, errors.New("args must contain exactly one JSON object")
+	}
+	return buildCreateEvalSessionInput(body, workspaceID)
+}
+
+// EstimateCost prices every child run from the same plan execution uses, then preallocates the session
+// id + a stable run id per child and materializes them into the cost envelope. The per-child amounts are
+// exactly what confirmed execution reserves.
+func (t createEvalSessionTool) EstimateCost(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (json.RawMessage, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	input, err := parseCreateEvalSessionArgs(args, conv.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	estimate, err := t.sessions.EstimateEvalSessionCost(ctx, caller, input)
+	if err != nil {
+		return nil, err
+	}
+	children := make([]createEvalSessionChildEnvelope, 0, len(estimate.Children))
+	for _, child := range estimate.Children {
+		children = append(children, createEvalSessionChildEnvelope{
+			RunID:        uuid.New(), // preallocated; stable across retry via the stored confirmation
+			AmountMicros: child.AmountMicros,
+			BillingMode:  child.BillingMode,
+			MatrixKey:    child.MatrixKey,
+			Seed:         child.Seed,
+			Lanes:        child.Lanes,
+		})
+	}
+	return json.Marshal(createEvalSessionEnvelope{
+		SchemaVersion:   createEvalSessionEstimateSchemaVersion,
+		Kind:            "create_eval_session",
+		EvalSessionID:   uuid.New(),
+		AggregateMicros: estimate.AggregateMicros,
+		Children:        children,
+	})
+}
+
+// Execute refuses: create_eval_session is cost-incurring and must run only through a confirmation that
+// carries the approved per-child cost envelope.
+func (createEvalSessionTool) Execute(context.Context, vibeeval.Actor, vibeeval.Conversation, json.RawMessage) (vibeeval.ToolOutput, error) {
+	return vibeeval.ToolOutput{}, errors.New("create_eval_session requires confirmation: it cannot run without an approved cost estimate")
+}
+
+// ExecuteConfirmed validates the approved envelope, binds its preallocated ids + per-child reservations
+// onto a freshly-expanded plan, and reserves+creates the session atomically (idempotent on the
+// preallocated session id). A workflow-start failure after commit is an effect-created
+// success-with-warning, never a terminal failure.
+func (t createEvalSessionTool) ExecuteConfirmed(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage, pc vibeeval.PendingConfirmation) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	// Trust the approved envelope: a malformed/missing/inconsistent estimate fails BEFORE any side effect.
+	envelope, err := parseCreateEvalSessionEnvelope(pc.Estimate)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	input, err := parseCreateEvalSessionArgs(args, conv.WorkspaceID)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	input.EvalSessionID = envelope.EvalSessionID
+	input.ChildReservations = make([]EvalSessionChildReservation, 0, len(envelope.Children))
+	for _, child := range envelope.Children {
+		lanes := make([]EvalSessionChildLane, 0, len(child.Lanes))
+		for _, lane := range child.Lanes {
+			lanes = append(lanes, EvalSessionChildLane{
+				DeploymentID:              lane.DeploymentID,
+				AgentDeploymentSnapshotID: lane.AgentDeploymentSnapshotID,
+				Managed:                   lane.Managed,
+			})
+		}
+		input.ChildReservations = append(input.ChildReservations, EvalSessionChildReservation{
+			RunID:        child.RunID,
+			AmountMicros: child.AmountMicros,
+			MatrixKey:    child.MatrixKey,
+			Seed:         child.Seed,
+			Lanes:        lanes,
+		})
+	}
+
+	result, err := t.sessions.CreateEvalSession(ctx, caller, input)
+	if err != nil {
+		// The session + child runs + reservations committed but the workflow failed to start: the
+		// approved effect happened, so surface a warning that recovery is needed (never terminal failure).
+		var startErr EvalSessionWorkflowStartError
+		if errors.As(err, &startErr) {
+			return vibeeval.ToolOutput{
+				Result: map[string]any{"eval_session_id": startErr.Session.ID, "run_ids": startErr.RunIDs, "status": startErr.Session.Status, "warning": "eval session created and credit reserved, but workflow start failed; it will be retried"},
+				AuditResult: map[string]any{
+					"eval_session_id": startErr.Session.ID.String(),
+					"run_count":       len(startErr.RunIDs),
+					"reserved_micros": envelope.AggregateMicros,
+					"workflow_start":  "failed_pending_recovery",
+				},
+			}, nil
+		}
+		return vibeeval.ToolOutput{}, err
+	}
+	return vibeeval.ToolOutput{
+		Result: map[string]any{"eval_session_id": result.Session.ID, "run_ids": result.RunIDs, "status": result.Session.Status},
+		AuditResult: map[string]any{
+			"eval_session_id": result.Session.ID.String(),
+			"run_count":       len(result.RunIDs),
+			"reserved_micros": envelope.AggregateMicros,
+		},
+	}, nil
+}
+
+// parseCreateEvalSessionEnvelope strictly validates the approved cost envelope before any side effect
+// (4d-3, pin #3): schema/kind, a session id, at least one child, no duplicate child run ids, the
+// aggregate equals the sum of child amounts, and each child's billing mode agrees with its amount.
+func parseCreateEvalSessionEnvelope(raw json.RawMessage) (createEvalSessionEnvelope, error) {
+	if len(raw) == 0 {
+		return createEvalSessionEnvelope{}, errors.New("approved cost estimate is missing")
+	}
+	var envelope createEvalSessionEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate is malformed: %w", err)
+	}
+	if envelope.SchemaVersion != createEvalSessionEstimateSchemaVersion || envelope.Kind != "create_eval_session" {
+		return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate has unexpected schema (version=%d kind=%q)", envelope.SchemaVersion, envelope.Kind)
+	}
+	if envelope.EvalSessionID == uuid.Nil {
+		return createEvalSessionEnvelope{}, errors.New("approved cost estimate has no eval session id")
+	}
+	if len(envelope.Children) == 0 {
+		return createEvalSessionEnvelope{}, errors.New("approved cost estimate has no child runs")
+	}
+	seen := make(map[uuid.UUID]struct{}, len(envelope.Children))
+	var sum int64
+	for i, child := range envelope.Children {
+		if child.RunID == uuid.Nil {
+			return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate child %d has no run id", i)
+		}
+		if _, dup := seen[child.RunID]; dup {
+			return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate has duplicate child run id %s", child.RunID)
+		}
+		seen[child.RunID] = struct{}{}
+		if child.AmountMicros < 0 {
+			return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate child %s has negative amount %d", child.RunID, child.AmountMicros)
+		}
+		// billing_mode must agree with the amount (managed>0, byok==0) so a corrupt envelope can't
+		// reserve the wrong thing for a child.
+		switch child.BillingMode {
+		case "managed":
+			if child.AmountMicros <= 0 {
+				return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate child %s is managed but reserves no credit", child.RunID)
+			}
+		case "byok":
+			if child.AmountMicros != 0 {
+				return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate child %s is byok but reserves %d", child.RunID, child.AmountMicros)
+			}
+		default:
+			return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate child %s has unknown billing_mode %q", child.RunID, child.BillingMode)
+		}
+		sum += child.AmountMicros
+	}
+	if sum != envelope.AggregateMicros {
+		return createEvalSessionEnvelope{}, fmt.Errorf("approved cost estimate aggregate %d != sum of child amounts %d", envelope.AggregateMicros, sum)
+	}
+	return envelope, nil
+}

--- a/backend/internal/api/vibe_eval_create_eval_session_test.go
+++ b/backend/internal/api/vibe_eval_create_eval_session_test.go
@@ -1,0 +1,283 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+type fakeSessionCreator struct {
+	est          EvalSessionCostEstimate
+	estErr       error
+	createCalled bool
+	createInput  CreateEvalSessionInput
+	result       CreateEvalSessionResult
+	createErr    error
+}
+
+func (f *fakeSessionCreator) EstimateEvalSessionCost(_ context.Context, _ Caller, _ CreateEvalSessionInput) (EvalSessionCostEstimate, error) {
+	return f.est, f.estErr
+}
+func (f *fakeSessionCreator) CreateEvalSession(_ context.Context, _ Caller, in CreateEvalSessionInput) (CreateEvalSessionResult, error) {
+	f.createCalled = true
+	f.createInput = in
+	return f.result, f.createErr
+}
+
+func sessionCtx() context.Context {
+	return context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+}
+
+// boundCreateEvalSessionArgs is a minimal valid create_eval_session argument object.
+func boundCreateEvalSessionArgs() json.RawMessage {
+	return json.RawMessage(`{"challenge_pack_version_id":"` + uuid.New().String() + `","participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}],"execution_mode":"single_agent","eval_session":{"repetitions":2,"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},"seed_fanout":{"strategy":"explicit","seeds":[1,2]},"schema_version":1}}`)
+}
+
+func sessionEnvelope(t *testing.T, sessionID uuid.UUID, children []createEvalSessionChildEnvelope) json.RawMessage {
+	t.Helper()
+	var aggregate int64
+	for _, c := range children {
+		aggregate += c.AmountMicros
+	}
+	raw, err := json.Marshal(createEvalSessionEnvelope{
+		SchemaVersion:   1,
+		Kind:            "create_eval_session",
+		EvalSessionID:   sessionID,
+		AggregateMicros: aggregate,
+		Children:        children,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestCreateEvalSessionTool_ExecuteRefusesUnconfirmed(t *testing.T) {
+	fake := &fakeSessionCreator{}
+	_, err := createEvalSessionTool{sessions: fake}.Execute(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs())
+	if err == nil {
+		t.Fatal("expected create_eval_session.Execute to refuse unconfirmed")
+	}
+	if fake.createCalled {
+		t.Fatal("no session must be created on the unconfirmed path")
+	}
+}
+
+func TestCreateEvalSessionTool_EstimateCostEnvelope(t *testing.T) {
+	seed := int64(7)
+	fake := &fakeSessionCreator{est: EvalSessionCostEstimate{
+		AggregateMicros: 3_000_000,
+		Children: []EvalSessionChildCostEstimate{
+			{MatrixKey: "m1", AmountMicros: 2_000_000, BillingMode: "managed"},
+			{MatrixKey: "m2", Seed: &seed, AmountMicros: 1_000_000, BillingMode: "managed"},
+		},
+	}}
+	raw, err := createEvalSessionTool{sessions: fake}.EstimateCost(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs())
+	if err != nil {
+		t.Fatalf("EstimateCost: %v", err)
+	}
+	env, err := parseCreateEvalSessionEnvelope(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if env.EvalSessionID == uuid.Nil || env.AggregateMicros != 3_000_000 || len(env.Children) != 2 {
+		t.Fatalf("envelope = %+v, want session id + 3M aggregate + 2 children", env)
+	}
+	for _, c := range env.Children {
+		if c.RunID == uuid.Nil {
+			t.Fatalf("child %+v has no preallocated run id", c)
+		}
+	}
+	if env.Children[1].Seed == nil || *env.Children[1].Seed != 7 {
+		t.Fatalf("second child seed = %v, want 7 carried through", env.Children[1].Seed)
+	}
+}
+
+func TestCreateEvalSessionTool_EstimateFailureNoEnvelope(t *testing.T) {
+	fake := &fakeSessionCreator{estErr: ErrVibeEvalMixedBilling}
+	_, err := createEvalSessionTool{sessions: fake}.EstimateCost(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs())
+	if err == nil {
+		t.Fatal("expected estimate failure to propagate (no envelope)")
+	}
+}
+
+func TestCreateEvalSessionTool_ConfirmedBindsApprovedPlan(t *testing.T) {
+	sessionID := uuid.New()
+	runA, runB := uuid.New(), uuid.New()
+	// The fake's live estimate is irrelevant; confirmed execution binds the APPROVED envelope amounts.
+	fake := &fakeSessionCreator{result: CreateEvalSessionResult{
+		Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued},
+		RunIDs:  []uuid.UUID{runA, runB},
+	}}
+	env := sessionEnvelope(t, sessionID, []createEvalSessionChildEnvelope{
+		{RunID: runA, AmountMicros: 2_000_000, BillingMode: "managed"},
+		{RunID: runB, AmountMicros: 0, BillingMode: "byok"},
+	})
+	out, err := createEvalSessionTool{sessions: fake}.ExecuteConfirmed(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs(), vibeeval.PendingConfirmation{Estimate: env})
+	if err != nil {
+		t.Fatalf("ExecuteConfirmed: %v", err)
+	}
+	if fake.createInput.EvalSessionID != sessionID {
+		t.Fatalf("session id = %s, want approved %s", fake.createInput.EvalSessionID, sessionID)
+	}
+	if len(fake.createInput.ChildReservations) != 2 {
+		t.Fatalf("child reservations = %d, want 2", len(fake.createInput.ChildReservations))
+	}
+	if fake.createInput.ChildReservations[0].RunID != runA || fake.createInput.ChildReservations[0].AmountMicros != 2_000_000 {
+		t.Fatalf("managed binding = %+v, want runA 2M", fake.createInput.ChildReservations[0])
+	}
+	if fake.createInput.ChildReservations[1].AmountMicros != 0 {
+		t.Fatalf("byok binding amount = %d, want 0", fake.createInput.ChildReservations[1].AmountMicros)
+	}
+	if out.AuditResult["reserved_micros"] != int64(2_000_000) {
+		t.Fatalf("audit reserved = %v, want 2M aggregate", out.AuditResult["reserved_micros"])
+	}
+}
+
+func TestCreateEvalSessionTool_ConfirmedWorkflowStartFailureIsSuccess(t *testing.T) {
+	sessionID := uuid.New()
+	runA := uuid.New()
+	fake := &fakeSessionCreator{createErr: EvalSessionWorkflowStartError{
+		Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued},
+		RunIDs:  []uuid.UUID{runA},
+		Cause:   errors.New("temporal down"),
+	}}
+	env := sessionEnvelope(t, sessionID, []createEvalSessionChildEnvelope{{RunID: runA, AmountMicros: 1_000_000, BillingMode: "managed"}})
+	out, err := createEvalSessionTool{sessions: fake}.ExecuteConfirmed(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs(), vibeeval.PendingConfirmation{Estimate: env})
+	if err != nil {
+		t.Fatalf("workflow-start failure must finalize success-with-warning, got err: %v", err)
+	}
+	if out.AuditResult["workflow_start"] != "failed_pending_recovery" {
+		t.Fatalf("audit = %+v, want failed_pending_recovery warning", out.AuditResult)
+	}
+}
+
+func TestCreateEvalSessionTool_ConfirmedMalformedEnvelopeNoSideEffect(t *testing.T) {
+	rid := uuid.New().String()
+	sid := uuid.New().String()
+	cases := map[string]json.RawMessage{
+		"missing":           nil,
+		"garbage":           json.RawMessage(`{not json`),
+		"wrongKind":         json.RawMessage(`{"schema_version":1,"kind":"create_run","eval_session_id":"` + sid + `","children":[]}`),
+		"noSessionID":       json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","children":[{"run_id":"` + rid + `","amount_micros":1,"billing_mode":"managed"}],"aggregate_micros":1}`),
+		"noChildren":        json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","eval_session_id":"` + sid + `","children":[],"aggregate_micros":0}`),
+		"aggregateMismatch": json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","eval_session_id":"` + sid + `","children":[{"run_id":"` + rid + `","amount_micros":2,"billing_mode":"managed"}],"aggregate_micros":5}`),
+		"byokPositive":      json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","eval_session_id":"` + sid + `","children":[{"run_id":"` + rid + `","amount_micros":2,"billing_mode":"byok"}],"aggregate_micros":2}`),
+		"managedZero":       json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","eval_session_id":"` + sid + `","children":[{"run_id":"` + rid + `","amount_micros":0,"billing_mode":"managed"}],"aggregate_micros":0}`),
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeSessionCreator{}
+			_, err := createEvalSessionTool{sessions: fake}.ExecuteConfirmed(sessionCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateEvalSessionArgs(), vibeeval.PendingConfirmation{Estimate: raw})
+			if err == nil {
+				t.Fatal("expected error for malformed/inconsistent envelope")
+			}
+			if fake.createCalled {
+				t.Fatal("no session must be created when the approved envelope is invalid")
+			}
+		})
+	}
+}
+
+func TestParseCreateEvalSessionEnvelope_DuplicateChildRunID(t *testing.T) {
+	rid := uuid.New().String()
+	sid := uuid.New().String()
+	raw := json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","eval_session_id":"` + sid + `","aggregate_micros":4,"children":[{"run_id":"` + rid + `","amount_micros":2,"billing_mode":"managed"},{"run_id":"` + rid + `","amount_micros":2,"billing_mode":"managed"}]}`)
+	if _, err := parseCreateEvalSessionEnvelope(raw); err == nil {
+		t.Fatal("expected duplicate child run id to be rejected")
+	}
+}
+
+// childPlanWithLane builds a single-lane managed child plan for a given deployment + snapshot.
+func childPlanWithLane(deploymentID, snapshotID uuid.UUID, byok bool) evalSessionChildPlan {
+	d := repository.RunnableDeployment{ID: deploymentID, AgentDeploymentSnapshotID: snapshotID}
+	if byok {
+		acct := uuid.New()
+		d.SourceProviderAccountID = &acct
+	}
+	return evalSessionChildPlan{
+		Run:         repository.CreateQueuedRunParams{ExecutionMode: "single_agent"},
+		Deployments: []repository.RunnableDeployment{d},
+		MatrixKey:   "",
+	}
+}
+
+func laneBinding(runID, deploymentID, snapshotID uuid.UUID, micros int64, managed bool) EvalSessionChildReservation {
+	return EvalSessionChildReservation{
+		RunID:        runID,
+		AmountMicros: micros,
+		Lanes:        []EvalSessionChildLane{{DeploymentID: deploymentID, AgentDeploymentSnapshotID: snapshotID, Managed: managed}},
+	}
+}
+
+func TestBindEvalSessionChildReservations_MatchingLanesBind(t *testing.T) {
+	dep, snap, runID := uuid.New(), uuid.New(), uuid.New()
+	children := []evalSessionChildPlan{childPlanWithLane(dep, snap, false)}
+	bindings := []EvalSessionChildReservation{laneBinding(runID, dep, snap, 2_000_000, true)}
+	childRuns, err := bindEvalSessionChildReservations(children, bindings)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	if childRuns[0].RunID != runID || childRuns[0].EvalCreditReservation == nil || childRuns[0].EvalCreditReservation.AmountMicros != 2_000_000 {
+		t.Fatalf("childRun = %+v, want runID %s + 2M reservation", childRuns[0], runID)
+	}
+}
+
+func TestBindEvalSessionChildReservations_LaneDriftFailsClosed(t *testing.T) {
+	dep, snap, runID := uuid.New(), uuid.New(), uuid.New()
+	children := []evalSessionChildPlan{childPlanWithLane(dep, snap, false)}
+
+	cases := map[string]EvalSessionChildReservation{
+		// Snapshot changed under the same deployment ⇒ a different frozen model/rate/BYOK lane.
+		"changed_snapshot": laneBinding(runID, dep, uuid.New(), 2_000_000, true),
+		// Deployment changed entirely.
+		"changed_deployment": laneBinding(runID, uuid.New(), snap, 2_000_000, true),
+		// Lane flipped managed→BYOK (envelope said managed; fresh lane is managed too, but binding claims BYOK).
+		"flipped_managed_flag": laneBinding(runID, dep, snap, 2_000_000, false),
+		// Lane count mismatch (binding has zero lanes).
+		"lane_count_mismatch": {RunID: runID, AmountMicros: 2_000_000, Lanes: nil},
+	}
+	for name, binding := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := bindEvalSessionChildReservations(children, []EvalSessionChildReservation{binding})
+			var verr RunCreationValidationError
+			if !errors.As(err, &verr) || verr.Code != "stale_estimate" {
+				t.Fatalf("err = %v, want stale_estimate validation error", err)
+			}
+		})
+	}
+}
+
+func TestBindEvalSessionChildReservations_EmptyBindingsIsRESTPassthrough(t *testing.T) {
+	dep, snap := uuid.New(), uuid.New()
+	children := []evalSessionChildPlan{childPlanWithLane(dep, snap, false)}
+	childRuns, err := bindEvalSessionChildReservations(children, nil)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	if childRuns[0].RunID != uuid.Nil || childRuns[0].EvalCreditReservation != nil {
+		t.Fatalf("REST path must not preallocate ids or reserve, got %+v", childRuns[0])
+	}
+}
+
+func TestParseCreateEvalSessionEnvelope_ValidManagedAndBYOK(t *testing.T) {
+	sid := uuid.New()
+	runA, runB := uuid.New(), uuid.New()
+	raw := sessionEnvelope(t, sid, []createEvalSessionChildEnvelope{
+		{RunID: runA, AmountMicros: 2_000_000, BillingMode: "managed"},
+		{RunID: runB, AmountMicros: 0, BillingMode: "byok"},
+	})
+	env, err := parseCreateEvalSessionEnvelope(raw)
+	if err != nil {
+		t.Fatalf("valid mixed managed/byok session rejected: %v", err)
+	}
+	if env.AggregateMicros != 2_000_000 || len(env.Children) != 2 {
+		t.Fatalf("env = %+v, want 2M aggregate + 2 children", env)
+	}
+}

--- a/backend/internal/api/vibe_eval_create_run.go
+++ b/backend/internal/api/vibe_eval_create_run.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+// evalCreditReservationFor builds a reservation request for run creation: only when a run id is
+// preallocated AND a positive managed amount is approved (BYOK/REST → nil, no reservation).
+func evalCreditReservationFor(runID uuid.UUID, micros int64) *repository.EvalCreditReservation {
+	if runID == uuid.Nil || micros <= 0 {
+		return nil
+	}
+	return &repository.EvalCreditReservation{AmountMicros: micros, Key: "run:" + runID.String()}
+}
+
+// createRunEstimateEnvelope is the typed, versioned cost envelope stored on the confirmation
+// (pc.Estimate) at propose time and bound at confirmed execution. The preallocated RunID makes the
+// reservation key and the run share a stable id across retry; AmountMicros is exactly what gets
+// reserved (never recomputed at execution).
+type createRunEstimateEnvelope struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Kind          string                 `json:"kind"` // "create_run"
+	AmountMicros  int64                  `json:"amount_micros"`
+	RunID         uuid.UUID              `json:"run_id"`
+	BillingMode   string                 `json:"billing_mode"` // "managed" | "byok"
+	Lanes         []EvalCostLaneEstimate `json:"lanes,omitempty"`
+}
+
+const createRunEstimateSchemaVersion = 1
+
+// vibeEvalRunCreator is the manager surface create_run wraps (RunCreationManager satisfies it).
+type vibeEvalRunCreator interface {
+	EstimateEvalCost(ctx context.Context, caller Caller, input EstimateEvalCostInput) (CostEstimate, error)
+	CreateRun(ctx context.Context, caller Caller, input CreateRunInput) (CreateRunResult, error)
+}
+
+type createRunArgs struct {
+	ChallengePackVersionID string   `json:"challenge_pack_version_id"`
+	AgentDeploymentIDs     []string `json:"agent_deployment_ids"`
+}
+
+func (a createRunArgs) parse() (uuid.UUID, []uuid.UUID, error) {
+	versionID, err := uuid.Parse(a.ChallengePackVersionID)
+	if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("challenge_pack_version_id is not a UUID: %w", err)
+	}
+	ids := make([]uuid.UUID, 0, len(a.AgentDeploymentIDs))
+	for _, raw := range a.AgentDeploymentIDs {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			return uuid.Nil, nil, fmt.Errorf("agent_deployment_id %q is not a UUID: %w", raw, err)
+		}
+		ids = append(ids, id)
+	}
+	return versionID, ids, nil
+}
+
+// createRunTool is the first cost-incurring guide tool. It estimates at propose time (CostEstimator),
+// refuses unconfirmed execution (Execute), and reserves+creates atomically on approval (ConfirmedTool).
+type createRunTool struct{ runs vibeEvalRunCreator }
+
+var (
+	_ vibeeval.Tool          = createRunTool{}
+	_ vibeeval.CostEstimator = createRunTool{}
+	_ vibeeval.ConfirmedTool = createRunTool{}
+)
+
+func (createRunTool) Name() string                { return "create_run" }
+func (createRunTool) Phases() []string            { return []string{vibeeval.PhaseRun} }
+func (createRunTool) RiskTier() vibeeval.RiskTier { return vibeeval.CostIncurringTier }
+func (createRunTool) RequiredAction() string      { return string(ActionCreateRun) }
+func (createRunTool) Definition() provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:        "create_run",
+		Description: "Create and start an eval run for a challenge_pack_version and agent deployments. Requires confirmation; reserves managed eval credit for the approved cost.",
+		Parameters:  json.RawMessage(`{"type":"object","required":["challenge_pack_version_id","agent_deployment_ids"],"properties":{"challenge_pack_version_id":{"type":"string"},"agent_deployment_ids":{"type":"array","items":{"type":"string"}}}}`),
+	}
+}
+
+// EstimateCost computes the approved cost envelope at propose time: it prices the run and preallocates
+// the run id. The amount here is exactly what confirmed execution will reserve.
+func (t createRunTool) EstimateCost(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage) (json.RawMessage, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var in createRunArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	versionID, deploymentIDs, err := in.parse()
+	if err != nil {
+		return nil, err
+	}
+	est, err := t.runs.EstimateEvalCost(ctx, caller, EstimateEvalCostInput{
+		WorkspaceID: conv.WorkspaceID, ChallengePackVersionID: versionID, AgentDeploymentIDs: deploymentIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	billingMode := "managed"
+	if est.TotalMicros == 0 {
+		billingMode = "byok"
+	}
+	return json.Marshal(createRunEstimateEnvelope{
+		SchemaVersion: createRunEstimateSchemaVersion,
+		Kind:          "create_run",
+		AmountMicros:  est.TotalMicros,
+		RunID:         uuid.New(), // preallocated; stable across retry via the stored confirmation
+		BillingMode:   billingMode,
+		Lanes:         est.Lanes,
+	})
+}
+
+// Execute refuses: create_run is cost-incurring and must run only through a confirmation that carries
+// the approved cost envelope.
+func (createRunTool) Execute(context.Context, vibeeval.Actor, vibeeval.Conversation, json.RawMessage) (vibeeval.ToolOutput, error) {
+	return vibeeval.ToolOutput{}, errors.New("create_run requires confirmation: it cannot run without an approved cost estimate")
+}
+
+// ExecuteConfirmed reserves exactly the approved amount and creates the run atomically (idempotent on
+// the preallocated run id). A workflow-start failure after the run/reservation committed is an
+// effect-created success-with-warning, never a terminal failure.
+func (t createRunTool) ExecuteConfirmed(ctx context.Context, _ vibeeval.Actor, conv vibeeval.Conversation, args json.RawMessage, pc vibeeval.PendingConfirmation) (vibeeval.ToolOutput, error) {
+	caller, err := CallerFromContext(ctx)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	// Trust the approved envelope: a malformed/missing estimate fails BEFORE any side effect.
+	envelope, err := parseCreateRunEnvelope(pc.Estimate)
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+	var in createRunArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return vibeeval.ToolOutput{}, fmt.Errorf("invalid bound args: %w", err)
+	}
+	versionID, deploymentIDs, err := in.parse()
+	if err != nil {
+		return vibeeval.ToolOutput{}, err
+	}
+
+	result, err := t.runs.CreateRun(ctx, caller, CreateRunInput{
+		WorkspaceID:            conv.WorkspaceID,
+		ChallengePackVersionID: versionID,
+		AgentDeploymentIDs:     deploymentIDs,
+		RunID:                  envelope.RunID,
+		ReservationMicros:      envelope.AmountMicros, // exactly the approved amount; 0 for BYOK
+	})
+	if err != nil {
+		// The run + reservation committed but the workflow failed to start: the approved effect
+		// happened, so finalize succeeded (with a warning) and surface that recovery is needed.
+		var startErr RunWorkflowStartError
+		if errors.As(err, &startErr) {
+			return vibeeval.ToolOutput{
+				Result:      map[string]any{"run_id": startErr.Run.ID, "status": startErr.Run.Status, "warning": "run created and credit reserved, but workflow start failed; it will be retried"},
+				AuditResult: map[string]any{"run_id": startErr.Run.ID.String(), "reserved_micros": envelope.AmountMicros, "workflow_start": "failed_pending_recovery"},
+			}, nil
+		}
+		return vibeeval.ToolOutput{}, err
+	}
+	return vibeeval.ToolOutput{
+		Result:      map[string]any{"run_id": result.Run.ID, "status": result.Run.Status},
+		AuditResult: map[string]any{"run_id": result.Run.ID.String(), "reserved_micros": envelope.AmountMicros, "billing_mode": envelope.BillingMode},
+	}, nil
+}
+
+func parseCreateRunEnvelope(raw json.RawMessage) (createRunEstimateEnvelope, error) {
+	if len(raw) == 0 {
+		return createRunEstimateEnvelope{}, errors.New("approved cost estimate is missing")
+	}
+	var envelope createRunEstimateEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return createRunEstimateEnvelope{}, fmt.Errorf("approved cost estimate is malformed: %w", err)
+	}
+	if envelope.SchemaVersion != createRunEstimateSchemaVersion || envelope.Kind != "create_run" {
+		return createRunEstimateEnvelope{}, fmt.Errorf("approved cost estimate has unexpected schema (version=%d kind=%q)", envelope.SchemaVersion, envelope.Kind)
+	}
+	if envelope.RunID == uuid.Nil {
+		return createRunEstimateEnvelope{}, errors.New("approved cost estimate has no run id")
+	}
+	if envelope.AmountMicros < 0 {
+		return createRunEstimateEnvelope{}, fmt.Errorf("approved cost estimate has negative amount %d", envelope.AmountMicros)
+	}
+	// billing_mode must agree with the amount: a corrupt envelope (byok+positive, managed+zero) would
+	// otherwise reserve the wrong thing — fail before any side effect.
+	switch envelope.BillingMode {
+	case "managed":
+		if envelope.AmountMicros <= 0 {
+			return createRunEstimateEnvelope{}, errors.New("approved cost estimate is managed but reserves no credit")
+		}
+	case "byok":
+		if envelope.AmountMicros != 0 {
+			return createRunEstimateEnvelope{}, fmt.Errorf("approved cost estimate is byok but reserves %d", envelope.AmountMicros)
+		}
+	default:
+		return createRunEstimateEnvelope{}, fmt.Errorf("approved cost estimate has unknown billing_mode %q", envelope.BillingMode)
+	}
+	return envelope, nil
+}

--- a/backend/internal/api/vibe_eval_create_run_test.go
+++ b/backend/internal/api/vibe_eval_create_run_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/vibeeval"
+	"github.com/google/uuid"
+)
+
+type fakeRunCreator struct {
+	est          CostEstimate
+	estErr       error
+	createCalled bool
+	createInput  CreateRunInput
+	result       CreateRunResult
+	createErr    error
+}
+
+func (f *fakeRunCreator) EstimateEvalCost(_ context.Context, _ Caller, _ EstimateEvalCostInput) (CostEstimate, error) {
+	return f.est, f.estErr
+}
+func (f *fakeRunCreator) CreateRun(_ context.Context, _ Caller, in CreateRunInput) (CreateRunResult, error) {
+	f.createCalled = true
+	f.createInput = in
+	return f.result, f.createErr
+}
+
+func createRunCtx() context.Context {
+	return context.WithValue(context.Background(), callerContextKey{}, Caller{UserID: uuid.New()})
+}
+
+func boundCreateRunArgs() json.RawMessage {
+	return json.RawMessage(`{"challenge_pack_version_id":"` + uuid.New().String() + `","agent_deployment_ids":["` + uuid.New().String() + `"]}`)
+}
+
+func envelopeJSON(t *testing.T, amount int64, runID uuid.UUID, mode string) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(createRunEstimateEnvelope{SchemaVersion: 1, Kind: "create_run", AmountMicros: amount, RunID: runID, BillingMode: mode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestCreateRunTool_ExecuteRefusesUnconfirmed(t *testing.T) {
+	fake := &fakeRunCreator{}
+	_, err := createRunTool{runs: fake}.Execute(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs())
+	if err == nil {
+		t.Fatal("expected create_run.Execute to refuse unconfirmed")
+	}
+	if fake.createCalled {
+		t.Fatal("no run must be created on the unconfirmed path")
+	}
+}
+
+func TestCreateRunTool_EstimateCostEnvelope(t *testing.T) {
+	fake := &fakeRunCreator{est: CostEstimate{TotalMicros: 1_500_000, Lanes: []EvalCostLaneEstimate{{Micros: 1_500_000}}}}
+	raw, err := createRunTool{runs: fake}.EstimateCost(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs())
+	if err != nil {
+		t.Fatalf("EstimateCost: %v", err)
+	}
+	env, err := parseCreateRunEnvelope(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if env.AmountMicros != 1_500_000 || env.RunID == uuid.Nil || env.BillingMode != "managed" {
+		t.Fatalf("envelope = %+v, want 1.5M managed with a run id", env)
+	}
+}
+
+func TestCreateRunTool_ConfirmedReservesApprovedAmount(t *testing.T) {
+	// The fake's live estimate (9.9M) differs from the APPROVED envelope (1.5M); confirmed execution
+	// must reserve the approved amount, never the recomputed one.
+	runID := uuid.New()
+	fake := &fakeRunCreator{est: CostEstimate{TotalMicros: 9_900_000}, result: CreateRunResult{Run: domain.Run{ID: runID, Status: domain.RunStatusQueued}}}
+	pc := vibeeval.PendingConfirmation{ToolName: "create_run", Estimate: envelopeJSON(t, 1_500_000, runID, "managed")}
+	out, err := createRunTool{runs: fake}.ExecuteConfirmed(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs(), pc)
+	if err != nil {
+		t.Fatalf("ExecuteConfirmed: %v", err)
+	}
+	if fake.createInput.RunID != runID || fake.createInput.ReservationMicros != 1_500_000 {
+		t.Fatalf("create input = {RunID:%s, Micros:%d}, want approved {%s, 1.5M}", fake.createInput.RunID, fake.createInput.ReservationMicros, runID)
+	}
+	if out.AuditResult["reserved_micros"] != int64(1_500_000) {
+		t.Fatalf("audit reserved = %v, want 1.5M", out.AuditResult["reserved_micros"])
+	}
+}
+
+func TestCreateRunTool_ConfirmedMalformedEstimateNoSideEffect(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"missing":   nil,
+		"garbage":   json.RawMessage(`{not json`),
+		"wrongKind": json.RawMessage(`{"schema_version":1,"kind":"create_eval_session","run_id":"` + uuid.New().String() + `"}`),
+		"noRunID":   json.RawMessage(`{"schema_version":1,"kind":"create_run","amount_micros":100}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeRunCreator{}
+			_, err := createRunTool{runs: fake}.ExecuteConfirmed(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs(), vibeeval.PendingConfirmation{Estimate: raw})
+			if err == nil {
+				t.Fatal("expected error for malformed/missing estimate")
+			}
+			if fake.createCalled {
+				t.Fatal("no run must be created when the approved estimate is invalid")
+			}
+		})
+	}
+}
+
+func TestCreateRunTool_ConfirmedWorkflowStartFailureIsSuccess(t *testing.T) {
+	runID := uuid.New()
+	fake := &fakeRunCreator{createErr: RunWorkflowStartError{Run: domain.Run{ID: runID, Status: domain.RunStatusQueued}, Cause: errors.New("temporal down")}}
+	out, err := createRunTool{runs: fake}.ExecuteConfirmed(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs(), vibeeval.PendingConfirmation{Estimate: envelopeJSON(t, 1_000_000, runID, "managed")})
+	if err != nil {
+		t.Fatalf("workflow-start failure must finalize success-with-warning, got err: %v", err)
+	}
+	if out.AuditResult["workflow_start"] != "failed_pending_recovery" {
+		t.Fatalf("audit = %+v, want failed_pending_recovery warning", out.AuditResult)
+	}
+}
+
+func TestCreateRunTool_ConfirmedBYOKZeroReservation(t *testing.T) {
+	runID := uuid.New()
+	fake := &fakeRunCreator{result: CreateRunResult{Run: domain.Run{ID: runID, Status: domain.RunStatusQueued}}}
+	_, err := createRunTool{runs: fake}.ExecuteConfirmed(createRunCtx(), vibeeval.Actor{}, vibeeval.Conversation{WorkspaceID: uuid.New()}, boundCreateRunArgs(), vibeeval.PendingConfirmation{Estimate: envelopeJSON(t, 0, runID, "byok")})
+	if err != nil {
+		t.Fatalf("ExecuteConfirmed: %v", err)
+	}
+	if fake.createInput.ReservationMicros != 0 {
+		t.Fatalf("BYOK reservation = %d, want 0 (no reservation)", fake.createInput.ReservationMicros)
+	}
+}
+
+func TestParseCreateRunEnvelope_BillingModeConsistency(t *testing.T) {
+	rid := uuid.New().String()
+	cases := map[string]json.RawMessage{
+		"byokWithPositiveAmount": json.RawMessage(`{"schema_version":1,"kind":"create_run","run_id":"` + rid + `","billing_mode":"byok","amount_micros":100}`),
+		"managedWithZeroAmount":  json.RawMessage(`{"schema_version":1,"kind":"create_run","run_id":"` + rid + `","billing_mode":"managed","amount_micros":0}`),
+		"unknownMode":            json.RawMessage(`{"schema_version":1,"kind":"create_run","run_id":"` + rid + `","billing_mode":"weird","amount_micros":100}`),
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseCreateRunEnvelope(raw); err == nil {
+				t.Fatal("expected billing_mode/amount inconsistency to be rejected")
+			}
+		})
+	}
+	// Valid managed + valid byok pass.
+	if _, err := parseCreateRunEnvelope(json.RawMessage(`{"schema_version":1,"kind":"create_run","run_id":"` + rid + `","billing_mode":"managed","amount_micros":100}`)); err != nil {
+		t.Fatalf("valid managed rejected: %v", err)
+	}
+	if _, err := parseCreateRunEnvelope(json.RawMessage(`{"schema_version":1,"kind":"create_run","run_id":"` + rid + `","billing_mode":"byok","amount_micros":0}`)); err != nil {
+		t.Fatalf("valid byok rejected: %v", err)
+	}
+}

--- a/backend/internal/billing/catalog.go
+++ b/backend/internal/billing/catalog.go
@@ -40,12 +40,13 @@ type Limit struct {
 }
 
 type PlanLimits struct {
-	Seats                  Limit `json:"seats"`
-	Workspaces             Limit `json:"workspaces"`
-	RacesPerWorkspaceMonth Limit `json:"races_per_workspace_month"`
-	MaxModelsPerRace       Limit `json:"max_models_per_race"`
-	ReplayRetentionDays    Limit `json:"replay_retention_days"`
-	ConcurrentRaces        Limit `json:"concurrent_races"`
+	Seats                            Limit `json:"seats"`
+	Workspaces                       Limit `json:"workspaces"`
+	RacesPerWorkspaceMonth           Limit `json:"races_per_workspace_month"`
+	MaxModelsPerRace                 Limit `json:"max_models_per_race"`
+	ReplayRetentionDays              Limit `json:"replay_retention_days"`
+	ConcurrentRaces                  Limit `json:"concurrent_races"`
+	GuideAgentTurnsPerWorkspaceMonth Limit `json:"guide_agent_turns_per_workspace_month"`
 }
 
 type Plan struct {
@@ -83,19 +84,22 @@ func (ids DodoProductIDs) Validate() error {
 }
 
 type EffectiveEntitlements struct {
-	PlanKey                string          `json:"plan_key"`
-	BillingPeriod          string          `json:"billing_period"`
-	Status                 string          `json:"status"`
-	SeatQuantity           int             `json:"seat_quantity"`
-	SeatsLimit             *int            `json:"seats_limit"`
-	WorkspacesLimit        *int            `json:"workspaces_limit"`
-	RacesPerWorkspaceMonth *int            `json:"races_per_workspace_month"`
-	MaxModelsPerRace       *int            `json:"max_models_per_race"`
-	ReplayRetentionDays    *int            `json:"replay_retention_days"`
-	ConcurrentRaces        *int            `json:"concurrent_races"`
-	FeatureFlags           map[string]bool `json:"feature_flags"`
-	UpgradeTarget          string          `json:"upgrade_target,omitempty"`
-	ExpiresAt              *time.Time      `json:"expires_at,omitempty"`
+	PlanKey                string `json:"plan_key"`
+	BillingPeriod          string `json:"billing_period"`
+	Status                 string `json:"status"`
+	SeatQuantity           int    `json:"seat_quantity"`
+	SeatsLimit             *int   `json:"seats_limit"`
+	WorkspacesLimit        *int   `json:"workspaces_limit"`
+	RacesPerWorkspaceMonth *int   `json:"races_per_workspace_month"`
+	MaxModelsPerRace       *int   `json:"max_models_per_race"`
+	ReplayRetentionDays    *int   `json:"replay_retention_days"`
+	ConcurrentRaces        *int   `json:"concurrent_races"`
+	// GuideAgentTurnsPerWorkspaceMonth is the monthly guide-agent turn allowance (4e), separate from the
+	// eval-credit wallet. nil ⇒ unlimited/custom.
+	GuideAgentTurnsPerWorkspaceMonth *int            `json:"guide_agent_turns_per_workspace_month"`
+	FeatureFlags                     map[string]bool `json:"feature_flags"`
+	UpgradeTarget                    string          `json:"upgrade_target,omitempty"`
+	ExpiresAt                        *time.Time      `json:"expires_at,omitempty"`
 }
 
 func Catalog() []Plan {
@@ -111,12 +115,13 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodMonthly},
 			Limits: PlanLimits{
-				Seats:                  valueLimit(1),
-				Workspaces:             valueLimit(1),
-				RacesPerWorkspaceMonth: valueLimit(25),
-				MaxModelsPerRace:       valueLimit(4),
-				ReplayRetentionDays:    valueLimit(7),
-				ConcurrentRaces:        valueLimit(1),
+				Seats:                            valueLimit(1),
+				Workspaces:                       valueLimit(1),
+				RacesPerWorkspaceMonth:           valueLimit(25),
+				MaxModelsPerRace:                 valueLimit(4),
+				ReplayRetentionDays:              valueLimit(7),
+				ConcurrentRaces:                  valueLimit(1),
+				GuideAgentTurnsPerWorkspaceMonth: valueLimit(50),
 			},
 			FeatureFlags: map[string]bool{
 				"byok_llm":          true,
@@ -132,12 +137,13 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   5,
 			BillingPeriods: []string{PeriodMonthly, PeriodYearly},
 			Limits: PlanLimits{
-				Seats:                  perSeatLimit(5),
-				Workspaces:             valueLimit(1),
-				RacesPerWorkspaceMonth: perSeatLimit(500),
-				MaxModelsPerRace:       valueLimit(8),
-				ReplayRetentionDays:    valueLimit(30),
-				ConcurrentRaces:        valueLimit(3),
+				Seats:                            perSeatLimit(5),
+				Workspaces:                       valueLimit(1),
+				RacesPerWorkspaceMonth:           perSeatLimit(500),
+				MaxModelsPerRace:                 valueLimit(8),
+				ReplayRetentionDays:              valueLimit(30),
+				ConcurrentRaces:                  valueLimit(3),
+				GuideAgentTurnsPerWorkspaceMonth: perSeatLimit(1000),
 			},
 			FeatureFlags: map[string]bool{
 				"byok_llm":                   true,
@@ -156,12 +162,13 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodMonthly, PeriodYearly},
 			Limits: PlanLimits{
-				Seats:                  perSeatLimit(1),
-				Workspaces:             unlimitedLimit(),
-				RacesPerWorkspaceMonth: perSeatLimit(2000),
-				MaxModelsPerRace:       valueLimit(12),
-				ReplayRetentionDays:    valueLimit(90),
-				ConcurrentRaces:        valueLimit(10),
+				Seats:                            perSeatLimit(1),
+				Workspaces:                       unlimitedLimit(),
+				RacesPerWorkspaceMonth:           perSeatLimit(2000),
+				MaxModelsPerRace:                 valueLimit(12),
+				ReplayRetentionDays:              valueLimit(90),
+				ConcurrentRaces:                  valueLimit(10),
+				GuideAgentTurnsPerWorkspaceMonth: perSeatLimit(4000),
 			},
 			FeatureFlags: map[string]bool{
 				"byok_llm":                   true,
@@ -182,12 +189,13 @@ func CatalogWithDodoProductIDs(productIDs DodoProductIDs) []Plan {
 			DefaultSeats:   1,
 			BillingPeriods: []string{PeriodCustom},
 			Limits: PlanLimits{
-				Seats:                  customLimit(),
-				Workspaces:             customLimit(),
-				RacesPerWorkspaceMonth: customLimit(),
-				MaxModelsPerRace:       customLimit(),
-				ReplayRetentionDays:    unlimitedLimit(),
-				ConcurrentRaces:        customLimit(),
+				Seats:                            customLimit(),
+				Workspaces:                       customLimit(),
+				RacesPerWorkspaceMonth:           customLimit(),
+				MaxModelsPerRace:                 customLimit(),
+				ReplayRetentionDays:              unlimitedLimit(),
+				ConcurrentRaces:                  customLimit(),
+				GuideAgentTurnsPerWorkspaceMonth: customLimit(),
 			},
 			FeatureFlags: map[string]bool{
 				"byok_llm":                   true,
@@ -290,18 +298,19 @@ func MaterializeEntitlements(plan Plan, billingPeriod string, seatQuantity int, 
 		status = EntitlementStatusActive
 	}
 	return EffectiveEntitlements{
-		PlanKey:                plan.Key,
-		BillingPeriod:          billingPeriod,
-		Status:                 status,
-		SeatQuantity:           seatQuantity,
-		SeatsLimit:             materializeLimit(plan.Limits.Seats, seatQuantity),
-		WorkspacesLimit:        materializeLimit(plan.Limits.Workspaces, seatQuantity),
-		RacesPerWorkspaceMonth: materializeLimit(plan.Limits.RacesPerWorkspaceMonth, seatQuantity),
-		MaxModelsPerRace:       materializeLimit(plan.Limits.MaxModelsPerRace, seatQuantity),
-		ReplayRetentionDays:    materializeLimit(plan.Limits.ReplayRetentionDays, seatQuantity),
-		ConcurrentRaces:        materializeLimit(plan.Limits.ConcurrentRaces, seatQuantity),
-		FeatureFlags:           cloneFlags(plan.FeatureFlags),
-		UpgradeTarget:          plan.UpgradeTarget,
+		PlanKey:                          plan.Key,
+		BillingPeriod:                    billingPeriod,
+		Status:                           status,
+		SeatQuantity:                     seatQuantity,
+		SeatsLimit:                       materializeLimit(plan.Limits.Seats, seatQuantity),
+		WorkspacesLimit:                  materializeLimit(plan.Limits.Workspaces, seatQuantity),
+		RacesPerWorkspaceMonth:           materializeLimit(plan.Limits.RacesPerWorkspaceMonth, seatQuantity),
+		MaxModelsPerRace:                 materializeLimit(plan.Limits.MaxModelsPerRace, seatQuantity),
+		ReplayRetentionDays:              materializeLimit(plan.Limits.ReplayRetentionDays, seatQuantity),
+		ConcurrentRaces:                  materializeLimit(plan.Limits.ConcurrentRaces, seatQuantity),
+		GuideAgentTurnsPerWorkspaceMonth: materializeLimit(plan.Limits.GuideAgentTurnsPerWorkspaceMonth, seatQuantity),
+		FeatureFlags:                     cloneFlags(plan.FeatureFlags),
+		UpgradeTarget:                    plan.UpgradeTarget,
 	}
 }
 

--- a/backend/internal/billing/gates.go
+++ b/backend/internal/billing/gates.go
@@ -133,6 +133,32 @@ func CheckRaceQuota(entitlements EffectiveEntitlements, used int, requested int,
 	}
 }
 
+// CheckGuideAgentAllowance gates monthly guide-agent turns per workspace (4e), mirroring CheckRaceQuota.
+// A nil limit is unlimited. This is the platform guide-agent usage allowance, NOT the eval-credit wallet.
+func CheckGuideAgentAllowance(entitlements EffectiveEntitlements, used int, requested int, resetAt time.Time) GateDecision {
+	if decision := CheckEntitlementActive(entitlements, time.Now().UTC()); !decision.Allowed {
+		return decision
+	}
+	if entitlements.GuideAgentTurnsPerWorkspaceMonth == nil || used+requested <= *entitlements.GuideAgentTurnsPerWorkspaceMonth {
+		return Allow(entitlements)
+	}
+	remaining := *entitlements.GuideAgentTurnsPerWorkspaceMonth - used
+	if remaining < 0 {
+		remaining = 0
+	}
+	return GateDecision{
+		Allowed:       false,
+		Code:          GateCodeQuotaExceeded,
+		Message:       fmt.Sprintf("%s workspace guide-agent turn allowance is exhausted", entitlements.PlanKey),
+		PlanKey:       entitlements.PlanKey,
+		UpgradeTarget: entitlements.UpgradeTarget,
+		Limit:         cloneInt(entitlements.GuideAgentTurnsPerWorkspaceMonth),
+		Used:          used,
+		Remaining:     &remaining,
+		ResetAt:       &resetAt,
+	}
+}
+
 func CheckConcurrency(entitlements EffectiveEntitlements, active int, requested int) GateDecision {
 	if decision := CheckEntitlementActive(entitlements, time.Now().UTC()); !decision.Allowed {
 		return decision

--- a/backend/internal/billing/guide_agent_allowance_test.go
+++ b/backend/internal/billing/guide_agent_allowance_test.go
@@ -1,0 +1,48 @@
+package billing
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGuideAgentAllowanceMaterialization pins the §C limits: Free flat 50, Pro 1000·seats, Team
+// 4000·seats, Enterprise unlimited (nil).
+func TestGuideAgentAllowanceMaterialization(t *testing.T) {
+	free := MaterializeEntitlements(MustPlan(PlanFree), PeriodMonthly, 1, "active")
+	assertIntPtr(t, "free guide turns", free.GuideAgentTurnsPerWorkspaceMonth, 50)
+
+	pro := MaterializeEntitlements(MustPlan(PlanPro), PeriodMonthly, 5, "active")
+	assertIntPtr(t, "pro guide turns (1000*5)", pro.GuideAgentTurnsPerWorkspaceMonth, 5000)
+
+	team := MaterializeEntitlements(MustPlan(PlanTeam), PeriodYearly, 2, "active")
+	assertIntPtr(t, "team guide turns (4000*2)", team.GuideAgentTurnsPerWorkspaceMonth, 8000)
+
+	enterprise := MaterializeEntitlements(MustPlan(PlanEnterprise), PeriodCustom, 3, "active")
+	if enterprise.GuideAgentTurnsPerWorkspaceMonth != nil {
+		t.Fatalf("enterprise guide turns = %v, want nil (custom/unlimited)", *enterprise.GuideAgentTurnsPerWorkspaceMonth)
+	}
+}
+
+func TestCheckGuideAgentAllowance(t *testing.T) {
+	reset := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	limited := MaterializeEntitlements(MustPlan(PlanFree), PeriodMonthly, 1, "active") // 50
+
+	// Under the limit → allowed.
+	if d := CheckGuideAgentAllowance(limited, 49, 1, reset); !d.Allowed {
+		t.Fatalf("used 49 + 1 should be allowed, got %+v", d)
+	}
+	// At the limit → blocked, structured quota decision.
+	d := CheckGuideAgentAllowance(limited, 50, 1, reset)
+	if d.Allowed || d.Code != GateCodeQuotaExceeded {
+		t.Fatalf("used 50 + 1 should be quota-exceeded, got %+v", d)
+	}
+	if d.Limit == nil || *d.Limit != 50 || d.Remaining == nil || *d.Remaining != 0 {
+		t.Fatalf("decision limits = %+v, want limit 50 / remaining 0", d)
+	}
+
+	// Unlimited (nil) → always allowed, even at a high used count.
+	unlimited := MaterializeEntitlements(MustPlan(PlanEnterprise), PeriodCustom, 1, "active")
+	if d := CheckGuideAgentAllowance(unlimited, 1_000_000, 1, reset); !d.Allowed {
+		t.Fatalf("nil limit must be unlimited, got %+v", d)
+	}
+}

--- a/backend/internal/repository/billing.go
+++ b/backend/internal/repository/billing.go
@@ -160,11 +160,12 @@ type BillingOverview struct {
 }
 
 type WorkspaceUsageSnapshot struct {
-	WorkspaceID uuid.UUID `json:"workspace_id"`
-	RaceCount   int       `json:"race_count"`
-	ActiveRuns  int       `json:"active_runs"`
-	WindowStart time.Time `json:"window_start"`
-	WindowEnd   time.Time `json:"window_end"`
+	WorkspaceID         uuid.UUID `json:"workspace_id"`
+	RaceCount           int       `json:"race_count"`
+	GuideAgentTurnCount int       `json:"guide_agent_turn_count"`
+	ActiveRuns          int       `json:"active_runs"`
+	WindowStart         time.Time `json:"window_start"`
+	WindowEnd           time.Time `json:"window_end"`
 }
 
 type RunEntitlementGate struct {
@@ -227,20 +228,21 @@ func upsertOrganizationEntitlements(ctx context.Context, queries *repositorysqlc
 		return fmt.Errorf("marshal feature flags: %w", err)
 	}
 	if err := queries.UpsertOrganizationEntitlements(ctx, repositorysqlc.UpsertOrganizationEntitlementsParams{
-		OrganizationID:         orgID,
-		PlanKey:                entitlements.PlanKey,
-		BillingPeriod:          entitlements.BillingPeriod,
-		Status:                 entitlements.Status,
-		SeatQuantity:           int32(entitlements.SeatQuantity),
-		SeatsLimit:             int32Ptr(entitlements.SeatsLimit),
-		WorkspacesLimit:        int32Ptr(entitlements.WorkspacesLimit),
-		RacesPerWorkspaceMonth: int32Ptr(entitlements.RacesPerWorkspaceMonth),
-		MaxModelsPerRace:       int32Ptr(entitlements.MaxModelsPerRace),
-		ReplayRetentionDays:    int32Ptr(entitlements.ReplayRetentionDays),
-		ConcurrencyLimit:       int32Ptr(entitlements.ConcurrentRaces),
-		FeatureFlags:           featureFlags,
-		SourceSubscriptionID:   sourceSubscriptionID,
-		ExpiresAt:              toPGTimestamp(expiresAt),
+		OrganizationID:                   orgID,
+		PlanKey:                          entitlements.PlanKey,
+		BillingPeriod:                    entitlements.BillingPeriod,
+		Status:                           entitlements.Status,
+		SeatQuantity:                     int32(entitlements.SeatQuantity),
+		SeatsLimit:                       int32Ptr(entitlements.SeatsLimit),
+		WorkspacesLimit:                  int32Ptr(entitlements.WorkspacesLimit),
+		RacesPerWorkspaceMonth:           int32Ptr(entitlements.RacesPerWorkspaceMonth),
+		MaxModelsPerRace:                 int32Ptr(entitlements.MaxModelsPerRace),
+		ReplayRetentionDays:              int32Ptr(entitlements.ReplayRetentionDays),
+		ConcurrencyLimit:                 int32Ptr(entitlements.ConcurrentRaces),
+		GuideAgentTurnsPerWorkspaceMonth: int32Ptr(entitlements.GuideAgentTurnsPerWorkspaceMonth),
+		FeatureFlags:                     featureFlags,
+		SourceSubscriptionID:             sourceSubscriptionID,
+		ExpiresAt:                        toPGTimestamp(expiresAt),
 	}); err != nil {
 		return fmt.Errorf("upsert organization entitlements: %w", err)
 	}
@@ -277,12 +279,12 @@ func (r *Repository) CountActiveWorkspaceRuns(ctx context.Context, workspaceID u
 }
 
 func (r *Repository) GetWorkspaceUsageSnapshot(ctx context.Context, workspaceID uuid.UUID, windowStart, windowEnd time.Time) (WorkspaceUsageSnapshot, error) {
-	count, err := r.queries.GetWorkspaceUsageWindowRaceCount(ctx, repositorysqlc.GetWorkspaceUsageWindowRaceCountParams{
+	counts, err := r.queries.GetWorkspaceUsageWindowCounts(ctx, repositorysqlc.GetWorkspaceUsageWindowCountsParams{
 		WorkspaceID: workspaceID,
 		WindowStart: pgtype.Timestamptz{Time: windowStart.UTC(), Valid: true},
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		count = 0
+		counts = repositorysqlc.GetWorkspaceUsageWindowCountsRow{}
 	} else if err != nil {
 		return WorkspaceUsageSnapshot{}, fmt.Errorf("get workspace usage window: %w", err)
 	}
@@ -291,11 +293,12 @@ func (r *Repository) GetWorkspaceUsageSnapshot(ctx context.Context, workspaceID 
 		return WorkspaceUsageSnapshot{}, err
 	}
 	return WorkspaceUsageSnapshot{
-		WorkspaceID: workspaceID,
-		RaceCount:   int(count),
-		ActiveRuns:  activeRuns,
-		WindowStart: windowStart,
-		WindowEnd:   windowEnd,
+		WorkspaceID:         workspaceID,
+		RaceCount:           int(counts.RaceCount),
+		GuideAgentTurnCount: int(counts.GuideAgentTurnCount),
+		ActiveRuns:          activeRuns,
+		WindowStart:         windowStart,
+		WindowEnd:           windowEnd,
 	}, nil
 }
 
@@ -609,18 +612,19 @@ func mapEffectiveEntitlements(row repositorysqlc.GetOrganizationEntitlementsRow)
 		featureFlags = map[string]bool{}
 	}
 	entitlements := billing.EffectiveEntitlements{
-		PlanKey:                row.PlanKey,
-		BillingPeriod:          row.BillingPeriod,
-		Status:                 row.Status,
-		SeatQuantity:           int(row.SeatQuantity),
-		SeatsLimit:             intPtrFromInt32(row.SeatsLimit),
-		WorkspacesLimit:        intPtrFromInt32(row.WorkspacesLimit),
-		RacesPerWorkspaceMonth: intPtrFromInt32(row.RacesPerWorkspaceMonth),
-		MaxModelsPerRace:       intPtrFromInt32(row.MaxModelsPerRace),
-		ReplayRetentionDays:    intPtrFromInt32(row.ReplayRetentionDays),
-		ConcurrentRaces:        intPtrFromInt32(row.ConcurrencyLimit),
-		FeatureFlags:           featureFlags,
-		ExpiresAt:              optionalTime(row.ExpiresAt),
+		PlanKey:                          row.PlanKey,
+		BillingPeriod:                    row.BillingPeriod,
+		Status:                           row.Status,
+		SeatQuantity:                     int(row.SeatQuantity),
+		SeatsLimit:                       intPtrFromInt32(row.SeatsLimit),
+		WorkspacesLimit:                  intPtrFromInt32(row.WorkspacesLimit),
+		RacesPerWorkspaceMonth:           intPtrFromInt32(row.RacesPerWorkspaceMonth),
+		MaxModelsPerRace:                 intPtrFromInt32(row.MaxModelsPerRace),
+		ReplayRetentionDays:              intPtrFromInt32(row.ReplayRetentionDays),
+		ConcurrentRaces:                  intPtrFromInt32(row.ConcurrencyLimit),
+		GuideAgentTurnsPerWorkspaceMonth: intPtrFromInt32(row.GuideAgentTurnsPerWorkspaceMonth),
+		FeatureFlags:                     featureFlags,
+		ExpiresAt:                        optionalTime(row.ExpiresAt),
 	}
 	if plan, ok := billing.PlanByKey(entitlements.PlanKey); ok {
 		entitlements.UpgradeTarget = plan.UpgradeTarget

--- a/backend/internal/repository/eval_credit.go
+++ b/backend/internal/repository/eval_credit.go
@@ -1,0 +1,400 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Eval credit wallet (reserve -> settle) errors.
+var (
+	// ErrInsufficientEvalCredit is returned when a reserve would overdraw the wallet.
+	ErrInsufficientEvalCredit = errors.New("insufficient eval credit")
+	// ErrEvalCreditKeyConflict is returned when an idempotency key is reused with a different amount.
+	ErrEvalCreditKeyConflict = errors.New("eval credit idempotency key reused with a different amount")
+	// ErrEvalCreditMissingKey is returned when a grant/reserve is called without an idempotency key
+	// (an empty key would store NULL and silently bypass idempotency → double-credit).
+	ErrEvalCreditMissingKey = errors.New("eval credit idempotency key is required")
+	// ErrEvalCreditReservationNotFound is returned when settling/releasing an unknown reservation.
+	ErrEvalCreditReservationNotFound = errors.New("eval credit reservation not found")
+	// ErrEvalCreditReservationResolved is returned when settling a released reservation (or vice-versa).
+	ErrEvalCreditReservationResolved = errors.New("eval credit reservation already resolved")
+	// ErrEvalCreditWalletNotFound is returned when reading a wallet that was never granted/seeded.
+	ErrEvalCreditWalletNotFound = errors.New("eval credit wallet not found")
+)
+
+// WalletBalance is the current eval-credit position for an org. available = granted - reserved - spent.
+type WalletBalance struct {
+	OrganizationID  uuid.UUID
+	CurrencyCode    string
+	AvailableMicros int64
+	ReservedMicros  int64
+	SpentMicros     int64
+}
+
+// CreditReservation is a single held reservation (one per run).
+type CreditReservation struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	ReservationKey string
+	AmountMicros   int64
+	Status         string // open | settled | released
+}
+
+// CreditRef carries optional traceability references recorded on the ledger entry.
+type CreditRef struct {
+	RunID            *uuid.UUID
+	EvalSessionID    *uuid.UUID
+	ToolInvocationID *uuid.UUID
+	ConfirmationID   *uuid.UUID
+	ActorUserID      *uuid.UUID
+	Reason           string
+	Metadata         json.RawMessage
+}
+
+func (ref CreditRef) metadataOrEmpty() []byte {
+	if len(ref.Metadata) == 0 {
+		return []byte("{}")
+	}
+	return ref.Metadata
+}
+
+// ledgerEntry inserts one immutable ledger row inside an open transaction.
+func insertEvalCreditLedger(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, entryType string, amount, availDelta, reservedDelta, spentDelta int64, idempotencyKey string, reservationID *uuid.UUID, ref CreditRef, metadata []byte) error {
+	if metadata == nil {
+		metadata = ref.metadataOrEmpty()
+	}
+	var idem *string
+	if idempotencyKey != "" {
+		idem = &idempotencyKey
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO org_eval_credit_ledger (
+			id, organization_id, entry_type, amount_micros,
+			available_delta_micros, reserved_delta_micros, spent_delta_micros,
+			idempotency_key, reservation_id, run_id, eval_session_id, tool_invocation_id,
+			confirmation_id, actor_user_id, reason, metadata
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+	`, uuid.New(), orgID, entryType, amount, availDelta, reservedDelta, spentDelta,
+		idem, reservationID, ref.RunID, ref.EvalSessionID, ref.ToolInvocationID,
+		ref.ConfirmationID, ref.ActorUserID, nilIfEmptyString(ref.Reason), metadata)
+	return err
+}
+
+func nilIfEmptyString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// GrantEvalCredit adds credit to an org's wallet (creating the wallet on first grant). Idempotent on
+// grantKey: a repeat with the same amount is a no-op; the same key with a different amount errors. A
+// concurrent same-key grant that loses the unique-index race resolves to the winner's balance rather
+// than leaking a constraint error.
+func (r *Repository) GrantEvalCredit(ctx context.Context, orgID uuid.UUID, grantKey string, micros int64, ref CreditRef) (WalletBalance, error) {
+	if micros <= 0 {
+		return WalletBalance{}, fmt.Errorf("grant amount must be positive, got %d", micros)
+	}
+	if grantKey == "" {
+		return WalletBalance{}, ErrEvalCreditMissingKey
+	}
+	bal, err := r.grantEvalCreditOnce(ctx, orgID, grantKey, micros, ref)
+	if isUniqueViolation(err) {
+		return r.resolveExistingGrant(ctx, orgID, grantKey, micros)
+	}
+	return bal, err
+}
+
+// resolveExistingGrant returns the wallet balance after a concurrent same-key grant won the race
+// (or a conflict if the winner's amount differs).
+func (r *Repository) resolveExistingGrant(ctx context.Context, orgID uuid.UUID, grantKey string, micros int64) (WalletBalance, error) {
+	var existing int64
+	if err := r.db.QueryRow(ctx, `
+		SELECT amount_micros FROM org_eval_credit_ledger
+		WHERE organization_id = $1 AND entry_type = 'grant' AND idempotency_key = $2
+	`, orgID, grantKey).Scan(&existing); err != nil {
+		return WalletBalance{}, fmt.Errorf("resolve existing grant: %w", err)
+	}
+	if existing != micros {
+		return WalletBalance{}, ErrEvalCreditKeyConflict
+	}
+	return r.GetEvalCreditBalance(ctx, orgID)
+}
+
+func (r *Repository) grantEvalCreditOnce(ctx context.Context, orgID uuid.UUID, grantKey string, micros int64, ref CreditRef) (WalletBalance, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return WalletBalance{}, fmt.Errorf("begin grant eval credit: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO org_eval_credit_wallets (organization_id) VALUES ($1)
+		ON CONFLICT (organization_id) DO NOTHING
+	`, orgID); err != nil {
+		return WalletBalance{}, fmt.Errorf("ensure wallet: %w", err)
+	}
+
+	// Idempotency: a prior grant with this key must match the amount exactly.
+	var existing int64
+	err = tx.QueryRow(ctx, `
+		SELECT amount_micros FROM org_eval_credit_ledger
+		WHERE organization_id = $1 AND entry_type = 'grant' AND idempotency_key = $2
+	`, orgID, grantKey).Scan(&existing)
+	switch {
+	case err == nil:
+		if existing != micros {
+			return WalletBalance{}, ErrEvalCreditKeyConflict
+		}
+		return r.readWalletTx(ctx, tx, orgID) // already granted; no double-credit
+	case !errors.Is(err, pgx.ErrNoRows):
+		return WalletBalance{}, fmt.Errorf("check grant idempotency: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_wallets SET available_micros = available_micros + $2, updated_at = now()
+		WHERE organization_id = $1
+	`, orgID, micros); err != nil {
+		return WalletBalance{}, fmt.Errorf("apply grant: %w", err)
+	}
+	if err := insertEvalCreditLedger(ctx, tx, orgID, "grant", micros, micros, 0, 0, grantKey, nil, ref, nil); err != nil {
+		return WalletBalance{}, fmt.Errorf("grant ledger: %w", err)
+	}
+	bal, err := r.readWalletTx(ctx, tx, orgID)
+	if err != nil {
+		return WalletBalance{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return WalletBalance{}, fmt.Errorf("commit grant: %w", err)
+	}
+	return bal, nil
+}
+
+// ReserveEvalCredit holds `micros` against the org wallet. Idempotent on reservationKey: a repeat with
+// the same amount returns the existing reservation; a different amount errors. Fails with
+// ErrInsufficientEvalCredit (leaving balances unchanged) when available < micros.
+func (r *Repository) ReserveEvalCredit(ctx context.Context, orgID uuid.UUID, reservationKey string, micros int64, ref CreditRef) (CreditReservation, error) {
+	if micros <= 0 {
+		return CreditReservation{}, fmt.Errorf("reserve amount must be positive, got %d", micros)
+	}
+	if reservationKey == "" {
+		return CreditReservation{}, ErrEvalCreditMissingKey
+	}
+	res, err := r.reserveEvalCreditOnce(ctx, orgID, reservationKey, micros, ref)
+	if isUniqueViolation(err) {
+		// A concurrent same-key reserve won the race (its tx committed the reservation; our debit
+		// rolled back). Return the winner idempotently rather than leaking the constraint error.
+		return r.resolveExistingReservation(ctx, orgID, reservationKey, micros)
+	}
+	return res, err
+}
+
+// resolveExistingReservation returns an existing reservation by key (or a conflict if amounts differ).
+func (r *Repository) resolveExistingReservation(ctx context.Context, orgID uuid.UUID, reservationKey string, micros int64) (CreditReservation, error) {
+	var ex CreditReservation
+	if err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, reservation_key, amount_micros, status
+		FROM org_eval_credit_reservations WHERE organization_id = $1 AND reservation_key = $2
+	`, orgID, reservationKey).Scan(&ex.ID, &ex.OrganizationID, &ex.ReservationKey, &ex.AmountMicros, &ex.Status); err != nil {
+		return CreditReservation{}, fmt.Errorf("resolve existing reservation: %w", err)
+	}
+	if ex.AmountMicros != micros {
+		return CreditReservation{}, ErrEvalCreditKeyConflict
+	}
+	return ex, nil
+}
+
+func (r *Repository) reserveEvalCreditOnce(ctx context.Context, orgID uuid.UUID, reservationKey string, micros int64, ref CreditRef) (CreditReservation, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return CreditReservation{}, fmt.Errorf("begin reserve eval credit: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Idempotency: an existing reservation with this key (any status) is returned if the amount matches.
+	var ex CreditReservation
+	err = tx.QueryRow(ctx, `
+		SELECT id, organization_id, reservation_key, amount_micros, status
+		FROM org_eval_credit_reservations WHERE organization_id = $1 AND reservation_key = $2
+	`, orgID, reservationKey).Scan(&ex.ID, &ex.OrganizationID, &ex.ReservationKey, &ex.AmountMicros, &ex.Status)
+	switch {
+	case err == nil:
+		if ex.AmountMicros != micros {
+			return CreditReservation{}, ErrEvalCreditKeyConflict
+		}
+		return ex, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return CreditReservation{}, fmt.Errorf("check reserve idempotency: %w", err)
+	}
+
+	// Atomic conditional debit — 0 rows updated means insufficient available credit (Invariant 1).
+	tag, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_wallets
+		SET available_micros = available_micros - $2, reserved_micros = reserved_micros + $2, updated_at = now()
+		WHERE organization_id = $1 AND available_micros >= $2
+	`, orgID, micros)
+	if err != nil {
+		return CreditReservation{}, fmt.Errorf("reserve debit: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return CreditReservation{}, ErrInsufficientEvalCredit
+	}
+
+	res := CreditReservation{ID: uuid.New(), OrganizationID: orgID, ReservationKey: reservationKey, AmountMicros: micros, Status: "open"}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO org_eval_credit_reservations (id, organization_id, reservation_key, amount_micros, status, run_id, eval_session_id)
+		VALUES ($1,$2,$3,$4,'open',$5,$6)
+	`, res.ID, orgID, reservationKey, micros, ref.RunID, ref.EvalSessionID); err != nil {
+		return CreditReservation{}, fmt.Errorf("insert reservation: %w", err)
+	}
+	if err := insertEvalCreditLedger(ctx, tx, orgID, "reserve", micros, -micros, micros, 0, reservationKey, &res.ID, ref, nil); err != nil {
+		return CreditReservation{}, fmt.Errorf("reserve ledger: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return CreditReservation{}, fmt.Errorf("commit reserve: %w", err)
+	}
+	return res, nil
+}
+
+// SettleEvalCredit converts a reservation to actual spend (capped at the reserved amount) and releases
+// any remainder. Terminal-idempotent: a second settle is a no-op; settling a released reservation
+// errors. actual > reserved never drives the wallet negative — the overage is recorded in metadata.
+func (r *Repository) SettleEvalCredit(ctx context.Context, reservationID uuid.UUID, settlementKey string, actualMicros int64, ref CreditRef) error {
+	if actualMicros < 0 {
+		return fmt.Errorf("actual cost must be non-negative, got %d", actualMicros)
+	}
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin settle eval credit: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	orgID, amount, status, err := lockReservation(ctx, tx, reservationID)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case "settled":
+		return nil // terminal idempotent
+	case "released":
+		return ErrEvalCreditReservationResolved
+	}
+
+	settle := actualMicros
+	if settle > amount {
+		settle = amount
+	}
+	refund := amount - settle // >= 0
+	overage := actualMicros - amount
+	if overage < 0 {
+		overage = 0
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_wallets
+		SET reserved_micros = reserved_micros - $2, spent_micros = spent_micros + $3,
+		    available_micros = available_micros + $4, updated_at = now()
+		WHERE organization_id = $1
+	`, orgID, amount, settle, refund); err != nil {
+		return fmt.Errorf("settle wallet: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_reservations SET status = 'settled', resolved_at = now() WHERE id = $1
+	`, reservationID); err != nil {
+		return fmt.Errorf("settle reservation: %w", err)
+	}
+	meta, _ := json.Marshal(map[string]any{"actual_micros": actualMicros, "overage_micros": overage})
+	if err := insertEvalCreditLedger(ctx, tx, orgID, "settle", settle, refund, -amount, settle, settlementKey, &reservationID, ref, meta); err != nil {
+		return fmt.Errorf("settle ledger: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit settle: %w", err)
+	}
+	return nil
+}
+
+// ReleaseEvalCredit cancels a reservation in full (run never spent). Terminal-idempotent: a second
+// release is a no-op; releasing a settled reservation errors.
+func (r *Repository) ReleaseEvalCredit(ctx context.Context, reservationID uuid.UUID, releaseKey string, ref CreditRef) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin release eval credit: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	orgID, amount, status, err := lockReservation(ctx, tx, reservationID)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case "released":
+		return nil // terminal idempotent
+	case "settled":
+		return ErrEvalCreditReservationResolved
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_wallets
+		SET reserved_micros = reserved_micros - $2, available_micros = available_micros + $2, updated_at = now()
+		WHERE organization_id = $1
+	`, orgID, amount); err != nil {
+		return fmt.Errorf("release wallet: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE org_eval_credit_reservations SET status = 'released', resolved_at = now() WHERE id = $1
+	`, reservationID); err != nil {
+		return fmt.Errorf("release reservation: %w", err)
+	}
+	if err := insertEvalCreditLedger(ctx, tx, orgID, "release", amount, amount, -amount, 0, releaseKey, &reservationID, ref, nil); err != nil {
+		return fmt.Errorf("release ledger: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit release: %w", err)
+	}
+	return nil
+}
+
+// lockReservation reads + row-locks a reservation for a terminal transition.
+func lockReservation(ctx context.Context, tx pgx.Tx, reservationID uuid.UUID) (orgID uuid.UUID, amount int64, status string, err error) {
+	err = tx.QueryRow(ctx, `
+		SELECT organization_id, amount_micros, status FROM org_eval_credit_reservations
+		WHERE id = $1 FOR UPDATE
+	`, reservationID).Scan(&orgID, &amount, &status)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, 0, "", ErrEvalCreditReservationNotFound
+	}
+	if err != nil {
+		return uuid.Nil, 0, "", fmt.Errorf("lock reservation: %w", err)
+	}
+	return orgID, amount, status, nil
+}
+
+// GetEvalCreditBalance returns the org's wallet position.
+func (r *Repository) GetEvalCreditBalance(ctx context.Context, orgID uuid.UUID) (WalletBalance, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return WalletBalance{}, fmt.Errorf("begin balance: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	return r.readWalletTx(ctx, tx, orgID)
+}
+
+func (r *Repository) readWalletTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID) (WalletBalance, error) {
+	var b WalletBalance
+	err := tx.QueryRow(ctx, `
+		SELECT organization_id, currency_code, available_micros, reserved_micros, spent_micros
+		FROM org_eval_credit_wallets WHERE organization_id = $1
+	`, orgID).Scan(&b.OrganizationID, &b.CurrencyCode, &b.AvailableMicros, &b.ReservedMicros, &b.SpentMicros)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WalletBalance{}, ErrEvalCreditWalletNotFound
+	}
+	if err != nil {
+		return WalletBalance{}, fmt.Errorf("read wallet: %w", err)
+	}
+	return b, nil
+}

--- a/backend/internal/repository/eval_credit.go
+++ b/backend/internal/repository/eval_credit.go
@@ -237,9 +237,31 @@ func (r *Repository) reserveEvalCreditOnce(ctx context.Context, orgID uuid.UUID,
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	res, err := r.reserveEvalCreditInTx(ctx, tx, orgID, reservationKey, micros, ref)
+	if err != nil {
+		return CreditReservation{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return CreditReservation{}, fmt.Errorf("commit reserve: %w", err)
+	}
+	return res, nil
+}
+
+// reserveEvalCreditInTx performs the idempotency check + atomic conditional debit + reservation/ledger
+// insert within an EXISTING transaction (so reserve can be atomic with run creation — 4d-2). Returns
+// ErrInsufficientEvalCredit when the wallet lacks credit; the caller rolls the tx back. A unique
+// violation on the key (concurrent same-key reserve) propagates for the caller to resolve idempotently.
+func (r *Repository) reserveEvalCreditInTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, reservationKey string, micros int64, ref CreditRef) (CreditReservation, error) {
+	if micros <= 0 {
+		return CreditReservation{}, fmt.Errorf("reserve amount must be positive, got %d", micros)
+	}
+	if reservationKey == "" {
+		return CreditReservation{}, ErrEvalCreditMissingKey
+	}
+
 	// Idempotency: an existing reservation with this key (any status) is returned if the amount matches.
 	var ex CreditReservation
-	err = tx.QueryRow(ctx, `
+	err := tx.QueryRow(ctx, `
 		SELECT id, organization_id, reservation_key, amount_micros, status
 		FROM org_eval_credit_reservations WHERE organization_id = $1 AND reservation_key = $2
 	`, orgID, reservationKey).Scan(&ex.ID, &ex.OrganizationID, &ex.ReservationKey, &ex.AmountMicros, &ex.Status)
@@ -275,9 +297,6 @@ func (r *Repository) reserveEvalCreditOnce(ctx context.Context, orgID uuid.UUID,
 	}
 	if err := insertEvalCreditLedger(ctx, tx, orgID, "reserve", micros, -micros, micros, 0, reservationKey, &res.ID, ref, nil); err != nil {
 		return CreditReservation{}, fmt.Errorf("reserve ledger: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return CreditReservation{}, fmt.Errorf("commit reserve: %w", err)
 	}
 	return res, nil
 }

--- a/backend/internal/repository/eval_credit.go
+++ b/backend/internal/repository/eval_credit.go
@@ -132,17 +132,28 @@ func (r *Repository) grantEvalCreditOnce(ctx context.Context, orgID uuid.UUID, g
 		return WalletBalance{}, fmt.Errorf("begin grant eval credit: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	bal, err := r.grantEvalCreditInTx(ctx, tx, orgID, grantKey, micros, ref)
+	if err != nil {
+		return WalletBalance{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return WalletBalance{}, fmt.Errorf("commit grant: %w", err)
+	}
+	return bal, nil
+}
 
+// grantEvalCreditInTx applies an idempotent grant within an existing transaction. Used both by the
+// standalone GrantEvalCredit and to seed the signup grant atomically with org creation.
+func (r *Repository) grantEvalCreditInTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, grantKey string, micros int64, ref CreditRef) (WalletBalance, error) {
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO org_eval_credit_wallets (organization_id) VALUES ($1)
 		ON CONFLICT (organization_id) DO NOTHING
 	`, orgID); err != nil {
 		return WalletBalance{}, fmt.Errorf("ensure wallet: %w", err)
 	}
-
 	// Idempotency: a prior grant with this key must match the amount exactly.
 	var existing int64
-	err = tx.QueryRow(ctx, `
+	err := tx.QueryRow(ctx, `
 		SELECT amount_micros FROM org_eval_credit_ledger
 		WHERE organization_id = $1 AND entry_type = 'grant' AND idempotency_key = $2
 	`, orgID, grantKey).Scan(&existing)
@@ -155,7 +166,6 @@ func (r *Repository) grantEvalCreditOnce(ctx context.Context, orgID uuid.UUID, g
 	case !errors.Is(err, pgx.ErrNoRows):
 		return WalletBalance{}, fmt.Errorf("check grant idempotency: %w", err)
 	}
-
 	if _, err := tx.Exec(ctx, `
 		UPDATE org_eval_credit_wallets SET available_micros = available_micros + $2, updated_at = now()
 		WHERE organization_id = $1
@@ -165,14 +175,21 @@ func (r *Repository) grantEvalCreditOnce(ctx context.Context, orgID uuid.UUID, g
 	if err := insertEvalCreditLedger(ctx, tx, orgID, "grant", micros, micros, 0, 0, grantKey, nil, ref, nil); err != nil {
 		return WalletBalance{}, fmt.Errorf("grant ledger: %w", err)
 	}
-	bal, err := r.readWalletTx(ctx, tx, orgID)
-	if err != nil {
-		return WalletBalance{}, err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return WalletBalance{}, fmt.Errorf("commit grant: %w", err)
-	}
-	return bal, nil
+	return r.readWalletTx(ctx, tx, orgID)
+}
+
+// SignupEvalCreditMicros is the eval credit granted to every new org ($3.00). signupEvalCreditGrantKey
+// is the stable idempotency key so re-runs / imports / backfill never double-grant.
+const (
+	SignupEvalCreditMicros   = 3_000_000
+	signupEvalCreditGrantKey = "signup-eval-credit:v1"
+)
+
+// SeedOrgEvalCreditTx grants the signup eval credit to a new org inside an existing transaction
+// (atomic with org creation). Idempotent on the stable grant key.
+func (r *Repository) SeedOrgEvalCreditTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID) error {
+	_, err := r.grantEvalCreditInTx(ctx, tx, orgID, signupEvalCreditGrantKey, SignupEvalCreditMicros, CreditRef{Reason: "signup eval credit"})
+	return err
 }
 
 // ReserveEvalCredit holds `micros` against the org wallet. Idempotent on reservationKey: a repeat with

--- a/backend/internal/repository/eval_credit.go
+++ b/backend/internal/repository/eval_credit.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -25,6 +26,9 @@ var (
 	ErrEvalCreditReservationResolved = errors.New("eval credit reservation already resolved")
 	// ErrEvalCreditWalletNotFound is returned when reading a wallet that was never granted/seeded.
 	ErrEvalCreditWalletNotFound = errors.New("eval credit wallet not found")
+	// ErrMultipleOpenEvalCreditReservations is returned when a run has more than one open reservation,
+	// which violates the one-reservation-per-run invariant (never settle one and silently leak the rest).
+	ErrMultipleOpenEvalCreditReservations = errors.New("multiple open eval credit reservations for run")
 )
 
 // WalletBalance is the current eval-credit position for an org. available = granted - reserved - spent.
@@ -399,6 +403,79 @@ func (r *Repository) GetEvalCreditBalance(ctx context.Context, orgID uuid.UUID) 
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	return r.readWalletTx(ctx, tx, orgID)
+}
+
+// GetOpenReservationByRunID returns the run's open eval-credit reservation, if any. Used by the
+// worker's settlement activity (4c) — a run with no open reservation is BYOK / unmanaged and settles
+// to a no-op.
+func (r *Repository) GetOpenReservationByRunID(ctx context.Context, runID uuid.UUID) (CreditReservation, bool, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, reservation_key, amount_micros, status
+		FROM org_eval_credit_reservations
+		WHERE run_id = $1 AND status = 'open'
+		ORDER BY created_at
+	`, runID)
+	if err != nil {
+		return CreditReservation{}, false, fmt.Errorf("get open reservation by run: %w", err)
+	}
+	defer rows.Close()
+
+	var found []CreditReservation
+	for rows.Next() {
+		var res CreditReservation
+		if err := rows.Scan(&res.ID, &res.OrganizationID, &res.ReservationKey, &res.AmountMicros, &res.Status); err != nil {
+			return CreditReservation{}, false, fmt.Errorf("scan open reservation: %w", err)
+		}
+		found = append(found, res)
+	}
+	if err := rows.Err(); err != nil {
+		return CreditReservation{}, false, fmt.Errorf("iterate open reservations: %w", err)
+	}
+	switch len(found) {
+	case 0:
+		return CreditReservation{}, false, nil
+	case 1:
+		return found[0], true, nil
+	default:
+		// One-reservation-per-run is an invariant; settling one would silently leak the others.
+		return CreditReservation{}, false, fmt.Errorf("%w: run %s has %d", ErrMultipleOpenEvalCreditReservations, runID, len(found))
+	}
+}
+
+// GetRunActualCostMicros sums a run's observed model cost from the persisted per-agent scorecards
+// (the run_model_cost_usd metric) and converts USD → micros. A run/agent with no scorecard yet
+// (failed/cancelled before scoring) contributes 0. Note: run_cost_summaries is NOT populated by the
+// current scoring path, so the per-agent scorecards are the authoritative cost surface.
+//
+// COST CONTRACT (explicit for 4d): this sums ALL agents' costs, which is correct only when every
+// cost-incurring lane in the run is AgentClash-managed (the all-managed case 4c settles today). A
+// MIXED run (some lanes BYOK, some managed) would over-charge the managed reservation for BYOK spend.
+// 4d owns the resolution: either reserve/settle only the managed portion (per-lane cost), or treat a
+// run with any managed lane as fully managed and reserve accordingly — and record the chosen billing
+// mode in the reservation so settlement is not guessing. Until 4d, only fully-managed runs get a
+// reservation, so summing all agents matches what is reserved.
+func (r *Repository) GetRunActualCostMicros(ctx context.Context, runID uuid.UUID) (int64, error) {
+	agents, err := r.ListRunAgentsByRunID(ctx, runID)
+	if err != nil {
+		return 0, fmt.Errorf("list run agents for cost: %w", err)
+	}
+	var totalUSD float64
+	for _, agent := range agents {
+		sc, err := r.GetRunAgentScorecardByRunAgentID(ctx, agent.ID)
+		if errors.Is(err, ErrRunAgentScorecardNotFound) {
+			continue
+		}
+		if err != nil {
+			return 0, fmt.Errorf("get run agent scorecard: %w", err)
+		}
+		if cost := totalCostUSDFromRunAgentScorecardDocument(sc.Scorecard); cost != nil && *cost > 0 {
+			totalUSD += *cost
+		}
+	}
+	if totalUSD <= 0 {
+		return 0, nil
+	}
+	return int64(math.Round(totalUSD * 1_000_000)), nil
 }
 
 func (r *Repository) readWalletTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID) (WalletBalance, error) {

--- a/backend/internal/repository/eval_credit_deployment_test.go
+++ b/backend/internal/repository/eval_credit_deployment_test.go
@@ -1,0 +1,89 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestListRunnableDeployments_SnapshotBillingFields proves the 4d-1 query extension: BYOK signal,
+// model identity, and the FROZEN output rate all come from the snapshot → model_alias → catalog path
+// (the frozen alias rate, not a live catalog read).
+func TestListRunnableDeployments_SnapshotBillingFields(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	org := uuid.New()
+	ws := uuid.New()
+	user := uuid.New()
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed: %v\nsql: %s", err, sql)
+		}
+	}
+	exec(`INSERT INTO organizations (id, name, slug) VALUES ($1,$2,$3)`, org, "o", uniqueSlug("o"))
+	exec(`INSERT INTO workspaces (id, organization_id, name, slug) VALUES ($1,$2,$3,$4)`, ws, org, "w", uniqueSlug("w"))
+	exec(`INSERT INTO users (id, workos_user_id, email, display_name) VALUES ($1,$2,$3,$4)`, user, "wk-"+user.String()[:8], user.String()[:8]+"@e.com", "U")
+
+	runtimeProfile := uuid.New()
+	exec(`INSERT INTO runtime_profiles (id, organization_id, workspace_id, name, slug, execution_target) VALUES ($1,$2,$3,$4,$5,'native')`, runtimeProfile, org, ws, "rp", uniqueSlug("rp"))
+	providerAccount := uuid.New()
+	exec(`INSERT INTO provider_accounts (id, organization_id, workspace_id, provider_key, name, credential_reference, limits_config) VALUES ($1,$2,$3,'openai','acct','secret://x','{}'::jsonb)`, providerAccount, org, ws)
+	catalog := uuid.New()
+	modelID := "gpt-4.1-" + catalog.String()[:8] // unique per run (model_catalog UNIQUE on provider_key+model_id)
+	exec(`INSERT INTO model_catalog_entries (id, provider_key, provider_model_id, display_name, model_family, metadata) VALUES ($1,'openai',$2,'GPT-4.1','gpt-4.1','{}'::jsonb)`, catalog, modelID)
+	// FROZEN alias output rate = 5.0 (distinctive) — what the estimate must use.
+	alias := uuid.New()
+	exec(`INSERT INTO model_aliases (id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, output_cost_per_million_tokens) VALUES ($1,$2,$3,$4,$5,'a','A',5.0)`, alias, org, ws, providerAccount, catalog)
+	build := uuid.New()
+	exec(`INSERT INTO agent_builds (id, organization_id, workspace_id, name, slug, created_by_user_id) VALUES ($1,$2,$3,'b',$4,$5)`, build, org, ws, uniqueSlug("b"), user)
+	buildVersion := uuid.New()
+	exec(`INSERT INTO agent_build_versions (id, agent_build_id, version_number, version_status, build_definition, prompt_spec, output_schema, trace_contract, created_by_user_id) VALUES ($1,$2,1,'ready','{}'::jsonb,'p','{}'::jsonb,'{}'::jsonb,$3)`, buildVersion, build, user)
+
+	managed := seedDeploymentWithSnapshot(t, ctx, db, org, ws, build, buildVersion, runtimeProfile, alias, nil, alias) // managed: no source provider account
+	byok := seedDeploymentWithSnapshot(t, ctx, db, org, ws, build, buildVersion, runtimeProfile, alias, &providerAccount, alias)
+
+	deployments, err := repo.ListRunnableDeploymentsWithLatestSnapshot(ctx, ws, []uuid.UUID{managed, byok})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	byID := map[uuid.UUID]repository.RunnableDeployment{}
+	for _, d := range deployments {
+		byID[d.ID] = d
+	}
+	m, b := byID[managed], byID[byok]
+
+	// Managed lane: no source provider account; identity + FROZEN rate from the snapshot path.
+	if m.SourceProviderAccountID != nil {
+		t.Fatalf("managed lane SourceProviderAccountID = %v, want nil", m.SourceProviderAccountID)
+	}
+	if m.ProviderKey != "openai" || m.ProviderModelID != modelID {
+		t.Fatalf("managed lane model identity = %s/%s, want openai/%s", m.ProviderKey, m.ProviderModelID, modelID)
+	}
+	if m.OutputCostPerMillionTokens != 5.0 {
+		t.Fatalf("managed lane frozen rate = %v, want 5.0 (from the model alias)", m.OutputCostPerMillionTokens)
+	}
+	// BYOK lane: source provider account present.
+	if b.SourceProviderAccountID == nil || *b.SourceProviderAccountID != providerAccount {
+		t.Fatalf("byok lane SourceProviderAccountID = %v, want %s", b.SourceProviderAccountID, providerAccount)
+	}
+}
+
+func seedDeploymentWithSnapshot(t *testing.T, ctx context.Context, db *pgxpool.Pool, org, ws, build, buildVersion, runtimeProfile, alias uuid.UUID, sourceProviderAccount *uuid.UUID, sourceAlias uuid.UUID) uuid.UUID {
+	t.Helper()
+	deployment := uuid.New()
+	if _, err := db.Exec(ctx, `INSERT INTO agent_deployments (id, organization_id, workspace_id, agent_build_id, current_build_version_id, runtime_profile_id, model_alias_id, name, slug, deployment_type, deployment_config) VALUES ($1,$2,$3,$4,$5,$6,$7,'d',$8,'native','{}'::jsonb)`,
+		deployment, org, ws, build, buildVersion, runtimeProfile, alias, uniqueSlug("d")); err != nil {
+		t.Fatalf("seed deployment: %v", err)
+	}
+	if _, err := db.Exec(ctx, `INSERT INTO agent_deployment_snapshots (id, organization_id, workspace_id, agent_build_id, agent_deployment_id, source_agent_build_version_id, source_runtime_profile_id, source_provider_account_id, source_model_alias_id, deployment_type, snapshot_hash, snapshot_config) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'native',$10,'{}'::jsonb)`,
+		uuid.New(), org, ws, build, deployment, buildVersion, runtimeProfile, sourceProviderAccount, sourceAlias, "hash-"+deployment.String()[:8]); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	return deployment
+}

--- a/backend/internal/repository/eval_credit_deployment_test.go
+++ b/backend/internal/repository/eval_credit_deployment_test.go
@@ -74,6 +74,74 @@ func TestListRunnableDeployments_SnapshotBillingFields(t *testing.T) {
 	}
 }
 
+// TestListRunnableDeploymentsByBuildVersionID_SnapshotBillingFields proves the build-version
+// participant path surfaces the SAME frozen billing identity as the deployment-id path (4d-3 blocker):
+// without it, build-version eval-session participants would be misclassified managed/BYOK or priced at
+// zero.
+func TestListRunnableDeploymentsByBuildVersionID_SnapshotBillingFields(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	org := uuid.New()
+	ws := uuid.New()
+	user := uuid.New()
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed: %v\nsql: %s", err, sql)
+		}
+	}
+	exec(`INSERT INTO organizations (id, name, slug) VALUES ($1,$2,$3)`, org, "o", uniqueSlug("o"))
+	exec(`INSERT INTO workspaces (id, organization_id, name, slug) VALUES ($1,$2,$3,$4)`, ws, org, "w", uniqueSlug("w"))
+	exec(`INSERT INTO users (id, workos_user_id, email, display_name) VALUES ($1,$2,$3,$4)`, user, "wk-"+user.String()[:8], user.String()[:8]+"@e.com", "U")
+
+	runtimeProfile := uuid.New()
+	exec(`INSERT INTO runtime_profiles (id, organization_id, workspace_id, name, slug, execution_target) VALUES ($1,$2,$3,$4,$5,'native')`, runtimeProfile, org, ws, "rp", uniqueSlug("rp"))
+	providerAccount := uuid.New()
+	exec(`INSERT INTO provider_accounts (id, organization_id, workspace_id, provider_key, name, credential_reference, limits_config) VALUES ($1,$2,$3,'openai','acct','secret://x','{}'::jsonb)`, providerAccount, org, ws)
+	catalog := uuid.New()
+	modelID := "gpt-4.1-" + catalog.String()[:8]
+	exec(`INSERT INTO model_catalog_entries (id, provider_key, provider_model_id, display_name, model_family, metadata) VALUES ($1,'openai',$2,'GPT-4.1','gpt-4.1','{}'::jsonb)`, catalog, modelID)
+	alias := uuid.New()
+	exec(`INSERT INTO model_aliases (id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, output_cost_per_million_tokens) VALUES ($1,$2,$3,$4,$5,'a','A',5.0)`, alias, org, ws, providerAccount, catalog)
+	build := uuid.New()
+	exec(`INSERT INTO agent_builds (id, organization_id, workspace_id, name, slug, created_by_user_id) VALUES ($1,$2,$3,'b',$4,$5)`, build, org, ws, uniqueSlug("b"), user)
+	buildVersion := uuid.New()
+	exec(`INSERT INTO agent_build_versions (id, agent_build_id, version_number, version_status, build_definition, prompt_spec, output_schema, trace_contract, created_by_user_id) VALUES ($1,$2,1,'ready','{}'::jsonb,'p','{}'::jsonb,'{}'::jsonb,$3)`, buildVersion, build, user)
+
+	managed := seedDeploymentWithSnapshot(t, ctx, db, org, ws, build, buildVersion, runtimeProfile, alias, nil, alias)
+	byok := seedDeploymentWithSnapshot(t, ctx, db, org, ws, build, buildVersion, runtimeProfile, alias, &providerAccount, alias)
+
+	results, err := repo.ListRunnableDeploymentsByBuildVersionID(ctx, ws, []uuid.UUID{buildVersion})
+	if err != nil {
+		t.Fatalf("list by build version: %v", err)
+	}
+	byID := map[uuid.UUID]repository.RunnableDeployment{}
+	for _, r := range results {
+		if r.AgentBuildVersionID != buildVersion {
+			t.Fatalf("build version id = %s, want %s", r.AgentBuildVersionID, buildVersion)
+		}
+		byID[r.Deployment.ID] = r.Deployment
+	}
+	m, b := byID[managed], byID[byok]
+
+	// Managed lane: identity + FROZEN rate populated from the snapshot path (not zero / not unclassified).
+	if m.SourceProviderAccountID != nil {
+		t.Fatalf("managed lane SourceProviderAccountID = %v, want nil", m.SourceProviderAccountID)
+	}
+	if m.ProviderKey != "openai" || m.ProviderModelID != modelID {
+		t.Fatalf("managed lane model identity = %s/%s, want openai/%s", m.ProviderKey, m.ProviderModelID, modelID)
+	}
+	if m.OutputCostPerMillionTokens != 5.0 {
+		t.Fatalf("managed lane frozen rate = %v, want 5.0 (build-version path must surface it)", m.OutputCostPerMillionTokens)
+	}
+	// BYOK lane: source provider account present (correctly classified BYOK).
+	if b.SourceProviderAccountID == nil || *b.SourceProviderAccountID != providerAccount {
+		t.Fatalf("byok lane SourceProviderAccountID = %v, want %s", b.SourceProviderAccountID, providerAccount)
+	}
+}
+
 func seedDeploymentWithSnapshot(t *testing.T, ctx context.Context, db *pgxpool.Pool, org, ws, build, buildVersion, runtimeProfile, alias uuid.UUID, sourceProviderAccount *uuid.UUID, sourceAlias uuid.UUID) uuid.UUID {
 	t.Helper()
 	deployment := uuid.New()

--- a/backend/internal/repository/eval_credit_integration_test.go
+++ b/backend/internal/repository/eval_credit_integration_test.go
@@ -1,0 +1,328 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// seedEvalCreditOrg inserts a fresh organization (the wallet FK target). No global truncate — each
+// test gets its own org so they don't collide.
+func seedEvalCreditOrg(t *testing.T, ctx context.Context, db *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	orgID := uuid.New()
+	if _, err := db.Exec(ctx, `INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`,
+		orgID, "eval-credit-test", "eval-credit-"+orgID.String()[:8]); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	return orgID
+}
+
+func TestEvalCredit_GrantIdempotencyAndConflict(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+
+	if _, err := repo.GrantEvalCredit(ctx, org, "seed:v1", 3_000_000, repository.CreditRef{Reason: "signup"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	// Same key + same amount → idempotent no-op (still 3M, not 6M).
+	bal, err := repo.GrantEvalCredit(ctx, org, "seed:v1", 3_000_000, repository.CreditRef{})
+	if err != nil {
+		t.Fatalf("grant repeat: %v", err)
+	}
+	if bal.AvailableMicros != 3_000_000 {
+		t.Fatalf("available = %d, want 3000000 (no double-grant)", bal.AvailableMicros)
+	}
+	// Same key + different amount → conflict.
+	if _, err := repo.GrantEvalCredit(ctx, org, "seed:v1", 9_000_000, repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditKeyConflict) {
+		t.Fatalf("err = %v, want repository.ErrEvalCreditKeyConflict", err)
+	}
+}
+
+func TestEvalCredit_ReserveDebitsAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 3_000_000)
+
+	res, err := repo.ReserveEvalCredit(ctx, org, "run:abc", 1_000_000, repository.CreditRef{})
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	bal := mustBalance(t, ctx, repo, org)
+	if bal.AvailableMicros != 2_000_000 || bal.ReservedMicros != 1_000_000 {
+		t.Fatalf("balance = %+v, want available 2M reserved 1M", bal)
+	}
+	// Repeat with same key + amount → same reservation, no extra debit.
+	res2, err := repo.ReserveEvalCredit(ctx, org, "run:abc", 1_000_000, repository.CreditRef{})
+	if err != nil || res2.ID != res.ID {
+		t.Fatalf("idempotent reserve mismatch: res2=%+v err=%v", res2, err)
+	}
+	if b := mustBalance(t, ctx, repo, org); b.ReservedMicros != 1_000_000 {
+		t.Fatalf("reserved = %d after idempotent repeat, want 1M", b.ReservedMicros)
+	}
+	// Same key + different amount → conflict.
+	if _, err := repo.ReserveEvalCredit(ctx, org, "run:abc", 2_000_000, repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditKeyConflict) {
+		t.Fatalf("err = %v, want repository.ErrEvalCreditKeyConflict", err)
+	}
+}
+
+func TestEvalCredit_ReserveInsufficientLeavesUnchanged(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 1_000_000)
+
+	if _, err := repo.ReserveEvalCredit(ctx, org, "run:big", 2_000_000, repository.CreditRef{}); !errors.Is(err, repository.ErrInsufficientEvalCredit) {
+		t.Fatalf("err = %v, want repository.ErrInsufficientEvalCredit", err)
+	}
+	if b := mustBalance(t, ctx, repo, org); b.AvailableMicros != 1_000_000 || b.ReservedMicros != 0 {
+		t.Fatalf("balance changed on failed reserve: %+v", b)
+	}
+}
+
+func TestEvalCredit_SettleReleasesUnusedAndSpends(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 3_000_000)
+	res, _ := repo.ReserveEvalCredit(ctx, org, "run:x", 1_000_000, repository.CreditRef{})
+
+	// Actual 600k of the 1M reserved → spent 600k, 400k returned to available.
+	if err := repo.SettleEvalCredit(ctx, res.ID, "settle:x", 600_000, repository.CreditRef{}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	b := mustBalance(t, ctx, repo, org)
+	if b.SpentMicros != 600_000 || b.ReservedMicros != 0 || b.AvailableMicros != 2_400_000 {
+		t.Fatalf("balance = %+v, want spent 600k reserved 0 available 2.4M", b)
+	}
+}
+
+func TestEvalCredit_SettleOverageNeverNegative(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 2_000_000)
+	res, _ := repo.ReserveEvalCredit(ctx, org, "run:o", 1_000_000, repository.CreditRef{})
+
+	// Actual 1.5M exceeds the 1M reserve → spent capped at 1M, no refund, wallet non-negative.
+	if err := repo.SettleEvalCredit(ctx, res.ID, "settle:o", 1_500_000, repository.CreditRef{}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	b := mustBalance(t, ctx, repo, org)
+	if b.SpentMicros != 1_000_000 || b.ReservedMicros != 0 || b.AvailableMicros != 1_000_000 {
+		t.Fatalf("balance = %+v, want spent 1M reserved 0 available 1M (overage absorbed)", b)
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}
+
+func TestEvalCredit_ReleaseReturnsFull(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 3_000_000)
+	res, _ := repo.ReserveEvalCredit(ctx, org, "run:r", 1_000_000, repository.CreditRef{})
+
+	if err := repo.ReleaseEvalCredit(ctx, res.ID, "rel:r", repository.CreditRef{}); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if b := mustBalance(t, ctx, repo, org); b.AvailableMicros != 3_000_000 || b.ReservedMicros != 0 || b.SpentMicros != 0 {
+		t.Fatalf("balance = %+v, want fully restored", b)
+	}
+}
+
+func TestEvalCredit_TerminalCannotDoubleApply(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 3_000_000)
+
+	// settle then release → error; second settle → no-op.
+	r1, _ := repo.ReserveEvalCredit(ctx, org, "run:s1", 1_000_000, repository.CreditRef{})
+	if err := repo.SettleEvalCredit(ctx, r1.ID, "k", 500_000, repository.CreditRef{}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if err := repo.ReleaseEvalCredit(ctx, r1.ID, "k", repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditReservationResolved) {
+		t.Fatalf("release-after-settle err = %v, want resolved", err)
+	}
+	if err := repo.SettleEvalCredit(ctx, r1.ID, "k", 999_999, repository.CreditRef{}); err != nil {
+		t.Fatalf("double settle should be a no-op, got %v", err)
+	}
+	// release then settle → error.
+	r2, _ := repo.ReserveEvalCredit(ctx, org, "run:s2", 1_000_000, repository.CreditRef{})
+	if err := repo.ReleaseEvalCredit(ctx, r2.ID, "k2", repository.CreditRef{}); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if err := repo.SettleEvalCredit(ctx, r2.ID, "k2", 100, repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditReservationResolved) {
+		t.Fatalf("settle-after-release err = %v, want resolved", err)
+	}
+	b := mustBalance(t, ctx, repo, org)
+	if b.SpentMicros != 500_000 { // only r1's settle counts
+		t.Fatalf("spent = %d, want 500k", b.SpentMicros)
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}
+
+func TestEvalCredit_ParallelReserveRaceForLastMicros(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 1_000_000) // room for exactly ONE 1M reserve
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var oks, insufficient int
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := "race:" + uuid.New().String() // distinct keys → all race for the last micros
+			_, err := repo.ReserveEvalCredit(ctx, org, key, 1_000_000, repository.CreditRef{})
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				oks++
+			case errors.Is(err, repository.ErrInsufficientEvalCredit):
+				insufficient++
+			default:
+				t.Errorf("unexpected reserve error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if oks != 1 || insufficient != n-1 {
+		t.Fatalf("race: oks=%d insufficient=%d, want 1 and %d", oks, insufficient, n-1)
+	}
+	if b := mustBalance(t, ctx, repo, org); b.AvailableMicros != 0 || b.ReservedMicros != 1_000_000 {
+		t.Fatalf("balance after race = %+v, want available 0 reserved 1M", b)
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}
+
+// --- helpers ---
+
+func mustGrant(t *testing.T, ctx context.Context, repo *repository.Repository, org uuid.UUID, key string, micros int64) {
+	t.Helper()
+	if _, err := repo.GrantEvalCredit(ctx, org, key, micros, repository.CreditRef{}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+}
+
+func mustBalance(t *testing.T, ctx context.Context, repo *repository.Repository, org uuid.UUID) repository.WalletBalance {
+	t.Helper()
+	b, err := repo.GetEvalCreditBalance(ctx, org)
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	return b
+}
+
+// assertLedgerReconciles proves Invariant 6: the immutable ledger's delta sums equal the wallet.
+func assertLedgerReconciles(t *testing.T, ctx context.Context, db *pgxpool.Pool, org uuid.UUID) {
+	t.Helper()
+	var avail, reserved, spent int64
+	if err := db.QueryRow(ctx, `
+		SELECT COALESCE(SUM(available_delta_micros),0), COALESCE(SUM(reserved_delta_micros),0), COALESCE(SUM(spent_delta_micros),0)
+		FROM org_eval_credit_ledger WHERE organization_id = $1
+	`, org).Scan(&avail, &reserved, &spent); err != nil {
+		t.Fatalf("ledger sum: %v", err)
+	}
+	var wAvail, wReserved, wSpent int64
+	if err := db.QueryRow(ctx, `
+		SELECT available_micros, reserved_micros, spent_micros FROM org_eval_credit_wallets WHERE organization_id = $1
+	`, org).Scan(&wAvail, &wReserved, &wSpent); err != nil {
+		t.Fatalf("wallet read: %v", err)
+	}
+	if avail != wAvail || reserved != wReserved || spent != wSpent {
+		t.Fatalf("ledger does not reconcile: ledger(%d,%d,%d) wallet(%d,%d,%d)", avail, reserved, spent, wAvail, wReserved, wSpent)
+	}
+}
+
+func TestEvalCredit_EmptyKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	if _, err := repo.GrantEvalCredit(ctx, org, "", 1_000_000, repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditMissingKey) {
+		t.Fatalf("grant empty key err = %v, want ErrEvalCreditMissingKey", err)
+	}
+	mustGrant(t, ctx, repo, org, "seed", 1_000_000)
+	if _, err := repo.ReserveEvalCredit(ctx, org, "", 1_000_000, repository.CreditRef{}); !errors.Is(err, repository.ErrEvalCreditMissingKey) {
+		t.Fatalf("reserve empty key err = %v, want ErrEvalCreditMissingKey", err)
+	}
+}
+
+func TestEvalCredit_ConcurrentSameKeyGrantIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+
+	const n = 8
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := repo.GrantEvalCredit(ctx, org, "signup:v1", 3_000_000, repository.CreditRef{}); err != nil {
+				t.Errorf("concurrent grant: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if b := mustBalance(t, ctx, repo, org); b.AvailableMicros != 3_000_000 {
+		t.Fatalf("available = %d after %d concurrent same-key grants, want 3M (credited once)", b.AvailableMicros, n)
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}
+
+func TestEvalCredit_ConcurrentSameKeyReserveIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 5_000_000)
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	ids := map[uuid.UUID]struct{}{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := repo.ReserveEvalCredit(ctx, org, "run:same", 1_000_000, repository.CreditRef{})
+			if err != nil {
+				t.Errorf("concurrent reserve: %v", err)
+				return
+			}
+			mu.Lock()
+			ids[res.ID] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	if len(ids) != 1 {
+		t.Fatalf("got %d distinct reservation ids, want 1 (idempotent on key)", len(ids))
+	}
+	if b := mustBalance(t, ctx, repo, org); b.ReservedMicros != 1_000_000 || b.AvailableMicros != 4_000_000 {
+		t.Fatalf("balance = %+v, want reserved 1M available 4M (debited once)", b)
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}

--- a/backend/internal/repository/eval_credit_run_create_test.go
+++ b/backend/internal/repository/eval_credit_run_create_test.go
@@ -1,0 +1,199 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// runReserveFixture is the minimal valid fixture for CreateQueuedRun + an eval-credit reservation.
+type runReserveFixture struct {
+	org        uuid.UUID
+	workspace  uuid.UUID
+	versionID  uuid.UUID
+	deployment uuid.UUID
+	snapshot   uuid.UUID
+}
+
+func seedRunReserveFixture(t *testing.T, ctx context.Context, db *pgxpool.Pool, repo *repository.Repository, grantMicros int64) runReserveFixture {
+	t.Helper()
+	org, ws, user := uuid.New(), uuid.New(), uuid.New()
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed: %v\nsql: %s", err, sql)
+		}
+	}
+	exec(`INSERT INTO organizations (id, name, slug) VALUES ($1,$2,$3)`, org, "o", uniqueSlug("o"))
+	exec(`INSERT INTO workspaces (id, organization_id, name, slug) VALUES ($1,$2,$3,$4)`, ws, org, "w", uniqueSlug("w"))
+	exec(`INSERT INTO users (id, workos_user_id, email, display_name) VALUES ($1,$2,$3,$4)`, user, "wk-"+user.String()[:8], user.String()[:8]+"@e.com", "U")
+	if grantMicros > 0 {
+		if _, err := repo.GrantEvalCredit(ctx, org, "test-grant", grantMicros, repository.CreditRef{Reason: "test"}); err != nil {
+			t.Fatalf("grant: %v", err)
+		}
+	}
+
+	runtimeProfile := uuid.New()
+	exec(`INSERT INTO runtime_profiles (id, organization_id, workspace_id, name, slug, execution_target) VALUES ($1,$2,$3,$4,$5,'native')`, runtimeProfile, org, ws, "rp", uniqueSlug("rp"))
+	providerAccount := uuid.New()
+	exec(`INSERT INTO provider_accounts (id, organization_id, workspace_id, provider_key, name, credential_reference, limits_config) VALUES ($1,$2,$3,'openai','acct','secret://x','{}'::jsonb)`, providerAccount, org, ws)
+	catalog := uuid.New()
+	exec(`INSERT INTO model_catalog_entries (id, provider_key, provider_model_id, display_name, model_family, metadata) VALUES ($1,'openai',$2,'GPT','gpt','{}'::jsonb)`, catalog, "gpt-"+catalog.String()[:8])
+	alias := uuid.New()
+	exec(`INSERT INTO model_aliases (id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, output_cost_per_million_tokens) VALUES ($1,$2,$3,$4,$5,'a','A',3.0)`, alias, org, ws, providerAccount, catalog)
+	build := uuid.New()
+	exec(`INSERT INTO agent_builds (id, organization_id, workspace_id, name, slug, created_by_user_id) VALUES ($1,$2,$3,'b',$4,$5)`, build, org, ws, uniqueSlug("b"), user)
+	buildVersion := uuid.New()
+	exec(`INSERT INTO agent_build_versions (id, agent_build_id, version_number, version_status, build_definition, prompt_spec, output_schema, trace_contract, created_by_user_id) VALUES ($1,$2,1,'ready','{}'::jsonb,'p','{}'::jsonb,'{}'::jsonb,$3)`, buildVersion, build, user)
+	deployment := seedDeploymentWithSnapshot(t, ctx, db, org, ws, build, buildVersion, runtimeProfile, alias, nil, alias)
+	var snapshot uuid.UUID
+	if err := db.QueryRow(ctx, `SELECT id FROM agent_deployment_snapshots WHERE agent_deployment_id=$1`, deployment).Scan(&snapshot); err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+
+	pack := uuid.New()
+	exec(`INSERT INTO challenge_packs (id, workspace_id, slug, name, family) VALUES ($1,$2,$3,'P','support')`, pack, ws, uniqueSlug("pack"))
+	version := uuid.New()
+	exec(`INSERT INTO challenge_pack_versions (id, challenge_pack_id, version_number, lifecycle_status, manifest_checksum, manifest) VALUES ($1,$2,1,'runnable','cs',$3)`, version, pack, []byte(`{}`))
+
+	return runReserveFixture{org: org, workspace: ws, versionID: version, deployment: deployment, snapshot: snapshot}
+}
+
+func (f runReserveFixture) params(runID uuid.UUID, reservation *repository.EvalCreditReservation) repository.CreateQueuedRunParams {
+	return repository.CreateQueuedRunParams{
+		RunID:                  runID,
+		EvalCreditReservation:  reservation,
+		OrganizationID:         f.org,
+		WorkspaceID:            f.workspace,
+		ChallengePackVersionID: f.versionID,
+		Name:                   "test run",
+		ExecutionMode:          "single_agent",
+		RunAgents: []repository.CreateQueuedRunAgentParams{
+			{AgentDeploymentID: f.deployment, AgentDeploymentSnapshotID: f.snapshot, LaneIndex: 0, Label: "agent-a"},
+		},
+	}
+}
+
+func walletReserved(t *testing.T, ctx context.Context, repo *repository.Repository, org uuid.UUID) (available, reserved int64) {
+	t.Helper()
+	bal, err := repo.GetEvalCreditBalance(ctx, org)
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	return bal.AvailableMicros, bal.ReservedMicros
+}
+
+func TestCreateQueuedRun_InsufficientCreditRollsBackBoth(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	fx := seedRunReserveFixture(t, ctx, db, repo, 1_000_000) // only $1
+
+	runID := uuid.New()
+	_, err := repo.CreateQueuedRun(ctx, fx.params(runID, &repository.EvalCreditReservation{AmountMicros: 5_000_000, Key: "run:" + runID.String()}))
+	if !errors.Is(err, repository.ErrInsufficientEvalCredit) {
+		t.Fatalf("err = %v, want ErrInsufficientEvalCredit", err)
+	}
+	// No run, no reservation, wallet untouched.
+	if _, err := repo.GetRunByID(ctx, runID); err == nil {
+		t.Fatal("run must not exist after rollback")
+	}
+	if avail, reserved := walletReserved(t, ctx, repo, fx.org); avail != 1_000_000 || reserved != 0 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {1M, 0}", avail, reserved)
+	}
+}
+
+func TestCreateQueuedRun_ReserveCreateIdempotentOnRetry(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	fx := seedRunReserveFixture(t, ctx, db, repo, 10_000_000)
+
+	runID := uuid.New()
+	reservation := &repository.EvalCreditReservation{AmountMicros: 2_000_000, Key: "run:" + runID.String()}
+	first, err := repo.CreateQueuedRun(ctx, fx.params(runID, reservation))
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if first.Run.ID != runID {
+		t.Fatalf("run id = %s, want preallocated %s", first.Run.ID, runID)
+	}
+	// Retry with the same preallocated id + reservation key: returns the existing run, no double effect.
+	second, err := repo.CreateQueuedRun(ctx, fx.params(runID, reservation))
+	if err != nil {
+		t.Fatalf("retry create: %v", err)
+	}
+	if second.Run.ID != runID {
+		t.Fatalf("retry run id = %s, want %s", second.Run.ID, runID)
+	}
+	// Exactly one debit: available 10M - 2M = 8M, reserved 2M (not 4M).
+	if avail, reserved := walletReserved(t, ctx, repo, fx.org); avail != 8_000_000 || reserved != 2_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {8M, 2M} (debited once)", avail, reserved)
+	}
+}
+
+func TestCreateQueuedRun_NoReservationLeavesWalletUntouched(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	fx := seedRunReserveFixture(t, ctx, db, repo, 3_000_000)
+
+	// REST / BYOK path: no reservation param.
+	result, err := repo.CreateQueuedRun(ctx, fx.params(uuid.Nil, nil))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if result.Run.Status != domain.RunStatusQueued {
+		t.Fatalf("status = %s, want queued", result.Run.Status)
+	}
+	if avail, reserved := walletReserved(t, ctx, repo, fx.org); avail != 3_000_000 || reserved != 0 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {3M, 0} (untouched)", avail, reserved)
+	}
+}
+
+func TestCreateQueuedRun_IdempotencyMismatchOnDifferentEffect(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	fx := seedRunReserveFixture(t, ctx, db, repo, 10_000_000)
+
+	runID := uuid.New()
+	if _, err := repo.CreateQueuedRun(ctx, fx.params(runID, &repository.EvalCreditReservation{AmountMicros: 2_000_000, Key: "run:" + runID.String()})); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same preallocated id, but a DIFFERENT requested effect (reservation amount) → must error, not
+	// silently return the existing run.
+	_, err := repo.CreateQueuedRun(ctx, fx.params(runID, &repository.EvalCreditReservation{AmountMicros: 5_000_000, Key: "run:" + runID.String()}))
+	if !errors.Is(err, repository.ErrRunIdempotencyMismatch) {
+		t.Fatalf("err = %v, want ErrRunIdempotencyMismatch", err)
+	}
+	// The wallet was debited exactly once (the first 2M), not by the mismatched retry.
+	if avail, reserved := walletReserved(t, ctx, repo, fx.org); avail != 8_000_000 || reserved != 2_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {8M, 2M}", avail, reserved)
+	}
+}
+
+func TestCreateQueuedRun_IdempotencyMismatchOnRunShapingField(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	fx := seedRunReserveFixture(t, ctx, db, repo, 10_000_000)
+
+	runID := uuid.New()
+	res := &repository.EvalCreditReservation{AmountMicros: 1_000_000, Key: "run:" + runID.String()}
+	first := fx.params(runID, res) // OfficialPackMode "" ⇒ full
+	if _, err := repo.CreateQueuedRun(ctx, first); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same id + same reservation, but a different run-shaping field (OfficialPackMode) → mismatch.
+	retry := fx.params(runID, res)
+	retry.OfficialPackMode = domain.OfficialPackModeSuiteOnly
+	if _, err := repo.CreateQueuedRun(ctx, retry); !errors.Is(err, repository.ErrRunIdempotencyMismatch) {
+		t.Fatalf("err = %v, want ErrRunIdempotencyMismatch on differing OfficialPackMode", err)
+	}
+}

--- a/backend/internal/repository/eval_credit_run_test.go
+++ b/backend/internal/repository/eval_credit_run_test.go
@@ -1,0 +1,72 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestEvalCredit_GetOpenReservationByRunID(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 3_000_000)
+
+	runID := uuid.New()
+	res, err := repo.ReserveEvalCredit(ctx, org, "run:"+runID.String(), 1_000_000, repository.CreditRef{RunID: &runID})
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	got, found, err := repo.GetOpenReservationByRunID(ctx, runID)
+	if err != nil || !found || got.ID != res.ID {
+		t.Fatalf("open reservation lookup: found=%v id=%v err=%v", found, got.ID, err)
+	}
+
+	// Once resolved it is no longer "open".
+	if err := repo.SettleEvalCredit(ctx, res.ID, "settle", 500_000, repository.CreditRef{}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if _, found, _ := repo.GetOpenReservationByRunID(ctx, runID); found {
+		t.Fatal("settled reservation should not be returned as open")
+	}
+}
+
+func TestEvalCredit_GetRunActualCostMicros_NoScorecard(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	// Unknown run → no agents → no scorecards → 0 (the failed/cancelled-before-scoring case).
+	micros, err := repo.GetRunActualCostMicros(ctx, uuid.New())
+	if err != nil {
+		t.Fatalf("cost: %v", err)
+	}
+	if micros != 0 {
+		t.Fatalf("cost = %d, want 0 (no scorecard)", micros)
+	}
+}
+
+func TestEvalCredit_GetOpenReservationByRunID_DuplicateErrors(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	org := seedEvalCreditOrg(t, ctx, db)
+	mustGrant(t, ctx, repo, org, "seed", 5_000_000)
+
+	runID := uuid.New()
+	// Two distinct reservations both pointing at the same run (invariant violation).
+	if _, err := repo.ReserveEvalCredit(ctx, org, "run:"+runID.String()+":a", 1_000_000, repository.CreditRef{RunID: &runID}); err != nil {
+		t.Fatalf("reserve a: %v", err)
+	}
+	if _, err := repo.ReserveEvalCredit(ctx, org, "run:"+runID.String()+":b", 1_000_000, repository.CreditRef{RunID: &runID}); err != nil {
+		t.Fatalf("reserve b: %v", err)
+	}
+	if _, _, err := repo.GetOpenReservationByRunID(ctx, runID); !errors.Is(err, repository.ErrMultipleOpenEvalCreditReservations) {
+		t.Fatalf("err = %v, want ErrMultipleOpenEvalCreditReservations", err)
+	}
+}

--- a/backend/internal/repository/eval_credit_seed_integration_test.go
+++ b/backend/internal/repository/eval_credit_seed_integration_test.go
@@ -77,23 +77,28 @@ func TestEvalCreditSeed_NoOrgWithoutWallet(t *testing.T) {
 
 	// Create orgs via both production paths.
 	u1 := seedUser(t, ctx, db)
-	if _, err := repo.CreateOrganizationWithAdmin(ctx, repository.CreateOrgWithAdminInput{Name: "A", Slug: uniqueSlug("a"), UserID: u1}); err != nil {
+	org1, err := repo.CreateOrganizationWithAdmin(ctx, repository.CreateOrgWithAdminInput{Name: "A", Slug: uniqueSlug("a"), UserID: u1})
+	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	u2 := seedUser(t, ctx, db)
-	if _, err := repo.Onboard(ctx, repository.OnboardInput{UserID: u2, OrganizationName: "B", OrganizationSlug: uniqueSlug("b"), WorkspaceName: "W", WorkspaceSlug: uniqueSlug("bw")}); err != nil {
+	res, err := repo.Onboard(ctx, repository.OnboardInput{UserID: u2, OrganizationName: "B", OrganizationSlug: uniqueSlug("b"), WorkspaceName: "W", WorkspaceSlug: uniqueSlug("bw")})
+	if err != nil {
 		t.Fatalf("onboard: %v", err)
 	}
 
+	// Scoped to the orgs THIS test created — a shared test DB has other tests' fixture orgs inserted
+	// via raw SQL that legitimately predate the wallet.
 	var orphans int
 	if err := db.QueryRow(ctx, `
 		SELECT count(*) FROM organizations o
-		WHERE NOT EXISTS (SELECT 1 FROM org_eval_credit_wallets w WHERE w.organization_id = o.id)
-	`).Scan(&orphans); err != nil {
+		WHERE o.id = ANY($1)
+		  AND NOT EXISTS (SELECT 1 FROM org_eval_credit_wallets w WHERE w.organization_id = o.id)
+	`, []uuid.UUID{org1.ID, res.Organization.ID}).Scan(&orphans); err != nil {
 		t.Fatalf("scan orphans: %v", err)
 	}
 	if orphans != 0 {
-		t.Fatalf("%d organization(s) have no eval-credit wallet", orphans)
+		t.Fatalf("%d production-path organization(s) have no eval-credit wallet", orphans)
 	}
 }
 

--- a/backend/internal/repository/eval_credit_seed_integration_test.go
+++ b/backend/internal/repository/eval_credit_seed_integration_test.go
@@ -1,0 +1,200 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func seedUser(t *testing.T, ctx context.Context, db *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	short := id.String()[:8]
+	if _, err := db.Exec(ctx, `INSERT INTO users (id, workos_user_id, email, display_name) VALUES ($1,$2,$3,$4)`,
+		id, "workos-"+short, short+"@example.com", "Test"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func uniqueSlug(prefix string) string { return prefix + "-" + uuid.New().String()[:8] }
+
+func TestEvalCreditSeed_CreateOrganizationWithAdmin(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	user := seedUser(t, ctx, db)
+
+	org, err := repo.CreateOrganizationWithAdmin(ctx, repository.CreateOrgWithAdminInput{
+		Name: "Acme", Slug: uniqueSlug("acme"), UserID: user,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrganizationWithAdmin: %v", err)
+	}
+	bal, err := repo.GetEvalCreditBalance(ctx, org.ID)
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if bal.AvailableMicros != repository.SignupEvalCreditMicros {
+		t.Fatalf("available = %d, want %d ($3.00 seeded)", bal.AvailableMicros, repository.SignupEvalCreditMicros)
+	}
+}
+
+func TestEvalCreditSeed_Onboard(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+	user := seedUser(t, ctx, db)
+
+	res, err := repo.Onboard(ctx, repository.OnboardInput{
+		UserID:           user,
+		OrganizationName: "Acme",
+		OrganizationSlug: uniqueSlug("acme-org"),
+		WorkspaceName:    "Default",
+		WorkspaceSlug:    uniqueSlug("acme-ws"),
+	})
+	if err != nil {
+		t.Fatalf("Onboard: %v", err)
+	}
+	bal, err := repo.GetEvalCreditBalance(ctx, res.Organization.ID)
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if bal.AvailableMicros != repository.SignupEvalCreditMicros {
+		t.Fatalf("available = %d, want %d ($3.00 seeded)", bal.AvailableMicros, repository.SignupEvalCreditMicros)
+	}
+}
+
+// TestEvalCreditSeed_NoOrgWithoutWallet pins the invariant: every org created via a production path
+// has an eval-credit wallet. (Run against a throwaway DB; it inspects every org row.)
+func TestEvalCreditSeed_NoOrgWithoutWallet(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	// Create orgs via both production paths.
+	u1 := seedUser(t, ctx, db)
+	if _, err := repo.CreateOrganizationWithAdmin(ctx, repository.CreateOrgWithAdminInput{Name: "A", Slug: uniqueSlug("a"), UserID: u1}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	u2 := seedUser(t, ctx, db)
+	if _, err := repo.Onboard(ctx, repository.OnboardInput{UserID: u2, OrganizationName: "B", OrganizationSlug: uniqueSlug("b"), WorkspaceName: "W", WorkspaceSlug: uniqueSlug("bw")}); err != nil {
+		t.Fatalf("onboard: %v", err)
+	}
+
+	var orphans int
+	if err := db.QueryRow(ctx, `
+		SELECT count(*) FROM organizations o
+		WHERE NOT EXISTS (SELECT 1 FROM org_eval_credit_wallets w WHERE w.organization_id = o.id)
+	`).Scan(&orphans); err != nil {
+		t.Fatalf("scan orphans: %v", err)
+	}
+	if orphans != 0 {
+		t.Fatalf("%d organization(s) have no eval-credit wallet", orphans)
+	}
+}
+
+// backfillSQL mirrors 00062_backfill_eval_credit_seed.sql's Up body, to exercise it against data
+// (the migration runs on an empty DB during setup, so its data path is otherwise untested).
+const backfillSQL = `
+INSERT INTO org_eval_credit_wallets (organization_id)
+SELECT id FROM organizations ON CONFLICT (organization_id) DO NOTHING;
+WITH missing AS (
+    SELECT o.id AS org_id FROM organizations o
+    WHERE NOT EXISTS (SELECT 1 FROM org_eval_credit_ledger l
+        WHERE l.organization_id = o.id AND l.entry_type='grant' AND l.idempotency_key='signup-eval-credit:v1')
+),
+credited AS (
+    UPDATE org_eval_credit_wallets w SET available_micros = available_micros + 3000000, updated_at = now()
+    FROM missing m WHERE w.organization_id = m.org_id RETURNING w.organization_id
+)
+INSERT INTO org_eval_credit_ledger (id, organization_id, entry_type, amount_micros,
+    available_delta_micros, reserved_delta_micros, spent_delta_micros, idempotency_key, reason)
+SELECT gen_random_uuid(), organization_id, 'grant', 3000000, 3000000, 0, 0,
+       'signup-eval-credit:v1', 'backfill signup eval credit' FROM credited;`
+
+func TestEvalCreditSeed_BackfillIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	// A pre-wallet org: insert directly, bypassing the seeding wiring.
+	org := uuid.New()
+	if _, err := db.Exec(ctx, `INSERT INTO organizations (id, name, slug, status) VALUES ($1,'old','`+uniqueSlug("old")+`','active')`, org); err != nil {
+		t.Fatalf("insert org: %v", err)
+	}
+
+	for i := 0; i < 2; i++ { // running the backfill twice must not double-grant
+		if _, err := db.Exec(ctx, backfillSQL); err != nil {
+			t.Fatalf("backfill run %d: %v", i, err)
+		}
+		bal, err := repo.GetEvalCreditBalance(ctx, org)
+		if err != nil {
+			t.Fatalf("balance: %v", err)
+		}
+		if bal.AvailableMicros != repository.SignupEvalCreditMicros {
+			t.Fatalf("after backfill run %d: available = %d, want %d", i, bal.AvailableMicros, repository.SignupEvalCreditMicros)
+		}
+	}
+	assertLedgerReconciles(t, ctx, db, org)
+}
+
+// backfillDownSQL mirrors 00062's Down body.
+const backfillDownSQL = `
+WITH backfilled AS (
+    SELECT organization_id FROM org_eval_credit_ledger
+    WHERE entry_type='grant' AND idempotency_key='signup-eval-credit:v1' AND reason='backfill signup eval credit'
+),
+decremented AS (
+    UPDATE org_eval_credit_wallets w SET available_micros = available_micros - 3000000, updated_at = now()
+    FROM backfilled b WHERE w.organization_id = b.organization_id AND w.available_micros >= 3000000
+    RETURNING w.organization_id
+)
+DELETE FROM org_eval_credit_ledger l USING decremented d
+WHERE l.organization_id = d.organization_id
+  AND l.entry_type='grant' AND l.idempotency_key='signup-eval-credit:v1' AND l.reason='backfill signup eval credit';`
+
+func TestEvalCreditSeed_BackfillDownReconciles(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	insertOrg := func() uuid.UUID {
+		id := uuid.New()
+		if _, err := db.Exec(ctx, `INSERT INTO organizations (id, name, slug, status) VALUES ($1,'o','`+uniqueSlug("o")+`','active')`, id); err != nil {
+			t.Fatalf("insert org: %v", err)
+		}
+		return id
+	}
+
+	// Clean (unspent) org → Down fully reverts: available 0, grant row gone, reconciles.
+	clean := insertOrg()
+	if _, err := db.Exec(ctx, backfillSQL); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	// Spent org → after reserving, available < 3M so Down must SKIP it (and keep its ledger row).
+	spent := insertOrg()
+	if _, err := db.Exec(ctx, backfillSQL); err != nil {
+		t.Fatalf("backfill 2: %v", err)
+	}
+	if _, err := repo.ReserveEvalCredit(ctx, spent, "run:keep", 600_000, repository.CreditRef{}); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	if _, err := db.Exec(ctx, backfillDownSQL); err != nil {
+		t.Fatalf("down: %v", err)
+	}
+
+	if b := mustBalance(t, ctx, repo, clean); b.AvailableMicros != 0 {
+		t.Fatalf("clean org after down: available = %d, want 0", b.AvailableMicros)
+	}
+	assertLedgerReconciles(t, ctx, db, clean)
+
+	if b := mustBalance(t, ctx, repo, spent); b.AvailableMicros != 2_400_000 || b.ReservedMicros != 600_000 {
+		t.Fatalf("spent org after down: %+v, want available 2.4M reserved 600k (Down skipped)", b)
+	}
+	assertLedgerReconciles(t, ctx, db, spent) // ledger row kept → still reconciles
+}

--- a/backend/internal/repository/eval_credit_session_create_test.go
+++ b/backend/internal/repository/eval_credit_session_create_test.go
@@ -1,0 +1,258 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+// sessionChildParams builds one valid eval-session child run for the shared fixture, optionally with a
+// preallocated run id + eval-credit reservation (nil reservation ⇒ a BYOK/REST child).
+func sessionChildParams(fixture testFixture, name string, runID uuid.UUID, micros int64) repository.CreateQueuedRunParams {
+	var reservation *repository.EvalCreditReservation
+	if micros > 0 {
+		reservation = &repository.EvalCreditReservation{AmountMicros: micros, Key: "run:" + runID.String()}
+	}
+	return repository.CreateQueuedRunParams{
+		RunID:                  runID,
+		EvalCreditReservation:  reservation,
+		OrganizationID:         fixture.organizationID,
+		WorkspaceID:            fixture.workspaceID,
+		ChallengePackVersionID: fixture.challengePackVersionID,
+		ChallengeInputSetID:    &fixture.challengeInputSetID,
+		OfficialPackMode:       domain.OfficialPackModeFull,
+		CreatedByUserID:        &fixture.userID,
+		Name:                   name,
+		ExecutionMode:          "single_agent",
+		ExecutionPlan:          []byte(`{"participants":[{"lane_index":0}]}`),
+		RunAgents: []repository.CreateQueuedRunAgentParams{
+			{
+				AgentDeploymentID:         fixture.agentDeploymentID,
+				AgentDeploymentSnapshotID: fixture.agentDeploymentSnapshotID,
+				LaneIndex:                 0,
+				Label:                     "primary",
+			},
+		},
+		CaseSelections: []repository.CreateQueuedRunCaseSelectionParams{
+			{
+				ChallengeIdentityID: fixture.firstChallengeIdentityID,
+				SelectionOrigin:     repository.RunCaseSelectionOriginOfficial,
+				SelectionRank:       1,
+			},
+		},
+	}
+}
+
+func sessionParams(sessionID uuid.UUID, runs []repository.CreateQueuedRunParams) repository.CreateEvalSessionWithQueuedRunsParams {
+	return repository.CreateEvalSessionWithQueuedRunsParams{
+		SessionID: sessionID,
+		Session: repository.CreateEvalSessionParams{
+			Repetitions:            int32(len(runs)),
+			AggregationConfig:      []byte(`{"schema_version":1,"method":"mean","report_variance":true,"confidence_interval":0.95}`),
+			SuccessThresholdConfig: []byte(`{"schema_version":1}`),
+			RoutingTaskSnapshot:    []byte(`{"schema_version":1,"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}}`),
+			SchemaVersion:          1,
+		},
+		Runs: runs,
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_ReservesEachManagedChildAtomically(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 10_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	childA, childB := uuid.New(), uuid.New()
+	result, err := repo.CreateEvalSessionWithQueuedRuns(ctx, sessionParams(sessionID, []repository.CreateQueuedRunParams{
+		sessionChildParams(fixture, "child A", childA, 2_000_000),
+		sessionChildParams(fixture, "child B", childB, 2_000_000),
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if result.Session.ID != sessionID {
+		t.Fatalf("session id = %s, want preallocated %s", result.Session.ID, sessionID)
+	}
+	if len(result.Runs) != 2 {
+		t.Fatalf("child count = %d, want 2", len(result.Runs))
+	}
+	// Both children reserved: available 10M - 4M = 6M, reserved 4M.
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 6_000_000 || reserved != 4_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {6M, 4M}", avail, reserved)
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_InsufficientOnOneChildRollsBackAll(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 3_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	childA, childB := uuid.New(), uuid.New()
+	// Two managed children at 2M each = 4M > 3M granted: the second child's reservation must fail and
+	// roll back the WHOLE session (no session, no runs, no reservations).
+	_, err := repo.CreateEvalSessionWithQueuedRuns(ctx, sessionParams(sessionID, []repository.CreateQueuedRunParams{
+		sessionChildParams(fixture, "child A", childA, 2_000_000),
+		sessionChildParams(fixture, "child B", childB, 2_000_000),
+	}))
+	if !errors.Is(err, repository.ErrInsufficientEvalCredit) {
+		t.Fatalf("err = %v, want ErrInsufficientEvalCredit", err)
+	}
+	if _, err := repo.GetEvalSessionByID(ctx, sessionID); err == nil {
+		t.Fatal("session must not exist after rollback")
+	}
+	if _, err := repo.GetRunByID(ctx, childA); err == nil {
+		t.Fatal("child A run must not exist after rollback")
+	}
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 3_000_000 || reserved != 0 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {3M, 0} (untouched)", avail, reserved)
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_IdempotentRetry(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 10_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	childA, childB := uuid.New(), uuid.New()
+	build := func() repository.CreateEvalSessionWithQueuedRunsParams {
+		return sessionParams(sessionID, []repository.CreateQueuedRunParams{
+			sessionChildParams(fixture, "child A", childA, 2_000_000),
+			sessionChildParams(fixture, "child B", childB, 2_000_000),
+		})
+	}
+	first, err := repo.CreateEvalSessionWithQueuedRuns(ctx, build())
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	second, err := repo.CreateEvalSessionWithQueuedRuns(ctx, build())
+	if err != nil {
+		t.Fatalf("retry create: %v", err)
+	}
+	if second.Session.ID != first.Session.ID || len(second.Runs) != 2 {
+		t.Fatalf("retry session = %s (%d runs), want %s (2 runs)", second.Session.ID, len(second.Runs), first.Session.ID)
+	}
+	// Exactly one debit across both attempts: available 10M - 4M = 6M, reserved 4M (not 8M).
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 6_000_000 || reserved != 4_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {6M, 4M} (debited once)", avail, reserved)
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_SameEffectMismatch(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 10_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	childA, childB := uuid.New(), uuid.New()
+	if _, err := repo.CreateEvalSessionWithQueuedRuns(ctx, sessionParams(sessionID, []repository.CreateQueuedRunParams{
+		sessionChildParams(fixture, "child A", childA, 2_000_000),
+		sessionChildParams(fixture, "child B", childB, 2_000_000),
+	})); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same session id, but child B now requests a DIFFERENT reservation amount → must error, not silently
+	// return the existing session or double-debit.
+	_, err := repo.CreateEvalSessionWithQueuedRuns(ctx, sessionParams(sessionID, []repository.CreateQueuedRunParams{
+		sessionChildParams(fixture, "child A", childA, 2_000_000),
+		sessionChildParams(fixture, "child B", childB, 5_000_000),
+	}))
+	// A diverging child reservation surfaces as the precise run-level mismatch; a diverging session
+	// config / child set surfaces as the session-level one. Either is a same-effect conflict.
+	if !errors.Is(err, repository.ErrEvalSessionIdempotencyMismatch) && !errors.Is(err, repository.ErrRunIdempotencyMismatch) {
+		t.Fatalf("err = %v, want an idempotency mismatch", err)
+	}
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 6_000_000 || reserved != 4_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {6M, 4M} (debited once)", avail, reserved)
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_SessionConfigMismatch(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 10_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	childA := uuid.New()
+	base := sessionParams(sessionID, []repository.CreateQueuedRunParams{sessionChildParams(fixture, "child A", childA, 2_000_000)})
+	if _, err := repo.CreateEvalSessionWithQueuedRuns(ctx, base); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same session id + same child, but a DIFFERENT session config snapshot → session-level mismatch.
+	drifted := sessionParams(sessionID, []repository.CreateQueuedRunParams{sessionChildParams(fixture, "child A", childA, 2_000_000)})
+	drifted.Session.SuccessThresholdConfig = []byte(`{"schema_version":1,"min_pass_rate":0.9}`)
+	if _, err := repo.CreateEvalSessionWithQueuedRuns(ctx, drifted); !errors.Is(err, repository.ErrEvalSessionIdempotencyMismatch) {
+		t.Fatalf("err = %v, want ErrEvalSessionIdempotencyMismatch on differing session config", err)
+	}
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 8_000_000 || reserved != 2_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {8M, 2M} (debited once)", avail, reserved)
+	}
+}
+
+func TestCreateEvalSessionWithQueuedRuns_ByokChildHasNoReservation(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	if _, err := repo.GrantEvalCredit(ctx, fixture.organizationID, "seed", 10_000_000, repository.CreditRef{Reason: "test"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	sessionID := uuid.New()
+	managedChild, byokChild := uuid.New(), uuid.New()
+	result, err := repo.CreateEvalSessionWithQueuedRuns(ctx, sessionParams(sessionID, []repository.CreateQueuedRunParams{
+		sessionChildParams(fixture, "managed child", managedChild, 2_000_000),
+		sessionChildParams(fixture, "byok child", byokChild, 0), // 0 ⇒ no reservation
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(result.Runs) != 2 {
+		t.Fatalf("child count = %d, want 2", len(result.Runs))
+	}
+	// Only the managed child reserved: available 10M - 2M = 8M, reserved 2M.
+	if avail, reserved := walletReserved(t, ctx, repo, fixture.organizationID); avail != 8_000_000 || reserved != 2_000_000 {
+		t.Fatalf("wallet = {avail:%d, reserved:%d}, want {8M, 2M}", avail, reserved)
+	}
+	// Exactly one reservation row, and it belongs to the managed child (not the BYOK child).
+	var count int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM org_eval_credit_reservations WHERE organization_id = $1`, fixture.organizationID).Scan(&count); err != nil {
+		t.Fatalf("count reservations: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("reservation count = %d, want 1", count)
+	}
+	var byokCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM org_eval_credit_reservations WHERE run_id = $1`, byokChild).Scan(&byokCount); err != nil {
+		t.Fatalf("count byok reservations: %v", err)
+	}
+	if byokCount != 0 {
+		t.Fatalf("byok child reservation count = %d, want 0", byokCount)
+	}
+}

--- a/backend/internal/repository/eval_session_runs.go
+++ b/backend/internal/repository/eval_session_runs.go
@@ -2,13 +2,32 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	repositorysqlc "github.com/agentclash/agentclash/backend/internal/repository/sqlc"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// jsonSemanticEqual reports whether two JSON documents are semantically equal (ignoring key order and
+// insignificant whitespace), by decoding both to generic values. Used to compare a request's config
+// snapshot against the jsonb form Postgres stored and re-canonicalized.
+func jsonSemanticEqual(a, b json.RawMessage) bool {
+	var av, bv any
+	if err := json.Unmarshal(normalizeJSON(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(normalizeJSON(b), &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
 
 type BuildVersionRunnableDeployment struct {
 	AgentBuildVersionID uuid.UUID
@@ -16,6 +35,11 @@ type BuildVersionRunnableDeployment struct {
 }
 
 type CreateEvalSessionWithQueuedRunsParams struct {
+	// SessionID, when set, is the preallocated eval-session id (the guide confirmed path supplies it so
+	// the whole session + N child runs + N reservations are idempotent across retry/re-entry on a stable
+	// id). Zero ⇒ a fresh id is minted (REST/manual creates). Each child carries its own preallocated
+	// RunID + optional EvalCreditReservation on CreateQueuedRunParams.
+	SessionID       uuid.UUID
 	Session         CreateEvalSessionParams
 	Runs            []CreateQueuedRunParams
 	EntitlementGate *RunEntitlementGate
@@ -35,6 +59,10 @@ func (r *Repository) ListRunnableDeploymentsByBuildVersionID(
 		return []BuildVersionRunnableDeployment{}, nil
 	}
 
+	// Mirror ListRunnableDeploymentsWithLatestSnapshot's frozen billing identity (4d-1): the build-version
+	// path MUST surface source_provider_account_id (BYOK signal), provider/model identity, and the frozen
+	// output rate — otherwise build-version eval-session participants are misclassified managed/BYOK or
+	// priced at zero. LEFT JOINs so a lane with no managed alias still returns one row.
 	rows, err := r.db.Query(ctx, `
 		SELECT DISTINCT ON (agent_deployments.id)
 			agent_deployments.current_build_version_id,
@@ -44,12 +72,20 @@ func (r *Repository) ListRunnableDeploymentsByBuildVersionID(
 			agent_deployments.name,
 			agent_deployment_snapshots.id AS agent_deployment_snapshot_id,
 			agent_deployments.spend_policy_id,
-			agent_deployments.routing_policy_id
+			agent_deployments.routing_policy_id,
+			agent_deployment_snapshots.source_provider_account_id,
+			model_catalog_entries.provider_key,
+			model_catalog_entries.provider_model_id,
+			model_aliases.output_cost_per_million_tokens
 		FROM agent_deployments
 		JOIN agent_deployment_snapshots
 		  ON agent_deployment_snapshots.agent_deployment_id = agent_deployments.id
 		 AND agent_deployment_snapshots.organization_id = agent_deployments.organization_id
 		 AND agent_deployment_snapshots.workspace_id = agent_deployments.workspace_id
+		LEFT JOIN model_aliases
+		  ON model_aliases.id = agent_deployment_snapshots.source_model_alias_id
+		LEFT JOIN model_catalog_entries
+		  ON model_catalog_entries.id = model_aliases.model_catalog_entry_id
 		WHERE agent_deployments.workspace_id = $1
 		  AND agent_deployments.current_build_version_id = ANY($2::uuid[])
 		  AND agent_deployments.status = 'active'
@@ -64,6 +100,8 @@ func (r *Repository) ListRunnableDeploymentsByBuildVersionID(
 	deployments := make([]BuildVersionRunnableDeployment, 0)
 	for rows.Next() {
 		var item BuildVersionRunnableDeployment
+		var providerKey, providerModelID *string
+		var outputRate pgtype.Numeric
 		if err := rows.Scan(
 			&item.AgentBuildVersionID,
 			&item.Deployment.ID,
@@ -73,9 +111,22 @@ func (r *Repository) ListRunnableDeploymentsByBuildVersionID(
 			&item.Deployment.AgentDeploymentSnapshotID,
 			&item.Deployment.SpendPolicyID,
 			&item.Deployment.RoutingPolicyID,
+			&item.Deployment.SourceProviderAccountID,
+			&providerKey,
+			&providerModelID,
+			&outputRate,
 		); err != nil {
 			return nil, fmt.Errorf("scan runnable deployment by build version id: %w", err)
 		}
+		// Convert the frozen rate carefully: NULL → 0 (the managed estimate blocks on a non-positive
+		// rate), but an INVALID numeric is an error — never a silent 0 (same rule as the deployment path).
+		rate, err := numericRateToFloat64(outputRate)
+		if err != nil {
+			return nil, fmt.Errorf("convert frozen output rate for deployment %s: %w", item.Deployment.ID, err)
+		}
+		item.Deployment.ProviderKey = derefString(providerKey)
+		item.Deployment.ProviderModelID = derefString(providerModelID)
+		item.Deployment.OutputCostPerMillionTokens = rate
 		deployments = append(deployments, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -89,6 +140,22 @@ func (r *Repository) CreateEvalSessionWithQueuedRuns(
 	ctx context.Context,
 	params CreateEvalSessionWithQueuedRunsParams,
 ) (CreateEvalSessionWithQueuedRunsResult, error) {
+	// Validate every child up front, before any side effect, so a malformed child fails the whole
+	// session deterministically rather than mid-transaction.
+	for _, runParams := range params.Runs {
+		if err := validateCreateQueuedRunParams(runParams); err != nil {
+			return CreateEvalSessionWithQueuedRunsResult{}, err
+		}
+	}
+
+	// Stable session id: the guide confirmed path preallocates it (so the session + its child runs +
+	// reservations are idempotent across retry); REST/manual creates mint a fresh one.
+	preallocated := params.SessionID != uuid.Nil
+	sessionID := params.SessionID
+	if !preallocated {
+		sessionID = uuid.New()
+	}
+
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return CreateEvalSessionWithQueuedRunsResult{}, fmt.Errorf("begin eval session create transaction: %w", err)
@@ -96,6 +163,28 @@ func (r *Repository) CreateEvalSessionWithQueuedRuns(
 	defer rollback(ctx, tx)
 
 	queries := r.queries.WithTx(tx)
+
+	// Idempotency on the preallocated session id: if the session already exists, a prior attempt
+	// committed the session + child runs + reservations — return them rather than failing on a
+	// duplicate primary key (or double-debiting). But verify the SAME requested effect first: returning
+	// a session created for different config/children/reservations would mask a corrupt or colliding
+	// request.
+	if preallocated {
+		if existingRow, err := queries.GetEvalSessionByID(ctx, repositorysqlc.GetEvalSessionByIDParams{ID: sessionID}); err == nil {
+			existingSession, mapErr := mapEvalSession(existingRow)
+			if mapErr != nil {
+				return CreateEvalSessionWithQueuedRunsResult{}, fmt.Errorf("map existing eval session %s: %w", sessionID, mapErr)
+			}
+			existingRuns, verifyErr := verifyExistingEvalSessionMatchesRequest(ctx, queries, tx, existingSession, params)
+			if verifyErr != nil {
+				return CreateEvalSessionWithQueuedRunsResult{}, verifyErr
+			}
+			return CreateEvalSessionWithQueuedRunsResult{Session: existingSession, Runs: existingRuns}, nil
+		} else if !errors.Is(err, pgx.ErrNoRows) {
+			return CreateEvalSessionWithQueuedRunsResult{}, fmt.Errorf("check existing eval session %s: %w", sessionID, err)
+		}
+	}
+
 	if params.EntitlementGate != nil && len(params.Runs) > 0 {
 		workspaceID := params.Runs[0].WorkspaceID
 		if err := enforceRunEntitlementGate(ctx, tx, workspaceID, params.EntitlementGate); err != nil {
@@ -103,6 +192,7 @@ func (r *Repository) CreateEvalSessionWithQueuedRuns(
 		}
 	}
 	sessionRow, err := queries.CreateEvalSession(ctx, repositorysqlc.CreateEvalSessionParams{
+		ID:                     sessionID,
 		Status:                 string(domain.EvalSessionStatusQueued),
 		Repetitions:            params.Session.Repetitions,
 		AggregationConfig:      normalizeJSON(params.Session.AggregationConfig),
@@ -122,8 +212,18 @@ func (r *Repository) CreateEvalSessionWithQueuedRuns(
 	queuedAt := time.Now().UTC()
 	runs := make([]domain.Run, 0, len(params.Runs))
 	for idx, runParams := range params.Runs {
-		if err := validateCreateQueuedRunParams(runParams); err != nil {
-			return CreateEvalSessionWithQueuedRunsResult{}, err
+		// Reserve each managed child's eval credit in the SAME tx as session+run creation: insufficient
+		// credit on ANY child rolls back the whole session — no session, no child runs, no reservations
+		// (4d-3, pin #5). BYOK children carry no reservation. Mirrors CreateQueuedRun's reserve-before-create.
+		if runParams.EvalCreditReservation != nil && runParams.EvalCreditReservation.AmountMicros > 0 {
+			if runParams.RunID == uuid.Nil {
+				return CreateEvalSessionWithQueuedRunsResult{}, fmt.Errorf("child run %d: a managed eval-credit reservation requires a preallocated run id", idx+1)
+			}
+			childRunID := runParams.RunID
+			if _, err := r.reserveEvalCreditInTx(ctx, tx, runParams.OrganizationID, runParams.EvalCreditReservation.Key,
+				runParams.EvalCreditReservation.AmountMicros, CreditRef{RunID: &childRunID, Reason: "vibe eval session child run reservation"}); err != nil {
+				return CreateEvalSessionWithQueuedRunsResult{}, err
+			}
 		}
 
 		result, err := createQueuedRunWithQueries(ctx, queries, runParams, queuedAt)
@@ -154,4 +254,75 @@ func (r *Repository) CreateEvalSessionWithQueuedRuns(
 		Session: session,
 		Runs:    runs,
 	}, nil
+}
+
+// ErrEvalSessionIdempotencyMismatch means a preallocated eval-session id already exists but for a
+// DIFFERENT requested effect (session config, child run set, or per-child reservation) — the retry is
+// not the same operation, so returning the existing session would mask a corrupt or colliding request.
+var ErrEvalSessionIdempotencyMismatch = errors.New("preallocated eval session id exists for a different request")
+
+// verifyExistingEvalSessionMatchesRequest proves a pre-existing eval session (found on the idempotent
+// retry path) is the same effect the caller is requesting — session config, the exact child run set
+// (matched by preallocated run id), each child's run-shaping fields + reservation, and that BYOK
+// children carry no stray managed reservation — so returning it as success is safe (4d-3 idempotency).
+func verifyExistingEvalSessionMatchesRequest(
+	ctx context.Context,
+	qtx *repositorysqlc.Queries,
+	tx pgx.Tx,
+	session domain.EvalSession,
+	params CreateEvalSessionWithQueuedRunsParams,
+) ([]domain.Run, error) {
+	if session.Repetitions != params.Session.Repetitions || session.SchemaVersion != params.Session.SchemaVersion {
+		return nil, fmt.Errorf("%w: session %s config differs (repetitions/schema_version)", ErrEvalSessionIdempotencyMismatch, session.ID)
+	}
+	// Compare config snapshots SEMANTICALLY: the stored values are jsonb, which Postgres re-canonicalizes
+	// (key order / whitespace), so a raw byte compare against re-normalized params would spuriously differ.
+	if !jsonSemanticEqual(params.Session.AggregationConfig, session.AggregationConfig.Document) ||
+		!jsonSemanticEqual(params.Session.SuccessThresholdConfig, session.SuccessThresholdConfig.Document) ||
+		!jsonSemanticEqual(params.Session.RoutingTaskSnapshot, session.RoutingTaskSnapshot.Document) {
+		return nil, fmt.Errorf("%w: session %s config snapshot differs", ErrEvalSessionIdempotencyMismatch, session.ID)
+	}
+
+	rows, err := qtx.ListRunsByEvalSessionID(ctx, repositorysqlc.ListRunsByEvalSessionIDParams{EvalSessionID: &session.ID})
+	if err != nil {
+		return nil, fmt.Errorf("load existing child runs for session %s: %w", session.ID, err)
+	}
+	if len(rows) != len(params.Runs) {
+		return nil, fmt.Errorf("%w: session %s has %d child runs, request has %d", ErrEvalSessionIdempotencyMismatch, session.ID, len(rows), len(params.Runs))
+	}
+	existingByID := make(map[uuid.UUID]domain.Run, len(rows))
+	orderedRuns := make([]domain.Run, 0, len(rows))
+	for _, row := range rows {
+		run, mapErr := mapRun(row)
+		if mapErr != nil {
+			return nil, fmt.Errorf("map existing child run %s: %w", row.ID, mapErr)
+		}
+		existingByID[run.ID] = run
+	}
+
+	for _, childParams := range params.Runs {
+		if childParams.RunID == uuid.Nil {
+			return nil, fmt.Errorf("%w: session %s idempotency requires preallocated child run ids", ErrEvalSessionIdempotencyMismatch, session.ID)
+		}
+		existing, ok := existingByID[childParams.RunID]
+		if !ok {
+			return nil, fmt.Errorf("%w: session %s has no child run %s", ErrEvalSessionIdempotencyMismatch, session.ID, childParams.RunID)
+		}
+		if err := verifyExistingRunMatchesRequest(ctx, qtx, tx, existing, childParams); err != nil {
+			return nil, err
+		}
+		// A BYOK child (no reservation requested) must not carry a stray managed reservation for its run
+		// id — otherwise a corrupt prior attempt could silently hold credit against a BYOK run.
+		if childParams.EvalCreditReservation == nil {
+			var count int
+			if err := tx.QueryRow(ctx, `SELECT count(*) FROM org_eval_credit_reservations WHERE run_id = $1`, childParams.RunID).Scan(&count); err != nil {
+				return nil, fmt.Errorf("check stray reservation for byok child %s: %w", childParams.RunID, err)
+			}
+			if count != 0 {
+				return nil, fmt.Errorf("%w: byok child run %s has %d unexpected reservation(s)", ErrEvalSessionIdempotencyMismatch, childParams.RunID, count)
+			}
+		}
+		orderedRuns = append(orderedRuns, existing)
+	}
+	return orderedRuns, nil
 }

--- a/backend/internal/repository/eval_sessions.go
+++ b/backend/internal/repository/eval_sessions.go
@@ -39,6 +39,7 @@ func (r *Repository) CreateEvalSession(ctx context.Context, params CreateEvalSes
 	}
 
 	row, err := r.queries.CreateEvalSession(ctx, repositorysqlc.CreateEvalSessionParams{
+		ID:                     uuid.New(),
 		Status:                 string(domain.EvalSessionStatusQueued),
 		Repetitions:            params.Repetitions,
 		AggregationConfig:      normalizeJSON(params.AggregationConfig),

--- a/backend/internal/repository/guide_agent_allowance.go
+++ b/backend/internal/repository/guide_agent_allowance.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/billing"
+	"github.com/google/uuid"
+)
+
+// ConsumeGuideAgentTurn atomically meters ONE guide-agent turn against a workspace's monthly allowance
+// (4e) — the platform guide-agent usage quota on workspace_usage_windows.guide_agent_turn_count, DISTINCT
+// from the eval-credit wallet. In one tx it ensures the usage window exists, locks it FOR UPDATE, checks
+// the allowance, and increments only if allowed. On exhaustion it returns billing.GateError WITHOUT
+// incrementing. The FOR UPDATE lock makes the concurrent last-turn race authoritative (one caller wins).
+//
+// This mirrors enforceRunEntitlementGate's race-quota block, but standalone (no surrounding run-creation
+// tx) since a guide turn is metered at accept-time before any model call.
+func (r *Repository) ConsumeGuideAgentTurn(
+	ctx context.Context,
+	workspaceID uuid.UUID,
+	entitlements billing.EffectiveEntitlements,
+	windowStart, windowEnd time.Time,
+) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin guide agent turn transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO workspace_usage_windows (workspace_id, window_start, window_end, race_count, guide_agent_turn_count)
+		VALUES ($1, $2, $3, 0, 0)
+		ON CONFLICT (workspace_id, window_start) DO NOTHING
+	`, workspaceID, windowStart, windowEnd); err != nil {
+		return fmt.Errorf("ensure workspace usage window: %w", err)
+	}
+
+	var used int
+	if err := tx.QueryRow(ctx, `
+		SELECT guide_agent_turn_count
+		FROM workspace_usage_windows
+		WHERE workspace_id = $1
+		  AND window_start = $2
+		FOR UPDATE
+	`, workspaceID, windowStart).Scan(&used); err != nil {
+		return fmt.Errorf("lock workspace usage window: %w", err)
+	}
+
+	if decision := billing.CheckGuideAgentAllowance(entitlements, used, 1, windowEnd); !decision.Allowed {
+		return billing.GateError{Decision: decision}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE workspace_usage_windows
+		SET guide_agent_turn_count = guide_agent_turn_count + 1
+		WHERE workspace_id = $1
+		  AND window_start = $2
+	`, workspaceID, windowStart); err != nil {
+		return fmt.Errorf("consume guide agent turn: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit guide agent turn: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/repository/guide_agent_allowance_test.go
+++ b/backend/internal/repository/guide_agent_allowance_test.go
@@ -1,0 +1,129 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/billing"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func guideEntitlements(limit *int) billing.EffectiveEntitlements {
+	return billing.EffectiveEntitlements{
+		PlanKey:                          "free",
+		BillingPeriod:                    "monthly",
+		Status:                           "active",
+		SeatQuantity:                     1,
+		GuideAgentTurnsPerWorkspaceMonth: limit,
+	}
+}
+
+func guideTurnCount(t *testing.T, ctx context.Context, db *pgxpool.Pool, workspaceID uuid.UUID, windowStart time.Time) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(ctx, `SELECT guide_agent_turn_count FROM workspace_usage_windows WHERE workspace_id=$1 AND window_start=$2`, workspaceID, windowStart).Scan(&count); err != nil {
+		t.Fatalf("read guide_agent_turn_count: %v", err)
+	}
+	return count
+}
+
+func intPtr(n int) *int { return &n }
+
+func TestConsumeGuideAgentTurn_IncrementsAndBlocksAtLimit(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	windowStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ent := guideEntitlements(intPtr(2)) // allowance of 2 turns
+
+	// Two consumes succeed and increment.
+	for i := 1; i <= 2; i++ {
+		if err := repo.ConsumeGuideAgentTurn(ctx, fixture.workspaceID, ent, windowStart, windowEnd); err != nil {
+			t.Fatalf("consume %d: %v", i, err)
+		}
+		if got := guideTurnCount(t, ctx, db, fixture.workspaceID, windowStart); got != i {
+			t.Fatalf("count after consume %d = %d, want %d", i, got, i)
+		}
+	}
+
+	// Third is blocked with a billing GateError, and does NOT increment.
+	err := repo.ConsumeGuideAgentTurn(ctx, fixture.workspaceID, ent, windowStart, windowEnd)
+	var gateErr billing.GateError
+	if !errors.As(err, &gateErr) || gateErr.Decision.Code != billing.GateCodeQuotaExceeded {
+		t.Fatalf("third consume err = %v, want quota-exceeded GateError", err)
+	}
+	if got := guideTurnCount(t, ctx, db, fixture.workspaceID, windowStart); got != 2 {
+		t.Fatalf("count after blocked consume = %d, want 2 (no increment)", got)
+	}
+}
+
+func TestConsumeGuideAgentTurn_UnlimitedAllowed(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	windowStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ent := guideEntitlements(nil) // unlimited
+
+	for i := 1; i <= 5; i++ {
+		if err := repo.ConsumeGuideAgentTurn(ctx, fixture.workspaceID, ent, windowStart, windowEnd); err != nil {
+			t.Fatalf("unlimited consume %d: %v", i, err)
+		}
+	}
+	if got := guideTurnCount(t, ctx, db, fixture.workspaceID, windowStart); got != 5 {
+		t.Fatalf("count = %d, want 5 (unlimited never blocks)", got)
+	}
+}
+
+func TestConsumeGuideAgentTurn_ConcurrentLastTurnRace(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	windowStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ent := guideEntitlements(intPtr(1)) // exactly ONE turn left
+
+	const workers = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var success, blocked int
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			err := repo.ConsumeGuideAgentTurn(ctx, fixture.workspaceID, ent, windowStart, windowEnd)
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				success++
+				return
+			}
+			var gateErr billing.GateError
+			if errors.As(err, &gateErr) {
+				blocked++
+			} else {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != 1 || blocked != workers-1 {
+		t.Fatalf("race outcome = {success:%d, blocked:%d}, want {1, %d}", success, blocked, workers-1)
+	}
+	if got := guideTurnCount(t, ctx, db, fixture.workspaceID, windowStart); got != 1 {
+		t.Fatalf("count = %d, want exactly 1 (the last turn consumed once)", got)
+	}
+}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -3653,6 +3653,11 @@ func (r *Repository) Onboard(ctx context.Context, input OnboardInput) (OnboardRe
 		return OnboardResult{}, fmt.Errorf("insert workspace admin membership: %w", err)
 	}
 
+	// Seed the signup eval credit ($3.00) atomically with org creation (idempotent on the stable key).
+	if err := r.SeedOrgEvalCreditTx(ctx, tx, org.ID); err != nil {
+		return OnboardResult{}, fmt.Errorf("seed eval credit: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return OnboardResult{}, fmt.Errorf("commit tx: %w", err)
 	}
@@ -4516,6 +4521,11 @@ func (r *Repository) CreateOrganizationWithAdmin(ctx context.Context, input Crea
 	`, org.ID, defaultEntitlements.PlanKey, defaultEntitlements.BillingPeriod, defaultEntitlements.Status, defaultEntitlements.SeatQuantity, defaultEntitlements.SeatsLimit, defaultEntitlements.WorkspacesLimit, defaultEntitlements.RacesPerWorkspaceMonth, defaultEntitlements.MaxModelsPerRace, defaultEntitlements.ReplayRetentionDays, defaultEntitlements.ConcurrentRaces, featureFlags)
 	if err != nil {
 		return OrganizationRow{}, fmt.Errorf("insert default organization entitlements: %w", err)
+	}
+
+	// Seed the signup eval credit ($3.00) atomically with org creation (idempotent on the stable key).
+	if err := r.SeedOrgEvalCreditTx(ctx, tx, org.ID); err != nil {
+		return OrganizationRow{}, fmt.Errorf("seed eval credit: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -176,6 +176,13 @@ type RunnableDeployment struct {
 	AgentDeploymentSnapshotID uuid.UUID
 	SpendPolicyID             *uuid.UUID
 	RoutingPolicyID           *uuid.UUID
+	// Frozen billing identity from the snapshot (4d-1). SourceProviderAccountID set ⇒ BYOK lane.
+	// OutputCostPerMillionTokens is the FROZEN model-alias output rate (0 when absent — the estimate
+	// blocks on a non-positive managed rate; it is never silently defaulted on conversion failure).
+	SourceProviderAccountID    *uuid.UUID
+	ProviderKey                string
+	ProviderModelID            string
+	OutputCostPerMillionTokens float64
 }
 
 type CreateQueuedRunAgentParams struct {
@@ -471,18 +478,46 @@ func (r *Repository) ListRunnableDeploymentsWithLatestSnapshot(
 
 	deployments := make([]RunnableDeployment, 0, len(rows))
 	for _, row := range rows {
+		// Convert the frozen rate carefully: NULL → 0 (the managed estimate then blocks on a
+		// non-positive rate), but an INVALID numeric surfaces as an error — never a silent 0.
+		outputRate, err := numericRateToFloat64(row.OutputCostPerMillionTokens)
+		if err != nil {
+			return nil, fmt.Errorf("convert frozen output rate for deployment %s: %w", row.ID, err)
+		}
 		deployments = append(deployments, RunnableDeployment{
-			ID:                        row.ID,
-			OrganizationID:            row.OrganizationID,
-			WorkspaceID:               row.WorkspaceID,
-			Name:                      row.Name,
-			AgentDeploymentSnapshotID: row.AgentDeploymentSnapshotID,
-			SpendPolicyID:             row.SpendPolicyID,
-			RoutingPolicyID:           row.RoutingPolicyID,
+			ID:                         row.ID,
+			OrganizationID:             row.OrganizationID,
+			WorkspaceID:                row.WorkspaceID,
+			Name:                       row.Name,
+			AgentDeploymentSnapshotID:  row.AgentDeploymentSnapshotID,
+			SpendPolicyID:              row.SpendPolicyID,
+			RoutingPolicyID:            row.RoutingPolicyID,
+			SourceProviderAccountID:    row.SourceProviderAccountID,
+			ProviderKey:                derefString(row.ProviderKey),
+			ProviderModelID:            derefString(row.ProviderModelID),
+			OutputCostPerMillionTokens: outputRate,
 		})
 	}
 
 	return deployments, nil
+}
+
+// numericRateToFloat64 converts a frozen-rate pgtype.Numeric to float64. A NULL numeric → 0 (a
+// legitimate "no rate"; callers treat a non-positive managed rate as a block). A present-but-
+// uninterpretable numeric returns an error — it must NEVER be silently coerced to 0 (that could make a
+// managed run free). Distinct from numericToFloat64, which swallows the error to 0.
+func numericRateToFloat64(n pgtype.Numeric) (float64, error) {
+	if !n.Valid {
+		return 0, nil
+	}
+	f, err := n.Float64Value()
+	if err != nil {
+		return 0, fmt.Errorf("numeric to float64: %w", err)
+	}
+	if !f.Valid {
+		return 0, errors.New("numeric to float64: result is not valid")
+	}
+	return f.Float64, nil
 }
 
 func (r *Repository) CreateQueuedRun(ctx context.Context, params CreateQueuedRunParams) (CreateQueuedRunResult, error) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -192,7 +192,19 @@ type CreateQueuedRunAgentParams struct {
 	Label                     string
 }
 
+// EvalCreditReservation requests an eval-credit reservation made atomically with run creation (4d-2).
+// AmountMicros must be > 0 (BYOK/all-managed-zero runs pass nil — no reservation). Key is the
+// idempotency key (the guide path uses "run:<run_id>").
+type EvalCreditReservation struct {
+	AmountMicros int64
+	Key          string
+}
+
 type CreateQueuedRunParams struct {
+	// RunID, when set, is the preallocated run id (the guide confirmed path supplies it so the
+	// reservation key and the run share a stable id across retry/re-entry). Zero ⇒ a fresh id is minted.
+	RunID                  uuid.UUID
+	EvalCreditReservation  *EvalCreditReservation
 	OrganizationID         uuid.UUID
 	WorkspaceID            uuid.UUID
 	ChallengePackVersionID uuid.UUID
@@ -525,11 +537,38 @@ func (r *Repository) CreateQueuedRun(ctx context.Context, params CreateQueuedRun
 		return CreateQueuedRunResult{}, err
 	}
 
+	// Stable run id: the guide confirmed path preallocates it (so reserve + create share an id that is
+	// idempotent across retry); REST/manual creates mint a fresh one.
+	preallocated := params.RunID != uuid.Nil
+	if !preallocated {
+		params.RunID = uuid.New()
+	}
+
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return CreateQueuedRunResult{}, fmt.Errorf("begin queued run creation transaction: %w", err)
 	}
 	defer rollback(ctx, tx)
+	qtx := r.queries.WithTx(tx)
+
+	// Idempotency on the preallocated id: if the run already exists, reserve+create already committed
+	// on a prior attempt — return it rather than failing on a duplicate primary key (4d-2). But verify
+	// it is the SAME requested effect first: returning a run with this id that was created for a
+	// different org/workspace/challenge/agents/reservation would mask a corrupt or colliding request.
+	if preallocated {
+		if existing, err := qtx.GetRunByID(ctx, repositorysqlc.GetRunByIDParams{ID: params.RunID}); err == nil {
+			run, mapErr := mapRun(existing)
+			if mapErr != nil {
+				return CreateQueuedRunResult{}, fmt.Errorf("map existing run %s: %w", params.RunID, mapErr)
+			}
+			if err := verifyExistingRunMatchesRequest(ctx, qtx, tx, run, params); err != nil {
+				return CreateQueuedRunResult{}, err
+			}
+			return CreateQueuedRunResult{Run: run}, nil
+		} else if !errors.Is(err, pgx.ErrNoRows) {
+			return CreateQueuedRunResult{}, fmt.Errorf("check existing run %s: %w", params.RunID, err)
+		}
+	}
 
 	if params.EntitlementGate != nil {
 		if err := enforceRunEntitlementGate(ctx, tx, params.WorkspaceID, params.EntitlementGate); err != nil {
@@ -537,7 +576,17 @@ func (r *Repository) CreateQueuedRun(ctx context.Context, params CreateQueuedRun
 		}
 	}
 
-	result, err := createQueuedRunWithQueries(ctx, r.queries.WithTx(tx), params, time.Now().UTC())
+	// Reserve eval credit in the SAME tx as run creation: insufficient credit rolls back both, so a
+	// queued run never exists without its backing reservation (4d-2).
+	if params.EvalCreditReservation != nil && params.EvalCreditReservation.AmountMicros > 0 {
+		runID := params.RunID
+		if _, err := r.reserveEvalCreditInTx(ctx, tx, params.OrganizationID, params.EvalCreditReservation.Key,
+			params.EvalCreditReservation.AmountMicros, CreditRef{RunID: &runID, Reason: "vibe eval run reservation"}); err != nil {
+			return CreateQueuedRunResult{}, err
+		}
+	}
+
+	result, err := createQueuedRunWithQueries(ctx, qtx, params, time.Now().UTC())
 	if err != nil {
 		return CreateQueuedRunResult{}, err
 	}
@@ -547,6 +596,97 @@ func (r *Repository) CreateQueuedRun(ctx context.Context, params CreateQueuedRun
 	}
 
 	return result, nil
+}
+
+// ErrRunIdempotencyMismatch means a preallocated run id already exists but for a DIFFERENT requested
+// effect (org/workspace/challenge/agents/reservation) — the retry is not the same operation.
+var ErrRunIdempotencyMismatch = errors.New("preallocated run id exists for a different request")
+
+// verifyExistingRunMatchesRequest proves a pre-existing run (found on the idempotent retry path) is the
+// same effect the caller is requesting, so returning it as success is safe (4d-2 idempotency).
+func verifyExistingRunMatchesRequest(ctx context.Context, qtx *repositorysqlc.Queries, tx pgx.Tx, run domain.Run, params CreateQueuedRunParams) error {
+	if run.OrganizationID != params.OrganizationID || run.WorkspaceID != params.WorkspaceID || run.ChallengePackVersionID != params.ChallengePackVersionID {
+		return fmt.Errorf("%w: tenancy/challenge differ for run %s", ErrRunIdempotencyMismatch, run.ID)
+	}
+	// Normalize OfficialPackMode the same way create does (empty ⇒ full) before comparing.
+	wantOfficialPackMode := params.OfficialPackMode
+	if wantOfficialPackMode == "" {
+		wantOfficialPackMode = domain.OfficialPackModeFull
+	}
+	if run.OfficialPackMode != wantOfficialPackMode ||
+		run.ExecutionMode != params.ExecutionMode ||
+		run.RaceContext != params.RaceContext ||
+		!uuidPtrEqual(run.ChallengeInputSetID, params.ChallengeInputSetID) ||
+		!int32PtrEqual(run.RaceContextMinStepGap, params.RaceContextMinStepGap) {
+		return fmt.Errorf("%w: run-shaping fields differ for run %s", ErrRunIdempotencyMismatch, run.ID)
+	}
+
+	agents, err := qtx.ListRunAgentsByRunID(ctx, repositorysqlc.ListRunAgentsByRunIDParams{RunID: run.ID})
+	if err != nil {
+		return fmt.Errorf("load existing run agents for %s: %w", run.ID, err)
+	}
+	if len(agents) != len(params.RunAgents) {
+		return fmt.Errorf("%w: run %s has %d agents, request has %d", ErrRunIdempotencyMismatch, run.ID, len(agents), len(params.RunAgents))
+	}
+	existingByLane := make(map[int32]repositorysqlc.RunAgent, len(agents))
+	for _, a := range agents {
+		existingByLane[a.LaneIndex] = a
+	}
+	for _, want := range params.RunAgents {
+		got, ok := existingByLane[want.LaneIndex]
+		if !ok || uuidValue(got.AgentDeploymentID) != want.AgentDeploymentID || uuidValue(got.AgentDeploymentSnapshotID) != want.AgentDeploymentSnapshotID {
+			return fmt.Errorf("%w: run %s lane %d differs", ErrRunIdempotencyMismatch, run.ID, want.LaneIndex)
+		}
+	}
+
+	// Reservation compatibility: if a reservation was requested, the same-keyed reservation must exist
+	// with the same amount (it was committed atomically with the run on the first attempt).
+	if params.EvalCreditReservation != nil {
+		var amount int64
+		var resRunID *uuid.UUID
+		var status string
+		err := tx.QueryRow(ctx, `SELECT amount_micros, run_id, status FROM org_eval_credit_reservations WHERE organization_id = $1 AND reservation_key = $2`,
+			params.OrganizationID, params.EvalCreditReservation.Key).Scan(&amount, &resRunID, &status)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: run %s has no reservation %q", ErrRunIdempotencyMismatch, run.ID, params.EvalCreditReservation.Key)
+		}
+		if err != nil {
+			return fmt.Errorf("check existing reservation for run %s: %w", run.ID, err)
+		}
+		if amount != params.EvalCreditReservation.AmountMicros {
+			return fmt.Errorf("%w: run %s reservation amount %d != requested %d", ErrRunIdempotencyMismatch, run.ID, amount, params.EvalCreditReservation.AmountMicros)
+		}
+		if uuidValue(resRunID) != run.ID {
+			return fmt.Errorf("%w: reservation %q belongs to run %v, not %s", ErrRunIdempotencyMismatch, params.EvalCreditReservation.Key, resRunID, run.ID)
+		}
+		switch status {
+		case "open", "settled", "released":
+		default:
+			return fmt.Errorf("%w: reservation %q has unexpected status %q", ErrRunIdempotencyMismatch, params.EvalCreditReservation.Key, status)
+		}
+	}
+	return nil
+}
+
+func uuidValue(p *uuid.UUID) uuid.UUID {
+	if p == nil {
+		return uuid.Nil
+	}
+	return *p
+}
+
+func uuidPtrEqual(a, b *uuid.UUID) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func int32PtrEqual(a, b *int32) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func enforceRunEntitlementGate(ctx context.Context, tx pgx.Tx, workspaceID uuid.UUID, gate *RunEntitlementGate) error {
@@ -699,6 +839,11 @@ func createQueuedRunWithQueries(
 	if params.OfficialPackMode == "" {
 		params.OfficialPackMode = domain.OfficialPackModeFull
 	}
+	// Every run is created with an explicit id (CreateQueuedRun preallocates for the guide path; other
+	// callers mint here) so the insert id is always valid.
+	if params.RunID == uuid.Nil {
+		params.RunID = uuid.New()
+	}
 
 	queuedAtValue := pgtype.Timestamptz{Time: queuedAt.UTC(), Valid: true}
 	executionPlan := cloneJSON(params.ExecutionPlan)
@@ -711,6 +856,7 @@ func createQueuedRunWithQueries(
 	}
 
 	runRow, err := queries.CreateRun(ctx, repositorysqlc.CreateRunParams{
+		ID:                     params.RunID,
 		OrganizationID:         params.OrganizationID,
 		WorkspaceID:            params.WorkspaceID,
 		ChallengePackVersionID: cloneUUIDPtr(&params.ChallengePackVersionID),

--- a/backend/internal/repository/sqlc/billing.sql.go
+++ b/backend/internal/repository/sqlc/billing.sql.go
@@ -554,6 +554,7 @@ SELECT
     max_models_per_race,
     replay_retention_days,
     concurrency_limit,
+    guide_agent_turns_per_workspace_month,
     feature_flags,
     source_subscription_id,
     effective_at,
@@ -568,21 +569,22 @@ type GetOrganizationEntitlementsParams struct {
 }
 
 type GetOrganizationEntitlementsRow struct {
-	PlanKey                string
-	BillingPeriod          string
-	Status                 string
-	SeatQuantity           int32
-	SeatsLimit             *int32
-	WorkspacesLimit        *int32
-	RacesPerWorkspaceMonth *int32
-	MaxModelsPerRace       *int32
-	ReplayRetentionDays    *int32
-	ConcurrencyLimit       *int32
-	FeatureFlags           []byte
-	SourceSubscriptionID   *uuid.UUID
-	EffectiveAt            pgtype.Timestamptz
-	ExpiresAt              pgtype.Timestamptz
-	UpdatedAt              pgtype.Timestamptz
+	PlanKey                          string
+	BillingPeriod                    string
+	Status                           string
+	SeatQuantity                     int32
+	SeatsLimit                       *int32
+	WorkspacesLimit                  *int32
+	RacesPerWorkspaceMonth           *int32
+	MaxModelsPerRace                 *int32
+	ReplayRetentionDays              *int32
+	ConcurrencyLimit                 *int32
+	GuideAgentTurnsPerWorkspaceMonth *int32
+	FeatureFlags                     []byte
+	SourceSubscriptionID             *uuid.UUID
+	EffectiveAt                      pgtype.Timestamptz
+	ExpiresAt                        pgtype.Timestamptz
+	UpdatedAt                        pgtype.Timestamptz
 }
 
 func (q *Queries) GetOrganizationEntitlements(ctx context.Context, arg GetOrganizationEntitlementsParams) (GetOrganizationEntitlementsRow, error) {
@@ -599,6 +601,7 @@ func (q *Queries) GetOrganizationEntitlements(ctx context.Context, arg GetOrgani
 		&i.MaxModelsPerRace,
 		&i.ReplayRetentionDays,
 		&i.ConcurrencyLimit,
+		&i.GuideAgentTurnsPerWorkspaceMonth,
 		&i.FeatureFlags,
 		&i.SourceSubscriptionID,
 		&i.EffectiveAt,
@@ -608,23 +611,28 @@ func (q *Queries) GetOrganizationEntitlements(ctx context.Context, arg GetOrgani
 	return i, err
 }
 
-const getWorkspaceUsageWindowRaceCount = `-- name: GetWorkspaceUsageWindowRaceCount :one
-SELECT race_count
+const getWorkspaceUsageWindowCounts = `-- name: GetWorkspaceUsageWindowCounts :one
+SELECT race_count, guide_agent_turn_count
 FROM workspace_usage_windows
 WHERE workspace_id = $1
   AND window_start = $2
 `
 
-type GetWorkspaceUsageWindowRaceCountParams struct {
+type GetWorkspaceUsageWindowCountsParams struct {
 	WorkspaceID uuid.UUID
 	WindowStart pgtype.Timestamptz
 }
 
-func (q *Queries) GetWorkspaceUsageWindowRaceCount(ctx context.Context, arg GetWorkspaceUsageWindowRaceCountParams) (int32, error) {
-	row := q.db.QueryRow(ctx, getWorkspaceUsageWindowRaceCount, arg.WorkspaceID, arg.WindowStart)
-	var race_count int32
-	err := row.Scan(&race_count)
-	return race_count, err
+type GetWorkspaceUsageWindowCountsRow struct {
+	RaceCount           int32
+	GuideAgentTurnCount int32
+}
+
+func (q *Queries) GetWorkspaceUsageWindowCounts(ctx context.Context, arg GetWorkspaceUsageWindowCountsParams) (GetWorkspaceUsageWindowCountsRow, error) {
+	row := q.db.QueryRow(ctx, getWorkspaceUsageWindowCounts, arg.WorkspaceID, arg.WindowStart)
+	var i GetWorkspaceUsageWindowCountsRow
+	err := row.Scan(&i.RaceCount, &i.GuideAgentTurnCount)
+	return i, err
 }
 
 const markBillingCheckoutIntentCompleted = `-- name: MarkBillingCheckoutIntentCompleted :execrows
@@ -846,6 +854,7 @@ INSERT INTO organization_entitlements (
     max_models_per_race,
     replay_retention_days,
     concurrency_limit,
+    guide_agent_turns_per_workspace_month,
     feature_flags,
     source_subscription_id,
     effective_at,
@@ -863,10 +872,11 @@ VALUES (
     $9,
     $10,
     $11,
-    $12::jsonb,
-    $13,
+    $12,
+    $13::jsonb,
+    $14,
     now(),
-    $14
+    $15
 )
 ON CONFLICT (organization_id) DO UPDATE SET
     plan_key = EXCLUDED.plan_key,
@@ -879,6 +889,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
     max_models_per_race = EXCLUDED.max_models_per_race,
     replay_retention_days = EXCLUDED.replay_retention_days,
     concurrency_limit = EXCLUDED.concurrency_limit,
+    guide_agent_turns_per_workspace_month = EXCLUDED.guide_agent_turns_per_workspace_month,
     feature_flags = EXCLUDED.feature_flags,
     source_subscription_id = EXCLUDED.source_subscription_id,
     effective_at = EXCLUDED.effective_at,
@@ -886,20 +897,21 @@ ON CONFLICT (organization_id) DO UPDATE SET
 `
 
 type UpsertOrganizationEntitlementsParams struct {
-	OrganizationID         uuid.UUID
-	PlanKey                string
-	BillingPeriod          string
-	Status                 string
-	SeatQuantity           int32
-	SeatsLimit             *int32
-	WorkspacesLimit        *int32
-	RacesPerWorkspaceMonth *int32
-	MaxModelsPerRace       *int32
-	ReplayRetentionDays    *int32
-	ConcurrencyLimit       *int32
-	FeatureFlags           []byte
-	SourceSubscriptionID   *uuid.UUID
-	ExpiresAt              pgtype.Timestamptz
+	OrganizationID                   uuid.UUID
+	PlanKey                          string
+	BillingPeriod                    string
+	Status                           string
+	SeatQuantity                     int32
+	SeatsLimit                       *int32
+	WorkspacesLimit                  *int32
+	RacesPerWorkspaceMonth           *int32
+	MaxModelsPerRace                 *int32
+	ReplayRetentionDays              *int32
+	ConcurrencyLimit                 *int32
+	GuideAgentTurnsPerWorkspaceMonth *int32
+	FeatureFlags                     []byte
+	SourceSubscriptionID             *uuid.UUID
+	ExpiresAt                        pgtype.Timestamptz
 }
 
 func (q *Queries) UpsertOrganizationEntitlements(ctx context.Context, arg UpsertOrganizationEntitlementsParams) error {
@@ -915,6 +927,7 @@ func (q *Queries) UpsertOrganizationEntitlements(ctx context.Context, arg Upsert
 		arg.MaxModelsPerRace,
 		arg.ReplayRetentionDays,
 		arg.ConcurrencyLimit,
+		arg.GuideAgentTurnsPerWorkspaceMonth,
 		arg.FeatureFlags,
 		arg.SourceSubscriptionID,
 		arg.ExpiresAt,

--- a/backend/internal/repository/sqlc/eval_sessions.sql.go
+++ b/backend/internal/repository/sqlc/eval_sessions.sql.go
@@ -60,6 +60,7 @@ func (q *Queries) AttachRunToEvalSession(ctx context.Context, arg AttachRunToEva
 
 const createEvalSession = `-- name: CreateEvalSession :one
 INSERT INTO eval_sessions (
+    id,
     status,
     repetitions,
     aggregation_config,
@@ -76,12 +77,14 @@ INSERT INTO eval_sessions (
     $5,
     $6,
     $7,
-    $8
+    $8,
+    $9
 )
 RETURNING id, status, repetitions, aggregation_config, success_threshold_config, routing_task_snapshot, schema_version, created_at, started_at, finished_at, updated_at
 `
 
 type CreateEvalSessionParams struct {
+	ID                     uuid.UUID
 	Status                 string
 	Repetitions            int32
 	AggregationConfig      []byte
@@ -94,6 +97,7 @@ type CreateEvalSessionParams struct {
 
 func (q *Queries) CreateEvalSession(ctx context.Context, arg CreateEvalSessionParams) (EvalSession, error) {
 	row := q.db.QueryRow(ctx, createEvalSession,
+		arg.ID,
 		arg.Status,
 		arg.Repetitions,
 		arg.AggregationConfig,

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -125,7 +125,7 @@ type Querier interface {
 	// Crash-safe re-entry: returns the row only if it is still 'executing' and the presented hash
 	// matches, so a retried POST can resume effect execution exactly once. 0 rows => not resumable.
 	GetVibeEvalPendingConfirmationForResume(ctx context.Context, arg GetVibeEvalPendingConfirmationForResumeParams) (VibeEvalPendingConfirmation, error)
-	GetWorkspaceUsageWindowRaceCount(ctx context.Context, arg GetWorkspaceUsageWindowRaceCountParams) (int32, error)
+	GetWorkspaceUsageWindowCounts(ctx context.Context, arg GetWorkspaceUsageWindowCountsParams) (GetWorkspaceUsageWindowCountsRow, error)
 	InsertDatasetBaseline(ctx context.Context, arg InsertDatasetBaselineParams) (DatasetBaseline, error)
 	InsertDatasetExample(ctx context.Context, arg InsertDatasetExampleParams) (DatasetExample, error)
 	InsertDatasetExampleRevision(ctx context.Context, arg InsertDatasetExampleRevisionParams) (DatasetExampleRevision, error)

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -181,6 +181,10 @@ type Querier interface {
 	ListRunRegressionCoverageCasesByRunID(ctx context.Context, arg ListRunRegressionCoverageCasesByRunIDParams) ([]ListRunRegressionCoverageCasesByRunIDRow, error)
 	ListRunStatusHistoryByRunID(ctx context.Context, arg ListRunStatusHistoryByRunIDParams) ([]RunStatusHistory, error)
 	ListRunnableChallengePVersionsByPackID(ctx context.Context, arg ListRunnableChallengePVersionsByPackIDParams) ([]ListRunnableChallengePVersionsByPackIDRow, error)
+	// The frozen billing identity for each lane comes from the SNAPSHOT path (4d-1):
+	// source_provider_account_id is the BYOK signal; the model identity (provider_key/provider_model_id)
+	// and the FROZEN output rate (model_aliases.output_cost_per_million_tokens) drive the eval-credit
+	// estimate. LEFT JOINs so a deployment with no managed alias still returns one row.
 	ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context, arg ListRunnableDeploymentsWithLatestSnapshotParams) ([]ListRunnableDeploymentsWithLatestSnapshotRow, error)
 	ListRunsByEvalSessionID(ctx context.Context, arg ListRunsByEvalSessionIDParams) ([]Run, error)
 	ListRunsByWorkspaceID(ctx context.Context, arg ListRunsByWorkspaceIDParams) ([]Run, error)

--- a/backend/internal/repository/sqlc/run_creation.sql.go
+++ b/backend/internal/repository/sqlc/run_creation.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const getChallengeInputSetByID = `-- name: GetChallengeInputSetByID :one
@@ -155,12 +156,20 @@ SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.name,
     agent_deployment_snapshots.id AS agent_deployment_snapshot_id,
     agent_deployments.spend_policy_id,
-    agent_deployments.routing_policy_id
+    agent_deployments.routing_policy_id,
+    agent_deployment_snapshots.source_provider_account_id,
+    model_catalog_entries.provider_key,
+    model_catalog_entries.provider_model_id,
+    model_aliases.output_cost_per_million_tokens
 FROM agent_deployments
 JOIN agent_deployment_snapshots
   ON agent_deployment_snapshots.agent_deployment_id = agent_deployments.id
  AND agent_deployment_snapshots.organization_id = agent_deployments.organization_id
  AND agent_deployment_snapshots.workspace_id = agent_deployments.workspace_id
+LEFT JOIN model_aliases
+  ON model_aliases.id = agent_deployment_snapshots.source_model_alias_id
+LEFT JOIN model_catalog_entries
+  ON model_catalog_entries.id = model_aliases.model_catalog_entry_id
 WHERE agent_deployments.workspace_id = $1
   AND agent_deployments.id = ANY($2::uuid[])
   AND agent_deployments.status = 'active'
@@ -174,15 +183,23 @@ type ListRunnableDeploymentsWithLatestSnapshotParams struct {
 }
 
 type ListRunnableDeploymentsWithLatestSnapshotRow struct {
-	ID                        uuid.UUID
-	OrganizationID            uuid.UUID
-	WorkspaceID               uuid.UUID
-	Name                      string
-	AgentDeploymentSnapshotID uuid.UUID
-	SpendPolicyID             *uuid.UUID
-	RoutingPolicyID           *uuid.UUID
+	ID                         uuid.UUID
+	OrganizationID             uuid.UUID
+	WorkspaceID                uuid.UUID
+	Name                       string
+	AgentDeploymentSnapshotID  uuid.UUID
+	SpendPolicyID              *uuid.UUID
+	RoutingPolicyID            *uuid.UUID
+	SourceProviderAccountID    *uuid.UUID
+	ProviderKey                *string
+	ProviderModelID            *string
+	OutputCostPerMillionTokens pgtype.Numeric
 }
 
+// The frozen billing identity for each lane comes from the SNAPSHOT path (4d-1):
+// source_provider_account_id is the BYOK signal; the model identity (provider_key/provider_model_id)
+// and the FROZEN output rate (model_aliases.output_cost_per_million_tokens) drive the eval-credit
+// estimate. LEFT JOINs so a deployment with no managed alias still returns one row.
 func (q *Queries) ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context, arg ListRunnableDeploymentsWithLatestSnapshotParams) ([]ListRunnableDeploymentsWithLatestSnapshotRow, error) {
 	rows, err := q.db.Query(ctx, listRunnableDeploymentsWithLatestSnapshot, arg.WorkspaceID, arg.DeploymentIds)
 	if err != nil {
@@ -200,6 +217,10 @@ func (q *Queries) ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context,
 			&i.AgentDeploymentSnapshotID,
 			&i.SpendPolicyID,
 			&i.RoutingPolicyID,
+			&i.SourceProviderAccountID,
+			&i.ProviderKey,
+			&i.ProviderModelID,
+			&i.OutputCostPerMillionTokens,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -32,6 +32,7 @@ func (q *Queries) CountRunsByWorkspaceID(ctx context.Context, arg CountRunsByWor
 
 const createRun = `-- name: CreateRun :one
 INSERT INTO runs (
+    id,
     organization_id,
     workspace_id,
     challenge_pack_version_id,
@@ -72,12 +73,14 @@ INSERT INTO runs (
     $17,
     $18,
     $19,
-    $20
+    $20,
+    $21
 )
 RETURNING id, organization_id, workspace_id, challenge_pack_version_id, challenge_input_set_id, created_by_user_id, name, status, execution_mode, temporal_workflow_id, temporal_run_id, execution_plan, queued_at, started_at, finished_at, cancelled_at, failed_at, created_at, updated_at, official_pack_mode, eval_session_id, race_context, race_context_min_step_gap, ci_metadata, source_type
 `
 
 type CreateRunParams struct {
+	ID                     uuid.UUID
 	OrganizationID         uuid.UUID
 	WorkspaceID            uuid.UUID
 	ChallengePackVersionID *uuid.UUID
@@ -102,6 +105,7 @@ type CreateRunParams struct {
 
 func (q *Queries) CreateRun(ctx context.Context, arg CreateRunParams) (Run, error) {
 	row := q.db.QueryRow(ctx, createRun,
+		arg.ID,
 		arg.OrganizationID,
 		arg.WorkspaceID,
 		arg.ChallengePackVersionID,

--- a/backend/internal/vibeeval/confirmation.go
+++ b/backend/internal/vibeeval/confirmation.go
@@ -23,8 +23,11 @@ type PendingConfirmation struct {
 	PayloadHash    string
 	BoundArgs      json.RawMessage // exact args to execute on approve
 	Summary        string
-	Status         string
-	ExpiresAt      time.Time
+	// Estimate is server-generated, immutable confirmation metadata (e.g. a cost-incurring tool's
+	// approved cost envelope). Opaque to the engine; the proposing tool owns the shape.
+	Estimate  json.RawMessage
+	Status    string
+	ExpiresAt time.Time
 }
 
 // NewPendingConfirmation is the input to ConfirmationStore.Create.
@@ -41,6 +44,7 @@ type NewPendingConfirmation struct {
 	PayloadHash      string
 	BoundArgs        json.RawMessage
 	Summary          string
+	Estimate         json.RawMessage // server-computed approved estimate envelope (cost-incurring tools)
 	ExpiresAt        time.Time
 }
 

--- a/backend/internal/vibeeval/loop.go
+++ b/backend/internal/vibeeval/loop.go
@@ -61,7 +61,10 @@ type Event struct {
 	Summary        string    `json:"summary,omitempty"`
 	PayloadHash    string    `json:"payload_hash,omitempty"` // the client echoes this on resolve (hash of args, not the args)
 	ExpiresAt      string    `json:"expires_at,omitempty"`   // RFC3339, on confirmation.required
-	StopReason     string    `json:"stop_reason,omitempty"`
+	// Estimate is the server-computed cost envelope on confirmation.required for cost-incurring tools,
+	// so the human approves the exact cost. Opaque JSON (the proposing tool owns the shape).
+	Estimate   json.RawMessage `json:"estimate,omitempty"`
+	StopReason string          `json:"stop_reason,omitempty"`
 }
 
 // EventSink receives turn events as they happen. nil is tolerated.
@@ -250,7 +253,23 @@ func (l *AgentLoop) runLoop(ctx context.Context, actor Actor, authorizer Workspa
 				}
 				continue
 			}
-			pc, err := l.requireConfirmation(ctx, actor, conv, assistantMsg.ID, tc)
+			// Cost-incurring tools produce a server-computed estimate at propose time (after authz,
+			// before the confirmation is persisted) so the human approves the exact cost envelope. If
+			// the estimate cannot be produced, propose nothing and block the batch with synthetic
+			// results — an unpriceable managed action must never reach a confirmation card.
+			estimate, eerr := l.estimateConfirmationCost(ctx, actor, conv, tc)
+			if eerr != nil {
+				for _, btc := range resp.ToolCalls {
+					action, tier := l.actionAndTier(btc.Name)
+					content, reason := "not executed because a required confirmation could not be prepared", "estimate_unavailable"
+					if btc.ID == tc.ID {
+						content = "error: " + eerr.Error()
+					}
+					pmsgs = append(pmsgs, l.appendSyntheticToolResult(ctx, conv, actor, &assistantMsg.ID, nil, btc, action, tier, content, AuditOutcomeError, reason, sink))
+				}
+				continue
+			}
+			pc, err := l.requireConfirmation(ctx, actor, conv, assistantMsg.ID, tc, estimate)
 			if err != nil {
 				sink(Event{Type: EventError, Text: err.Error()})
 				result.StopReason = "error"
@@ -258,7 +277,7 @@ func (l *AgentLoop) runLoop(ctx context.Context, actor Actor, authorizer Workspa
 			}
 			result.StopReason = "confirmation_required"
 			result.PendingConfirmation = &pc
-			sink(Event{Type: EventConfirmationRequired, ToolName: pc.ToolName, ToolCallID: pc.ToolCallID, ConfirmationID: pc.ID.String(), Action: pc.Action, Summary: pc.Summary, PayloadHash: pc.PayloadHash, ExpiresAt: pc.ExpiresAt.UTC().Format(time.RFC3339)})
+			sink(Event{Type: EventConfirmationRequired, ToolName: pc.ToolName, ToolCallID: pc.ToolCallID, ConfirmationID: pc.ID.String(), Action: pc.Action, Summary: pc.Summary, PayloadHash: pc.PayloadHash, Estimate: pc.Estimate, ExpiresAt: pc.ExpiresAt.UTC().Format(time.RFC3339)})
 			return l.finish(result, sink), nil
 		}
 
@@ -297,7 +316,7 @@ func (l *AgentLoop) firstConfirmationTierCall(calls []provider.ToolCall) int {
 // the propose as outcome=confirmation_required. The caller (runLoop) has already authorized the
 // action before reaching here, so a card is never shown for a forbidden action; the api endpoint
 // re-authorizes again on resolve (defense in depth).
-func (l *AgentLoop) requireConfirmation(ctx context.Context, actor Actor, conv Conversation, messageID uuid.UUID, tc provider.ToolCall) (PendingConfirmation, error) {
+func (l *AgentLoop) requireConfirmation(ctx context.Context, actor Actor, conv Conversation, messageID uuid.UUID, tc provider.ToolCall, estimate json.RawMessage) (PendingConfirmation, error) {
 	if l.confirmations == nil {
 		return PendingConfirmation{}, fmt.Errorf("confirmation store not configured for tool %s", tc.Name)
 	}
@@ -317,6 +336,7 @@ func (l *AgentLoop) requireConfirmation(ctx context.Context, actor Actor, conv C
 		PayloadHash:      hash,
 		BoundArgs:        append(json.RawMessage(nil), tc.Arguments...),
 		Summary:          confirmationSummary(tool),
+		Estimate:         estimate,
 		ExpiresAt:        time.Now().Add(l.limits.ConfirmationTTL),
 	})
 	if err != nil {
@@ -330,14 +350,41 @@ func confirmationSummary(tool Tool) string {
 	return "Confirm " + tool.Name() + " (" + string(tool.RiskTier()) + ")"
 }
 
+// estimateConfirmationCost computes the approved cost envelope for a cost-incurring tool at propose
+// time. Only CostIncurringTier tools are estimated; a CostIncurringTier tool MUST implement
+// CostEstimator (a missing implementation is a configuration error and blocks the propose). Non-cost
+// tiers return nil (no estimate). An error propagates so the batch is blocked, not proposed.
+func (l *AgentLoop) estimateConfirmationCost(ctx context.Context, actor Actor, conv Conversation, tc provider.ToolCall) (json.RawMessage, error) {
+	tool, ok := l.registry.Resolve(tc.Name)
+	if !ok || tool.RiskTier() != CostIncurringTier {
+		return nil, nil
+	}
+	estimator, ok := tool.(CostEstimator)
+	if !ok {
+		return nil, fmt.Errorf("cost-incurring tool %s does not implement CostEstimator", tc.Name)
+	}
+	estimate, err := estimator.EstimateCost(ctx, actor, conv, tc.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	if len(estimate) == 0 {
+		return nil, fmt.Errorf("cost estimate for %s was empty", tc.Name)
+	}
+	return estimate, nil
+}
+
 // executeTool resolves, authorizes, runs, redacts, and persists one tool call. It returns the
 // audit record and the provider tool-result message to append. A draft+ tier call writes one
 // audit row (outcome ok/error) regardless of exit path; messageID links the assistant tool-call
 // row and confirmationID is set when this call was resolved from a confirmation.
-func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, tc provider.ToolCall, messageID, confirmationID *uuid.UUID, sink EventSink) (rec ToolInvocationRecord, msg provider.Message) {
+func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer WorkspaceAuthorizer, conv Conversation, tc provider.ToolCall, messageID *uuid.UUID, confirmed *PendingConfirmation, sink EventSink) (rec ToolInvocationRecord, msg provider.Message) {
 	rec = ToolInvocationRecord{ToolName: tc.Name}
 	sink(Event{Type: EventToolCall, ToolName: tc.Name, ToolCallID: tc.ID})
 
+	var confirmationID *uuid.UUID
+	if confirmed != nil {
+		confirmationID = &confirmed.ID
+	}
 	outcome := AuditOutcomeError
 	var resultMeta json.RawMessage
 	defer func() {
@@ -365,7 +412,20 @@ func (l *AgentLoop) executeTool(ctx context.Context, actor Actor, authorizer Wor
 		return rec, fail("error: not authorized for " + tc.Name)
 	}
 
-	out, err := tool.Execute(ctx, actor, conv, tc.Arguments)
+	// The confirmed call dispatches to ExecuteConfirmed (passing the approved confirmation) when the
+	// tool implements it, so a cost-incurring tool reserves exactly the approved estimate. All other
+	// paths use Execute.
+	var out ToolOutput
+	var err error
+	if confirmed != nil && tc.ID == confirmed.ToolCallID {
+		if ct, ok := tool.(ConfirmedTool); ok {
+			out, err = ct.ExecuteConfirmed(ctx, actor, conv, tc.Arguments, *confirmed)
+		} else {
+			out, err = tool.Execute(ctx, actor, conv, tc.Arguments)
+		}
+	} else {
+		out, err = tool.Execute(ctx, actor, conv, tc.Arguments)
+	}
 	if err != nil {
 		rec.Error = err.Error()
 		return rec, fail("error executing " + tc.Name + ": " + err.Error())
@@ -470,7 +530,7 @@ func (l *AgentLoop) ResumeConfirmedTurn(ctx context.Context, actor Actor, author
 			if approve {
 				bound := provider.ToolCall{ID: pc.ToolCallID, Name: pc.ToolName, Arguments: pc.BoundArgs}
 				var rec ToolInvocationRecord
-				rec, toolMsg = l.executeTool(ctx, actor, authorizer, conv, bound, pc.MessageID, &pc.ID, sink)
+				rec, toolMsg = l.executeTool(ctx, actor, authorizer, conv, bound, pc.MessageID, &pc, sink)
 				result.ToolInvocations = append(result.ToolInvocations, rec)
 				toolCalls++
 				// Surface finalization failures: a swallowed MarkSucceeded leaves the row 'executing',

--- a/backend/internal/vibeeval/loop_confirmation_test.go
+++ b/backend/internal/vibeeval/loop_confirmation_test.go
@@ -16,12 +16,19 @@ var errTest = errors.New("test error")
 // --- confirmation/audit fakes ---
 
 type fakeWriteTool struct {
-	name    string
-	action  string
-	tier    RiskTier
-	called  *bool
-	result  any
-	execErr error
+	name        string
+	action      string
+	tier        RiskTier
+	called      *bool
+	result      any
+	execErr     error
+	estimate    json.RawMessage // returned by EstimateCost (cost-incurring tools)
+	estimateErr error
+}
+
+// EstimateCost makes fakeWriteTool a CostEstimator; the loop only calls it for CostIncurringTier tools.
+func (t fakeWriteTool) EstimateCost(context.Context, Actor, Conversation, json.RawMessage) (json.RawMessage, error) {
+	return t.estimate, t.estimateErr
 }
 
 func (t fakeWriteTool) Name() string           { return t.name }
@@ -61,6 +68,7 @@ func (s *fakeConfirmationStore) Create(_ context.Context, nc NewPendingConfirmat
 		PayloadHash:    nc.PayloadHash,
 		BoundArgs:      nc.BoundArgs,
 		Summary:        nc.Summary,
+		Estimate:       nc.Estimate,
 		Status:         "pending",
 		ExpiresAt:      nc.ExpiresAt,
 	}, nil
@@ -482,5 +490,61 @@ func TestRunTurn_PartialLimitsStillGiveConfirmationTTL(t *testing.T) {
 	}
 	if !cs.created[0].ExpiresAt.After(time.Now().Add(time.Minute)) {
 		t.Fatalf("ExpiresAt = %v, want a non-zero TTL well in the future (ConfirmationTTL defaulted)", cs.created[0].ExpiresAt)
+	}
+}
+
+func TestRunTurn_CostIncurringStoresEstimateAndSSE(t *testing.T) {
+	estimate := json.RawMessage(`{"schema_version":1,"kind":"create_run","amount_micros":1500000,"run_id":"11111111-1111-1111-1111-111111111111"}`)
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "create_run", action: "create_run", tier: CostIncurringTier, result: "x", estimate: estimate})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "create_run", Arguments: json.RawMessage(`{"x":1}`)}}},
+	}}
+	cs := &fakeConfirmationStore{}
+	var events []Event
+	res, err := newConfirmLoop(inv, &memStore{}, reg, cs, &fakeAuditWriter{}).RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, conv(), "run it", func(e Event) { events = append(events, e) })
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if res.StopReason != "confirmation_required" {
+		t.Fatalf("stop reason = %q, want confirmation_required", res.StopReason)
+	}
+	if len(cs.created) != 1 || string(cs.created[0].Estimate) != string(estimate) {
+		t.Fatalf("stored estimate = %s, want %s", cs.created[0].Estimate, estimate)
+	}
+	var carried bool
+	for _, e := range events {
+		if e.Type == EventConfirmationRequired && string(e.Estimate) == string(estimate) {
+			carried = true
+		}
+	}
+	if !carried {
+		t.Fatal("confirmation.required SSE must carry the estimate envelope")
+	}
+}
+
+func TestRunTurn_EstimateFailureNoConfirmation(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	reg.Register(fakeWriteTool{name: "create_run", action: "create_run", tier: CostIncurringTier, called: &called, estimateErr: errTest})
+
+	inv := &scriptedInvoker{responses: []provider.Response{
+		{ToolCalls: []provider.ToolCall{{ID: "tc1", Name: "create_run", Arguments: json.RawMessage(`{"x":1}`)}}},
+		{OutputText: "ok"}, // the model reacts after the synthetic error result
+	}}
+	cs := &fakeConfirmationStore{}
+	res, err := newConfirmLoop(inv, &memStore{}, reg, cs, &fakeAuditWriter{}).RunTurn(context.Background(), Actor{UserID: uuid.New()}, allowAll{}, conv(), "run it", nil)
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if len(cs.created) != 0 {
+		t.Fatalf("estimate failure must create NO confirmation, got %d", len(cs.created))
+	}
+	if called {
+		t.Fatal("the tool must not execute when the estimate fails")
+	}
+	if res.StopReason == "confirmation_required" {
+		t.Fatal("must not stop for confirmation when the estimate failed")
 	}
 }

--- a/backend/internal/vibeeval/tool.go
+++ b/backend/internal/vibeeval/tool.go
@@ -23,6 +23,23 @@ type Tool interface {
 	Execute(ctx context.Context, actor Actor, conv Conversation, args json.RawMessage) (ToolOutput, error)
 }
 
+// CostEstimator is implemented by cost-incurring tools. The engine calls EstimateCost at PROPOSE time
+// for CostIncurringTier tools — after authorization, before persisting the confirmation — to produce
+// the server-computed, immutable cost envelope shown on the confirmation card and bound at confirmed
+// execution. The returned JSON is opaque to the engine; the tool owns its shape. An error means the
+// action is unpriceable and MUST NOT be proposed.
+type CostEstimator interface {
+	EstimateCost(ctx context.Context, actor Actor, conv Conversation, args json.RawMessage) (json.RawMessage, error)
+}
+
+// ConfirmedTool is implemented by tools whose confirmed execution must read the approved confirmation
+// (e.g. to reserve exactly the approved cost envelope). On resume, the engine calls ExecuteConfirmed
+// for the matching call instead of Execute, passing the resolved PendingConfirmation. A ConfirmedTool's
+// plain Execute should refuse (the action requires a confirmation's approved estimate).
+type ConfirmedTool interface {
+	ExecuteConfirmed(ctx context.Context, actor Actor, conv Conversation, args json.RawMessage, pc PendingConfirmation) (ToolOutput, error)
+}
+
 // ToolOutput is a tool's result. Result re-enters model context only after redaction
 // (EvidenceRedactor). AuditResult is a metadata-only summary (no secrets/contents); the
 // generalized audit log consumes it in Step 3.

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -36,6 +36,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.FinalizeMultiTurnPostRun, sdkactivity.RegisterOptions{Name: finalizeMultiTurnPostRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
+	registrar.RegisterActivityWithOptions(activities.FinalizeRunCredit, sdkactivity.RegisterOptions{Name: finalizeRunCreditActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateExecution, sdkactivity.RegisterOptions{Name: simulateExecutionActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateEvaluation, sdkactivity.RegisterOptions{Name: simulateEvaluationActivityName})

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -26,6 +26,11 @@ type RunRepository interface {
 	GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, error)
 	ListRunAgentsByRunID(ctx context.Context, runID uuid.UUID) ([]domain.RunAgent, error)
 	GetRunAgentByID(ctx context.Context, id uuid.UUID) (domain.RunAgent, error)
+	// Eval credit settlement (4c): the worker finalizes a managed run's reservation at a terminal state.
+	GetOpenReservationByRunID(ctx context.Context, runID uuid.UUID) (repository.CreditReservation, bool, error)
+	GetRunActualCostMicros(ctx context.Context, runID uuid.UUID) (int64, error)
+	SettleEvalCredit(ctx context.Context, reservationID uuid.UUID, settlementKey string, actualMicros int64, ref repository.CreditRef) error
+	ReleaseEvalCredit(ctx context.Context, reservationID uuid.UUID, releaseKey string, ref repository.CreditRef) error
 	GetRunAgentExecutionContextByID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentExecutionContext, error)
 	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 	CreateEvaluationSpec(ctx context.Context, params repository.CreateEvaluationSpecParams) (repository.EvaluationSpecRecord, error)

--- a/backend/internal/workflow/run_credit.go
+++ b/backend/internal/workflow/run_credit.go
@@ -1,0 +1,53 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+const finalizeRunCreditActivityName = "workflow.finalize_run_credit"
+
+// FinalizeRunCreditInput drives the per-run eval-credit settlement at a terminal RunWorkflow state.
+type FinalizeRunCreditInput struct {
+	RunID          uuid.UUID
+	TerminalStatus string // completed | failed | cancelled
+}
+
+// runCreditStore is the narrow wallet surface FinalizeRunCredit needs (the repository satisfies it;
+// a fake drives the unit tests).
+type runCreditStore interface {
+	GetOpenReservationByRunID(ctx context.Context, runID uuid.UUID) (repository.CreditReservation, bool, error)
+	GetRunActualCostMicros(ctx context.Context, runID uuid.UUID) (int64, error)
+	SettleEvalCredit(ctx context.Context, reservationID uuid.UUID, settlementKey string, actualMicros int64, ref repository.CreditRef) error
+	ReleaseEvalCredit(ctx context.Context, reservationID uuid.UUID, releaseKey string, ref repository.CreditRef) error
+}
+
+// FinalizeRunCredit settles (or releases) a managed run's eval-credit reservation at a terminal state.
+// Idempotent at the wallet layer (Settle/Release are terminal on the reservation), so Temporal
+// retry/replay is safe.
+func (a *Activities) FinalizeRunCredit(ctx context.Context, input FinalizeRunCreditInput) error {
+	return finalizeRunCredit(ctx, a.repo, input)
+}
+
+func finalizeRunCredit(ctx context.Context, store runCreditStore, input FinalizeRunCreditInput) error {
+	res, found, err := store.GetOpenReservationByRunID(ctx, input.RunID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		// No managed reservation — BYOK or an unmanaged run. Nothing to finalize.
+		return nil
+	}
+	actual, err := store.GetRunActualCostMicros(ctx, input.RunID)
+	if err != nil {
+		return err
+	}
+	ref := repository.CreditRef{RunID: &input.RunID, Reason: "run " + input.TerminalStatus}
+	// Settle observed spend; release when nothing was spent (driven by actual cost, not terminal status).
+	if actual > 0 {
+		return store.SettleEvalCredit(ctx, res.ID, "run:"+input.RunID.String()+":settle", actual, ref)
+	}
+	return store.ReleaseEvalCredit(ctx, res.ID, "run:"+input.RunID.String()+":release", ref)
+}

--- a/backend/internal/workflow/run_credit_test.go
+++ b/backend/internal/workflow/run_credit_test.go
@@ -1,0 +1,62 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeRunCreditStore struct {
+	reservation repository.CreditReservation
+	found       bool
+	cost        int64
+	settled     []int64
+	released    int
+}
+
+func (f *fakeRunCreditStore) GetOpenReservationByRunID(context.Context, uuid.UUID) (repository.CreditReservation, bool, error) {
+	return f.reservation, f.found, nil
+}
+func (f *fakeRunCreditStore) GetRunActualCostMicros(context.Context, uuid.UUID) (int64, error) {
+	return f.cost, nil
+}
+func (f *fakeRunCreditStore) SettleEvalCredit(_ context.Context, _ uuid.UUID, _ string, micros int64, _ repository.CreditRef) error {
+	f.settled = append(f.settled, micros)
+	return nil
+}
+func (f *fakeRunCreditStore) ReleaseEvalCredit(context.Context, uuid.UUID, string, repository.CreditRef) error {
+	f.released++
+	return nil
+}
+
+func TestFinalizeRunCredit_SettlesObservedSpend(t *testing.T) {
+	f := &fakeRunCreditStore{found: true, reservation: repository.CreditReservation{ID: uuid.New(), AmountMicros: 1_000_000}, cost: 600_000}
+	if err := finalizeRunCredit(context.Background(), f, FinalizeRunCreditInput{RunID: uuid.New(), TerminalStatus: "completed"}); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if len(f.settled) != 1 || f.settled[0] != 600_000 || f.released != 0 {
+		t.Fatalf("settled=%v released=%d, want one settle of 600k, no release", f.settled, f.released)
+	}
+}
+
+func TestFinalizeRunCredit_ReleasesWhenZeroCost(t *testing.T) {
+	f := &fakeRunCreditStore{found: true, reservation: repository.CreditReservation{ID: uuid.New(), AmountMicros: 1_000_000}, cost: 0}
+	if err := finalizeRunCredit(context.Background(), f, FinalizeRunCreditInput{RunID: uuid.New(), TerminalStatus: "failed"}); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if f.released != 1 || len(f.settled) != 0 {
+		t.Fatalf("released=%d settled=%v, want one release, no settle", f.released, f.settled)
+	}
+}
+
+func TestFinalizeRunCredit_NoReservationIsNoop(t *testing.T) {
+	f := &fakeRunCreditStore{found: false} // BYOK / unmanaged run
+	if err := finalizeRunCredit(context.Background(), f, FinalizeRunCreditInput{RunID: uuid.New(), TerminalStatus: "completed"}); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if len(f.settled) != 0 || f.released != 0 {
+		t.Fatalf("settled=%v released=%d, want no-op", f.settled, f.released)
+	}
+}

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -26,6 +26,27 @@ var defaultActivityOptions = sdkworkflow.ActivityOptions{
 	},
 }
 
+// finalizeRunCreditActivityOptions retries eval-credit settlement generously — defaultActivityOptions
+// is MaximumAttempts:1, but financial correctness must survive transient DB hiccups.
+var finalizeRunCreditActivityOptions = sdkworkflow.ActivityOptions{
+	StartToCloseTimeout: defaultActivityTimeout,
+	RetryPolicy: &temporal.RetryPolicy{
+		MaximumAttempts:    8,
+		InitialInterval:    time.Second,
+		BackoffCoefficient: 2.0,
+		MaximumInterval:    30 * time.Second,
+	},
+}
+
+// executeFinalizeRunCredit runs the FinalizeRunCredit activity (idempotent settlement/release) with
+// dedicated retry options on the given context.
+func executeFinalizeRunCredit(ctx sdkworkflow.Context, runID uuid.UUID, terminalStatus string) error {
+	finalizeCtx := sdkworkflow.WithActivityOptions(ctx, finalizeRunCreditActivityOptions)
+	return sdkworkflow.ExecuteActivity(finalizeCtx, finalizeRunCreditActivityName, FinalizeRunCreditInput{
+		RunID: runID, TerminalStatus: terminalStatus,
+	}).Get(finalizeCtx, nil)
+}
+
 func RunWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	ctx = sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions)
 
@@ -88,6 +109,11 @@ func runWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	}
 	scoreSummary, err := scoreEvaluatingRunAgents(ctx, input.RunID, updatedRunAgents)
 	if err != nil {
+		return err
+	}
+	// Settle eval credit before completing — block the Completed transition until finalization succeeds
+	// (the activity is idempotent + retried). The scorecard is persisted by scoring above.
+	if err := executeFinalizeRunCredit(ctx, input.RunID, "completed"); err != nil {
 		return err
 	}
 	if err := transitionRunStatus(ctx, input.RunID, domain.RunStatusCompleted, stringPtr(scoreSummary)); err != nil {
@@ -300,6 +326,11 @@ func markRunFailed(ctx sdkworkflow.Context, runID uuid.UUID, workflowErr error) 
 		return fmt.Errorf("run workflow failed: %v; additionally failed to mark run failed: %w", workflowErr, activityErr)
 	}
 
+	// Cleanup AFTER the terminal transition: finalize eval credit (settle observed spend, else release)
+	// best-effort + retried. The run-failure outcome is authoritative and must not be blocked or masked
+	// by a settlement hiccup; a persistently stuck reservation is recoverable later (reaper — future work).
+	_ = executeFinalizeRunCredit(ctx, runID, "failed")
+
 	return workflowErr
 }
 
@@ -327,6 +358,10 @@ func markRunCancelled(ctx sdkworkflow.Context, runID uuid.UUID, workflowErr erro
 		}
 		return fmt.Errorf("run workflow cancelled: %v; additionally failed to mark run cancelled: %w", workflowErr, activityErr)
 	}
+
+	// Cleanup AFTER the terminal transition: finalize eval credit (release the hold for a
+	// cancelled-before-spend run) best-effort + retried on the disconnected context.
+	_ = executeFinalizeRunCredit(disconnectedCtx, runID, "cancelled")
 
 	return workflowErr
 }

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -1562,6 +1562,20 @@ func (r *fakeRunRepository) GetRunByID(_ context.Context, id uuid.UUID) (domain.
 	return cloneRun(r.run), nil
 }
 
+// Eval-credit settlement stubs (4c): no managed reservation by default → FinalizeRunCredit no-ops.
+func (r *fakeRunRepository) GetOpenReservationByRunID(_ context.Context, _ uuid.UUID) (repository.CreditReservation, bool, error) {
+	return repository.CreditReservation{}, false, nil
+}
+func (r *fakeRunRepository) GetRunActualCostMicros(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (r *fakeRunRepository) SettleEvalCredit(_ context.Context, _ uuid.UUID, _ string, _ int64, _ repository.CreditRef) error {
+	return nil
+}
+func (r *fakeRunRepository) ReleaseEvalCredit(_ context.Context, _ uuid.UUID, _ string, _ repository.CreditRef) error {
+	return nil
+}
+
 func (r *fakeRunRepository) ListRunAgentsByRunID(_ context.Context, runID uuid.UUID) ([]domain.RunAgent, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -8413,12 +8413,14 @@ components:
 
     WorkspaceUsageSnapshot:
       type: object
-      required: [workspace_id, race_count, active_runs, window_start, window_end]
+      required: [workspace_id, race_count, guide_agent_turn_count, active_runs, window_start, window_end]
       properties:
         workspace_id:
           type: string
           format: uuid
         race_count:
+          type: integer
+        guide_agent_turn_count:
           type: integer
         active_runs:
           type: integer
@@ -8518,6 +8520,7 @@ components:
           billing_period,
           status,
           monthly_races,
+          monthly_guide_agent_turns,
           concurrent_races,
           seats,
           window_start,
@@ -8537,6 +8540,8 @@ components:
         status:
           type: string
         monthly_races:
+          $ref: "#/components/schemas/QuotaCounter"
+        monthly_guide_agent_turns:
           $ref: "#/components/schemas/QuotaCounter"
         concurrent_races:
           $ref: "#/components/schemas/QuotaCounter"


### PR DESCRIPTION
## What & why
The financial subsystem for the Vibe Eval guide agent (epic #875) — **please review carefully; every surface is fail-closed.** Adds the per-org eval-credit wallet, cross-plane settlement, the cost-incurring guide tools, and a per-workspace guide-turn allowance kept distinct from the wallet.

- **Wallet (4a–4c):** immutable ledger, integer micros, atomic conditional reserve→settle/release; **$3 seeded** in both org-creation paths + idempotent backfill; cross-plane settlement from a worker `FinalizeRunCredit` activity at terminal run states (cost from per-agent scorecards; replay-safe/idempotent).
- **Cost-incurring tools (4d):** `estimate_eval_cost` (conservative-or-block; **frozen** model-alias pricing, never live catalog); `create_run` + `create_eval_session` through the confirmation engine — the approved cost envelope is bound to the confirmation and reserved **exactly** (never recomputed) **atomically** with run creation, idempotent on a preallocated run/session id, **same-effect verified** before any idempotent return; insufficient → rollback both; workflow-start failure after commit → **success-with-warning** (effect-created), never terminal failed.
- **Guide-turn allowance (4e):** monthly per-workspace quota on `workspace_usage_windows.guide_agent_turn_count`, hard-blocked **pre-SSE** with a friendly 402, distinct from the $3 wallet; mirrors race-quota machinery (stored entitlement + atomic `FOR UPDATE` consume). Per-plan: Free 50 / Pro 1000·seats / Team 4000·seats / Enterprise unlimited. Meters fresh turns + genuine approves; deny + invalid resolves are uncounted.

**Stack position:** PR 4 of 4 (top). Base is `feat/vibe-eval-3-confirmation` (PR 3).

## Scope
60 files, +5,296/−268. Migrations **00061–00063** (`org_eval_credit_wallet`, `backfill_eval_credit_seed`, `guide_agent_turn_allowance`).

## Test plan (proofs) — throwaway PG17 integration
- **4a** — 11 invariant tests (reserve/settle/release idempotency, parallel-reserve race, overage-never-negative, ledger reconciliation).
- **4b** — seed + backfill (no-org-without-wallet, down-reconcile).
- **4c** — settle/release/no-op + replay idempotency.
- **4d** — estimate matrix + reserve+create atomicity, insufficient→rollback, idempotent retry + same-effect mismatch, workflow-start→success-with-warning, REST no-wallet-side-effect.
- **4e** — atomic quota consume, concurrent last-turn race, pre-SSE block, approve-counted / deny-uncounted / invalid-uncounted, unlimited.
- `go build/vet` clean.

## Reviewer notes
- Follow-up logged (NOT in this PR): if model aliases are mutable under an existing snapshot, freeze model/rate onto the deployment snapshot (or extend the lane guard) rather than reading the alias.
- Known unrelated: 14 run-event/replay + 2 harness tests fail on clean HEAD too (Windows/throwaway-DB env) — not introduced here.

## Out of scope (design §10)
Step 5 (analyze/regress), Step 6 (admin/public-share), frontend #874.
