### PR TITLE
feat(web): redesign the challenge pack builder

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,6 +40,29 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
+/*
+ * Challenge-pack builder — quiet-utilitarian warm palette.
+ * The design system (docs/frontend/design/design-system.md) is warm and editorial,
+ * but the app's shadcn tokens are cold neutral grays. Rather than re-tint the whole
+ * app, the builder gets its own contained, reusable warm token set, consumed only
+ * through `builder-*` utilities (text-builder-fg, bg-builder-surface, …). The
+ * workspace is always dark, so these are defined once (no light variant needed).
+ * Accent is reserved for warnings/errors only — everything else is near-monochrome warm.
+ */
+:root {
+  --builder-fg: oklch(0.94 0.008 80); /* warm off-white — primary text */
+  --builder-fg-muted: oklch(0.94 0.008 80 / 0.58); /* descriptions, body */
+  --builder-fg-subtle: oklch(0.94 0.008 80 / 0.34); /* labels, nav */
+  --builder-fg-faint: oklch(0.94 0.008 80 / 0.16); /* section headers, dividers */
+  --builder-surface: oklch(0.94 0.01 80 / 0.035); /* control / panel background */
+  --builder-surface-hover: oklch(0.94 0.01 80 / 0.06);
+  --builder-panel: oklch(0.205 0.006 80); /* opaque warm surface — popovers, drawers */
+  --builder-border: oklch(0.94 0.01 80 / 0.1); /* hairline */
+  --builder-border-strong: oklch(0.94 0.01 80 / 0.2); /* focus / active edge */
+  --builder-warn: #d97757; /* terracotta — errors, warnings (sparingly) */
+  --builder-warn-soft: rgba(217, 119, 87, 0.12);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -708,6 +731,17 @@ body {
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --color-builder-fg: var(--builder-fg);
+  --color-builder-fg-muted: var(--builder-fg-muted);
+  --color-builder-fg-subtle: var(--builder-fg-subtle);
+  --color-builder-fg-faint: var(--builder-fg-faint);
+  --color-builder-surface: var(--builder-surface);
+  --color-builder-surface-hover: var(--builder-surface-hover);
+  --color-builder-panel: var(--builder-panel);
+  --color-builder-border: var(--builder-border);
+  --color-builder-border-strong: var(--builder-border-strong);
+  --color-builder-warn: var(--builder-warn);
+  --color-builder-warn-soft: var(--builder-warn-soft);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);

--- a/web/src/components/challenge-packs/builder-shell.tsx
+++ b/web/src/components/challenge-packs/builder-shell.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { AlertCircle, Eye, Loader2 } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { BuilderCenter } from "./editors/editor-registry";
 import { PackOutline } from "./outline/pack-outline";
-import { SpecCard } from "./pieces/spec-card";
+import { PreviewDrawer } from "./pieces/preview-drawer";
 import { usePackDraft } from "./use-pack-draft";
 
 export function BuilderShell() {
   const { state, publish } = usePackDraft();
   const invalid = state.compile != null && !state.compile.valid;
+  const issueCount = state.compile?.errors?.length ?? 0;
   const status = state.saving
     ? "Saving…"
     : state.compiling
@@ -19,35 +22,68 @@ export function BuilderShell() {
         ? "Saved"
         : "";
 
+  // The preview is an on-demand slide-over (the "N to fix" pill and the rail's
+  // issue dots keep validation discoverable while it's closed).
+  const [previewOpen, setPreviewOpen] = useState(false);
+
   return (
-    <div className="flex h-[calc(100vh-7rem)] min-h-[560px] flex-col overflow-hidden rounded-xl border border-border bg-card">
-      <header className="flex items-center justify-between border-b border-border px-4 py-2.5">
+    <div className="flex h-[calc(100dvh-7rem)] min-h-[560px] flex-col">
+      <header className="flex items-center justify-between gap-3 border-b border-builder-border pb-3">
         <div className="min-w-0">
-          <div className="truncate text-sm font-semibold">
+          <h1 className="truncate font-[family-name:var(--font-display)] text-xl leading-tight text-builder-fg">
             {state.composition.pack.name || "Untitled pack"}
+          </h1>
+          <div className="mt-1 flex items-center gap-1.5 text-xs text-builder-fg-subtle">
+            {(state.saving || state.compiling) && <Loader2 className="size-3 animate-spin" />}
+            {status}
           </div>
-          <div className="text-xs text-muted-foreground">{status}</div>
         </div>
-        <Button
-          size="sm"
-          onClick={() => void publish()}
-          disabled={state.publishing || invalid}
-          title={invalid ? "Resolve the validation issues first" : undefined}
-        >
-          {state.publishing && <Loader2 className="size-4 animate-spin" />}
-          Publish
-        </Button>
+        <div className="flex shrink-0 items-center gap-2">
+          {invalid && (
+            <button
+              type="button"
+              onClick={() => setPreviewOpen(true)}
+              className="flex items-center gap-1.5 rounded-md border border-builder-warn/30 bg-builder-warn-soft px-2.5 py-1 text-xs font-medium text-builder-warn transition-colors hover:bg-builder-warn/15"
+            >
+              <AlertCircle className="size-3.5" />
+              {issueCount} to fix
+            </button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPreviewOpen((v) => !v)}
+            aria-pressed={previewOpen}
+            className={cn(
+              "border-builder-border bg-transparent text-builder-fg-muted hover:bg-builder-surface hover:text-builder-fg",
+              previewOpen && "bg-builder-surface text-builder-fg",
+            )}
+          >
+            <Eye className="size-4" />
+            Preview
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => void publish()}
+            disabled={state.publishing || invalid}
+            title={invalid ? "Resolve the issues first" : undefined}
+          >
+            {state.publishing && <Loader2 className="size-4 animate-spin" />}
+            Publish
+          </Button>
+        </div>
       </header>
-      <div className="flex min-h-0 flex-1">
-        <aside className="w-64 shrink-0 border-r border-border">
+
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+        <aside className="shrink-0 overflow-y-auto border-b border-builder-border max-md:max-h-44 md:w-56 md:border-r md:border-b-0">
           <PackOutline />
         </aside>
-        <main className="min-w-0 flex-1 overflow-y-auto p-6">
-          <BuilderCenter />
+        <main className="min-w-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-[680px] px-6 py-8 lg:px-10">
+            <BuilderCenter />
+          </div>
         </main>
-        <aside className="hidden w-80 shrink-0 border-l border-border lg:block">
-          <SpecCard />
-        </aside>
+        <PreviewDrawer open={previewOpen} onClose={() => setPreviewOpen(false)} />
       </div>
     </div>
   );

--- a/web/src/components/challenge-packs/editors/challenge-editor.tsx
+++ b/web/src/components/challenge-packs/editors/challenge-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Field, controlClass } from "@/components/tools/field";
 import { updatePieceRef } from "../lib/draft";
 import type { ChallengeDefinition } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
 import { usePackDraft } from "../use-pack-draft";
 
 const DIFFICULTIES = ["easy", "medium", "hard", "expert"];
@@ -15,47 +16,41 @@ export function ChallengeEditor({ index }: { index: number }) {
     update((c) => updatePieceRef(c, "challenge", index, { inline: { ...def, ...patch } }));
 
   return (
-    <div className="max-w-2xl space-y-5">
-      <h2 className="text-base font-semibold">Challenge</h2>
-      <Field label="Key" hint="unique within the pack; cases target it by key">
+    <div className="space-y-6">
+      <EditorHeader title="Challenge" description="The task an agent is asked to do." />
+
+      <FieldRow label="Key" hint="unique within the pack; cases target it by key">
         <input
-          className={controlClass}
+          className={monoControlClass}
           value={def.key ?? ""}
           onChange={(e) => set({ key: e.target.value })}
           placeholder="refund-recovery"
         />
-      </Field>
-      <Field label="Title">
+      </FieldRow>
+      <FieldRow label="Title">
         <input
           className={controlClass}
           value={def.title ?? ""}
           onChange={(e) => set({ title: e.target.value })}
           placeholder="Recover a frustrated refund request"
         />
-      </Field>
-      <div className="grid grid-cols-2 gap-4">
-        <Field label="Category">
-          <input
-            className={controlClass}
-            value={def.category ?? ""}
-            onChange={(e) => set({ category: e.target.value })}
-            placeholder="support"
-          />
-        </Field>
-        <Field label="Difficulty">
-          <select
-            className={controlClass}
-            value={def.difficulty ?? "medium"}
-            onChange={(e) => set({ difficulty: e.target.value })}
-          >
-            {DIFFICULTIES.map((d) => (
-              <option key={d} value={d}>
-                {d}
-              </option>
-            ))}
-          </select>
-        </Field>
-      </div>
+      </FieldRow>
+      <FieldRow label="Category">
+        <input
+          className={controlClass}
+          value={def.category ?? ""}
+          onChange={(e) => set({ category: e.target.value })}
+          placeholder="support"
+        />
+      </FieldRow>
+      <FieldRow label="Difficulty">
+        <BuilderSelect
+          ariaLabel="Difficulty"
+          value={def.difficulty ?? "medium"}
+          onChange={(v) => set({ difficulty: v })}
+          options={DIFFICULTIES.map((d) => ({ value: d, label: d }))}
+        />
+      </FieldRow>
       <Field
         label="Instructions"
         hint="The prompt the agent sees. Supports {{placeholder}} from case payloads."

--- a/web/src/components/challenge-packs/editors/flow-editor.tsx
+++ b/web/src/components/challenge-packs/editors/flow-editor.tsx
@@ -6,7 +6,6 @@
 
 import { Plus, Trash2 } from "lucide-react";
 
-import { Field, controlClass } from "@/components/tools/field";
 import { Button } from "@/components/ui/button";
 import type {
   UserSimulatorActor,
@@ -14,6 +13,8 @@ import type {
   UserSimulatorSpec,
   UserSimulatorTrigger,
 } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, Field, FieldRow, monoControlClass } from "../ui/form";
 
 const ACTORS: { value: UserSimulatorActor; label: string }[] = [
   { value: "scripted", label: "Scripted — fixed messages" },
@@ -32,6 +33,8 @@ const TRIGGERS: UserSimulatorTrigger[] = [
   "never",
 ];
 
+const ON_TIMEOUT = ["stop", "fail"];
+
 function defaultSimulator(): UserSimulatorSpec {
   return {
     schema_version: 1,
@@ -49,8 +52,8 @@ export function CaseFlowEditor({
 }) {
   if (!value) {
     return (
-      <div className="rounded-md border border-dashed border-border p-3">
-        <p className="mb-2 text-xs text-muted-foreground">
+      <div className="rounded-md border border-dashed border-builder-border p-3">
+        <p className="mb-2 text-xs text-builder-fg-muted">
           Multi-turn mode: this case needs a conversation flow.
         </p>
         <Button size="xs" variant="outline" onClick={() => onChange(defaultSimulator())}>
@@ -66,15 +69,18 @@ export function CaseFlowEditor({
   const addPhase = () =>
     onChange({
       ...value,
-      phases: [...phases, { id: `phase-${phases.length + 1}`, actor: "scripted", turns: [{ message: "" }] }],
+      phases: [
+        ...phases,
+        { id: `phase-${phases.length + 1}`, actor: "scripted", turns: [{ message: "" }] },
+      ],
     });
   const removePhase = (i: number) =>
     onChange({ ...value, phases: phases.filter((_, j) => j !== i) });
 
   return (
-    <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
+    <div className="space-y-3 rounded-md border border-builder-border bg-builder-surface p-3">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <span className="text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
           Conversation ({phases.length} phase{phases.length === 1 ? "" : "s"})
         </span>
         <Button size="xs" variant="outline" onClick={addPhase}>
@@ -83,44 +89,40 @@ export function CaseFlowEditor({
       </div>
 
       {phases.map((phase, i) => (
-        <div key={i} className="space-y-3 rounded-md border border-border bg-background p-3">
+        <div key={i} className="space-y-3 rounded-md border border-builder-border bg-builder-panel p-3">
           <div className="flex items-center gap-2">
             <input
-              className={controlClass}
+              className={monoControlClass}
               value={phase.id}
               onChange={(e) => setPhase(i, { id: e.target.value })}
               placeholder="phase id"
             />
-            <select
-              className={controlClass}
+            <BuilderSelect
+              ariaLabel="Actor"
+              className="w-56"
               value={phase.actor}
-              onChange={(e) => setPhase(i, { actor: e.target.value as UserSimulatorActor })}
+              onChange={(v) => setPhase(i, { actor: v as UserSimulatorActor })}
+              options={ACTORS}
+            />
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              onClick={() => removePhase(i)}
+              aria-label="Remove phase"
             >
-              {ACTORS.map((a) => (
-                <option key={a.value} value={a.value}>
-                  {a.label}
-                </option>
-              ))}
-            </select>
-            <Button size="icon-sm" variant="ghost" onClick={() => removePhase(i)} aria-label="Remove phase">
               <Trash2 className="size-4" />
             </Button>
           </div>
 
           {i > 0 && (
-            <Field label="Trigger" hint="when this phase activates">
-              <select
-                className={controlClass}
+            <FieldRow label="Trigger" hint="when this phase activates">
+              <BuilderSelect
+                ariaLabel="Trigger"
                 value={phase.trigger ?? "always"}
-                onChange={(e) => setPhase(i, { trigger: e.target.value as UserSimulatorTrigger })}
-              >
-                {TRIGGERS.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
-                ))}
-              </select>
-            </Field>
+                onChange={(v) => setPhase(i, { trigger: v as UserSimulatorTrigger })}
+                options={TRIGGERS.map((t) => ({ value: t, label: t }))}
+              />
+            </FieldRow>
           )}
 
           {phase.actor === "scripted" && (
@@ -141,32 +143,28 @@ export function CaseFlowEditor({
                   placeholder="Frustrated customer who accepts a clear timeline if treated with empathy"
                 />
               </Field>
-              <div className="grid grid-cols-2 gap-3">
-                <Field label="Max turns">
-                  <input
-                    className={controlClass}
-                    type="number"
-                    min="1"
-                    value={phase.max_turns ?? ""}
-                    onChange={(e) =>
-                      setPhase(i, {
-                        max_turns: e.target.value ? Number(e.target.value) : undefined,
-                      })
-                    }
-                    placeholder="3"
-                  />
-                </Field>
-                <Field label="Model" hint="optional override">
-                  <input
-                    className={controlClass}
-                    value={phase.model ?? ""}
-                    onChange={(e) => setPhase(i, { model: e.target.value })}
-                  />
-                </Field>
-              </div>
-              <Field label="Exit when" hint='comma-separated, e.g. assistant_emitted:timeline'>
+              <FieldRow label="Max turns">
                 <input
                   className={controlClass}
+                  type="number"
+                  min="1"
+                  value={phase.max_turns ?? ""}
+                  onChange={(e) =>
+                    setPhase(i, { max_turns: e.target.value ? Number(e.target.value) : undefined })
+                  }
+                  placeholder="3"
+                />
+              </FieldRow>
+              <FieldRow label="Model" hint="optional override">
+                <input
+                  className={monoControlClass}
+                  value={phase.model ?? ""}
+                  onChange={(e) => setPhase(i, { model: e.target.value })}
+                />
+              </FieldRow>
+              <FieldRow label="Exit when" hint='comma-separated, e.g. assistant_emitted:timeline'>
+                <input
+                  className={monoControlClass}
                   value={(phase.until ?? []).join(", ")}
                   onChange={(e) =>
                     setPhase(i, {
@@ -177,13 +175,13 @@ export function CaseFlowEditor({
                     })
                   }
                 />
-              </Field>
+              </FieldRow>
             </div>
           )}
 
           {phase.actor === "human" && (
-            <div className="grid grid-cols-2 gap-3">
-              <Field label="Timeout (ms)">
+            <div className="space-y-3">
+              <FieldRow label="Timeout (ms)">
                 <input
                   className={controlClass}
                   type="number"
@@ -194,17 +192,15 @@ export function CaseFlowEditor({
                   }
                   placeholder="900000"
                 />
-              </Field>
-              <Field label="On timeout">
-                <select
-                  className={controlClass}
+              </FieldRow>
+              <FieldRow label="On timeout">
+                <BuilderSelect
+                  ariaLabel="On timeout"
                   value={phase.on_timeout ?? "stop"}
-                  onChange={(e) => setPhase(i, { on_timeout: e.target.value })}
-                >
-                  <option value="stop">stop</option>
-                  <option value="fail">fail</option>
-                </select>
-              </Field>
+                  onChange={(v) => setPhase(i, { on_timeout: v })}
+                  options={ON_TIMEOUT.map((t) => ({ value: t, label: t }))}
+                />
+              </FieldRow>
             </div>
           )}
         </div>

--- a/web/src/components/challenge-packs/editors/input-set-editor.tsx
+++ b/web/src/components/challenge-packs/editors/input-set-editor.tsx
@@ -3,10 +3,11 @@
 import { Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 
-import { Field, controlClass, monoControlClass } from "@/components/tools/field";
 import { Button } from "@/components/ui/button";
 import { pieceKeys, updatePieceRef } from "../lib/draft";
 import type { CaseDefinition, InputSetDefinition } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
 import { usePackDraft } from "../use-pack-draft";
 import { CaseFlowEditor } from "./flow-editor";
 
@@ -35,64 +36,66 @@ export function InputSetEditor({ index }: { index: number }) {
   const removeCase = (i: number) => set({ cases: cases.filter((_, j) => j !== i) });
 
   return (
-    <div className="max-w-3xl space-y-5">
-      <h2 className="text-base font-semibold">Input set</h2>
-      <p className="text-sm text-muted-foreground">
-        The cases (test data) a challenge runs against.
-      </p>
-      <div className="grid grid-cols-2 gap-4">
-        <Field label="Key">
-          <input
-            className={controlClass}
-            value={def.key ?? ""}
-            onChange={(e) => set({ key: e.target.value })}
-            placeholder="default"
-          />
-        </Field>
-        <Field label="Name">
-          <input
-            className={controlClass}
-            value={def.name ?? ""}
-            onChange={(e) => set({ name: e.target.value })}
-            placeholder="Default"
-          />
-        </Field>
-      </div>
+    <div className="space-y-6">
+      <EditorHeader
+        title="Input set"
+        description="The cases (test data) a challenge runs against."
+      />
+
+      <FieldRow label="Key">
+        <input
+          className={monoControlClass}
+          value={def.key ?? ""}
+          onChange={(e) => set({ key: e.target.value })}
+          placeholder="default"
+        />
+      </FieldRow>
+      <FieldRow label="Name">
+        <input
+          className={controlClass}
+          value={def.name ?? ""}
+          onChange={(e) => set({ name: e.target.value })}
+          placeholder="Default"
+        />
+      </FieldRow>
 
       <div>
         <div className="mb-2 flex items-center justify-between">
-          <span className="text-sm font-medium">Cases ({cases.length})</span>
+          <span className="text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
+            Cases {cases.length > 0 && <span className="tabular-nums">({cases.length})</span>}
+          </span>
           <Button size="xs" variant="outline" onClick={addCase} disabled={challengeKeys.length === 0}>
             <Plus className="size-3.5" /> Add case
           </Button>
         </div>
         {challengeKeys.length === 0 && (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-builder-fg-faint">
             Add a challenge first — each case targets a challenge by key.
           </p>
         )}
         <div className="space-y-3">
           {cases.map((cs, i) => (
-            <div key={i} className="space-y-3 rounded-lg border border-border p-3">
+            <div key={i} className="space-y-3 rounded-md border border-builder-border bg-builder-surface p-3">
               <div className="flex items-center gap-2">
-                <select
-                  className={controlClass}
-                  value={cs.challenge_key}
-                  onChange={(e) => setCase(i, { challenge_key: e.target.value })}
-                >
-                  {challengeKeys.map((k) => (
-                    <option key={k} value={k}>
-                      {k}
-                    </option>
-                  ))}
-                </select>
+                <BuilderSelect
+                  ariaLabel="Challenge"
+                  placeholder="challenge"
+                  value={cs.challenge_key ?? ""}
+                  onChange={(v) => setCase(i, { challenge_key: v })}
+                  options={challengeKeys.map((k) => ({ value: k, label: k }))}
+                />
                 <input
-                  className={controlClass}
+                  className={monoControlClass}
                   value={cs.case_key ?? ""}
                   onChange={(e) => setCase(i, { case_key: e.target.value })}
                   placeholder="case key"
                 />
-                <Button size="icon-sm" variant="ghost" onClick={() => removeCase(i)} aria-label="Remove case">
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => removeCase(i)}
+                  aria-label="Remove case"
+                >
                   <Trash2 className="size-4" />
                 </Button>
               </div>
@@ -122,7 +125,11 @@ function PayloadField({
   const [error, setError] = useState("");
 
   return (
-    <Field label="Payload" hint="JSON available to {{placeholders}} in the challenge instructions" error={error}>
+    <Field
+      label="Payload"
+      hint="JSON available to {{placeholders}} in the challenge instructions"
+      error={error}
+    >
       <textarea
         className={monoControlClass}
         rows={4}

--- a/web/src/components/challenge-packs/editors/judge-editor.tsx
+++ b/web/src/components/challenge-packs/editors/judge-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Field, controlClass } from "@/components/tools/field";
 import { updatePieceRef } from "../lib/draft";
 import type { JudgeMethodMode, LLMJudgeDeclaration } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
 import { usePackDraft } from "../use-pack-draft";
 
 const MODES: { value: JudgeMethodMode; label: string }[] = [
@@ -25,53 +26,47 @@ export function JudgeEditor({ index }: { index: number }) {
     set({ score_scale: { ...scale, ...patch } });
 
   return (
-    <div className="max-w-2xl space-y-5">
-      <h2 className="text-base font-semibold">LLM judge</h2>
-      <p className="text-sm text-muted-foreground">
-        An LLM-as-judge grader. Wire it into a scorecard dimension to make it count.
-      </p>
-      <Field label="Key" hint="unique; referenced by scorecard dimensions">
+    <div className="space-y-6">
+      <EditorHeader
+        title="LLM judge"
+        description="An LLM-as-judge grader. Wire it into a scorecard dimension to make it count."
+      />
+
+      <FieldRow label="Key" hint="unique; referenced by scorecard dimensions">
         <input
-          className={controlClass}
+          className={monoControlClass}
           value={def.key ?? ""}
           onChange={(e) => set({ key: e.target.value })}
           placeholder="empathy"
         />
-      </Field>
-      <div className="grid grid-cols-3 gap-4">
-        <Field label="Mode">
-          <select
-            className={controlClass}
-            value={mode}
-            onChange={(e) => set({ mode: e.target.value as JudgeMethodMode })}
-          >
-            {MODES.map((m) => (
-              <option key={m.value} value={m.value}>
-                {m.label}
-              </option>
-            ))}
-          </select>
-        </Field>
-        <Field label="Model">
-          <input
-            className={controlClass}
-            value={def.model ?? ""}
-            onChange={(e) => set({ model: e.target.value })}
-            placeholder="claude-haiku-4-5-20251001"
-          />
-        </Field>
-        <Field label="Samples" hint="median of N">
-          <input
-            className={controlClass}
-            type="number"
-            min="1"
-            max="10"
-            value={def.samples ?? ""}
-            onChange={(e) => set({ samples: e.target.value ? Number(e.target.value) : undefined })}
-            placeholder="3"
-          />
-        </Field>
-      </div>
+      </FieldRow>
+      <FieldRow label="Mode">
+        <BuilderSelect
+          ariaLabel="Mode"
+          value={mode}
+          onChange={(v) => set({ mode: v as JudgeMethodMode })}
+          options={MODES}
+        />
+      </FieldRow>
+      <FieldRow label="Model">
+        <input
+          className={monoControlClass}
+          value={def.model ?? ""}
+          onChange={(e) => set({ model: e.target.value })}
+          placeholder="claude-haiku-4-5-20251001"
+        />
+      </FieldRow>
+      <FieldRow label="Samples" hint="median of N">
+        <input
+          className={controlClass}
+          type="number"
+          min="1"
+          max="10"
+          value={def.samples ?? ""}
+          onChange={(e) => set({ samples: e.target.value ? Number(e.target.value) : undefined })}
+          placeholder="3"
+        />
+      </FieldRow>
 
       {(mode === "rubric" || mode === "reference") && (
         <>
@@ -84,38 +79,39 @@ export function JudgeEditor({ index }: { index: number }) {
               placeholder="Score 5 if the response is empathetic and gives a concrete next step..."
             />
           </Field>
-          <div className="grid grid-cols-2 gap-4">
-            <Field label="Scale min">
+          <FieldRow label="Scale">
+            <div className="flex items-center gap-2">
               <input
                 className={controlClass}
                 type="number"
+                aria-label="Scale min"
                 value={scale.min}
                 onChange={(e) => setScale({ min: Number(e.target.value) })}
               />
-            </Field>
-            <Field label="Scale max">
+              <span className="text-builder-fg-faint">to</span>
               <input
                 className={controlClass}
                 type="number"
+                aria-label="Scale max"
                 value={scale.max}
                 onChange={(e) => setScale({ max: Number(e.target.value) })}
               />
-            </Field>
-          </div>
+            </div>
+          </FieldRow>
         </>
       )}
 
       {mode === "reference" && (
-        <Field
+        <FieldRow
           label="Reference from"
           hint="evidence reference to the gold answer, e.g. case.expectations.reference_response"
         >
           <input
-            className={controlClass}
+            className={monoControlClass}
             value={def.reference_from ?? ""}
             onChange={(e) => set({ reference_from: e.target.value })}
           />
-        </Field>
+        </FieldRow>
       )}
 
       {mode === "assertion" && (
@@ -129,16 +125,17 @@ export function JudgeEditor({ index }: { index: number }) {
               placeholder="The assistant gives a concrete refund timeline instead of deflecting."
             />
           </Field>
-          <Field label="Expectation">
-            <label className="flex h-9 items-center gap-2 text-sm">
+          <FieldRow label="Expectation">
+            <label className="flex items-center gap-2 py-2 text-sm text-builder-fg-muted">
               <input
                 type="checkbox"
+                className="size-3.5 accent-builder-fg"
                 checked={def.expect ?? true}
                 onChange={(e) => set({ expect: e.target.checked })}
               />
               Assertion should be true
             </label>
-          </Field>
+          </FieldRow>
         </>
       )}
 
@@ -153,25 +150,26 @@ export function JudgeEditor({ index }: { index: number }) {
               placeholder="Rank the responses from best to worst by how well they resolve the issue..."
             />
           </Field>
-          <Field label="Position debiasing">
-            <label className="flex h-9 items-center gap-2 text-sm">
+          <FieldRow label="Position debiasing">
+            <label className="flex items-center gap-2 py-2 text-sm text-builder-fg-muted">
               <input
                 type="checkbox"
+                className="size-3.5 accent-builder-fg"
                 checked={def.position_debiasing ?? false}
                 onChange={(e) => set({ position_debiasing: e.target.checked })}
               />
               Randomize agent order across samples
             </label>
-          </Field>
+          </FieldRow>
         </>
       )}
 
-      <Field
+      <FieldRow
         label="Evidence"
         hint="comma-separated references the judge sees, e.g. final_output, case.payload.order_id"
       >
         <input
-          className={controlClass}
+          className={monoControlClass}
           value={(def.context_from ?? []).join(", ")}
           onChange={(e) =>
             set({
@@ -183,7 +181,7 @@ export function JudgeEditor({ index }: { index: number }) {
           }
           placeholder="final_output"
         />
-      </Field>
+      </FieldRow>
     </div>
   );
 }

--- a/web/src/components/challenge-packs/editors/pack-overview-editor.tsx
+++ b/web/src/components/challenge-packs/editors/pack-overview-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Field, controlClass } from "@/components/tools/field";
-import { usePackDraft } from "../use-pack-draft";
 import type { ExecutionMode } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
+import { usePackDraft } from "../use-pack-draft";
 
 const EXECUTION_MODES: { value: ExecutionMode; label: string }[] = [
   { value: "native", label: "Native — single-turn tool loop" },
@@ -16,62 +17,54 @@ export function PackOverviewEditor() {
   const { pack, version } = state.composition;
 
   return (
-    <div className="max-w-2xl space-y-5">
-      <div>
-        <h2 className="text-base font-semibold">Pack overview</h2>
-        <p className="text-sm text-muted-foreground">Name, identity, and how the pack runs.</p>
-      </div>
-      <Field label="Name">
+    <div className="space-y-6">
+      <EditorHeader title="Pack overview" description="Name, identity, and how the pack runs." />
+
+      <FieldRow label="Name">
         <input
           className={controlClass}
           value={pack.name}
           onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, name: e.target.value } }))}
           placeholder="Refund recovery"
         />
-      </Field>
-      <Field label="Slug" hint="kebab-case identifier, unique in your workspace">
+      </FieldRow>
+      <FieldRow label="Slug" hint="kebab-case identifier, unique in your workspace">
         <input
-          className={controlClass}
+          className={monoControlClass}
           value={pack.slug}
           onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, slug: e.target.value } }))}
           placeholder="refund-recovery"
         />
-      </Field>
-      <Field label="Family" hint="Category, e.g. support, security, sre">
+      </FieldRow>
+      <FieldRow label="Family" hint="Category, e.g. support, security, sre">
         <input
           className={controlClass}
           value={pack.family}
           onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, family: e.target.value } }))}
           placeholder="support"
         />
-      </Field>
+      </FieldRow>
       <Field label="Description">
         <textarea
           className={controlClass}
           rows={3}
           value={pack.description ?? ""}
-          onChange={(e) => update((c) => ({ ...c, pack: { ...c.pack, description: e.target.value } }))}
+          onChange={(e) =>
+            update((c) => ({ ...c, pack: { ...c.pack, description: e.target.value } }))
+          }
           placeholder="What this pack evaluates."
         />
       </Field>
-      <Field label="Execution mode">
-        <select
-          className={controlClass}
+      <FieldRow label="Execution mode">
+        <BuilderSelect
+          ariaLabel="Execution mode"
           value={version.execution_mode ?? "native"}
-          onChange={(e) =>
-            update((c) => ({
-              ...c,
-              version: { ...c.version, execution_mode: e.target.value as ExecutionMode },
-            }))
+          onChange={(v) =>
+            update((c) => ({ ...c, version: { ...c.version, execution_mode: v as ExecutionMode } }))
           }
-        >
-          {EXECUTION_MODES.map((m) => (
-            <option key={m.value} value={m.value}>
-              {m.label}
-            </option>
-          ))}
-        </select>
-      </Field>
+          options={EXECUTION_MODES}
+        />
+      </FieldRow>
     </div>
   );
 }

--- a/web/src/components/challenge-packs/editors/scorecard-editor.tsx
+++ b/web/src/components/challenge-packs/editors/scorecard-editor.tsx
@@ -2,10 +2,11 @@
 
 import { Plus, Trash2 } from "lucide-react";
 
-import { Field, controlClass } from "@/components/tools/field";
 import { Button } from "@/components/ui/button";
 import { pieceKeys, setDimensions } from "../lib/draft";
 import type { DimensionDeclaration, DimensionSource, ScoringStrategy } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
 import { usePackDraft } from "../use-pack-draft";
 
 const STRATEGIES: { value: ScoringStrategy; label: string }[] = [
@@ -48,72 +49,67 @@ export function ScorecardEditor() {
   const strategy = scorecard.strategy ?? "weighted";
 
   return (
-    <div className="max-w-2xl space-y-5">
-      <div>
-        <h2 className="text-base font-semibold">Scoring</h2>
-        <p className="text-sm text-muted-foreground">
-          Wire your validators and judges into scoring dimensions.
-        </p>
-      </div>
-      <div className="grid grid-cols-2 gap-4">
-        <Field label="Strategy">
-          <select
+    <div className="space-y-6">
+      <EditorHeader
+        title="Scoring"
+        description="Wire your validators and judges into scoring dimensions."
+      />
+
+      <FieldRow label="Strategy">
+        <BuilderSelect
+          ariaLabel="Strategy"
+          value={strategy}
+          onChange={(v) => setScorecard({ strategy: v as ScoringStrategy })}
+          options={STRATEGIES}
+        />
+      </FieldRow>
+      {strategy !== "binary" && (
+        <FieldRow label="Pass threshold" hint="overall score 0–1 to pass">
+          <input
             className={controlClass}
-            value={strategy}
-            onChange={(e) => setScorecard({ strategy: e.target.value as ScoringStrategy })}
-          >
-            {STRATEGIES.map((s) => (
-              <option key={s.value} value={s.value}>
-                {s.label}
-              </option>
-            ))}
-          </select>
-        </Field>
-        {strategy !== "binary" && (
-          <Field label="Pass threshold" hint="overall score 0–1 to pass">
-            <input
-              className={controlClass}
-              type="number"
-              step="0.05"
-              min="0"
-              max="1"
-              value={scorecard.pass_threshold ?? ""}
-              onChange={(e) => setScorecard({ pass_threshold: numberOrUndefined(e.target.value) })}
-              placeholder="0.75"
-            />
-          </Field>
-        )}
-      </div>
+            type="number"
+            step="0.05"
+            min="0"
+            max="1"
+            value={scorecard.pass_threshold ?? ""}
+            onChange={(e) => setScorecard({ pass_threshold: numberOrUndefined(e.target.value) })}
+            placeholder="0.75"
+          />
+        </FieldRow>
+      )}
 
       <div>
         <div className="mb-2 flex items-center justify-between">
-          <span className="text-sm font-medium">Dimensions ({dims.length})</span>
+          <span className="text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
+            Dimensions {dims.length > 0 && <span className="tabular-nums">({dims.length})</span>}
+          </span>
           <Button size="xs" variant="outline" onClick={addDim}>
             <Plus className="size-3.5" /> Add dimension
           </Button>
         </div>
         <div className="space-y-3">
           {dims.map((dim, i) => (
-            <div key={i} className="space-y-3 rounded-lg border border-border p-3">
+            <div key={i} className="space-y-3 rounded-md border border-builder-border bg-builder-surface p-3">
               <div className="flex items-center gap-2">
                 <input
-                  className={controlClass}
+                  className={monoControlClass}
                   value={dim.key}
                   onChange={(e) => setDim(i, { key: e.target.value })}
                   placeholder="correctness"
                 />
-                <select
-                  className={controlClass}
+                <BuilderSelect
+                  ariaLabel="Source"
+                  className="w-44"
                   value={dim.source}
-                  onChange={(e) => setDim(i, { source: e.target.value as DimensionSource })}
+                  onChange={(v) => setDim(i, { source: v as DimensionSource })}
+                  options={SOURCES}
+                />
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => removeDim(i)}
+                  aria-label="Remove dimension"
                 >
-                  {SOURCES.map((s) => (
-                    <option key={s.value} value={s.value}>
-                      {s.label}
-                    </option>
-                  ))}
-                </select>
-                <Button size="icon-sm" variant="ghost" onClick={() => removeDim(i)} aria-label="Remove dimension">
                   <Trash2 className="size-4" />
                 </Button>
               </div>
@@ -121,7 +117,7 @@ export function ScorecardEditor() {
               {dim.source === "validators" ? (
                 <Field label="Validators" hint="which validators feed this dimension">
                   {validatorKeys.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">Add a validator piece first.</p>
+                    <p className="text-xs text-builder-fg-faint">Add a validator piece first.</p>
                   ) : (
                     <div className="flex flex-wrap gap-2">
                       {validatorKeys.map((key) => {
@@ -129,10 +125,11 @@ export function ScorecardEditor() {
                         return (
                           <label
                             key={key}
-                            className="flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs"
+                            className="flex cursor-pointer items-center gap-1.5 rounded-md border border-builder-border px-2 py-1 font-[family-name:var(--font-mono)] text-xs text-builder-fg-muted transition-colors hover:border-builder-border-strong hover:text-builder-fg"
                           >
                             <input
                               type="checkbox"
+                              className="size-3.5 accent-builder-fg"
                               checked={checked}
                               onChange={(e) =>
                                 setDim(i, {
@@ -152,20 +149,15 @@ export function ScorecardEditor() {
               ) : (
                 <Field label="Judge" hint="which judge feeds this dimension">
                   {judgeKeys.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">Add a judge piece first.</p>
+                    <p className="text-xs text-builder-fg-faint">Add a judge piece first.</p>
                   ) : (
-                    <select
-                      className={controlClass}
+                    <BuilderSelect
+                      ariaLabel="Judge"
+                      placeholder="Select a judge…"
                       value={dim.judge_key ?? ""}
-                      onChange={(e) => setDim(i, { judge_key: e.target.value })}
-                    >
-                      <option value="">Select a judge…</option>
-                      {judgeKeys.map((key) => (
-                        <option key={key} value={key}>
-                          {key}
-                        </option>
-                      ))}
-                    </select>
+                      onChange={(v) => setDim(i, { judge_key: v })}
+                      options={judgeKeys.map((key) => ({ value: key, label: key }))}
+                    />
                   )}
                 </Field>
               )}
@@ -194,9 +186,10 @@ export function ScorecardEditor() {
                   />
                 </Field>
                 <Field label="Gate">
-                  <label className="flex h-9 items-center gap-2 text-sm">
+                  <label className="flex items-center gap-2 py-2 text-sm text-builder-fg-muted">
                     <input
                       type="checkbox"
+                      className="size-3.5 accent-builder-fg"
                       checked={dim.gate ?? false}
                       onChange={(e) => setDim(i, { gate: e.target.checked })}
                     />

--- a/web/src/components/challenge-packs/editors/validator-editor.tsx
+++ b/web/src/components/challenge-packs/editors/validator-editor.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 
-import { Field, controlClass, monoControlClass } from "@/components/tools/field";
 import { updatePieceRef } from "../lib/draft";
 import type { ValidatorDeclaration, ValidatorType } from "../lib/types";
+import { BuilderSelect } from "../ui/builder-select";
+import { controlClass, EditorHeader, Field, FieldRow, monoControlClass } from "../ui/form";
 import { usePackDraft } from "../use-pack-draft";
 import {
   type ConfigField,
@@ -15,6 +16,14 @@ import {
 } from "./validator-types";
 
 const EVIDENCE_TARGETS = ["final_output", "transcript.full", "transcript.from_mismatch"];
+
+const TYPE_GROUPS = VALIDATOR_GROUPS.map((group) => ({
+  label: group,
+  options: VALIDATOR_TYPES.filter((t) => t.group === group).map((t) => ({
+    value: t.value,
+    label: t.label,
+  })),
+}));
 
 export function ValidatorEditor({ index }: { index: number }) {
   const { state, update } = usePackDraft();
@@ -39,70 +48,56 @@ export function ValidatorEditor({ index }: { index: number }) {
   const filePath = (def.target ?? "").startsWith("file:") ? (def.target ?? "").slice(5) : "";
 
   return (
-    <div className="max-w-2xl space-y-5">
-      <h2 className="text-base font-semibold">Validator</h2>
-      <p className="text-sm text-muted-foreground">
-        A deterministic check. Wire it into a scorecard dimension to make it count.
-      </p>
+    <div className="space-y-6">
+      <EditorHeader
+        title="Validator"
+        description="A deterministic check. Wire it into a scorecard dimension to make it count."
+      />
 
-      <Field label="Key" hint="unique; referenced by scorecard dimensions">
+      <FieldRow label="Key" hint="unique; referenced by scorecard dimensions">
         <input
-          className={controlClass}
+          className={monoControlClass}
           value={def.key ?? ""}
           onChange={(e) => set({ key: e.target.value })}
           placeholder="mentions_refund"
         />
-      </Field>
+      </FieldRow>
 
-      <Field label="Check">
-        <select
-          className={controlClass}
+      <FieldRow label="Check">
+        <BuilderSelect
+          ariaLabel="Check"
           value={def.type ?? "contains"}
-          onChange={(e) => changeType(e.target.value as ValidatorType)}
-        >
-          {VALIDATOR_GROUPS.map((group) => (
-            <optgroup key={group} label={group}>
-              {VALIDATOR_TYPES.filter((t) => t.group === group).map((t) => (
-                <option key={t.value} value={t.value}>
-                  {t.label}
-                </option>
-              ))}
-            </optgroup>
-          ))}
-        </select>
-      </Field>
+          onChange={(v) => changeType(v as ValidatorType)}
+          groups={TYPE_GROUPS}
+        />
+      </FieldRow>
 
       {meta.forcesToolCalls ? (
-        <Field label="Target" hint="tool-call validators inspect the agent's tool calls">
-          <input className={controlClass} value="tool_calls" disabled />
-        </Field>
+        <FieldRow label="Target" hint="tool-call validators inspect the agent's tool calls">
+          <input className={monoControlClass} value="tool_calls" disabled />
+        </FieldRow>
       ) : meta.isFile ? (
-        <Field label="File path" hint="sandbox path to check">
+        <FieldRow label="File path" hint="sandbox path to check">
           <input
             className={monoControlClass}
             value={filePath}
             onChange={(e) => set({ target: `file:${e.target.value}` })}
             placeholder="/workspace/out.json"
           />
-        </Field>
+        </FieldRow>
       ) : (
-        <Field label="Target" hint="what gets checked">
-          <select
-            className={controlClass}
+        <FieldRow label="Target" hint="what gets checked">
+          <BuilderSelect
+            ariaLabel="Target"
             value={def.target ?? "final_output"}
-            onChange={(e) => set({ target: e.target.value })}
-          >
-            {EVIDENCE_TARGETS.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </Field>
+            onChange={(v) => set({ target: v })}
+            options={EVIDENCE_TARGETS.map((t) => ({ value: t, label: t }))}
+          />
+        </FieldRow>
       )}
 
       {meta.needsExpected && (
-        <Field
+        <FieldRow
           label="Expected"
           hint={'a literal (prefix "literal:") or an evidence reference like case.expectations.answer'}
         >
@@ -112,7 +107,7 @@ export function ValidatorEditor({ index }: { index: number }) {
             onChange={(e) => set({ expected_from: e.target.value })}
             placeholder="literal:refund"
           />
-        </Field>
+        </FieldRow>
       )}
 
       {meta.config?.map((field) => (
@@ -138,16 +133,22 @@ function ConfigFieldInput({
 }) {
   if (field.type === "boolean") {
     return (
-      <Field label={field.label} hint={field.hint}>
-        <label className="flex h-9 items-center gap-2 text-sm">
-          <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} /> Enabled
+      <FieldRow label={field.label} hint={field.hint}>
+        <label className="flex items-center gap-2 py-2 text-sm text-builder-fg-muted">
+          <input
+            type="checkbox"
+            className="size-3.5 accent-builder-fg"
+            checked={Boolean(value)}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          Enabled
         </label>
-      </Field>
+      </FieldRow>
     );
   }
   if (field.type === "number") {
     return (
-      <Field label={field.label} hint={field.hint}>
+      <FieldRow label={field.label} hint={field.hint}>
         <input
           className={controlClass}
           type="number"
@@ -156,21 +157,21 @@ function ConfigFieldInput({
           onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
           placeholder={field.placeholder}
         />
-      </Field>
+      </FieldRow>
     );
   }
   if (field.type === "json") {
     return <JsonConfigField field={field} value={value} onChange={onChange} />;
   }
   return (
-    <Field label={field.label} hint={field.hint}>
+    <FieldRow label={field.label} hint={field.hint}>
       <input
         className={controlClass}
         value={typeof value === "string" ? value : ""}
         onChange={(e) => onChange(e.target.value)}
         placeholder={field.placeholder}
       />
-    </Field>
+    </FieldRow>
   );
 }
 

--- a/web/src/components/challenge-packs/lib/humanize-errors.ts
+++ b/web/src/components/challenge-packs/lib/humanize-errors.ts
@@ -1,0 +1,101 @@
+// Turns the backend's raw validation field paths (e.g. "challenges[0].difficulty",
+// "input_sets[0].cases[1].payload", "pack.slug") into something a human can read
+// and act on: a friendly breadcrumb, and the builder selection that focuses the
+// offending field when the issue is clicked.
+
+import type { PieceKind } from "./types";
+import type { BuilderSelection } from "../use-pack-draft";
+
+/** Label for a top-level composition root. */
+const SECTION_LABEL: Record<string, string> = {
+  pack: "Overview",
+  version: "Overview",
+  challenges: "Challenges",
+  input_sets: "Inputs",
+  validators: "Checks",
+  judges: "Checks",
+  scorecard: "Scoring",
+};
+
+/** Singular noun for an indexed collection ("challenges[2]" → "Challenge 3"). */
+const SINGULAR: Record<string, string> = {
+  challenges: "Challenge",
+  input_sets: "Input set",
+  validators: "Validator",
+  judges: "Judge",
+  cases: "Case",
+  dimensions: "Dimension",
+  phases: "Phase",
+  turns: "Turn",
+};
+
+/** Nicer names for common leaf fields; falls back to title-casing the key. */
+const LEAF_LABEL: Record<string, string> = {
+  expected_from: "Expected",
+  pass_threshold: "Pass threshold",
+  judge_key: "Judge",
+  case_key: "Case key",
+  challenge_key: "Challenge",
+  execution_mode: "Execution mode",
+  tool_policy: "Tool policy",
+};
+
+function titleCase(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function leafLabel(key: string): string {
+  return LEAF_LABEL[key] ?? titleCase(key);
+}
+
+function parseSegment(seg: string): { key: string; indices: number[] } {
+  const match = seg.match(/^([^[\]]+)((?:\[\d+\])*)$/);
+  if (!match) return { key: seg, indices: [] };
+  const indices = match[2] ? [...match[2].matchAll(/\[(\d+)\]/g)].map((m) => Number(m[1])) : [];
+  return { key: match[1], indices };
+}
+
+/**
+ * "challenges[0].difficulty" → "Challenges → Challenge 1 → Difficulty"
+ * "pack.slug" → "Overview → Slug"
+ * "input_sets[0].cases[1].payload" → "Inputs → Input set 1 → Case 2 → Payload"
+ */
+export function humanizeFieldPath(field: string): string {
+  if (!field) return "This pack";
+  const parts: string[] = [];
+  field
+    .split(".")
+    .filter(Boolean)
+    .forEach((seg, i) => {
+      const { key, indices } = parseSegment(seg);
+      if (i === 0 && SECTION_LABEL[key]) {
+        parts.push(SECTION_LABEL[key]);
+      } else if (indices.length === 0) {
+        parts.push(leafLabel(key));
+      }
+      if (indices.length > 0) {
+        const singular = SINGULAR[key] ?? titleCase(key);
+        indices.forEach((idx) => parts.push(`${singular} ${idx + 1}`));
+      }
+    });
+  return parts.join(" → ") || "This pack";
+}
+
+const ROOT_TO_KIND: Record<string, PieceKind> = {
+  challenges: "challenge",
+  input_sets: "input_set",
+  input_set: "input_set",
+  validators: "validator",
+  judges: "judge",
+};
+
+/** The builder selection that focuses the field an error refers to, if known. */
+export function fieldToSelection(field: string): BuilderSelection | null {
+  const first = field.split(".")[0] ?? "";
+  const { key, indices } = parseSegment(first);
+  if (key === "pack" || key === "version") return { section: "overview" };
+  if (key === "scorecard") return { section: "scorecard" };
+  const kind = ROOT_TO_KIND[key];
+  if (kind) return { section: "piece", kind, index: indices[0] ?? 0 };
+  return null;
+}

--- a/web/src/components/challenge-packs/outline/pack-outline.tsx
+++ b/web/src/components/challenge-packs/outline/pack-outline.tsx
@@ -70,8 +70,15 @@ export function PackOutline() {
   };
   const removePiece = (kind: PieceKind, index: number) => {
     update((c) => removePieceRef(c, kind, index));
+    // Keep the current selection pointing at the same piece: only the viewed
+    // piece being removed warrants leaving; a removal at a lower index just
+    // shifts everything after it down by one.
     if (selection.section === "piece" && selection.kind === kind) {
-      select({ section: "overview" });
+      if (selection.index === index) {
+        select({ section: "overview" });
+      } else if (selection.index > index) {
+        select({ section: "piece", kind, index: selection.index - 1 });
+      }
     }
   };
 
@@ -244,7 +251,11 @@ function RailNav({
         <span className="flex-1 truncate">{label}</span>
         {issue && (
           <span
-            className="size-1.5 shrink-0 rounded-full bg-builder-warn group-hover/row:opacity-0"
+            className={cn(
+              "size-1.5 shrink-0 rounded-full bg-builder-warn",
+              // Fades only on removable rows, where the trash icon takes its place.
+              onRemove && "group-hover/row:opacity-0",
+            )}
             aria-label="has issues"
           />
         )}

--- a/web/src/components/challenge-packs/outline/pack-outline.tsx
+++ b/web/src/components/challenge-packs/outline/pack-outline.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { LayoutGrid, Library, Plus, SlidersHorizontal } from "lucide-react";
-import { useState } from "react";
+import { Library, Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
-import { addPieceRef, PIECE_KINDS, PIECE_KIND_META, pieceRefs } from "../lib/draft";
-import type { PieceDefinition, PieceKind, PieceRef } from "../lib/types";
+import { addPieceRef, PIECE_KIND_META, pieceRefs, removePieceRef } from "../lib/draft";
+import { fieldToSelection } from "../lib/humanize-errors";
+import type { Composition, PieceDefinition, PieceKind, PieceRef } from "../lib/types";
 import { LibraryPicker } from "../pieces/library-picker";
 import { type BuilderSelection, usePackDraft } from "../use-pack-draft";
 
@@ -42,81 +43,78 @@ export function PackOutline() {
   const { composition, selection } = state;
   const [pickerKind, setPickerKind] = useState<PieceKind | null>(null);
 
+  // Sections/pieces that have an unresolved validation issue, derived from the
+  // latest compile so the rail can flag exactly where work remains.
+  const issues = useMemo(
+    () =>
+      (state.compile?.errors ?? [])
+        .map((e) => fieldToSelection(e.field))
+        .filter((s): s is BuilderSelection => s != null),
+    [state.compile],
+  );
+  const sectionIssue = (section: "overview" | "scorecard") =>
+    issues.some((t) => t.section === section);
+  const pieceIssue = (kind: PieceKind, index: number) =>
+    issues.some((t) => t.section === "piece" && t.kind === kind && t.index === index);
+
   const addPiece = (kind: PieceKind) => {
     const count = pieceRefs(composition, kind).length;
-    const inline = defaultPieceInline(kind, count + 1);
-    update((c) => addPieceRef(c, kind, { inline }));
+    update((c) => addPieceRef(c, kind, { inline: defaultPieceInline(kind, count + 1) }));
     select({ section: "piece", kind, index: count });
   };
-
   const addFromLibrary = (kind: PieceKind, ref: PieceRef) => {
     const count = pieceRefs(composition, kind).length;
     update((c) => addPieceRef(c, kind, ref));
     select({ section: "piece", kind, index: count });
     setPickerKind(null);
   };
+  const removePiece = (kind: PieceKind, index: number) => {
+    update((c) => removePieceRef(c, kind, index));
+    if (selection.section === "piece" && selection.kind === kind) {
+      select({ section: "overview" });
+    }
+  };
+
+  const blockProps = {
+    composition,
+    selection,
+    pieceIssue,
+    onSelect: (kind: PieceKind, index: number) => select({ section: "piece", kind, index }),
+    onAddNew: addPiece,
+    onAddLibrary: setPickerKind,
+    onRemove: removePiece,
+  };
 
   return (
-    <nav className="flex h-full flex-col gap-1 overflow-y-auto p-3 text-sm">
-      <OutlineRow
-        icon={<LayoutGrid className="size-4" />}
+    <nav className="flex h-full flex-col gap-px overflow-y-auto p-3 text-sm">
+      <RailNav
+        num={1}
         label="Overview"
         active={isSelected(selection, { section: "overview" })}
+        issue={sectionIssue("overview")}
         onClick={() => select({ section: "overview" })}
       />
 
-      {PIECE_KINDS.map((kind) => {
-        const meta = PIECE_KIND_META[kind];
-        const refs = pieceRefs(composition, kind);
-        return (
-          <div key={kind} className="mt-3">
-            <div className="mb-1 flex items-center justify-between px-2">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {meta.pluralLabel}
-              </span>
-              <div className="flex items-center gap-0.5">
-                <button
-                  type="button"
-                  onClick={() => setPickerKind(kind)}
-                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  aria-label={`Add ${meta.label} from library`}
-                  title="Add from library"
-                >
-                  <Library className="size-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => addPiece(kind)}
-                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  aria-label={`Add ${meta.label}`}
-                  title={`New ${meta.label.toLowerCase()}`}
-                >
-                  <Plus className="size-3.5" />
-                </button>
-              </div>
-            </div>
-            {refs.length === 0 ? (
-              <p className="px-2 py-1 text-xs text-muted-foreground/70">{meta.description}</p>
-            ) : (
-              refs.map((ref, index) => (
-                <OutlineRow
-                  key={index}
-                  label={pieceLabel(kind, ref, index)}
-                  indented
-                  active={isSelected(selection, { section: "piece", kind, index })}
-                  onClick={() => select({ section: "piece", kind, index })}
-                />
-              ))
-            )}
-          </div>
-        );
-      })}
+      <PieceBlock num={2} title="Challenges" kind="challenge" {...blockProps} />
+      <PieceBlock num={3} title="Inputs" kind="input_set" {...blockProps} />
 
-      <div className="mt-3">
-        <OutlineRow
-          icon={<SlidersHorizontal className="size-4" />}
+      <div className="mt-4">
+        <div className="mb-1 flex items-center gap-2 px-2">
+          <SectionNumber n={4} />
+          <span className="text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
+            Checks
+          </span>
+        </div>
+        <PieceBlock title="Validators" kind="validator" sub {...blockProps} />
+        <PieceBlock title="Judges" kind="judge" sub {...blockProps} />
+      </div>
+
+      <div className="mt-4">
+        <RailNav
+          num={5}
           label="Scoring"
           active={isSelected(selection, { section: "scorecard" })}
+          issue={sectionIssue("scorecard")}
           onClick={() => select({ section: "scorecard" })}
         />
       </div>
@@ -133,31 +131,147 @@ export function PackOutline() {
   );
 }
 
-function OutlineRow({
-  icon,
+interface BlockProps {
+  composition: Composition;
+  selection: BuilderSelection;
+  pieceIssue: (kind: PieceKind, index: number) => boolean;
+  onSelect: (kind: PieceKind, index: number) => void;
+  onAddNew: (kind: PieceKind) => void;
+  onAddLibrary: (kind: PieceKind) => void;
+  onRemove: (kind: PieceKind, index: number) => void;
+}
+
+function PieceBlock({
+  kind,
+  title,
+  num,
+  sub,
+  composition,
+  selection,
+  pieceIssue,
+  onSelect,
+  onAddNew,
+  onAddLibrary,
+  onRemove,
+}: BlockProps & { kind: PieceKind; title: string; num?: number; sub?: boolean }) {
+  const meta = PIECE_KIND_META[kind];
+  const refs = pieceRefs(composition, kind);
+
+  return (
+    <div className={cn(num != null ? "mt-4" : "mt-2")}>
+      <div className="mb-1 flex items-center gap-2 px-2">
+        {num != null && <SectionNumber n={num} />}
+        <span
+          className={cn(
+            "flex-1 truncate text-xs font-medium tracking-wide",
+            sub ? "text-builder-fg-faint" : "uppercase text-builder-fg-subtle",
+          )}
+        >
+          {title}
+        </span>
+        {refs.length > 0 && (
+          <span className="text-[11px] tabular-nums text-builder-fg-faint">{refs.length}</span>
+        )}
+        <button
+          type="button"
+          onClick={() => onAddLibrary(kind)}
+          aria-label={`Add ${meta.label} from library`}
+          title="Add from library"
+          className="rounded p-0.5 text-builder-fg-subtle transition-colors hover:bg-builder-surface hover:text-builder-fg"
+        >
+          <Library className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onAddNew(kind)}
+          aria-label={`Add ${meta.label}`}
+          title={`New ${meta.label.toLowerCase()}`}
+          className="rounded p-0.5 text-builder-fg-subtle transition-colors hover:bg-builder-surface hover:text-builder-fg"
+        >
+          <Plus className="size-3.5" />
+        </button>
+      </div>
+      {refs.length === 0 ? (
+        <p className="px-2 pb-1 text-xs leading-relaxed text-builder-fg-faint">{meta.description}</p>
+      ) : (
+        refs.map((ref, index) => (
+          <RailNav
+            key={index}
+            label={pieceLabel(kind, ref, index)}
+            indent
+            active={isSelected(selection, { section: "piece", kind, index })}
+            issue={pieceIssue(kind, index)}
+            onClick={() => onSelect(kind, index)}
+            onRemove={() => onRemove(kind, index)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function RailNav({
+  num,
   label,
+  indent,
   active,
-  indented,
+  issue,
   onClick,
+  onRemove,
 }: {
-  icon?: React.ReactNode;
+  num?: number;
   label: string;
+  indent?: boolean;
   active: boolean;
-  indented?: boolean;
+  issue?: boolean;
   onClick: () => void;
+  onRemove?: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div className="group/row relative">
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "flex w-full items-center gap-2 truncate rounded-md py-1.5 pr-2 text-left transition-colors",
+          indent ? "pl-7" : "pl-2",
+          active
+            ? "bg-builder-surface-hover text-builder-fg"
+            : "text-builder-fg-muted hover:bg-builder-surface hover:text-builder-fg",
+        )}
+      >
+        {num != null && <SectionNumber n={num} active={active} />}
+        <span className="flex-1 truncate">{label}</span>
+        {issue && (
+          <span
+            className="size-1.5 shrink-0 rounded-full bg-builder-warn group-hover/row:opacity-0"
+            aria-label="has issues"
+          />
+        )}
+      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remove"
+          className="absolute top-1/2 right-1 -translate-y-1/2 rounded p-1 text-builder-fg-faint opacity-0 transition-colors transition-opacity hover:text-builder-warn group-hover/row:opacity-100"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function SectionNumber({ n, active }: { n: number; active?: boolean }) {
+  return (
+    <span
       className={cn(
-        "flex w-full items-center gap-2 truncate rounded-md px-2 py-1.5 text-left transition-colors",
-        indented && "pl-7",
-        active ? "bg-foreground text-background" : "hover:bg-muted",
+        "w-4 shrink-0 text-center text-[11px] tabular-nums",
+        active ? "text-builder-fg" : "text-builder-fg-faint",
       )}
     >
-      {icon}
-      <span className="truncate">{label}</span>
-    </button>
+      {n}
+    </span>
   );
 }

--- a/web/src/components/challenge-packs/pieces/library-picker.tsx
+++ b/web/src/components/challenge-packs/pieces/library-picker.tsx
@@ -7,12 +7,12 @@
 import { Loader2, Search, X } from "lucide-react";
 import { useState } from "react";
 
-import { controlClass } from "@/components/tools/field";
 import { useApiListQuery } from "@/lib/api/swr";
 import { cn } from "@/lib/utils";
 import { pieceLibraryPath, piecesPath } from "../lib/api";
 import { PIECE_KIND_META } from "../lib/draft";
 import type { ChallengePiece, PieceKind, PieceRef, StarterPiece } from "../lib/types";
+import { controlClass } from "../ui/form";
 
 export function LibraryPicker({
   workspaceId,
@@ -37,27 +37,29 @@ export function LibraryPicker({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       onClick={onClose}
     >
       <div
-        className="flex max-h-[70vh] w-full max-w-lg flex-col rounded-xl border border-border bg-card shadow-xl"
+        className="flex max-h-[70vh] w-full max-w-lg flex-col rounded-xl border border-builder-border bg-builder-panel shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <span className="text-sm font-semibold">Add {meta.label.toLowerCase()} from library</span>
+        <div className="flex items-center justify-between border-b border-builder-border px-4 py-3">
+          <span className="text-sm font-medium text-builder-fg">
+            Add {meta.label.toLowerCase()} from library
+          </span>
           <button
             type="button"
             onClick={onClose}
-            className="text-muted-foreground transition-colors hover:text-foreground"
+            className="rounded p-1 text-builder-fg-subtle transition-colors hover:bg-builder-surface hover:text-builder-fg"
             aria-label="Close"
           >
             <X className="size-4" />
           </button>
         </div>
-        <div className="border-b border-border p-3">
+        <div className="border-b border-builder-border p-3">
           <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-builder-fg-subtle" />
             <input
               className={cn(controlClass, "pl-8")}
               placeholder={`Search ${meta.pluralLabel.toLowerCase()}…`}
@@ -70,16 +72,16 @@ export function LibraryPicker({
         <div className="min-h-0 flex-1 overflow-y-auto p-2">
           {wsLoading || starterLoading ? (
             <div className="flex justify-center p-6">
-              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+              <Loader2 className="size-5 animate-spin text-builder-fg-subtle" />
             </div>
           ) : (
             <>
               <div className="mb-2">
-                <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
                   Your library
                 </div>
                 {workspacePieces.length === 0 ? (
-                  <p className="px-2 py-1 text-xs text-muted-foreground/70">
+                  <p className="px-2 py-1 text-xs text-builder-fg-faint">
                     Nothing saved yet — build a piece and use &ldquo;Save to library&rdquo;.
                   </p>
                 ) : (
@@ -95,7 +97,7 @@ export function LibraryPicker({
               </div>
               {starters.length > 0 && (
                 <div className="mb-2">
-                  <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <div className="px-2 py-1 text-xs font-medium uppercase tracking-wide text-builder-fg-subtle">
                     Starters
                   </div>
                   {starters.map((s) => (
@@ -129,10 +131,10 @@ function PickerRow({
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-muted"
+      className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-builder-surface"
     >
-      <span className="text-sm font-medium">{name}</span>
-      {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+      <span className="text-sm font-medium text-builder-fg">{name}</span>
+      {subtitle && <span className="text-xs text-builder-fg-subtle">{subtitle}</span>}
     </button>
   );
 }

--- a/web/src/components/challenge-packs/pieces/piece-frame.tsx
+++ b/web/src/components/challenge-packs/pieces/piece-frame.tsx
@@ -72,8 +72,14 @@ function PieceToolbar({ kind, index }: { kind: PieceKind; index: number }) {
   };
 
   return (
-    <div className="mb-4 flex justify-end">
-      <Button size="xs" variant="outline" onClick={save} disabled={saving}>
+    <div className="mb-5 flex justify-end">
+      <Button
+        size="xs"
+        variant="ghost"
+        onClick={save}
+        disabled={saving}
+        className="text-builder-fg-subtle hover:bg-builder-surface hover:text-builder-fg"
+      >
         {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Library className="size-3.5" />}
         Save to library
       </Button>
@@ -99,19 +105,23 @@ function ReferencedPieceView({
     );
 
   return (
-    <div className="max-w-2xl space-y-4">
-      <div className="flex items-center gap-2">
-        <Library className="size-4 text-muted-foreground" />
-        <h2 className="text-base font-semibold">{data?.name ?? "Library piece"}</h2>
+    <div className="space-y-5">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Library className="size-4 text-builder-fg-subtle" />
+          <h2 className="text-[0.95rem] font-medium tracking-tight text-builder-fg">
+            {data?.name ?? "Library piece"}
+          </h2>
+        </div>
+        <p className="text-sm leading-relaxed text-builder-fg-muted">
+          Referenced from your workspace library. Edit it in the library to update every pack that
+          uses it, or edit a copy to customize it just for this pack.
+        </p>
       </div>
-      <p className="text-sm text-muted-foreground">
-        Referenced from your workspace library. Edit it in the library to update every pack that uses
-        it, or edit a copy to customize it just for this pack.
-      </p>
       {isLoading ? (
-        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        <Loader2 className="size-5 animate-spin text-builder-fg-subtle" />
       ) : (
-        <pre className="overflow-auto rounded-lg border border-border bg-muted/40 p-3 text-xs">
+        <pre className="overflow-auto rounded-md border border-builder-border bg-builder-panel p-3 font-[family-name:var(--font-mono)] text-xs leading-relaxed text-builder-fg-muted">
           {JSON.stringify(data?.definition ?? {}, null, 2)}
         </pre>
       )}

--- a/web/src/components/challenge-packs/pieces/preview-drawer.tsx
+++ b/web/src/components/challenge-packs/pieces/preview-drawer.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// The live preview, as an on-demand slide-over so the editor column stays calm.
+// A slim close bar sits above the shared SpecCard (which carries its own
+// Preview / readable / YAML header).
+
+import { X } from "lucide-react";
+
+import { SpecCard } from "./spec-card";
+
+export function PreviewDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  if (!open) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close preview"
+        onClick={onClose}
+        className="fixed inset-0 z-40 bg-black/50"
+      />
+      <aside className="fixed inset-y-0 right-0 z-50 flex w-[min(26rem,100vw)] animate-in flex-col border-l border-builder-border bg-builder-panel slide-in-from-right-2 duration-200">
+        <div className="flex items-center justify-end border-b border-builder-border px-2 py-1.5">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close preview"
+            className="rounded p-1 text-builder-fg-subtle transition-colors hover:bg-builder-surface hover:text-builder-fg"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <SpecCard />
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/web/src/components/challenge-packs/pieces/preview-drawer.tsx
+++ b/web/src/components/challenge-packs/pieces/preview-drawer.tsx
@@ -5,10 +5,20 @@
 // Preview / readable / YAML header).
 
 import { X } from "lucide-react";
+import { useEffect } from "react";
 
 import { SpecCard } from "./spec-card";
 
 export function PreviewDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
   if (!open) return null;
 
   return (

--- a/web/src/components/challenge-packs/pieces/spec-card.tsx
+++ b/web/src/components/challenge-packs/pieces/spec-card.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { AlertCircle, CheckCircle2 } from "lucide-react";
-
 import { usePackDraft } from "../use-pack-draft";
 import { SpecCardView } from "./spec-card-view";
+import { ValidationPanel } from "./validation-panel";
 
 /**
  * Builder preview pane: binds the live draft compile state to the shared
@@ -21,35 +20,5 @@ export function SpecCard() {
       compiling={state.compiling}
       footer={<ValidationPanel valid={compile?.valid ?? false} errors={compile?.errors ?? []} />}
     />
-  );
-}
-
-function ValidationPanel({
-  valid,
-  errors,
-}: {
-  valid: boolean;
-  errors: { field: string; message: string }[];
-}) {
-  if (valid) {
-    return (
-      <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
-        <CheckCircle2 className="size-4" /> Ready to publish
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-1.5 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
-      <div className="flex items-center gap-2 text-sm font-medium text-amber-600 dark:text-amber-400">
-        <AlertCircle className="size-4" /> {errors.length} issue{errors.length === 1 ? "" : "s"} to resolve
-      </div>
-      <ul className="space-y-1 text-xs text-muted-foreground">
-        {errors.map((e, i) => (
-          <li key={i}>
-            <span className="font-mono text-foreground">{e.field}</span> — {e.message}
-          </li>
-        ))}
-      </ul>
-    </div>
   );
 }

--- a/web/src/components/challenge-packs/pieces/validation-panel.tsx
+++ b/web/src/components/challenge-packs/pieces/validation-panel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+// The "what's left to fix" panel. Replaces the old monospace dump of raw field
+// paths with readable breadcrumbs; each issue is a button that jumps straight to
+// the offending field via the builder's selection model.
+
+import { AlertCircle, ArrowRight, CheckCircle2 } from "lucide-react";
+
+import { fieldToSelection, humanizeFieldPath } from "../lib/humanize-errors";
+import type { ValidationIssue } from "../lib/types";
+import { usePackDraft } from "../use-pack-draft";
+
+export function ValidationPanel({
+  valid,
+  errors,
+}: {
+  valid: boolean;
+  errors: ValidationIssue[];
+}) {
+  const { select } = usePackDraft();
+
+  if (valid) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-builder-border bg-builder-surface px-3 py-2.5 text-sm text-builder-fg-muted">
+        <CheckCircle2 className="size-4 text-builder-fg-subtle" />
+        Ready to publish
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-builder-warn/30 bg-builder-warn-soft p-3">
+      <div className="flex items-center gap-2 text-sm font-medium text-builder-warn">
+        <AlertCircle className="size-4" />
+        {errors.length} {errors.length === 1 ? "thing" : "things"} to fix
+      </div>
+      <ul className="space-y-0.5">
+        {errors.map((issue, i) => {
+          const target = fieldToSelection(issue.field);
+          return (
+            <li key={`${issue.field}-${i}`}>
+              <button
+                type="button"
+                disabled={!target}
+                onClick={() => target && select(target)}
+                className="group flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs text-builder-fg-muted transition-colors hover:bg-builder-surface-hover hover:text-builder-fg disabled:cursor-default disabled:hover:bg-transparent"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="text-builder-fg">{humanizeFieldPath(issue.field)}</span>
+                  <span className="text-builder-fg-subtle"> — {issue.message}</span>
+                </span>
+                {target && (
+                  <ArrowRight className="mt-0.5 size-3 shrink-0 text-builder-fg-faint opacity-0 transition-opacity group-hover:opacity-100" />
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/challenge-packs/ui/builder-select.tsx
+++ b/web/src/components/challenge-packs/ui/builder-select.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+// The builder's single dropdown. Replaces native <select>, which rendered an
+// unreadable white system popup inside the dark app. We own the trigger styling
+// (built from the base primitive to avoid the shared SelectTrigger's fixed
+// height) and reuse the portaled, accessible popup parts from ui/select.
+
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { ChevronDownIcon } from "lucide-react";
+
+import { SelectContent, SelectGroup, SelectItem, SelectLabel } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+export type BuilderSelectOption = { value: string; label: string; disabled?: boolean };
+export type BuilderSelectGroup = { label: string; options: BuilderSelectOption[] };
+
+const triggerClass =
+  "flex w-full items-center justify-between gap-2 rounded-md border border-builder-border bg-builder-surface px-3 py-2 text-left text-sm text-builder-fg transition-colors select-none data-placeholder:text-builder-fg-faint hover:border-builder-border-strong focus:border-builder-fg-muted focus:bg-builder-surface-hover focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+export function BuilderSelect({
+  value,
+  onChange,
+  options,
+  groups,
+  placeholder,
+  ariaLabel,
+  id,
+  disabled,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options?: BuilderSelectOption[];
+  groups?: BuilderSelectGroup[];
+  placeholder?: string;
+  ariaLabel?: string;
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const renderItem = (o: BuilderSelectOption) => (
+    <SelectItem key={o.value} value={o.value} disabled={o.disabled}>
+      {o.label}
+    </SelectItem>
+  );
+
+  return (
+    <SelectPrimitive.Root
+      value={value}
+      onValueChange={(v) => {
+        if (v != null) onChange(v as string);
+      }}
+    >
+      <SelectPrimitive.Trigger
+        id={id}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        className={cn(triggerClass, className)}
+      >
+        <span className="min-w-0 truncate">
+          <SelectPrimitive.Value placeholder={placeholder} />
+        </span>
+        <SelectPrimitive.Icon
+          render={<ChevronDownIcon className="size-4 shrink-0 text-builder-fg-subtle" />}
+        />
+      </SelectPrimitive.Trigger>
+      <SelectContent
+        alignItemWithTrigger={false}
+        className="border border-builder-border bg-builder-panel"
+      >
+        {groups
+          ? groups.map((g) => (
+              <SelectGroup key={g.label}>
+                <SelectLabel>{g.label}</SelectLabel>
+                {g.options.map(renderItem)}
+              </SelectGroup>
+            ))
+          : options?.map(renderItem)}
+      </SelectContent>
+    </SelectPrimitive.Root>
+  );
+}

--- a/web/src/components/challenge-packs/ui/form.tsx
+++ b/web/src/components/challenge-packs/ui/form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+// Quiet-utilitarian form primitives for the challenge-pack builder: warm,
+// near-monochrome, mono-forward, with the accent (--builder-warn) reserved for
+// errors only. Kept separate from components/tools/field.tsx so the (shared)
+// tool builder is unaffected by the builder's bespoke styling.
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export const controlClass =
+  "block w-full rounded-md border border-builder-border bg-builder-surface px-3 py-2 text-sm text-builder-fg transition-colors placeholder:text-builder-fg-faint hover:border-builder-border-strong focus:border-builder-fg-muted focus:bg-builder-surface-hover focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+export const monoControlClass = cn(
+  controlClass,
+  "font-[family-name:var(--font-mono)] text-xs leading-relaxed",
+);
+
+/** Section title + one-line description that opens every editor. */
+export function EditorHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description?: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-[0.95rem] font-medium tracking-tight text-builder-fg">{title}</h2>
+      {description && (
+        <p className="text-sm leading-relaxed text-builder-fg-muted">{description}</p>
+      )}
+    </div>
+  );
+}
+
+/** Stacked label/control — use for textareas and anything multi-line. */
+export function Field({
+  label,
+  hint,
+  error,
+  htmlFor,
+  children,
+  className,
+}: {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: string;
+  htmlFor?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      {label && (
+        <label
+          htmlFor={htmlFor}
+          className="mb-1.5 block text-xs font-medium lowercase text-builder-fg-subtle"
+        >
+          {label}
+        </label>
+      )}
+      {hint && <p className="mb-1.5 text-xs text-builder-fg-faint">{hint}</p>}
+      {children}
+      {error && <p className="mt-1.5 text-xs text-builder-warn">{error}</p>}
+    </div>
+  );
+}
+
+/**
+ * Aligned `label … control` row — the signature compact, scannable look for
+ * single-line fields. Collapses to a stacked layout on narrow viewports.
+ */
+export function FieldRow({
+  label,
+  hint,
+  error,
+  htmlFor,
+  children,
+  className,
+}: {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: string;
+  htmlFor?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-x-4 gap-y-1.5 sm:grid-cols-[7.5rem_1fr] sm:items-start",
+        className,
+      )}
+    >
+      {label && (
+        <label
+          htmlFor={htmlFor}
+          className="text-xs font-medium lowercase text-builder-fg-subtle sm:pt-2.5"
+        >
+          {label}
+        </label>
+      )}
+      <div className="min-w-0">
+        {children}
+        {hint && <p className="mt-1.5 text-xs text-builder-fg-faint">{hint}</p>}
+        {error && <p className="mt-1.5 text-xs text-builder-warn">{error}</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

The challenge pack builder was hard to use and off-brand:

- Validation errors leaked **raw field paths** (e.g. `input_sets[0].cases[1].payload`) — users saw machine paths, not what to fix.
- Native `<select>` dropdowns rendered an unreadable **white system popup** on the dark theme (effectively invisible on laptops).
- It was built entirely on **cold neutral shadcn tokens**, ignoring the warm editorial design system.
- The cramped **3-pane IDE** layout assumed you already understood the domain model.

## What

- **Custom dropdown** — `BuilderSelect` wraps the base-ui popup and replaces every native `<select>`. It owns its portaled dark popup, so it can't fall back to the white OS list.
- **Human-readable, click-to-fix validation** — `humanizeFieldPath` turns paths into breadcrumbs ("Inputs → Input set 1 → Case 2 → Payload"); each issue is a button that jumps to the offending field. A "N to fix" header pill + rail issue dots surface them proactively.
- **Quiet-utilitarian visual language** — a scoped warm `builder-*` token set (the app's shadcn tokens are untouched) plus bespoke form primitives (`EditorHeader`, `FieldRow`, lowercase labels, mono identifiers).
- **Two-pane layout** — a numbered section rail (Overview · Challenges · Inputs · Checks · Scoring) + a single focused editor column + an on-demand preview slide-over drawer.
- Adds hover-to-remove on rail pieces (a prior gap).

Unchanged on purpose: the autosave/compile state layer (`use-pack-draft`) and `SpecCardView` (shared with the catalog).

## New / reworked files

- New: `ui/form.tsx`, `ui/builder-select.tsx`, `lib/humanize-errors.ts`, `pieces/preview-drawer.tsx`, `pieces/validation-panel.tsx`
- Reworked: `builder-shell`, `outline/pack-outline`, all 7 editors, `piece-frame`, `library-picker`, `spec-card`, `globals.css`

## Verification

- `npx tsc --noEmit` ✓
- `pnpm lint` ✓
- `pnpm build` ✓
- Live in-app QA against a running stack is **not yet done** — remaining risk is visual polish (spacing, drawer feel on real content).