### PR TITLE
feat(challenge-packs): ready-made pack library with one-click instantiate

### DIFF
--- a/backend/db/queries/challenge_packs.sql
+++ b/backend/db/queries/challenge_packs.sql
@@ -11,3 +11,15 @@ WHERE challenge_pack_id = @challenge_pack_id
   AND lifecycle_status = 'runnable'
   AND archived_at IS NULL
 ORDER BY created_at DESC;
+
+-- name: GetWorkspaceChallengePackVersionBySlug :one
+SELECT p.id AS challenge_pack_id, v.id AS challenge_pack_version_id
+FROM challenge_packs p
+JOIN challenge_pack_versions v ON v.challenge_pack_id = p.id
+WHERE p.workspace_id = sqlc.arg(workspace_id)::uuid
+  AND p.slug = @slug
+  AND p.archived_at IS NULL
+  AND v.lifecycle_status = 'runnable'
+  AND v.archived_at IS NULL
+ORDER BY v.version_number DESC
+LIMIT 1;

--- a/backend/internal/api/challenge_pack_catalog.go
+++ b/backend/internal/api/challenge_pack_catalog.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+)
+
+var errCatalogPackNotFound = errors.New("challenge pack catalog entry not found")
+
+// challengePackCatalogListHandler serves the curated library of ready-to-run
+// challenge packs — the full-pack analogue of GET /challenge-piece-library. It
+// is a global, read-only catalog (not workspace-scoped), so it needs no
+// workspace authorization beyond being an authenticated request. The heavy YAML
+// body is omitted from list responses; fetch the detail endpoint for it.
+func challengePackCatalogListHandler(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entries, err := challengepack.Catalog()
+		if err != nil {
+			logger.Error("load challenge pack catalog failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		family := strings.TrimSpace(r.URL.Query().Get("family"))
+		category := strings.TrimSpace(r.URL.Query().Get("category"))
+
+		items := make([]challengepack.CatalogEntry, 0, len(entries))
+		for _, entry := range entries {
+			if family != "" && !strings.EqualFold(entry.Family, family) {
+				continue
+			}
+			if category != "" && !strings.EqualFold(entry.Category, category) {
+				continue
+			}
+			items = append(items, entry.Summary())
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	}
+}
+
+// challengePackCatalogDetailHandler returns one catalog entry including its raw
+// runnable YAML, for the library detail view.
+func challengePackCatalogDetailHandler(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := strings.TrimSpace(chi.URLParam(r, "slug"))
+		entry, ok, err := challengepack.CatalogBySlug(slug)
+		if err != nil {
+			logger.Error("load challenge pack catalog entry failed", "slug", slug, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+		if !ok {
+			writeError(w, http.StatusNotFound, "not_found", "challenge pack catalog entry not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, entry)
+	}
+}
+
+// instantiateChallengePackCatalogHandler clones a curated catalog pack into the
+// caller's workspace as a runnable, fully-owned pack.
+//
+// It deliberately does NOT apply the FeaturePrivateChallengePacks entitlement
+// gate that publishChallengePackHandler uses: the curated library is the free
+// activation on-ramp, and the paywall stays on authoring (raw-YAML publish +
+// builder publish). To gate it later, thread an EntitlementGateService in here
+// and check the feature exactly as publishChallengePackHandler does.
+func instantiateChallengePackCatalogHandler(logger *slog.Logger, service ChallengePackAuthoringService, authorizer WorkspaceAuthorizer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, workspaceID, ActionPublishChallengePack); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		slug := strings.TrimSpace(chi.URLParam(r, "slug"))
+		result, err := service.InstantiateCatalogPack(r.Context(), workspaceID, slug)
+		if err != nil {
+			var validationErr ChallengePackAuthoringValidationError
+			switch {
+			case errors.Is(err, errCatalogPackNotFound):
+				writeError(w, http.StatusNotFound, "not_found", "challenge pack catalog entry not found")
+			case errors.As(err, &validationErr):
+				// A catalog pack that fails validation is a server-side content
+				// bug (CI guards against it), not a client error.
+				logger.Error("catalog pack failed validation on instantiate", "slug", slug, "errors", validationErr.Errors)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			case errors.Is(err, repository.ErrChallengePackMetadataConflict):
+				writeError(w, http.StatusConflict, "challenge_pack_metadata_conflict", err.Error())
+			default:
+				logger.Error("instantiate challenge pack catalog request failed", "slug", slug, "error", err)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		status := http.StatusCreated
+		if result.AlreadyExisted {
+			status = http.StatusOK
+		}
+		writeJSON(w, status, result)
+	}
+}

--- a/backend/internal/api/challenge_pack_catalog.go
+++ b/backend/internal/api/challenge_pack_catalog.go
@@ -105,6 +105,8 @@ func instantiateChallengePackCatalogHandler(logger *slog.Logger, service Challen
 				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
 			case errors.Is(err, repository.ErrChallengePackMetadataConflict):
 				writeError(w, http.StatusConflict, "challenge_pack_metadata_conflict", err.Error())
+			case errors.Is(err, repository.ErrChallengePackVersionExists):
+				writeError(w, http.StatusConflict, "challenge_pack_version_exists", err.Error())
 			default:
 				logger.Error("instantiate challenge pack catalog request failed", "slug", slug, "error", err)
 				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/backend/internal/api/challenge_pack_catalog_test.go
+++ b/backend/internal/api/challenge_pack_catalog_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -178,6 +179,19 @@ func TestInstantiateCatalogPackManagerIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInstantiateCatalogPackManagerReturnsConflictWhenExistingPackIsNotRunnable(t *testing.T) {
+	repo := &fakeChallengePackAuthoringRepository{
+		publishErr:  repository.ErrChallengePackVersionExists,
+		bySlugFound: false,
+	}
+	manager := NewChallengePackAuthoringManager(repo, nil)
+
+	_, err := manager.InstantiateCatalogPack(context.Background(), uuid.New(), "text-to-sql")
+	if !errors.Is(err, repository.ErrChallengePackVersionExists) {
+		t.Fatalf("error = %v, want ErrChallengePackVersionExists", err)
+	}
+}
+
 func TestInstantiateCatalogPackManagerUnknownSlug(t *testing.T) {
 	manager := NewChallengePackAuthoringManager(&fakeChallengePackAuthoringRepository{}, nil)
 	_, err := manager.InstantiateCatalogPack(context.Background(), uuid.New(), "does-not-exist")
@@ -218,6 +232,34 @@ func TestInstantiateChallengePackCatalogHandlerReturnsCreated(t *testing.T) {
 	}
 	if !response.Runnable {
 		t.Error("Runnable = false, want true")
+	}
+}
+
+func TestInstantiateChallengePackCatalogHandlerReturnsConflictWhenExistingPackIsNotRunnable(t *testing.T) {
+	logger := catalogTestLogger()
+	service := NewChallengePackAuthoringManager(&fakeChallengePackAuthoringRepository{
+		publishErr:  repository.ErrChallengePackVersionExists,
+		bySlugFound: false,
+	}, nil)
+	workspaceID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/challenge-pack-catalog/text-to-sql/instantiate", nil)
+	req = withChiURLParam(req, "slug", "text-to-sql")
+	ctx := context.WithValue(req.Context(), callerContextKey{}, Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceAdmin},
+		},
+	})
+	ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	instantiateChallengePackCatalogHandler(logger, service, NewCallerWorkspaceAuthorizer()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/backend/internal/api/challenge_pack_catalog_test.go
+++ b/backend/internal/api/challenge_pack_catalog_test.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func catalogTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func withChiURLParam(req *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestChallengePackCatalogListHandlerReturnsItems(t *testing.T) {
+	handler := challengePackCatalogListHandler(catalogTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/v1/challenge-pack-catalog", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Items []struct {
+			Slug     string `json:"slug"`
+			Category string `json:"category"`
+			YAML     string `json:"yaml"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(response.Items) == 0 {
+		t.Fatal("expected catalog items")
+	}
+	found := false
+	for _, item := range response.Items {
+		if item.Slug == "text-to-sql" {
+			found = true
+		}
+		if item.YAML != "" {
+			t.Errorf("list response must omit yaml; %s included it", item.Slug)
+		}
+		if item.Category == "" {
+			t.Errorf("%s has empty category", item.Slug)
+		}
+	}
+	if !found {
+		t.Error("expected text-to-sql in the catalog list")
+	}
+}
+
+func TestChallengePackCatalogListHandlerFiltersByCategory(t *testing.T) {
+	handler := challengePackCatalogListHandler(catalogTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/v1/challenge-pack-catalog?category=enterprise", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var response struct {
+		Items []struct {
+			Category string `json:"category"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(response.Items) == 0 {
+		t.Fatal("expected at least one enterprise pack")
+	}
+	for _, item := range response.Items {
+		if item.Category != challengepackCategoryEnterprise {
+			t.Errorf("category = %q, want enterprise", item.Category)
+		}
+	}
+}
+
+const challengepackCategoryEnterprise = "enterprise"
+
+func TestChallengePackCatalogDetailHandlerReturnsYAML(t *testing.T) {
+	handler := challengePackCatalogDetailHandler(catalogTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/v1/challenge-pack-catalog/json-output-conformance", nil)
+	req = withChiURLParam(req, "slug", "json-output-conformance")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Slug string `json:"slug"`
+		YAML string `json:"yaml"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.Slug != "json-output-conformance" {
+		t.Fatalf("slug = %q", response.Slug)
+	}
+	if response.YAML == "" {
+		t.Fatal("detail response must include yaml")
+	}
+}
+
+func TestChallengePackCatalogDetailHandlerNotFound(t *testing.T) {
+	handler := challengePackCatalogDetailHandler(catalogTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/v1/challenge-pack-catalog/nope", nil)
+	req = withChiURLParam(req, "slug", "nope")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestInstantiateCatalogPackManagerCreatesPack(t *testing.T) {
+	repo := &fakeChallengePackAuthoringRepository{}
+	manager := NewChallengePackAuthoringManager(repo, nil)
+
+	result, err := manager.InstantiateCatalogPack(context.Background(), uuid.New(), "json-output-conformance")
+	if err != nil {
+		t.Fatalf("InstantiateCatalogPack: %v", err)
+	}
+	if result.AlreadyExisted {
+		t.Error("AlreadyExisted = true, want false for a fresh clone")
+	}
+	if !result.Runnable {
+		t.Error("Runnable = false, want true")
+	}
+	if result.ChallengePackID == uuid.Nil || result.ChallengePackVersionID == uuid.Nil {
+		t.Fatal("expected non-nil pack and version ids")
+	}
+	if result.Slug != "json-output-conformance" {
+		t.Fatalf("slug = %q", result.Slug)
+	}
+}
+
+func TestInstantiateCatalogPackManagerIsIdempotent(t *testing.T) {
+	existingPackID := uuid.New()
+	existingVersionID := uuid.New()
+	repo := &fakeChallengePackAuthoringRepository{
+		publishErr:   repository.ErrChallengePackVersionExists,
+		bySlugPackID: existingPackID,
+		bySlugVerID:  existingVersionID,
+		bySlugFound:  true,
+	}
+	manager := NewChallengePackAuthoringManager(repo, nil)
+
+	result, err := manager.InstantiateCatalogPack(context.Background(), uuid.New(), "text-to-sql")
+	if err != nil {
+		t.Fatalf("InstantiateCatalogPack: %v", err)
+	}
+	if !result.AlreadyExisted {
+		t.Error("AlreadyExisted = false, want true when the pack already exists")
+	}
+	if result.ChallengePackID != existingPackID || result.ChallengePackVersionID != existingVersionID {
+		t.Fatalf("ids = %s/%s, want %s/%s", result.ChallengePackID, result.ChallengePackVersionID, existingPackID, existingVersionID)
+	}
+}
+
+func TestInstantiateCatalogPackManagerUnknownSlug(t *testing.T) {
+	manager := NewChallengePackAuthoringManager(&fakeChallengePackAuthoringRepository{}, nil)
+	_, err := manager.InstantiateCatalogPack(context.Background(), uuid.New(), "does-not-exist")
+	if err != errCatalogPackNotFound {
+		t.Fatalf("error = %v, want errCatalogPackNotFound", err)
+	}
+}
+
+func TestInstantiateChallengePackCatalogHandlerReturnsCreated(t *testing.T) {
+	logger := catalogTestLogger()
+	service := NewChallengePackAuthoringManager(&fakeChallengePackAuthoringRepository{}, nil)
+	workspaceID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/challenge-pack-catalog/text-to-sql/instantiate", nil)
+	req = withChiURLParam(req, "slug", "text-to-sql")
+	ctx := context.WithValue(req.Context(), callerContextKey{}, Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceAdmin},
+		},
+	})
+	ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	instantiateChallengePackCatalogHandler(logger, service, NewCallerWorkspaceAuthorizer()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var response InstantiateCatalogPackResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.ChallengePackID == uuid.Nil || response.ChallengePackVersionID == uuid.Nil {
+		t.Fatal("expected non-nil ids")
+	}
+	if !response.Runnable {
+		t.Error("Runnable = false, want true")
+	}
+}
+
+func TestInstantiateChallengePackCatalogHandlerUnknownSlug(t *testing.T) {
+	logger := catalogTestLogger()
+	service := NewChallengePackAuthoringManager(&fakeChallengePackAuthoringRepository{}, nil)
+	workspaceID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/challenge-pack-catalog/nope/instantiate", nil)
+	req = withChiURLParam(req, "slug", "nope")
+	ctx := context.WithValue(req.Context(), callerContextKey{}, Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceAdmin},
+		},
+	})
+	ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	instantiateChallengePackCatalogHandler(logger, service, NewCallerWorkspaceAuthorizer()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -122,11 +122,13 @@ type ChallengePackAuthoringRepository interface {
 	GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (repository.Artifact, error)
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
 	PublishChallengePackBundle(ctx context.Context, params repository.PublishChallengePackBundleParams) (repository.PublishedChallengePack, error)
+	GetWorkspaceChallengePackVersionBySlug(ctx context.Context, workspaceID uuid.UUID, slug string) (uuid.UUID, uuid.UUID, bool, error)
 }
 
 type ChallengePackAuthoringService interface {
 	ValidateBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (ValidateChallengePackResponse, error)
 	PublishBundle(ctx context.Context, workspaceID uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error)
+	InstantiateCatalogPack(ctx context.Context, workspaceID uuid.UUID, slug string) (InstantiateCatalogPackResponse, error)
 }
 
 type ChallengePackAuthoringManager struct {
@@ -240,6 +242,68 @@ func (m *ChallengePackAuthoringManager) PublishBundle(ctx context.Context, works
 		EvaluationSpecID:       published.EvaluationSpecID,
 		InputSetIDs:            published.InputSetIDs,
 		BundleArtifactID:       published.BundleArtifactID,
+	}, nil
+}
+
+// InstantiateCatalogPackResponse is returned when a curated catalog pack is
+// cloned into a workspace. On a fresh clone it carries the full publish result;
+// when the workspace already has the pack (AlreadyExisted), it carries the
+// existing pack + its latest runnable version so the caller can run it right away.
+type InstantiateCatalogPackResponse struct {
+	ChallengePackID        uuid.UUID   `json:"challenge_pack_id"`
+	ChallengePackVersionID uuid.UUID   `json:"challenge_pack_version_id"`
+	EvaluationSpecID       *uuid.UUID  `json:"evaluation_spec_id,omitempty"`
+	InputSetIDs            []uuid.UUID `json:"input_set_ids,omitempty"`
+	Slug                   string      `json:"slug"`
+	AlreadyExisted         bool        `json:"already_existed"`
+	Runnable               bool        `json:"runnable"`
+}
+
+// InstantiateCatalogPack clones a curated library pack (by slug) into the
+// workspace by republishing its embedded YAML through the normal authoring
+// path, so the result is an ordinary, runnable, fully-owned workspace pack the
+// user can run immediately or open in the builder to tweak.
+//
+// It is idempotent: adding the same template twice returns the existing pack
+// instead of failing on the (challenge_pack_id, version_number) uniqueness
+// constraint.
+func (m *ChallengePackAuthoringManager) InstantiateCatalogPack(ctx context.Context, workspaceID uuid.UUID, slug string) (InstantiateCatalogPackResponse, error) {
+	entry, ok, err := challengepack.CatalogBySlug(slug)
+	if err != nil {
+		return InstantiateCatalogPackResponse{}, err
+	}
+	if !ok {
+		return InstantiateCatalogPackResponse{}, errCatalogPackNotFound
+	}
+
+	published, err := m.PublishBundle(ctx, workspaceID, []byte(entry.YAML))
+	if err != nil {
+		if errors.Is(err, repository.ErrChallengePackVersionExists) {
+			packID, versionID, found, lookupErr := m.repo.GetWorkspaceChallengePackVersionBySlug(ctx, workspaceID, entry.Slug)
+			if lookupErr != nil {
+				return InstantiateCatalogPackResponse{}, lookupErr
+			}
+			if found {
+				return InstantiateCatalogPackResponse{
+					ChallengePackID:        packID,
+					ChallengePackVersionID: versionID,
+					Slug:                   entry.Slug,
+					AlreadyExisted:         true,
+					Runnable:               true,
+				}, nil
+			}
+		}
+		return InstantiateCatalogPackResponse{}, err
+	}
+
+	return InstantiateCatalogPackResponse{
+		ChallengePackID:        published.ChallengePackID,
+		ChallengePackVersionID: published.ChallengePackVersionID,
+		EvaluationSpecID:       &published.EvaluationSpecID,
+		InputSetIDs:            published.InputSetIDs,
+		Slug:                   entry.Slug,
+		AlreadyExisted:         false,
+		Runnable:               true,
 	}, nil
 }
 

--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -292,6 +292,7 @@ func (m *ChallengePackAuthoringManager) InstantiateCatalogPack(ctx context.Conte
 					Runnable:               true,
 				}, nil
 			}
+			return InstantiateCatalogPackResponse{}, fmt.Errorf("catalog pack %q already exists but has no runnable version: %w", entry.Slug, repository.ErrChallengePackVersionExists)
 		}
 		return InstantiateCatalogPackResponse{}, err
 	}

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -82,6 +82,7 @@ type fakeChallengePackAuthoringRepository struct {
 	bySlugPackID uuid.UUID
 	bySlugVerID  uuid.UUID
 	bySlugFound  bool
+	bySlugErr    error
 }
 
 func (f *fakeChallengePackAuthoringRepository) GetArtifactByID(_ context.Context, artifactID uuid.UUID) (repository.Artifact, error) {
@@ -111,6 +112,9 @@ func (f *fakeChallengePackAuthoringRepository) PublishChallengePackBundle(_ cont
 }
 
 func (f *fakeChallengePackAuthoringRepository) GetWorkspaceChallengePackVersionBySlug(_ context.Context, _ uuid.UUID, _ string) (uuid.UUID, uuid.UUID, bool, error) {
+	if f.bySlugErr != nil {
+		return uuid.Nil, uuid.Nil, false, f.bySlugErr
+	}
 	return f.bySlugPackID, f.bySlugVerID, f.bySlugFound, nil
 }
 

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -77,7 +77,11 @@ func (f *fakeChallengePackReadRepository) ListChallengeInputSetsByVersionID(_ co
 }
 
 type fakeChallengePackAuthoringRepository struct {
-	published repository.PublishedChallengePack
+	published    repository.PublishedChallengePack
+	publishErr   error
+	bySlugPackID uuid.UUID
+	bySlugVerID  uuid.UUID
+	bySlugFound  bool
 }
 
 func (f *fakeChallengePackAuthoringRepository) GetArtifactByID(_ context.Context, artifactID uuid.UUID) (repository.Artifact, error) {
@@ -92,6 +96,9 @@ func (f *fakeChallengePackAuthoringRepository) GetOrganizationIDByWorkspaceID(_ 
 }
 
 func (f *fakeChallengePackAuthoringRepository) PublishChallengePackBundle(_ context.Context, _ repository.PublishChallengePackBundleParams) (repository.PublishedChallengePack, error) {
+	if f.publishErr != nil {
+		return repository.PublishedChallengePack{}, f.publishErr
+	}
 	if f.published.ChallengePackID == uuid.Nil {
 		f.published = repository.PublishedChallengePack{
 			ChallengePackID:        uuid.New(),
@@ -101,6 +108,10 @@ func (f *fakeChallengePackAuthoringRepository) PublishChallengePackBundle(_ cont
 		}
 	}
 	return f.published, nil
+}
+
+func (f *fakeChallengePackAuthoringRepository) GetWorkspaceChallengePackVersionBySlug(_ context.Context, _ uuid.UUID, _ string) (uuid.UUID, uuid.UUID, bool, error) {
+	return f.bySlugPackID, f.bySlugVerID, f.bySlugFound, nil
 }
 
 type fakeChallengePackEntitlementGate struct {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -232,7 +232,11 @@ func registerProtectedRoutes(
 		Post("/workspaces/{workspaceID}/challenge-packs", publishChallengePackHandler(logger, challengePackAuthoringService, authorizer, entitlementGate))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/challenge-packs/validate", validateChallengePackHandler(logger, challengePackAuthoringService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/challenge-pack-catalog/{slug}/instantiate", instantiateChallengePackCatalogHandler(logger, challengePackAuthoringService, authorizer))
 	router.Get("/challenge-piece-library", challengePieceLibraryHandler(logger))
+	router.Get("/challenge-pack-catalog", challengePackCatalogListHandler(logger))
+	router.Get("/challenge-pack-catalog/{slug}", challengePackCatalogDetailHandler(logger))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-pieces", listChallengePiecesHandler(logger, challengePackBuilderService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -652,3 +652,7 @@ func (noopChallengePackAuthoringService) ValidateBundle(_ context.Context, _ uui
 func (noopChallengePackAuthoringService) PublishBundle(_ context.Context, _ uuid.UUID, _ []byte) (PublishChallengePackResponse, error) {
 	return PublishChallengePackResponse{}, errors.New("challenge pack authoring service is not configured")
 }
+
+func (noopChallengePackAuthoringService) InstantiateCatalogPack(_ context.Context, _ uuid.UUID, _ string) (InstantiateCatalogPackResponse, error) {
+	return InstantiateCatalogPackResponse{}, errors.New("challenge pack authoring service is not configured")
+}

--- a/backend/internal/api/test_helpers_test.go
+++ b/backend/internal/api/test_helpers_test.go
@@ -27,6 +27,10 @@ func (stubChallengePackAuthoringService) PublishBundle(_ context.Context, _ uuid
 	return PublishChallengePackResponse{}, errors.New("not implemented")
 }
 
+func (stubChallengePackAuthoringService) InstantiateCatalogPack(_ context.Context, _ uuid.UUID, _ string) (InstantiateCatalogPackResponse, error) {
+	return InstantiateCatalogPackResponse{}, errors.New("not implemented")
+}
+
 func (stubAgentBuildService) CreateBuild(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildInput) (repository.AgentBuild, error) {
 	return repository.AgentBuild{}, errors.New("not implemented")
 }

--- a/backend/internal/challengepack/catalog.go
+++ b/backend/internal/challengepack/catalog.go
@@ -1,0 +1,228 @@
+package challengepack
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// catalogFS embeds the curated, ready-to-run challenge packs shipped as the
+// product "library". Each file is a complete, runnable bundle (same schema as
+// examples/challenge-packs/*.yaml) with small inline fixtures so it runs
+// out-of-the-box and doubles as a template users clone and tweak. The catalog
+// is the global, in-code analogue of StarterPieceLibrary (see library.go) but
+// for full packs rather than individual pieces.
+//
+//go:embed catalog/*.yaml
+var catalogFS embed.FS
+
+const catalogDir = "catalog"
+
+// CatalogCategory groups packs for the library gallery. Editorial, not
+// load-bearing for execution.
+const (
+	CatalogCategoryEnterprise      = "enterprise"
+	CatalogCategoryAgentCapability = "agent_capability"
+	CatalogCategorySafety          = "safety"
+)
+
+// CatalogEntry is one curated pack in the library. Runnable fields (Slug, Name,
+// Family, Description, ExecutionMode, Difficulty, SpecCard) are derived from the
+// parsed Bundle so they can never drift from what actually runs; editorial
+// fields (Category, Tags, EstimatedCostUSD, EstimatedRuntimeMS) come from the
+// catalogMetadata registry below, since the bundle schema has no home for them.
+type CatalogEntry struct {
+	Slug               string   `json:"slug"`
+	Name               string   `json:"name"`
+	Family             string   `json:"family"`
+	Category           string   `json:"category,omitempty"`
+	Tags               []string `json:"tags,omitempty"`
+	Description        string   `json:"description,omitempty"`
+	Difficulty         string   `json:"difficulty,omitempty"`
+	ExecutionMode      string   `json:"execution_mode"`
+	EstimatedCostUSD   *float64 `json:"estimated_cost_usd,omitempty"`
+	EstimatedRuntimeMS *int64   `json:"estimated_runtime_ms,omitempty"`
+	SpecCard           SpecCard `json:"spec_card"`
+	// YAML is the raw, runnable bundle source. Returned on the detail endpoint
+	// and used verbatim by the instantiate path; omitted from list responses.
+	YAML string `json:"yaml,omitempty"`
+}
+
+// Summary returns a copy of the entry without the heavy YAML body, for list
+// responses.
+func (e CatalogEntry) Summary() CatalogEntry {
+	e.YAML = ""
+	return e
+}
+
+// catalogMeta holds the editorial fields that have no representation in the
+// runnable bundle schema.
+type catalogMeta struct {
+	Category     string
+	Tags         []string
+	EstCostUSD   *float64
+	EstRuntimeMS *int64
+}
+
+// catalogMetadata is keyed by pack slug. Every embedded catalog file must have
+// an entry here and vice versa — enforced by TestCatalog* in catalog_test.go.
+var catalogMetadata = map[string]catalogMeta{
+	"tool-calling-accuracy": {
+		Category:     CatalogCategoryAgentCapability,
+		Tags:         []string{"tool-use", "function-calling", "agents"},
+		EstCostUSD:   catalogFloatPtr(0.02),
+		EstRuntimeMS: catalogIntPtr(30000),
+	},
+	"text-to-sql": {
+		Category:     CatalogCategoryEnterprise,
+		Tags:         []string{"sql", "data-analysis", "code-execution"},
+		EstCostUSD:   catalogFloatPtr(0.03),
+		EstRuntimeMS: catalogIntPtr(45000),
+	},
+	"document-extraction": {
+		Category:     CatalogCategoryEnterprise,
+		Tags:         []string{"extraction", "json", "documents"},
+		EstCostUSD:   catalogFloatPtr(0.01),
+		EstRuntimeMS: catalogIntPtr(15000),
+	},
+	"json-output-conformance": {
+		Category:     CatalogCategoryAgentCapability,
+		Tags:         []string{"structured-output", "json", "regression"},
+		EstCostUSD:   catalogFloatPtr(0.005),
+		EstRuntimeMS: catalogIntPtr(10000),
+	},
+}
+
+var (
+	catalogOnce    sync.Once
+	catalogEntries []CatalogEntry
+	catalogErr     error
+)
+
+// Catalog returns the curated library packs, sorted by category then name.
+// Parsed and validated once, then cached.
+func Catalog() ([]CatalogEntry, error) {
+	catalogOnce.Do(func() {
+		catalogEntries, catalogErr = loadCatalog()
+	})
+	if catalogErr != nil {
+		return nil, catalogErr
+	}
+	out := make([]CatalogEntry, len(catalogEntries))
+	copy(out, catalogEntries)
+	return out, nil
+}
+
+// CatalogBySlug returns the full entry (including YAML) for a slug.
+func CatalogBySlug(slug string) (CatalogEntry, bool, error) {
+	entries, err := Catalog()
+	if err != nil {
+		return CatalogEntry{}, false, err
+	}
+	slug = strings.TrimSpace(slug)
+	for _, entry := range entries {
+		if entry.Slug == slug {
+			return entry, true, nil
+		}
+	}
+	return CatalogEntry{}, false, nil
+}
+
+func loadCatalog() ([]CatalogEntry, error) {
+	dirEntries, err := fs.ReadDir(catalogFS, catalogDir)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog dir: %w", err)
+	}
+
+	entries := make([]CatalogEntry, 0, len(dirEntries))
+	seen := map[string]struct{}{}
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() || !strings.HasSuffix(dirEntry.Name(), ".yaml") {
+			continue
+		}
+		data, err := catalogFS.ReadFile(catalogDir + "/" + dirEntry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read catalog file %s: %w", dirEntry.Name(), err)
+		}
+		// ParseYAML runs ValidateBundle, so an invalid catalog pack fails loudly
+		// here (and in TestCatalog*) rather than at instantiate time.
+		bundle, err := ParseYAML(data)
+		if err != nil {
+			return nil, fmt.Errorf("catalog file %s: %w", dirEntry.Name(), err)
+		}
+		if _, exists := seen[bundle.Pack.Slug]; exists {
+			return nil, fmt.Errorf("catalog file %s: duplicate pack slug %q", dirEntry.Name(), bundle.Pack.Slug)
+		}
+		seen[bundle.Pack.Slug] = struct{}{}
+
+		description := ""
+		if bundle.Pack.Description != nil {
+			description = strings.TrimSpace(*bundle.Pack.Description)
+		}
+		meta := catalogMetadata[bundle.Pack.Slug]
+
+		entries = append(entries, CatalogEntry{
+			Slug:               bundle.Pack.Slug,
+			Name:               bundle.Pack.Name,
+			Family:             bundle.Pack.Family,
+			Category:           meta.Category,
+			Tags:               meta.Tags,
+			Description:        description,
+			Difficulty:         maxDifficulty(bundle.Challenges),
+			ExecutionMode:      effectiveExecutionMode(bundle.Version.ExecutionMode),
+			EstimatedCostUSD:   meta.EstCostUSD,
+			EstimatedRuntimeMS: meta.EstRuntimeMS,
+			SpecCard:           SpecCardSummary(bundle),
+			YAML:               string(data),
+		})
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		ri, rj := categoryRank(entries[i].Category), categoryRank(entries[j].Category)
+		if ri != rj {
+			return ri < rj
+		}
+		return entries[i].Name < entries[j].Name
+	})
+	return entries, nil
+}
+
+func effectiveExecutionMode(mode string) string {
+	if strings.TrimSpace(mode) == "" {
+		return ExecutionModeNative
+	}
+	return mode
+}
+
+var difficultyRank = map[string]int{"easy": 1, "medium": 2, "hard": 3, "expert": 4}
+
+func maxDifficulty(challenges []ChallengeDefinition) string {
+	best := ""
+	bestRank := 0
+	for _, c := range challenges {
+		if r := difficultyRank[c.Difficulty]; r > bestRank {
+			bestRank = r
+			best = c.Difficulty
+		}
+	}
+	return best
+}
+
+var categoryOrder = map[string]int{
+	CatalogCategoryEnterprise:      0,
+	CatalogCategoryAgentCapability: 1,
+	CatalogCategorySafety:          2,
+}
+
+func categoryRank(category string) int {
+	if rank, ok := categoryOrder[category]; ok {
+		return rank
+	}
+	return len(categoryOrder)
+}
+
+func catalogFloatPtr(v float64) *float64 { return &v }
+func catalogIntPtr(v int64) *int64       { return &v }

--- a/backend/internal/challengepack/catalog/document-extraction.yaml
+++ b/backend/internal/challengepack/catalog/document-extraction.yaml
@@ -1,0 +1,170 @@
+###############################################################################
+# Challenge Pack: Document Extraction
+#
+# A structured-extraction eval. The agent is given a messy, free-form document
+# (an invoice) and must return a strict JSON object. Scoring is fully
+# deterministic: a JSON-schema validator checks the shape, and json_path_match
+# validators check that the precision-critical fields were extracted and
+# normalized correctly (invoice number, ISO date, total, per-line-item values).
+#
+# This is prompt_eval — a single LLM call, no tools or sandbox — so it is cheap,
+# fast, and reproducible. A great regression anchor for extraction prompts.
+#
+# Swap points (make it yours): replace the inline document in the challenge
+# instructions with your own, update the JSON schema to your target shape, and
+# point the json_path_match validators at your ground-truth field values.
+###############################################################################
+
+pack:
+  slug: document-extraction
+  name: Document Extraction
+  family: extraction
+  description: >-
+    Measures whether an agent extracts structured fields from a messy document
+    into a strict JSON schema, with field-level correctness checks on the
+    precision-critical values. Deterministic, single-call, reproducible.
+
+version:
+  number: 1
+  execution_mode: prompt_eval
+
+  evaluation_spec:
+    name: document-extraction-v1
+    version_number: 1
+    judge_mode: deterministic
+
+    validators:
+      # Overall shape: required keys + typed line items.
+      - key: valid_extraction_schema
+        type: json_schema
+        target: final_output
+        expected_from: "literal:{\"type\":\"object\",\"required\":[\"invoice_number\",\"vendor_name\",\"invoice_date\",\"currency\",\"total_amount\",\"line_items\"],\"properties\":{\"invoice_number\":{\"type\":\"string\",\"minLength\":3},\"vendor_name\":{\"type\":\"string\",\"minLength\":2},\"invoice_date\":{\"type\":\"string\"},\"currency\":{\"type\":\"string\"},\"total_amount\":{\"type\":\"number\"},\"line_items\":{\"type\":\"array\",\"minItems\":3,\"items\":{\"type\":\"object\",\"required\":[\"description\",\"quantity\",\"unit_price\",\"amount\"],\"properties\":{\"description\":{\"type\":\"string\"},\"quantity\":{\"type\":\"integer\"},\"unit_price\":{\"type\":\"number\"},\"amount\":{\"type\":\"number\"}}}}}}"
+
+      # Precision-critical fields.
+      - key: invoice_number_correct
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.invoice_number\",\"comparator\":\"equals\",\"value\":\"INV-2024-0042\"}"
+
+      - key: invoice_date_normalized_iso
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.invoice_date\",\"comparator\":\"equals\",\"value\":\"2024-03-14\"}"
+
+      - key: total_amount_correct
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.total_amount\",\"comparator\":\"equals\",\"value\":86.4}"
+
+      - key: first_line_item_quantity
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.line_items[0].quantity\",\"comparator\":\"equals\",\"value\":2}"
+
+      - key: third_line_item_amount
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.line_items[2].amount\",\"comparator\":\"equals\",\"value\":15}"
+
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+
+    runtime_limits:
+      max_duration_ms: 120000
+      max_total_tokens: 12000
+
+    scorecard:
+      strategy: weighted
+      pass_threshold: 0.7
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - valid_extraction_schema
+            - invoice_number_correct
+            - invoice_date_normalized_iso
+            - total_amount_correct
+            - first_line_item_quantity
+            - third_line_item_amount
+          gate: true
+          pass_threshold: 0.8
+          weight: 0.8
+        - key: reliability
+          source: reliability
+          weight: 0.1
+        - key: latency
+          source: latency
+          better_direction: lower
+          normalization:
+            target: 6000
+            max: 60000
+          weight: 0.05
+        - key: cost
+          source: cost
+          better_direction: lower
+          normalization:
+            target: 0.005
+            max: 0.1
+          weight: 0.05
+
+challenges:
+  - key: invoice-extraction
+    title: Extract structured fields from an invoice
+    category: extraction
+    difficulty: medium
+    instructions: |
+      Extract the following invoice into a single JSON object. Output ONLY the
+      JSON — no prose, no code fences.
+
+      --- DOCUMENT ---
+      ACME INDUSTRIAL SUPPLY CO.
+          Invoice # INV-2024-0042
+      Date: March 14, 2024
+      Bill To: Northwind Trading LLC
+
+      Qty   Description              Unit Price    Amount
+      2     Hex bolts (box)          $12.50        $25.00
+      1     Steel bracket            $40.00        $40.00
+      3     Rubber gasket            $5.00         $15.00
+
+      Subtotal: $80.00
+      Tax (8%): $6.40
+      TOTAL DUE: $86.40
+      --- END DOCUMENT ---
+
+      Return JSON matching this shape EXACTLY:
+
+          {
+            "invoice_number": "<string>",
+            "vendor_name": "<string>",
+            "invoice_date": "<YYYY-MM-DD>",
+            "currency": "<ISO 4217 code, e.g. USD>",
+            "total_amount": <number, the TOTAL DUE>,
+            "line_items": [
+              { "description": "<string>", "quantity": <integer>, "unit_price": <number>, "amount": <number> }
+            ]
+          }
+
+      Rules:
+        - Normalize the date to ISO format YYYY-MM-DD.
+        - currency must be the ISO 4217 code (USD), not a symbol.
+        - total_amount is the TOTAL DUE as a number (no currency symbol).
+        - Include every line item, in order, with numeric quantity/unit_price/amount.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: invoice-extraction
+        case_key: acme-invoice
+        payload:
+          document_type: invoice

--- a/backend/internal/challengepack/catalog/json-output-conformance.yaml
+++ b/backend/internal/challengepack/catalog/json-output-conformance.yaml
@@ -1,0 +1,155 @@
+###############################################################################
+# Challenge Pack: JSON Output Conformance
+#
+# A structured-output regression anchor. The agent must classify a support
+# ticket into a STRICT JSON schema (closed enums, typed fields, no extra keys)
+# and ground the values in the ticket. Scoring is fully deterministic: a strict
+# JSON-schema validator (additionalProperties:false + enums) plus json_path
+# checks on the grounded fields. prompt_eval — cheap, fast, reproducible.
+#
+# This is the pack to run on every model upgrade to catch silent regressions in
+# structured-output conformance.
+#
+# Swap points (make it yours): replace the schema with your own contract, swap
+# the ticket in the instructions, and point the json_path_match validators at
+# the correct values for your input.
+###############################################################################
+
+pack:
+  slug: json-output-conformance
+  name: JSON Output Conformance
+  family: agents
+  description: >-
+    Measures whether an agent emits schema-valid JSON under a strict contract
+    (closed enums, typed fields, no extra keys) with values grounded in the
+    input. Deterministic, single-call — the ideal model-migration regression
+    anchor.
+
+version:
+  number: 1
+  execution_mode: prompt_eval
+
+  evaluation_spec:
+    name: json-output-conformance-v1
+    version_number: 1
+    judge_mode: deterministic
+
+    validators:
+      # Strict shape: closed enums, typed fields, and NO additional properties.
+      - key: valid_strict_schema
+        type: json_schema
+        target: final_output
+        expected_from: "literal:{\"type\":\"object\",\"additionalProperties\":false,\"required\":[\"category\",\"priority\",\"sentiment\",\"requires_human\",\"summary\",\"tags\"],\"properties\":{\"category\":{\"type\":\"string\",\"enum\":[\"billing\",\"account\",\"outage\",\"feature_request\",\"other\"]},\"priority\":{\"type\":\"string\",\"enum\":[\"low\",\"medium\",\"high\",\"urgent\"]},\"sentiment\":{\"type\":\"string\",\"enum\":[\"positive\",\"neutral\",\"negative\"]},\"requires_human\":{\"type\":\"boolean\"},\"summary\":{\"type\":\"string\",\"minLength\":10,\"maxLength\":200},\"tags\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"type\":\"string\"}}}}"
+
+      # Grounded values for this unambiguous ticket.
+      - key: category_is_outage
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.category\",\"comparator\":\"equals\",\"value\":\"outage\"}"
+
+      - key: priority_is_urgent
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.priority\",\"comparator\":\"equals\",\"value\":\"urgent\"}"
+
+      - key: sentiment_is_negative
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.sentiment\",\"comparator\":\"equals\",\"value\":\"negative\"}"
+
+      - key: requires_human_true
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.requires_human\",\"comparator\":\"equals\",\"value\":true}"
+
+      - key: has_at_least_one_tag
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.tags[0]\",\"comparator\":\"exists\"}"
+
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+
+    runtime_limits:
+      max_duration_ms: 120000
+      max_total_tokens: 10000
+
+    scorecard:
+      strategy: weighted
+      pass_threshold: 0.7
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - valid_strict_schema
+            - category_is_outage
+            - priority_is_urgent
+            - sentiment_is_negative
+            - requires_human_true
+            - has_at_least_one_tag
+          gate: true
+          pass_threshold: 0.8
+          weight: 0.8
+        - key: reliability
+          source: reliability
+          weight: 0.1
+        - key: latency
+          source: latency
+          better_direction: lower
+          normalization:
+            target: 5000
+            max: 60000
+          weight: 0.05
+        - key: cost
+          source: cost
+          better_direction: lower
+          normalization:
+            target: 0.004
+            max: 0.08
+          weight: 0.05
+
+challenges:
+  - key: ticket-classification
+    title: Classify a support ticket into strict JSON
+    category: structured-output
+    difficulty: easy
+    instructions: |
+      Classify the following support ticket. Output ONLY a single JSON object —
+      no prose, no code fences, no extra keys.
+
+      --- TICKET ---
+      URGENT: our production checkout API has been returning 500 errors for the
+      last 20 minutes and no customers can complete a purchase. We are losing
+      revenue every minute. Please escalate to your on-call engineer now.
+      --- END TICKET ---
+
+      Return JSON matching this contract EXACTLY (no additional properties):
+
+          {
+            "category": one of ["billing","account","outage","feature_request","other"],
+            "priority": one of ["low","medium","high","urgent"],
+            "sentiment": one of ["positive","neutral","negative"],
+            "requires_human": <boolean>,
+            "summary": "<10-200 char summary of the issue>",
+            "tags": ["<one or more short tags>"]
+          }
+
+      Choose the single best enum value for each field based on the ticket.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: ticket-classification
+        case_key: checkout-outage
+        payload:
+          channel: email

--- a/backend/internal/challengepack/catalog/text-to-sql.yaml
+++ b/backend/internal/challengepack/catalog/text-to-sql.yaml
@@ -1,0 +1,164 @@
+###############################################################################
+# Challenge Pack: Text-to-SQL Execution Accuracy
+#
+# A Spider-2.0-style data-analysis eval. The agent is given a schema and a
+# natural-language question and must write a single SQL query. Scoring is
+# EXECUTION-BASED and deterministic: a sandboxed harness builds the database
+# in-memory, runs the agent's query, and asserts the exact result set. A safe-
+# SQL guard (folded into the same check) rejects destructive statements.
+#
+# Swap points (make it yours): replace the schema + seed rows in the
+# code_execution harness with your own database, rewrite the challenge question,
+# and update the `expected` result set the harness asserts against.
+###############################################################################
+
+pack:
+  slug: text-to-sql
+  name: Text-to-SQL Execution Accuracy
+  family: analysis
+  description: >-
+    Measures whether an agent can translate a natural-language question into a
+    correct SQL query, graded by EXECUTION (exact result-set match) in a
+    sandbox, with a safe-SQL guard against destructive statements.
+
+version:
+  number: 1
+  execution_mode: native
+  sandbox:
+    network_access: false
+
+  tool_policy:
+    allow_shell: true
+    allowed_tool_kinds:
+      - file
+
+  evaluation_spec:
+    name: text-to-sql-v1
+    version_number: 1
+    judge_mode: deterministic
+
+    post_execution_checks:
+      - key: answer
+        type: file_capture
+        path: /workspace/answer.sql
+
+    validators:
+      # The captured file must be a SELECT/CTE query (not prose, not DDL).
+      - key: writes_select_query
+        type: regex_match
+        target: file:answer
+        expected_from: "literal:(?is)^\\s*(select|with)\\b"
+
+      # Execution accuracy: build the DB, run the agent's query, assert the
+      # exact ordered result set. The harness also rejects destructive SQL, so
+      # this single deterministic check covers correctness AND safety.
+      - key: query_returns_correct_rows
+        type: code_execution
+        target: file:answer
+        config:
+          scoring: all_or_nothing
+          test_command: |
+            python3 - <<'PY'
+            import sqlite3, pathlib, re
+            con = sqlite3.connect(':memory:')
+            cur = con.cursor()
+            cur.execute("CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT, department TEXT, salary INTEGER)")
+            cur.execute("INSERT INTO employees VALUES (1,'Alice','Engineering',150000)")
+            cur.execute("INSERT INTO employees VALUES (2,'Bob','Engineering',120000)")
+            cur.execute("INSERT INTO employees VALUES (3,'Carol','Sales',200000)")
+            cur.execute("INSERT INTO employees VALUES (4,'Dan','Sales',90000)")
+            cur.execute("INSERT INTO employees VALUES (5,'Eve','Marketing',100000)")
+            sql = pathlib.Path('/workspace/answer.sql').read_text().strip().rstrip(';').strip()
+            low = sql.lower()
+            assert low.startswith('select') or low.startswith('with'), 'answer.sql must be a single SELECT query'
+            assert not re.search(r'\b(drop|delete|update|insert|alter|create|attach|detach|pragma|replace|truncate|vacuum)\b', low), 'destructive SQL is not allowed'
+            rows = cur.execute(sql).fetchall()
+            expected = [('Carol',), ('Alice',)]
+            assert rows == expected, f'got {rows!r}, expected {expected!r}'
+            print('OK')
+            PY
+
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+
+    runtime_limits:
+      max_duration_ms: 240000
+      max_total_tokens: 24000
+
+    scorecard:
+      strategy: weighted
+      pass_threshold: 0.7
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - query_returns_correct_rows
+          gate: true
+          pass_threshold: 1.0
+          weight: 0.65
+        - key: output_contract
+          source: validators
+          validators:
+            - writes_select_query
+          weight: 0.05
+        - key: reliability
+          source: reliability
+          weight: 0.1
+        - key: latency
+          source: latency
+          better_direction: lower
+          normalization:
+            target: 10000
+            max: 120000
+          weight: 0.1
+        - key: cost
+          source: cost
+          better_direction: lower
+          normalization:
+            target: 0.01
+            max: 0.25
+          weight: 0.1
+
+challenges:
+  - key: above-average-earners
+    title: Write SQL to find above-average earners
+    category: data-analysis
+    difficulty: medium
+    instructions: |
+      You are a data analyst with access to a SQLite database that has a single
+      table:
+
+        employees(id INTEGER, name TEXT, department TEXT, salary INTEGER)
+
+      Question:
+        Return the NAMES of all employees who earn strictly more than the
+        company-wide average salary (the average across every employee), ordered
+        by salary descending.
+
+      Requirements:
+        - Write a SINGLE SQL SELECT statement (a CTE with `WITH` is fine).
+        - The query must return exactly ONE column: the employee name.
+        - Do not modify the database — read-only queries only.
+
+      Write your final query — and nothing else — to the file
+      `/workspace/answer.sql`. Then reply with a one-line summary of your
+      approach.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: above-average-earners
+        case_key: default
+        payload:
+          dialect: sqlite
+          table: employees

--- a/backend/internal/challengepack/catalog/tool-calling-accuracy.yaml
+++ b/backend/internal/challengepack/catalog/tool-calling-accuracy.yaml
@@ -1,0 +1,228 @@
+###############################################################################
+# Challenge Pack: Tool-Calling Accuracy
+#
+# A BFCL-style function-calling eval. The agent is given a small catalog of
+# customer-operations tools and a task whose correct resolution requires
+# selecting the right tools, passing the right arguments, calling them in the
+# right order, and NOT reaching for the wrong tool. Scoring is fully
+# deterministic via tool_call_assertion validators that inspect the agent's
+# tool-call trace — no LLM judge, no flakiness.
+#
+# Swap points (make it yours): redefine `tools.custom` with your own tool
+# catalog, rewrite the challenge instructions for your task, and adjust the
+# tool_call_assertion validators to encode your expected trajectory.
+###############################################################################
+
+pack:
+  slug: tool-calling-accuracy
+  name: Tool-Calling Accuracy
+  family: agents
+  description: >-
+    Measures whether an agent selects the correct tools, supplies the correct
+    arguments, calls them in the right order, and abstains from the wrong tool —
+    the core of reliable function calling. Deterministic, BFCL-style.
+
+version:
+  number: 1
+  execution_mode: native
+  sandbox:
+    network_access: false
+
+  tools:
+    custom:
+      - name: get_order
+        description: Look up an order by its ID and return its current status and line items.
+        parameters:
+          type: object
+          properties:
+            order_id:
+              type: string
+              description: The order identifier, e.g. ORD-1001.
+          required:
+            - order_id
+          additionalProperties: false
+        implementation:
+          type: mock
+
+      - name: issue_refund
+        description: Issue a refund against an order for a specific amount in USD.
+        parameters:
+          type: object
+          properties:
+            order_id:
+              type: string
+              description: The order identifier to refund.
+            amount:
+              type: number
+              description: The refund amount in USD.
+          required:
+            - order_id
+            - amount
+          additionalProperties: false
+        implementation:
+          type: mock
+
+      - name: escalate_to_human
+        description: Escalate the case to a human agent. Use only when policy requires it.
+        parameters:
+          type: object
+          properties:
+            reason:
+              type: string
+              description: Why the case needs a human.
+          required:
+            - reason
+          additionalProperties: false
+        implementation:
+          type: mock
+
+      - name: search_knowledge_base
+        description: Search the internal help-center knowledge base for an article.
+        parameters:
+          type: object
+          properties:
+            query:
+              type: string
+              description: The search query.
+          required:
+            - query
+          additionalProperties: false
+        implementation:
+          type: mock
+
+  evaluation_spec:
+    name: tool-calling-accuracy-v1
+    version_number: 1
+    judge_mode: deterministic
+
+    validators:
+      # The agent must look the order up before acting on it.
+      - key: looks_up_order
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          tool_name: get_order
+          must_call: true
+
+      # The refund must be issued for the right order and the approved amount.
+      - key: issues_correct_refund
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          tool_name: issue_refund
+          arguments_contain:
+            order_id: "ORD-1001"
+            amount: 49.99
+
+      # Exactly one refund — not zero, not a double refund.
+      - key: refund_issued_once
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          tool_name: issue_refund
+          count: 1
+
+      # Order of operations: read before write.
+      - key: looks_up_before_refunding
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          ordered_tools:
+            - get_order
+            - issue_refund
+          order_mode: subsequence
+
+      # Abstention: this case is within policy, so the agent must NOT escalate.
+      - key: does_not_escalate
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          tool_name: escalate_to_human
+          must_call: false
+
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+      - key: tool_calls
+        type: numeric
+        collector: run_tool_call_count
+
+    runtime_limits:
+      max_duration_ms: 180000
+      max_total_tokens: 20000
+
+    # Correctness gates the run; reliability/latency/cost surface the
+    # cost-per-success tradeoff the platform ranks on.
+    scorecard:
+      strategy: weighted
+      pass_threshold: 0.7
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - looks_up_order
+            - issues_correct_refund
+            - refund_issued_once
+            - looks_up_before_refunding
+            - does_not_escalate
+          gate: true
+          pass_threshold: 0.8
+          weight: 0.7
+        - key: reliability
+          source: reliability
+          weight: 0.1
+        - key: latency
+          source: latency
+          better_direction: lower
+          normalization:
+            target: 8000
+            max: 120000
+          weight: 0.1
+        - key: cost
+          source: cost
+          better_direction: lower
+          normalization:
+            target: 0.01
+            max: 0.25
+          weight: 0.1
+
+challenges:
+  - key: refund-within-policy
+    title: Issue an approved refund using the right tools
+    category: tool-use
+    difficulty: medium
+    instructions: |
+      You are a customer-operations agent. You have four tools: get_order,
+      issue_refund, escalate_to_human, and search_knowledge_base.
+
+      Task: Customer wants a refund for order ORD-1001. The refund has ALREADY
+      been approved by a supervisor for the full item price of $49.99, and it is
+      squarely within the standard refund policy (no exceptions, no manager
+      sign-off needed).
+
+      Do the following using REAL tool calls — do not just describe what you
+      would do:
+        1. Look up order ORD-1001 with get_order.
+        2. Issue the refund of $49.99 against ORD-1001 with issue_refund.
+
+      Because the refund is pre-approved and within policy, you must NOT escalate
+      to a human. Issue exactly one refund. When finished, reply with a short
+      confirmation message to the customer.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: refund-within-policy
+        case_key: ord-1001
+        payload:
+          order_id: "ORD-1001"
+          approved_amount: 49.99

--- a/backend/internal/challengepack/catalog_test.go
+++ b/backend/internal/challengepack/catalog_test.go
@@ -1,0 +1,125 @@
+package challengepack
+
+import "testing"
+
+// TestCatalogLoadsAndIsRunnable is the runnability gate for the curated library:
+// every embedded pack must parse, validate, compose a manifest (the exact gate
+// the instantiate path hits via PublishChallengePackBundle), and produce a
+// usable spec card. A content bug fails CI here instead of at instantiate time.
+func TestCatalogLoadsAndIsRunnable(t *testing.T) {
+	entries, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog() error: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("Catalog() returned no entries")
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.Slug, func(t *testing.T) {
+			if entry.Slug == "" {
+				t.Fatal("entry has empty slug")
+			}
+			if entry.Name == "" {
+				t.Error("entry has empty name")
+			}
+			if entry.Family == "" {
+				t.Error("entry has empty family")
+			}
+			if entry.Category == "" {
+				t.Error("entry has empty category (missing catalogMetadata?)")
+			}
+			if entry.ExecutionMode == "" {
+				t.Error("entry has empty execution_mode")
+			}
+			if entry.YAML == "" {
+				t.Fatal("entry has empty YAML")
+			}
+
+			// Re-parse + manifest: this is exactly what PublishBundle does, so a
+			// pass here proves the pack is instantiable.
+			bundle, err := ParseYAML([]byte(entry.YAML))
+			if err != nil {
+				t.Fatalf("ParseYAML: %v", err)
+			}
+			if _, err := ManifestJSON(bundle); err != nil {
+				t.Fatalf("ManifestJSON: %v", err)
+			}
+			if len(entry.SpecCard.Dimensions) == 0 {
+				t.Error("spec card has no scoring dimensions")
+			}
+		})
+	}
+}
+
+// TestCatalogMetadataMatchesFiles enforces the 1:1 relationship between embedded
+// pack files and the editorial catalogMetadata registry, so neither can drift.
+func TestCatalogMetadataMatchesFiles(t *testing.T) {
+	entries, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog() error: %v", err)
+	}
+
+	slugs := map[string]struct{}{}
+	for _, entry := range entries {
+		slugs[entry.Slug] = struct{}{}
+		if _, ok := catalogMetadata[entry.Slug]; !ok {
+			t.Errorf("pack %q has no catalogMetadata entry", entry.Slug)
+		}
+	}
+	for slug := range catalogMetadata {
+		if _, ok := slugs[slug]; !ok {
+			t.Errorf("catalogMetadata has entry %q with no matching catalog file", slug)
+		}
+	}
+}
+
+// TestCatalogPacksAreAssetFree guards the v1 constraint that catalog packs use
+// only inline fixtures. Artifact-backed assets cannot be instantiated into a
+// workspace (validateStoredAssetReferences requires the artifact to already
+// exist and belong to that workspace), so a catalog pack that references one
+// would fail at instantiate time.
+func TestCatalogPacksAreAssetFree(t *testing.T) {
+	entries, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog() error: %v", err)
+	}
+	for _, entry := range entries {
+		bundle, err := ParseYAML([]byte(entry.YAML))
+		if err != nil {
+			t.Fatalf("%s: ParseYAML: %v", entry.Slug, err)
+		}
+		if len(bundle.Version.Assets) != 0 {
+			t.Errorf("%s: declares version assets; catalog packs must be asset-free", entry.Slug)
+		}
+		for _, ch := range bundle.Challenges {
+			if len(ch.Assets) != 0 || len(ch.ArtifactRefs) != 0 {
+				t.Errorf("%s: challenge %q declares assets/artifact_refs", entry.Slug, ch.Key)
+			}
+		}
+		for _, set := range bundle.InputSets {
+			for _, c := range set.Cases {
+				if len(c.Assets) != 0 || len(c.Artifacts) != 0 {
+					t.Errorf("%s: case %q declares assets/artifacts", entry.Slug, c.EffectiveKey())
+				}
+			}
+		}
+	}
+}
+
+func TestCatalogBySlug(t *testing.T) {
+	entry, ok, err := CatalogBySlug("json-output-conformance")
+	if err != nil {
+		t.Fatalf("CatalogBySlug error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected json-output-conformance to be in the catalog")
+	}
+	if entry.YAML == "" {
+		t.Error("CatalogBySlug should return the full entry including YAML")
+	}
+
+	if _, ok, _ := CatalogBySlug("does-not-exist"); ok {
+		t.Error("unexpected hit for unknown slug")
+	}
+}

--- a/backend/internal/repository/challenge_pack_catalog.go
+++ b/backend/internal/repository/challenge_pack_catalog.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	repositorysqlc "github.com/agentclash/agentclash/backend/internal/repository/sqlc"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
@@ -18,23 +19,15 @@ import (
 // own copy. Used by the catalog instantiate path to return the existing pack
 // idempotently when the same template is added twice.
 func (r *Repository) GetWorkspaceChallengePackVersionBySlug(ctx context.Context, workspaceID uuid.UUID, slug string) (challengePackID uuid.UUID, versionID uuid.UUID, found bool, err error) {
-	row := r.db.QueryRow(ctx, `
-SELECT p.id, v.id
-FROM challenge_packs p
-JOIN challenge_pack_versions v ON v.challenge_pack_id = p.id
-WHERE p.workspace_id = $1
-  AND p.slug = $2
-  AND p.archived_at IS NULL
-  AND v.lifecycle_status = 'runnable'
-  AND v.archived_at IS NULL
-ORDER BY v.version_number DESC
-LIMIT 1`, workspaceID, slug)
-
-	if scanErr := row.Scan(&challengePackID, &versionID); scanErr != nil {
-		if errors.Is(scanErr, pgx.ErrNoRows) {
+	row, err := r.queries.GetWorkspaceChallengePackVersionBySlug(ctx, repositorysqlc.GetWorkspaceChallengePackVersionBySlugParams{
+		WorkspaceID: workspaceID,
+		Slug:        slug,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return uuid.Nil, uuid.Nil, false, nil
 		}
-		return uuid.Nil, uuid.Nil, false, fmt.Errorf("get workspace challenge pack version by slug: %w", scanErr)
+		return uuid.Nil, uuid.Nil, false, fmt.Errorf("get workspace challenge pack version by slug: %w", err)
 	}
-	return challengePackID, versionID, true, nil
+	return row.ChallengePackID, row.ChallengePackVersionID, true, nil
 }

--- a/backend/internal/repository/challenge_pack_catalog.go
+++ b/backend/internal/repository/challenge_pack_catalog.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// GetWorkspaceChallengePackVersionBySlug returns the workspace's own challenge
+// pack id and its latest runnable version id for the given slug. found is false
+// when the workspace has no runnable pack at that slug.
+//
+// The workspace_id filter makes this unambiguous even when a global pack
+// (workspace_id IS NULL) shares the slug — it only ever matches the workspace's
+// own copy. Used by the catalog instantiate path to return the existing pack
+// idempotently when the same template is added twice.
+func (r *Repository) GetWorkspaceChallengePackVersionBySlug(ctx context.Context, workspaceID uuid.UUID, slug string) (challengePackID uuid.UUID, versionID uuid.UUID, found bool, err error) {
+	row := r.db.QueryRow(ctx, `
+SELECT p.id, v.id
+FROM challenge_packs p
+JOIN challenge_pack_versions v ON v.challenge_pack_id = p.id
+WHERE p.workspace_id = $1
+  AND p.slug = $2
+  AND p.archived_at IS NULL
+  AND v.lifecycle_status = 'runnable'
+  AND v.archived_at IS NULL
+ORDER BY v.version_number DESC
+LIMIT 1`, workspaceID, slug)
+
+	if scanErr := row.Scan(&challengePackID, &versionID); scanErr != nil {
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return uuid.Nil, uuid.Nil, false, nil
+		}
+		return uuid.Nil, uuid.Nil, false, fmt.Errorf("get workspace challenge pack version by slug: %w", scanErr)
+	}
+	return challengePackID, versionID, true, nil
+}

--- a/backend/internal/repository/sqlc/challenge_packs.sql.go
+++ b/backend/internal/repository/sqlc/challenge_packs.sql.go
@@ -12,6 +12,36 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getWorkspaceChallengePackVersionBySlug = `-- name: GetWorkspaceChallengePackVersionBySlug :one
+SELECT p.id AS challenge_pack_id, v.id AS challenge_pack_version_id
+FROM challenge_packs p
+JOIN challenge_pack_versions v ON v.challenge_pack_id = p.id
+WHERE p.workspace_id = $1::uuid
+  AND p.slug = $2
+  AND p.archived_at IS NULL
+  AND v.lifecycle_status = 'runnable'
+  AND v.archived_at IS NULL
+ORDER BY v.version_number DESC
+LIMIT 1
+`
+
+type GetWorkspaceChallengePackVersionBySlugParams struct {
+	WorkspaceID uuid.UUID
+	Slug        string
+}
+
+type GetWorkspaceChallengePackVersionBySlugRow struct {
+	ChallengePackID        uuid.UUID
+	ChallengePackVersionID uuid.UUID
+}
+
+func (q *Queries) GetWorkspaceChallengePackVersionBySlug(ctx context.Context, arg GetWorkspaceChallengePackVersionBySlugParams) (GetWorkspaceChallengePackVersionBySlugRow, error) {
+	row := q.db.QueryRow(ctx, getWorkspaceChallengePackVersionBySlug, arg.WorkspaceID, arg.Slug)
+	var i GetWorkspaceChallengePackVersionBySlugRow
+	err := row.Scan(&i.ChallengePackID, &i.ChallengePackVersionID)
+	return i, err
+}
+
 const listChallengePacks = `-- name: ListChallengePacks :many
 SELECT cp.id, cp.name, cp.description, cp.created_at, cp.updated_at
 FROM challenge_packs cp

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -117,6 +117,7 @@ type Querier interface {
 	GetRunnableChallengePackVersionByID(ctx context.Context, arg GetRunnableChallengePackVersionByIDParams) (ChallengePackVersion, error)
 	GetVibeEvalConversationByID(ctx context.Context, arg GetVibeEvalConversationByIDParams) (VibeEvalConversation, error)
 	GetVibeEvalDraftByID(ctx context.Context, arg GetVibeEvalDraftByIDParams) (VibeEvalDraft, error)
+	GetWorkspaceChallengePackVersionBySlug(ctx context.Context, arg GetWorkspaceChallengePackVersionBySlugParams) (GetWorkspaceChallengePackVersionBySlugRow, error)
 	GetWorkspaceUsageWindowRaceCount(ctx context.Context, arg GetWorkspaceUsageWindowRaceCountParams) (int32, error)
 	InsertDatasetBaseline(ctx context.Context, arg InsertDatasetBaselineParams) (DatasetBaseline, error)
 	InsertDatasetExample(ctx context.Context, arg InsertDatasetExampleParams) (DatasetExample, error)

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4736,6 +4736,113 @@ paths:
                       $ref: "#/components/schemas/StarterPiece"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
+  /v1/challenge-pack-catalog:
+    get:
+      operationId: listChallengePackCatalog
+      tags: [ChallengePacks]
+      summary: List the curated challenge-pack library
+      description: >
+        A global, read-only catalog of ready-to-run challenge packs ("templates")
+        users can clone into a workspace. Not workspace-scoped. The raw YAML body
+        is omitted from list items; fetch the detail endpoint for it.
+      security:
+        - bearerJWT: []
+      parameters:
+        - name: family
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [enterprise, agent_capability, safety]
+      responses:
+        "200":
+          description: Curated catalog entries
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChallengePackCatalogSummary"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+  /v1/challenge-pack-catalog/{slug}:
+    get:
+      operationId: getChallengePackCatalogEntry
+      tags: [ChallengePacks]
+      summary: Get a catalog entry including its runnable YAML
+      security:
+        - bearerJWT: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Catalog entry with raw YAML
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChallengePackCatalogEntry"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+  /v1/workspaces/{workspaceID}/challenge-pack-catalog/{slug}/instantiate:
+    post:
+      operationId: instantiateChallengePackCatalog
+      tags: [ChallengePacks]
+      summary: Clone a catalog pack into the workspace
+      description: >
+        Clones a curated library pack into the caller's workspace as a runnable,
+        fully-owned pack. Idempotent: adding the same template twice returns the
+        existing pack (200, already_existed=true) instead of erroring. Returns 201
+        for a fresh clone. The curated library is not gated by the private-packs
+        entitlement.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Workspace already had this pack; returns the existing copy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstantiateChallengePackCatalogResponse"
+        "201":
+          description: Catalog pack cloned into the workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstantiateChallengePackCatalogResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          description: A different pack already uses this slug in the workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /v1/workspaces/{workspaceID}/challenge-pieces:
     get:
       operationId: listChallengePieces
@@ -13020,6 +13127,74 @@ components:
         bundle_artifact_id:
           type: string
           format: uuid
+
+    ChallengePackCatalogSummary:
+      type: object
+      required: [slug, name, family, execution_mode, spec_card]
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        family:
+          type: string
+        category:
+          type: string
+          enum: [enterprise, agent_capability, safety]
+        tags:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        difficulty:
+          type: string
+          enum: [easy, medium, hard, expert]
+        execution_mode:
+          type: string
+        estimated_cost_usd:
+          type: number
+        estimated_runtime_ms:
+          type: integer
+          format: int64
+        spec_card:
+          $ref: "#/components/schemas/SpecCard"
+
+    ChallengePackCatalogEntry:
+      allOf:
+        - $ref: "#/components/schemas/ChallengePackCatalogSummary"
+        - type: object
+          required: [yaml]
+          properties:
+            yaml:
+              type: string
+              description: The raw, runnable challenge-pack bundle YAML.
+
+    InstantiateChallengePackCatalogResponse:
+      type: object
+      required: [challenge_pack_id, challenge_pack_version_id, slug, already_existed, runnable]
+      properties:
+        challenge_pack_id:
+          type: string
+          format: uuid
+        challenge_pack_version_id:
+          type: string
+          format: uuid
+        evaluation_spec_id:
+          type: string
+          format: uuid
+        input_set_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        slug:
+          type: string
+        already_existed:
+          type: boolean
+          description: True when the workspace already had this pack and the existing copy was returned.
+        runnable:
+          type: boolean
 
     # --- Challenge Pack Builder ---
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
@@ -5,6 +5,7 @@ import type { ChallengePack } from "@/lib/api/types";
 import { useApiListQuery } from "@/lib/api/swr";
 import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
 import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
 import { latestChallengePackVersion } from "@/lib/voice-evals";
@@ -49,6 +50,12 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <Link
+            href={`/workspaces/${workspaceId}/challenge-packs/library`}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            Browse library
+          </Link>
           <NewPackButton workspaceId={workspaceId} />
           <PublishPackDialog workspaceId={workspaceId} />
         </div>
@@ -62,7 +69,11 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
         <EmptyState
           icon={<Package className="size-10" />}
           title="No challenge packs"
-          description="Publish your first challenge pack to define benchmarks for agent evaluation."
+          description="Start from a ready-made template in the library — add it to your workspace and run it in one click — or publish your own."
+          action={{
+            label: "Browse the library",
+            href: `/workspaces/${workspaceId}/challenge-packs/library`,
+          }}
         />
       ) : (
         <div className="rounded-lg border border-border">

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/library/library-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/library/library-client.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { LibraryBig } from "lucide-react";
+
+import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
+import { TemplateGallery } from "@/components/challenge-packs/catalog/template-gallery";
+import { catalogPath } from "@/components/challenge-packs/lib/api";
+import type { CatalogPack } from "@/components/challenge-packs/lib/types";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useApiListQuery } from "@/lib/api/swr";
+
+export function LibraryClient({ workspaceId }: { workspaceId: string }) {
+  const { data, error, isLoading } = useApiListQuery<CatalogPack>(catalogPath());
+  const packs = data?.items ?? [];
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold tracking-tight">Pack Library</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Ready-to-run challenge packs. Add one to your workspace, run it, then customize it in the
+          builder.
+        </p>
+      </div>
+
+      {isLoading && !data ? (
+        <WorkspaceListLoading rows={6} />
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+          Failed to load the pack library.
+        </div>
+      ) : packs.length === 0 ? (
+        <EmptyState icon={<LibraryBig className="size-10" />} title="No templates available" />
+      ) : (
+        <TemplateGallery workspaceId={workspaceId} packs={packs} />
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/library/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/library/page.tsx
@@ -1,0 +1,10 @@
+import { LibraryClient } from "./library-client";
+
+export default async function ChallengePackLibraryPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = await params;
+  return <LibraryClient workspaceId={workspaceId} />;
+}

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -17,6 +17,7 @@ import {
   FileArchive,
   Lock,
   Cog,
+  LibraryBig,
   type LucideIcon,
 } from "lucide-react";
 
@@ -64,6 +65,11 @@ export const navSections: NavSection[] = [
         label: "Challenge Packs",
         href: (id) => `/workspaces/${id}/challenge-packs`,
         icon: PackageOpen,
+      },
+      {
+        label: "Pack Library",
+        href: (id) => `/workspaces/${id}/challenge-packs/library`,
+        icon: LibraryBig,
       },
       {
         label: "Datasets",

--- a/web/src/components/challenge-packs/catalog/catalog-taxonomy.ts
+++ b/web/src/components/challenge-packs/catalog/catalog-taxonomy.ts
@@ -1,0 +1,32 @@
+import type { CatalogCategory } from "../lib/types";
+
+export interface CatalogCategoryMeta {
+  key: CatalogCategory;
+  label: string;
+  description: string;
+}
+
+/**
+ * Category taxonomy for the library gallery, kept as data so the gallery groups
+ * packs purely off the `category` field. Adding a category is one entry here
+ * plus a backend enum value — no per-pack frontend code.
+ */
+export const CATALOG_CATEGORIES: readonly CatalogCategoryMeta[] = [
+  {
+    key: "enterprise",
+    label: "Enterprise use cases",
+    description: "Production agent + LLM tasks enterprises evaluate today.",
+  },
+  {
+    key: "agent_capability",
+    label: "Agent capabilities",
+    description: "Core agent skills: tool use, structured output, reasoning.",
+  },
+  {
+    key: "safety",
+    label: "Safety & security",
+    description: "Prompt-injection, jailbreak, and refusal-calibration suites.",
+  },
+];
+
+export const UNCATEGORIZED_LABEL = "Other";

--- a/web/src/components/challenge-packs/catalog/template-card.tsx
+++ b/web/src/components/challenge-packs/catalog/template-card.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { CatalogPack } from "../lib/types";
+
+const difficultyVariant: Record<string, "default" | "secondary" | "outline"> = {
+  easy: "secondary",
+  medium: "outline",
+  hard: "default",
+  expert: "default",
+};
+
+function formatCost(usd?: number): string | null {
+  if (usd == null) return null;
+  return usd < 0.01 ? `~$${usd.toFixed(3)}` : `~$${usd.toFixed(2)}`;
+}
+
+function formatRuntime(ms?: number): string | null {
+  if (ms == null) return null;
+  return `~${Math.round(ms / 1000)}s`;
+}
+
+export function TemplateCard({ pack, onSelect }: { pack: CatalogPack; onSelect: () => void }) {
+  const cost = formatCost(pack.estimated_cost_usd);
+  const runtime = formatRuntime(pack.estimated_runtime_ms);
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex h-full flex-col rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-foreground/30 hover:bg-muted/30"
+    >
+      <span className="text-sm font-semibold">{pack.name}</span>
+      {pack.description && (
+        <p className="mt-1.5 line-clamp-3 text-sm text-muted-foreground">{pack.description}</p>
+      )}
+      <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-3">
+        <Badge variant="outline">{pack.family}</Badge>
+        {pack.difficulty && (
+          <Badge variant={difficultyVariant[pack.difficulty] ?? "outline"}>{pack.difficulty}</Badge>
+        )}
+        <Badge variant="outline">{pack.execution_mode}</Badge>
+        {(cost || runtime) && (
+          <span className="ml-auto text-xs text-muted-foreground">
+            {[cost, runtime].filter(Boolean).join(" · ")}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/web/src/components/challenge-packs/catalog/template-detail.tsx
+++ b/web/src/components/challenge-packs/catalog/template-detail.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useApiQuery } from "@/lib/api/swr";
+import { catalogPackPath } from "../lib/api";
+import type { CatalogPack, CatalogPackDetail } from "../lib/types";
+import { SpecCardView } from "../pieces/spec-card-view";
+import { UseTemplateButton } from "./use-template-button";
+
+/**
+ * Right-side drawer showing a template's readable spec card (rendered instantly
+ * from the list summary) plus its runnable YAML (fetched lazily on open) and the
+ * Use-template action. Reuses the builder's SpecCardView so the "what it
+ * measures" panel is identical everywhere.
+ */
+export function TemplateDetail({
+  workspaceId,
+  pack,
+  open,
+  onOpenChange,
+}: {
+  workspaceId: string;
+  pack: CatalogPack | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: detail } = useApiQuery<CatalogPackDetail>(
+    pack && open ? catalogPackPath(pack.slug) : null,
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-xl">
+        {pack && (
+          <>
+            <SheetHeader className="space-y-1.5 border-b border-border px-4 py-3 text-left">
+              <SheetTitle>{pack.name}</SheetTitle>
+              {pack.description && <SheetDescription>{pack.description}</SheetDescription>}
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                <Badge variant="outline">{pack.family}</Badge>
+                {pack.difficulty && <Badge variant="outline">{pack.difficulty}</Badge>}
+                <Badge variant="outline">{pack.execution_mode}</Badge>
+              </div>
+            </SheetHeader>
+
+            <div className="min-h-0 flex-1">
+              <SpecCardView card={pack.spec_card} yaml={detail?.yaml} />
+            </div>
+
+            <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+              <UseTemplateButton workspaceId={workspaceId} slug={pack.slug} />
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/components/challenge-packs/catalog/template-gallery.tsx
+++ b/web/src/components/challenge-packs/catalog/template-gallery.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { CatalogPack } from "../lib/types";
+import { CATALOG_CATEGORIES, UNCATEGORIZED_LABEL } from "./catalog-taxonomy";
+import { TemplateCard } from "./template-card";
+import { TemplateDetail } from "./template-detail";
+
+/**
+ * Browsable grid of catalog templates, grouped by category. Filtering is
+ * in-memory (the catalog is a small, global, static list) and grouping is driven
+ * purely by each pack's `category`, so growing the catalog needs no UI changes.
+ */
+export function TemplateGallery({
+  workspaceId,
+  packs,
+}: {
+  workspaceId: string;
+  packs: CatalogPack[];
+}) {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<CatalogPack | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return packs;
+    return packs.filter((p) =>
+      [p.name, p.description ?? "", p.family, ...(p.tags ?? [])].some((s) =>
+        s.toLowerCase().includes(q),
+      ),
+    );
+  }, [packs, query]);
+
+  const groups = useMemo(
+    () =>
+      CATALOG_CATEGORIES.map((cat) => ({
+        ...cat,
+        packs: filtered.filter((p) => p.category === cat.key),
+      })).filter((g) => g.packs.length > 0),
+    [filtered],
+  );
+
+  const uncategorized = useMemo(
+    () => filtered.filter((p) => !CATALOG_CATEGORIES.some((c) => c.key === p.category)),
+    [filtered],
+  );
+
+  return (
+    <div className="space-y-8">
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search templates…"
+        className="w-full max-w-sm rounded-md border border-border bg-transparent px-3 py-1.5 text-sm outline-none focus:border-foreground/40"
+      />
+
+      {filtered.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No templates match your search.</p>
+      ) : (
+        <>
+          {groups.map((group) => (
+            <section key={group.key} className="space-y-3">
+              <div>
+                <h2 className="text-sm font-semibold">{group.label}</h2>
+                <p className="text-xs text-muted-foreground">{group.description}</p>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {group.packs.map((pack) => (
+                  <TemplateCard key={pack.slug} pack={pack} onSelect={() => setSelected(pack)} />
+                ))}
+              </div>
+            </section>
+          ))}
+
+          {uncategorized.length > 0 && (
+            <section className="space-y-3">
+              <h2 className="text-sm font-semibold">{UNCATEGORIZED_LABEL}</h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {uncategorized.map((pack) => (
+                  <TemplateCard key={pack.slug} pack={pack} onSelect={() => setSelected(pack)} />
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+
+      <TemplateDetail
+        workspaceId={workspaceId}
+        pack={selected}
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/catalog/use-template-button.tsx
+++ b/web/src/components/challenge-packs/catalog/use-template-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Loader2, Sparkles } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { instantiateCatalogPack } from "@/components/challenge-packs/lib/api";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api/errors";
+
+/**
+ * Clones a catalog template into the workspace and routes to the new pack so
+ * the user can run it. Idempotent on the backend — clicking twice reopens the
+ * existing copy instead of erroring.
+ */
+export function UseTemplateButton({
+  workspaceId,
+  slug,
+  className,
+}: {
+  workspaceId: string;
+  slug: string;
+  className?: string;
+}) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [busy, setBusy] = useState(false);
+
+  const onClick = async () => {
+    setBusy(true);
+    try {
+      const token = await getAccessToken();
+      const result = await instantiateCatalogPack(token, workspaceId, slug);
+      toast.success(
+        result.already_existed
+          ? "Already in your workspace — opening it"
+          : "Template added to your workspace",
+      );
+      router.push(`/workspaces/${workspaceId}/challenge-packs/${result.challenge_pack_id}`);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't add this template");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Button size="sm" onClick={onClick} disabled={busy} className={className}>
+      {busy ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
+      Use template
+    </Button>
+  );
+}

--- a/web/src/components/challenge-packs/lib/api.ts
+++ b/web/src/components/challenge-packs/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   CompileDraftResponse,
   Composition,
   ExecutionMode,
+  InstantiateCatalogPackResponse,
   PieceKind,
 } from "./types";
 
@@ -91,4 +92,30 @@ export async function createPiece(
   body: { kind: PieceKind; slug: string; name: string; description?: string; definition: unknown },
 ): Promise<ChallengePiece> {
   return createApiClient(token ?? undefined).post<ChallengePiece>(piecesPath(workspaceId), body);
+}
+
+// --- catalog (the curated library) ---
+// Reads use the SWR hooks against these paths; the instantiate mutation goes
+// through a fresh access token like the other authoring mutations above.
+
+export function catalogPath(): string {
+  return "/v1/challenge-pack-catalog";
+}
+
+export function catalogPackPath(slug: string): string {
+  return `${catalogPath()}/${slug}`;
+}
+
+export function catalogInstantiatePath(workspaceId: string, slug: string): string {
+  return `/v1/workspaces/${workspaceId}/challenge-pack-catalog/${slug}/instantiate`;
+}
+
+export async function instantiateCatalogPack(
+  token: Token,
+  workspaceId: string,
+  slug: string,
+): Promise<InstantiateCatalogPackResponse> {
+  return createApiClient(token ?? undefined).post<InstantiateCatalogPackResponse>(
+    catalogInstantiatePath(workspaceId, slug),
+  );
 }

--- a/web/src/components/challenge-packs/lib/types.ts
+++ b/web/src/components/challenge-packs/lib/types.ts
@@ -320,3 +320,39 @@ export interface CompileDraftResponse {
   spec_card: SpecCard;
   yaml: string;
 }
+
+// --- challenge pack catalog (the curated library / "templates") ---
+
+/** Editorial grouping for the library gallery (mirror of challengepack catalog categories). */
+export type CatalogCategory = "enterprise" | "agent_capability" | "safety";
+
+/** A curated, ready-to-run pack from GET /v1/challenge-pack-catalog. */
+export interface CatalogPack {
+  slug: string;
+  name: string;
+  family: string;
+  category?: CatalogCategory;
+  tags?: string[];
+  description?: string;
+  difficulty?: string;
+  execution_mode: ExecutionMode;
+  estimated_cost_usd?: number;
+  estimated_runtime_ms?: number;
+  spec_card: SpecCard;
+}
+
+/** Catalog detail (GET /v1/challenge-pack-catalog/{slug}) — adds the runnable YAML. */
+export interface CatalogPackDetail extends CatalogPack {
+  yaml: string;
+}
+
+/** Response of POST .../challenge-pack-catalog/{slug}/instantiate. */
+export interface InstantiateCatalogPackResponse {
+  challenge_pack_id: string;
+  challenge_pack_version_id: string;
+  evaluation_spec_id?: string;
+  input_set_ids?: string[];
+  slug: string;
+  already_existed: boolean;
+  runnable: boolean;
+}

--- a/web/src/components/challenge-packs/pieces/spec-card-view.tsx
+++ b/web/src/components/challenge-packs/pieces/spec-card-view.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Editor from "@monaco-editor/react";
+import { Loader2 } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { SpecCard } from "../lib/types";
+
+type View = "readable" | "yaml";
+
+/**
+ * Pure, presentational renderer for a compiled pack's spec card + YAML. Shared
+ * by the builder preview (which wraps it with usePackDraft + a validation
+ * footer) and the catalog/library detail view (which passes a static card +
+ * yaml). It owns no data fetching and no draft context.
+ */
+export function SpecCardView({
+  card,
+  yaml,
+  compiling = false,
+  footer,
+}: {
+  card: SpecCard | undefined;
+  yaml?: string;
+  compiling?: boolean;
+  footer?: ReactNode;
+}) {
+  const [view, setView] = useState<View>("readable");
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <span className="text-sm font-medium">Preview</span>
+        <div className="flex rounded-md border border-border p-0.5 text-xs">
+          {(["readable", "yaml"] as View[]).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              className={cn(
+                "rounded px-2 py-0.5 capitalize transition-colors",
+                view === v ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {v === "yaml" ? "YAML" : "Readable"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {compiling && !card && (
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          <Loader2 className="mr-2 size-4 animate-spin" /> Building preview…
+        </div>
+      )}
+
+      {view === "yaml" ? (
+        <div className="min-h-0 flex-1">
+          <Editor
+            height="100%"
+            defaultLanguage="yaml"
+            theme="vs-dark"
+            value={yaml ?? ""}
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              fontSize: 12,
+              wordWrap: "on",
+              scrollBeyondLastLine: false,
+            }}
+            loading={
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                <Loader2 className="size-5 animate-spin" />
+              </div>
+            }
+          />
+        </div>
+      ) : (
+        card && (
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+            <div>
+              <div className="text-sm font-semibold">{card.pack_name || "Untitled pack"}</div>
+              <div className="mt-1 flex flex-wrap gap-1.5">
+                {card.family && <Badge variant="outline">{card.family}</Badge>}
+                <Badge variant="outline">{card.execution_mode}</Badge>
+                <Badge variant="outline">{card.strategy}</Badge>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <Stat label="Challenges" value={card.challenge_count} />
+              <Stat label="Cases" value={card.case_count} />
+              <Stat label="Validators" value={card.validator_count} />
+              <Stat label="Judges" value={card.judge_count} />
+            </div>
+
+            <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
+              {card.pass_criteria}
+            </div>
+
+            {card.dimensions.length > 0 && (
+              <div className="space-y-1.5">
+                <div className="text-xs font-medium text-muted-foreground">Dimensions</div>
+                {card.dimensions.map((d) => (
+                  <div key={d.key} className="rounded-md border border-border px-2.5 py-1.5 text-xs">
+                    {d.summary}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {footer}
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-border px-2.5 py-1.5">
+      <div className="text-base font-semibold tabular-nums">{value}</div>
+      <div className="text-muted-foreground">{label}</div>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/pieces/spec-card.tsx
+++ b/web/src/components/challenge-packs/pieces/spec-card.tsx
@@ -1,117 +1,26 @@
 "use client";
 
-import Editor from "@monaco-editor/react";
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { AlertCircle, CheckCircle2 } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
 import { usePackDraft } from "../use-pack-draft";
+import { SpecCardView } from "./spec-card-view";
 
-type View = "readable" | "yaml";
-
+/**
+ * Builder preview pane: binds the live draft compile state to the shared
+ * SpecCardView and appends a validation footer. All visual rendering lives in
+ * SpecCardView so the catalog/library reuses the identical card.
+ */
 export function SpecCard() {
   const { state } = usePackDraft();
-  const [view, setView] = useState<View>("readable");
   const compile = state.compile;
-  const card = compile?.spec_card;
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
-        <span className="text-sm font-medium">Preview</span>
-        <div className="flex rounded-md border border-border p-0.5 text-xs">
-          {(["readable", "yaml"] as View[]).map((v) => (
-            <button
-              key={v}
-              type="button"
-              onClick={() => setView(v)}
-              className={cn(
-                "rounded px-2 py-0.5 capitalize transition-colors",
-                view === v ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {v === "yaml" ? "YAML" : "Readable"}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {state.compiling && !card && (
-        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-          <Loader2 className="mr-2 size-4 animate-spin" /> Building preview…
-        </div>
-      )}
-
-      {view === "yaml" ? (
-        <div className="min-h-0 flex-1">
-          <Editor
-            height="100%"
-            defaultLanguage="yaml"
-            theme="vs-dark"
-            value={compile?.yaml ?? ""}
-            options={{
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              wordWrap: "on",
-              scrollBeyondLastLine: false,
-            }}
-            loading={
-              <div className="flex h-full items-center justify-center text-muted-foreground">
-                <Loader2 className="size-5 animate-spin" />
-              </div>
-            }
-          />
-        </div>
-      ) : (
-        card && (
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
-            <div>
-              <div className="text-sm font-semibold">{card.pack_name || "Untitled pack"}</div>
-              <div className="mt-1 flex flex-wrap gap-1.5">
-                {card.family && <Badge variant="outline">{card.family}</Badge>}
-                <Badge variant="outline">{card.execution_mode}</Badge>
-                <Badge variant="outline">{card.strategy}</Badge>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-2 text-xs">
-              <Stat label="Challenges" value={card.challenge_count} />
-              <Stat label="Cases" value={card.case_count} />
-              <Stat label="Validators" value={card.validator_count} />
-              <Stat label="Judges" value={card.judge_count} />
-            </div>
-
-            <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
-              {card.pass_criteria}
-            </div>
-
-            {card.dimensions.length > 0 && (
-              <div className="space-y-1.5">
-                <div className="text-xs font-medium text-muted-foreground">Dimensions</div>
-                {card.dimensions.map((d) => (
-                  <div key={d.key} className="rounded-md border border-border px-2.5 py-1.5 text-xs">
-                    {d.summary}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <ValidationPanel valid={compile?.valid ?? false} errors={compile?.errors ?? []} />
-          </div>
-        )
-      )}
-    </div>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="rounded-md border border-border px-2.5 py-1.5">
-      <div className="text-base font-semibold tabular-nums">{value}</div>
-      <div className="text-muted-foreground">{label}</div>
-    </div>
+    <SpecCardView
+      card={compile?.spec_card}
+      yaml={compile?.yaml}
+      compiling={state.compiling}
+      footer={<ValidationPanel valid={compile?.valid ?? false} errors={compile?.errors ?? []} />}
+    />
   );
 }
 


### PR DESCRIPTION
## What & why

New users land on an empty challenge-packs page and have to author a pack from scratch before running a single eval. This ships a curated **challenge pack library** — ready-to-run packs users can browse, one-click add to their workspace, run immediately, and then tweak in the builder. It's the free activation on-ramp, and the first step of a 3-PR effort.

Pack selection is driven by research into the highest-demand mid-2026 enterprise + agent eval use cases (customer support, coding/SWE, RAG, tool-calling, text-to-SQL, extraction, safety…). PR1 ships the 4 highest-demand **deterministic** packs so the system proves out with zero LLM-judge cost or flakiness.

## What's in PR1

**Backend**
- Embedded catalog (`backend/internal/challengepack/catalog/*.yaml`) + loader (`catalog.go`). Runnable fields are derived from the parsed bundle (can't drift from what runs); editorial fields (category/tags/cost/runtime) live in a small Go registry. A test gate proves every pack parses, validates, composes a manifest, and is asset-free.
- Read API: `GET /v1/challenge-pack-catalog[/{slug}]` (global, mirrors the starter-piece library).
- Instantiate API: `POST /v1/workspaces/{id}/challenge-pack-catalog/{slug}/instantiate`, reusing the existing `PublishBundle` path. **Idempotent** — adding the same template twice returns the existing pack via a workspace-scoped by-slug lookup instead of erroring on the version-uniqueness constraint. **Not gated** by the private-packs entitlement (the curated library is free; the paywall stays on authoring).
- **No DB migrations, no worker changes** — instantiated packs are ordinary runnable workspace packs.

**Packs (4, all deterministic)**
- `tool-calling-accuracy` — BFCL-style; `tool_call_assertion` on tool selection, args, order, and abstention.
- `text-to-sql` — execution accuracy via a sandboxed SQLite harness (exact result-set match) + an inline safe-SQL guard.
- `document-extraction` — messy invoice → strict JSON with field-level `json_path_match` checks.
- `json-output-conformance` — strict schema (closed enums, no extra keys) + grounded values; a model-migration regression anchor.

Each ships inline fixtures (self-contained, runnable out of the box) and surfaces cost / latency / reliability dimensions alongside correctness.

**Web**
- New `/challenge-packs/library` gallery grouped by category, with search and a detail drawer.
- "Use template" clones the pack into the workspace and routes to it.
- Reuses the builder's spec card via an extracted pure `SpecCardView` (builder behavior unchanged).
- Activation funnels: the empty challenge-packs state now points to the library, plus a header action and a sidebar entry.

## Verification

- `go build ./...`, `go vet ./...`, `go test -short -race ./...` (full backend) — all green, including new catalog + instantiate tests (success / idempotent / unknown-slug / 404).
- Web `tsc --noEmit` and `eslint` — clean (the only lint warnings are pre-existing, in unrelated files).
- OpenAPI: new paths/schemas added; my additions resolve cleanly under `redocly lint`.

**Not yet run live against a sandbox.** The packs are schema-valid, instantiable, and the deterministic scoring path is sound (`code_execution` runs via `sh -lc`, so the SQL heredoc executes; no template-placeholder conflicts). A live race — especially for `text-to-sql` (E2B SQLite execution) and `tool-calling-accuracy` (mock-tool behavior) — is the recommended pre-merge check.

## Note (pre-existing, not in this PR)

`redocly lint` also surfaces 5 broken `#/components/schemas/ErrorResponse` refs in the **datasets** paths (the schema is undefined; the rest of the spec uses `ErrorEnvelope`). These pre-date this branch and are tracked separately.

## Follow-ups

- **PR2** — `Bundle→Composition` decompiler (edit any pack in the builder, lossless) + 5 LLM-judged / multi-turn packs (customer-support-policy, swe-bug-fix, rag-faithfulness, summarization-faithfulness, it-helpdesk-triage).
- **PR3** — safety packs (prompt-injection-defense, jailbreak-refusal, knowledge-reasoning-regression), expanded reusable validator/judge piece library, CLI `challenge-pack catalog list|use`, docs.
