### PR TITLE
feat(evaltest): local eval data model and report schema (#1106)

### DIFF
--- a/cli/cmd/evaltest_exit_codes.go
+++ b/cli/cmd/evaltest_exit_codes.go
@@ -1,0 +1,11 @@
+package cmd
+
+// Stable exit codes for `agentclash evaltest run`.
+// See schemas/evaltest/README.md for the contract.
+const (
+	evaltestExitPass           = 0
+	evaltestExitAssertionFail  = 1
+	evaltestExitConfigError    = 2
+	evaltestExitProviderError  = 3
+	evaltestExitInternalError  = 4
+)

--- a/cli/cmd/evaltest_schema_test.go
+++ b/cli/cmd/evaltest_schema_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+func TestEvalReportSchemaAcceptsFixtures(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	schemaPath := filepath.Join(repoRoot, "schemas", "evaltest", "eval-report.schema.json")
+	schema := loadEvalJSONSchema(t, schemaPath)
+
+	fixtures := []struct {
+		name       string
+		fixture    string
+		wantExit   int
+	}{
+		{name: "all pass", fixture: "all-pass.json", wantExit: 0},
+		{name: "metric failure", fixture: "metric-failure.json", wantExit: 1},
+		{name: "provider error", fixture: "provider-error.json", wantExit: 3},
+		{name: "config error", fixture: "config-error.json", wantExit: 2},
+		{name: "multi turn", fixture: "multi-turn.json", wantExit: 0},
+	}
+
+	for _, tt := range fixtures {
+		t.Run(tt.name, func(t *testing.T) {
+			fixturePath := filepath.Join(repoRoot, "schemas", "evaltest", "fixtures", tt.fixture)
+			doc := loadEvalJSONDocument(t, fixturePath)
+			if err := schema.Validate(doc); err != nil {
+				t.Fatalf("schema rejected fixture %s: %v", tt.fixture, err)
+			}
+
+			report, ok := doc.(map[string]any)
+			if !ok {
+				t.Fatalf("fixture %s is not an object", tt.fixture)
+			}
+			exitRaw := report["exit_code"]
+			var got int
+			switch v := exitRaw.(type) {
+			case float64:
+				got = int(v)
+			case int:
+				got = v
+			case int64:
+				got = int(v)
+			default:
+				t.Fatalf("exit_code missing or wrong type in %s: %T", tt.fixture, exitRaw)
+			}
+			if got != tt.wantExit {
+				t.Fatalf("exit_code = %d, want %d", got, tt.wantExit)
+			}
+		})
+	}
+}
+
+func TestEvalReportSchemaRejectsUnknownVersion(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	schemaPath := filepath.Join(repoRoot, "schemas", "evaltest", "eval-report.schema.json")
+	schema := loadEvalJSONSchema(t, schemaPath)
+
+	fixturePath := filepath.Join(repoRoot, "schemas", "evaltest", "fixtures", "all-pass.json")
+	doc := loadEvalJSONDocument(t, fixturePath)
+	report, ok := doc.(map[string]any)
+	if !ok {
+		t.Fatal("fixture is not an object")
+	}
+	report["schema_version"] = 999
+
+	if err := schema.Validate(report); err == nil {
+		t.Fatal("expected schema to reject unknown schema_version")
+	}
+}
+
+func TestAgentResultSchemaAcceptsMultiTurnFixture(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	schemaPath := filepath.Join(repoRoot, "schemas", "evaltest", "agent-result.schema.json")
+	schema := loadEvalJSONSchema(t, schemaPath)
+
+	fixturePath := filepath.Join(repoRoot, "schemas", "evaltest", "fixtures", "multi-turn.json")
+	report := loadEvalJSONDocument(t, fixturePath)
+	reportMap, ok := report.(map[string]any)
+	if !ok {
+		t.Fatal("report is not an object")
+	}
+	cases, ok := reportMap["cases"].([]any)
+	if !ok || len(cases) == 0 {
+		t.Fatal("expected cases array")
+	}
+	caseResult, ok := cases[0].(map[string]any)
+	if !ok {
+		t.Fatal("case result is not an object")
+	}
+	agentResult := caseResult["agent_result"]
+	if err := schema.Validate(agentResult); err != nil {
+		t.Fatalf("agent-result schema rejected multi-turn fixture: %v", err)
+	}
+}
+
+func TestEvaltestExitCodesDocumented(t *testing.T) {
+	want := map[int]string{
+		0: "success",
+		1: "assertion_failed",
+		2: "config_error",
+		3: "provider_error",
+		4: "internal_error",
+	}
+	for code, name := range want {
+		found := false
+		for _, entry := range documentedExitCodes {
+			if entry.Code == code {
+				for _, cmd := range entry.Commands {
+					if cmd == "evaltest run" {
+						found = true
+						break
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("exit code %d (%s) not documented for evaltest run", code, name)
+		}
+	}
+}
+
+func loadEvalJSONSchema(t *testing.T, path string) *jsonschema.Resolved {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema %s: %v", path, err)
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("unmarshal schema %s: %v", path, err)
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("resolve schema %s: %v", path, err)
+	}
+	return resolved
+}
+
+func loadEvalJSONDocument(t *testing.T, path string) any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read document %s: %v", path, err)
+	}
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal document %s: %v", path, err)
+	}
+	return doc
+}

--- a/cli/cmd/exit_codes.go
+++ b/cli/cmd/exit_codes.go
@@ -57,4 +57,11 @@ var documentedExitCodes = []ExitCode{
 	{Code: ciRunExitAPI, Name: "ci_run_api_error", Description: "ci run: an API error occurred.", Commands: []string{"ci run"}},
 	{Code: ciRunExitTimeout, Name: "ci_run_timeout", Description: "ci run: timed out waiting for a candidate run.", Commands: []string{"ci run"}},
 	{Code: ciRunExitRunFailed, Name: "ci_run_run_failed", Description: "ci run: a candidate run finished in a failed state.", Commands: []string{"ci run"}},
+
+	// `evaltest run` — local pre-deploy eval runner.
+	{Code: evaltestExitPass, Name: "success", Description: "evaltest run: all eval cases passed.", Commands: []string{"evaltest run"}},
+	{Code: evaltestExitAssertionFail, Name: "assertion_failed", Description: "evaltest run: one or more metric assertions failed.", Commands: []string{"evaltest run"}},
+	{Code: evaltestExitConfigError, Name: "config_error", Description: "evaltest run: invalid eval config or test authoring error.", Commands: []string{"evaltest run"}},
+	{Code: evaltestExitProviderError, Name: "provider_error", Description: "evaltest run: judge/model provider or runtime error.", Commands: []string{"evaltest run"}},
+	{Code: evaltestExitInternalError, Name: "internal_error", Description: "evaltest run: internal SDK/runner error.", Commands: []string{"evaltest run"}},
 }

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -5025,6 +5025,46 @@
       "commands": [
         "ci run"
       ]
+    },
+    {
+      "code": 0,
+      "name": "success",
+      "description": "evaltest run: all eval cases passed.",
+      "commands": [
+        "evaltest run"
+      ]
+    },
+    {
+      "code": 1,
+      "name": "assertion_failed",
+      "description": "evaltest run: one or more metric assertions failed.",
+      "commands": [
+        "evaltest run"
+      ]
+    },
+    {
+      "code": 2,
+      "name": "config_error",
+      "description": "evaltest run: invalid eval config or test authoring error.",
+      "commands": [
+        "evaltest run"
+      ]
+    },
+    {
+      "code": 3,
+      "name": "provider_error",
+      "description": "evaltest run: judge/model provider or runtime error.",
+      "commands": [
+        "evaltest run"
+      ]
+    },
+    {
+      "code": 4,
+      "name": "internal_error",
+      "description": "evaltest run: internal SDK/runner error.",
+      "commands": [
+        "evaltest run"
+      ]
     }
   ],
   "error_codes": [

--- a/schemas/evaltest/README.md
+++ b/schemas/evaltest/README.md
@@ -1,0 +1,41 @@
+# Local Eval Test Schemas
+
+Language-neutral JSON Schema contracts for the pre-deploy eval SDK (`agentclash evaltest`).
+
+Parent epic: [#1104](https://github.com/agentclash/agentclash/issues/1104)  
+ADR: [docs/adr/predeploy-eval-sdk-repo-strategy.md](../docs/adr/predeploy-eval-sdk-repo-strategy.md)
+
+## Schemas
+
+| File | Purpose |
+|------|---------|
+| `agent-result.schema.json` | Agent trace/result shape adapters must emit |
+| `eval-report.schema.json` | Full eval run report (SDK + CLI output) |
+
+## Exit codes
+
+The `agentclash evaltest run` command and SDK runners use these stable exit codes:
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 0 | `success` | All eval cases passed |
+| 1 | `assertion_failed` | One or more metric assertions failed |
+| 2 | `config_error` | Invalid eval config, unknown schema version, or test authoring error |
+| 3 | `provider_error` | Judge/model provider or runtime error during eval execution |
+| 4 | `internal_error` | Internal SDK/runner bug or unexpected failure |
+
+Exit code semantics are mirrored in the `exit_code` field of every `eval-report.schema.json` document.
+
+## Golden fixtures
+
+Fixtures in `fixtures/` validate against `eval-report.schema.json` in CI via `cli/cmd/evaltest_schema_test.go`:
+
+- `all-pass.json` — every case passed
+- `metric-failure.json` — deterministic metric failure with evidence
+- `provider-error.json` — provider/runtime error (exit 3)
+- `config-error.json` — malformed/authoring error (exit 2)
+- `multi-turn.json` — multi-turn messages and tool calls
+
+## Contract sync
+
+Python (`agentclash-evals`) and TypeScript (`@agentclash/evals`) SDKs must emit reports that validate against these schemas. Breaking changes require bumping `schema_version` and updating all fixtures.

--- a/schemas/evaltest/agent-result.schema.json
+++ b/schemas/evaltest/agent-result.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/evaltest/agent-result.schema.json",
+  "title": "AgentClash Local Eval Agent Result",
+  "description": "Language-neutral agent trace/result shape for pre-deploy evals. Adapters map framework outputs into this contract.",
+  "type": "object",
+  "required": ["input"],
+  "additionalProperties": false,
+  "properties": {
+    "input": {
+      "description": "Primary user/task input for this eval case.",
+      "type": "string"
+    },
+    "output": {
+      "description": "Final assistant/output text when available.",
+      "type": "string"
+    },
+    "messages": {
+      "description": "Ordered conversation turns (single- or multi-turn).",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/message"
+      }
+    },
+    "tool_calls": {
+      "description": "Tool invocations observed during the run.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tool_call"
+      }
+    },
+    "retrieval_context": {
+      "description": "Retrieved documents/chunks used by the agent.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/retrieval_context"
+      }
+    },
+    "metadata": {
+      "$ref": "#/$defs/run_metadata"
+    }
+  },
+  "$defs": {
+    "message": {
+      "type": "object",
+      "required": ["role", "content"],
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "enum": ["system", "user", "assistant", "tool"]
+        },
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tool_call_id": {
+          "type": "string"
+        }
+      }
+    },
+    "tool_call": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arguments": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "arguments_json": {
+          "description": "Raw JSON arguments string when object parsing is unavailable.",
+          "type": "string"
+        },
+        "turn_index": {
+          "description": "Zero-based turn index when tool calls are multi-turn.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "result": {
+          "description": "Tool result payload when captured.",
+          "type": "string"
+        }
+      }
+    },
+    "retrieval_context": {
+      "type": "object",
+      "required": ["content"],
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "run_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "latency_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "step_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "token_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/evaltest/eval-report.schema.json
+++ b/schemas/evaltest/eval-report.schema.json
@@ -1,0 +1,386 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/evaltest/eval-report.schema.json",
+  "title": "AgentClash Local Eval Report",
+  "description": "Versioned report emitted by Python/TypeScript SDKs and agentclash evaltest run.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "report_id",
+    "generated_at",
+    "runner",
+    "summary",
+    "cases",
+    "exit_code"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "report_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "runner": {
+      "$ref": "#/$defs/runner_info"
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/eval_case_result"
+      }
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/eval_failure"
+      }
+    },
+    "provider_errors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/provider_error"
+      }
+    },
+    "exit_code": {
+      "type": "integer",
+      "enum": [0, 1, 2, 3, 4]
+    },
+    "duration_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "total_cost_usd": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "$defs": {
+    "runner_info": {
+      "type": "object",
+      "required": ["name", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["agentclash-evals", "agentclash-evaltest", "@agentclash/evals"]
+        },
+        "version": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string",
+          "enum": ["python", "typescript", "go"]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "passed", "failed", "skipped", "errored"],
+      "additionalProperties": false,
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "errored": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "metric_failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "duration_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "total_cost_usd": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "eval_case": {
+      "type": "object",
+      "required": ["case_id", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "file": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "input": {
+          "type": "string"
+        },
+        "expected": {
+          "description": "Optional expected behavior notes for promotion/debugging.",
+          "type": "string"
+        }
+      }
+    },
+    "eval_case_result": {
+      "type": "object",
+      "required": ["case", "status", "metrics"],
+      "additionalProperties": false,
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/eval_case"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "skipped", "error"]
+        },
+        "agent_result": {
+          "$ref": "#/$defs/agent_result"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/metric_result"
+          }
+        },
+        "duration_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "metric_result": {
+      "type": "object",
+      "required": ["key", "name", "passed"],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "score": {
+          "type": "number"
+        },
+        "threshold": {
+          "type": "number"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "judge_evidence": {
+          "$ref": "#/$defs/judge_evidence"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "judge_evidence": {
+      "type": "object",
+      "required": ["prompt_template_id", "verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "prompt_template_id": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        },
+        "raw_output": {
+          "type": "string"
+        },
+        "raw_output_redacted": {
+          "type": "string"
+        },
+        "parsed_verdict": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["pass", "fail", "error"]
+        },
+        "retry_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "eval_failure": {
+      "type": "object",
+      "required": ["case_id", "metric_key", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "case_id": {
+          "type": "string"
+        },
+        "case_name": {
+          "type": "string"
+        },
+        "metric_key": {
+          "type": "string"
+        },
+        "metric_name": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "provider_error": {
+      "type": "object",
+      "required": ["code", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "case_id": {
+          "type": "string"
+        },
+        "metric_key": {
+          "type": "string"
+        }
+      }
+    },
+    "agent_result": {
+      "type": "object",
+      "required": ["input"],
+      "additionalProperties": false,
+      "properties": {
+        "input": {"type": "string"},
+        "output": {"type": "string"},
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role", "content"],
+            "additionalProperties": false,
+            "properties": {
+              "role": {"type": "string", "enum": ["system", "user", "assistant", "tool"]},
+              "content": {"type": "string"},
+              "name": {"type": "string"},
+              "tool_call_id": {"type": "string"}
+            }
+          }
+        },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "arguments": {"type": "object", "additionalProperties": true},
+              "arguments_json": {"type": "string"},
+              "turn_index": {"type": "integer", "minimum": 0},
+              "result": {"type": "string"}
+            }
+          }
+        },
+        "retrieval_context": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["content"],
+            "additionalProperties": false,
+            "properties": {
+              "content": {"type": "string"},
+              "source": {"type": "string"},
+              "score": {"type": "number"},
+              "metadata": {"type": "object", "additionalProperties": true}
+            }
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "model": {"type": "string"},
+            "provider": {"type": "string"},
+            "latency_ms": {"type": "number", "minimum": 0},
+            "cost_usd": {"type": "number", "minimum": 0},
+            "step_count": {"type": "integer", "minimum": 0},
+            "token_count": {"type": "integer", "minimum": 0},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "extra": {"type": "object", "additionalProperties": true}
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/evaltest/fixtures/all-pass.json
+++ b/schemas/evaltest/fixtures/all-pass.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "report_id": "rpt-all-pass-001",
+  "generated_at": "2026-06-24T12:00:00Z",
+  "runner": {
+    "name": "agentclash-evals",
+    "version": "0.1.0",
+    "language": "python"
+  },
+  "summary": {
+    "total": 2,
+    "passed": 2,
+    "failed": 0,
+    "skipped": 0,
+    "errored": 0,
+    "metric_failures": 0,
+    "duration_ms": 145.5,
+    "total_cost_usd": 0.002
+  },
+  "cases": [
+    {
+      "case": {
+        "case_id": "test_refund_agent",
+        "name": "test_refund_agent",
+        "file": "tests/test_refund.py",
+        "line": 12,
+        "input": "Customer was double charged. Resolve it."
+      },
+      "status": "passed",
+      "agent_result": {
+        "input": "Customer was double charged. Resolve it.",
+        "output": "I issued a refund for order #12345.",
+        "messages": [
+          {"role": "user", "content": "Customer was double charged. Resolve it."},
+          {"role": "assistant", "content": "I issued a refund for order #12345."}
+        ],
+        "tool_calls": [
+          {"name": "lookup_order", "arguments": {"order_id": "12345"}},
+          {"name": "issue_refund", "arguments": {"order_id": "12345", "amount_usd": 49.99}}
+        ],
+        "metadata": {
+          "model": "gpt-4.1-mini",
+          "latency_ms": 1200,
+          "cost_usd": 0.001
+        }
+      },
+      "metrics": [
+        {
+          "key": "contains_refund",
+          "name": "Contains",
+          "passed": true,
+          "reason": "output contains 'refund'",
+          "evidence": {"matched": "refund"}
+        },
+        {
+          "key": "tool_called",
+          "name": "ToolCalled",
+          "passed": true,
+          "reason": "expected tools were called",
+          "evidence": {"tools": ["lookup_order", "issue_refund"]}
+        }
+      ],
+      "duration_ms": 72.3,
+      "cost_usd": 0.001
+    },
+    {
+      "case": {
+        "case_id": "test_greeting",
+        "name": "test_greeting",
+        "file": "tests/test_refund.py",
+        "line": 28,
+        "input": "hello"
+      },
+      "status": "passed",
+      "agent_result": {
+        "input": "hello",
+        "output": "Hello! How can I help you today?",
+        "messages": [
+          {"role": "user", "content": "hello"},
+          {"role": "assistant", "content": "Hello! How can I help you today?"}
+        ],
+        "metadata": {"latency_ms": 300, "cost_usd": 0.001}
+      },
+      "metrics": [
+        {
+          "key": "contains_hello",
+          "name": "Contains",
+          "passed": true,
+          "reason": "output contains 'Hello'",
+          "evidence": {"matched": "Hello"}
+        }
+      ],
+      "duration_ms": 73.2,
+      "cost_usd": 0.001
+    }
+  ],
+  "exit_code": 0,
+  "duration_ms": 145.5,
+  "total_cost_usd": 0.002
+}

--- a/schemas/evaltest/fixtures/config-error.json
+++ b/schemas/evaltest/fixtures/config-error.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "report_id": "rpt-config-error-001",
+  "generated_at": "2026-06-24T12:15:00Z",
+  "runner": {
+    "name": "agentclash-evaltest",
+    "version": "0.1.0",
+    "language": "go"
+  },
+  "summary": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "errored": 0,
+    "metric_failures": 0,
+    "duration_ms": 5.0,
+    "total_cost_usd": 0
+  },
+  "cases": [],
+  "failures": [
+    {
+      "case_id": "config",
+      "metric_key": "config",
+      "reason": "eval config missing required field: tests"
+    }
+  ],
+  "exit_code": 2,
+  "duration_ms": 5.0,
+  "total_cost_usd": 0
+}

--- a/schemas/evaltest/fixtures/metric-failure.json
+++ b/schemas/evaltest/fixtures/metric-failure.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "report_id": "rpt-metric-failure-001",
+  "generated_at": "2026-06-24T12:05:00Z",
+  "runner": {
+    "name": "agentclash-evals",
+    "version": "0.1.0",
+    "language": "python"
+  },
+  "summary": {
+    "total": 1,
+    "passed": 0,
+    "failed": 1,
+    "skipped": 0,
+    "errored": 0,
+    "metric_failures": 1,
+    "duration_ms": 89.1,
+    "total_cost_usd": 0.001
+  },
+  "cases": [
+    {
+      "case": {
+        "case_id": "test_refund_missing_tool",
+        "name": "test_refund_missing_tool",
+        "file": "tests/test_refund.py",
+        "line": 45,
+        "input": "Customer was double charged. Resolve it.",
+        "expected": "Agent should call lookup_order and issue_refund"
+      },
+      "status": "failed",
+      "agent_result": {
+        "input": "Customer was double charged. Resolve it.",
+        "output": "I can help with that refund request.",
+        "messages": [
+          {"role": "user", "content": "Customer was double charged. Resolve it."},
+          {"role": "assistant", "content": "I can help with that refund request."}
+        ],
+        "tool_calls": [],
+        "metadata": {"model": "gpt-4.1-mini", "latency_ms": 800, "cost_usd": 0.001}
+      },
+      "metrics": [
+        {
+          "key": "tool_called",
+          "name": "ToolCalled",
+          "passed": false,
+          "reason": "missing required tools: lookup_order, issue_refund",
+          "evidence": {
+            "expected": ["lookup_order", "issue_refund"],
+            "actual": []
+          }
+        }
+      ],
+      "duration_ms": 89.1,
+      "cost_usd": 0.001
+    }
+  ],
+  "failures": [
+    {
+      "case_id": "test_refund_missing_tool",
+      "case_name": "test_refund_missing_tool",
+      "metric_key": "tool_called",
+      "metric_name": "ToolCalled",
+      "reason": "missing required tools: lookup_order, issue_refund",
+      "evidence": {
+        "expected": ["lookup_order", "issue_refund"],
+        "actual": []
+      },
+      "input": "Customer was double charged. Resolve it.",
+      "output": "I can help with that refund request."
+    }
+  ],
+  "exit_code": 1,
+  "duration_ms": 89.1,
+  "total_cost_usd": 0.001
+}

--- a/schemas/evaltest/fixtures/multi-turn.json
+++ b/schemas/evaltest/fixtures/multi-turn.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "report_id": "rpt-multi-turn-001",
+  "generated_at": "2026-06-24T12:20:00Z",
+  "runner": {
+    "name": "agentclash-evals",
+    "version": "0.1.0",
+    "language": "python"
+  },
+  "summary": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "errored": 0,
+    "metric_failures": 0,
+    "duration_ms": 3200.0,
+    "total_cost_usd": 0.003
+  },
+  "cases": [
+    {
+      "case": {
+        "case_id": "test_multi_turn_refund",
+        "name": "test_multi_turn_refund",
+        "file": "tests/test_multi_turn.py",
+        "line": 15,
+        "input": "I was double charged on order 9876.",
+        "expected": "Agent resolves refund after clarification turn"
+      },
+      "status": "passed",
+      "agent_result": {
+        "input": "I was double charged on order 9876.",
+        "output": "I've processed a full refund for order 9876. You should see it in 3-5 business days.",
+        "messages": [
+          {"role": "user", "content": "I was double charged on order 9876."},
+          {"role": "assistant", "content": "I see order 9876. Can you confirm the charge amount?"},
+          {"role": "user", "content": "It was $49.99 twice."},
+          {"role": "assistant", "content": "I've processed a full refund for order 9876. You should see it in 3-5 business days."}
+        ],
+        "tool_calls": [
+          {"name": "lookup_order", "arguments": {"order_id": "9876"}, "turn_index": 0},
+          {"name": "issue_refund", "arguments": {"order_id": "9876", "amount_usd": 49.99}, "turn_index": 1}
+        ],
+        "retrieval_context": [
+          {"content": "Refund policy: full refund within 30 days for duplicate charges.", "source": "policy.md", "score": 0.92}
+        ],
+        "metadata": {
+          "model": "gpt-4.1-mini",
+          "latency_ms": 3100,
+          "cost_usd": 0.003,
+          "step_count": 2
+        }
+      },
+      "metrics": [
+        {
+          "key": "contains_refund",
+          "name": "Contains",
+          "passed": true,
+          "reason": "output contains 'refund'",
+          "evidence": {"matched": "refund"}
+        },
+        {
+          "key": "tool_sequence",
+          "name": "ToolSequence",
+          "passed": true,
+          "reason": "tools called in expected order",
+          "evidence": {"sequence": ["lookup_order", "issue_refund"]}
+        }
+      ],
+      "duration_ms": 3200.0,
+      "cost_usd": 0.003
+    }
+  ],
+  "exit_code": 0,
+  "duration_ms": 3200.0,
+  "total_cost_usd": 0.003
+}

--- a/schemas/evaltest/fixtures/provider-error.json
+++ b/schemas/evaltest/fixtures/provider-error.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "report_id": "rpt-provider-error-001",
+  "generated_at": "2026-06-24T12:10:00Z",
+  "runner": {
+    "name": "agentclash-evals",
+    "version": "0.1.0",
+    "language": "python"
+  },
+  "summary": {
+    "total": 1,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "errored": 1,
+    "metric_failures": 0,
+    "duration_ms": 1500.0,
+    "total_cost_usd": 0
+  },
+  "cases": [
+    {
+      "case": {
+        "case_id": "test_task_completion",
+        "name": "test_task_completion",
+        "file": "tests/test_judge.py",
+        "line": 8,
+        "input": "Summarize the refund policy."
+      },
+      "status": "error",
+      "agent_result": {
+        "input": "Summarize the refund policy.",
+        "output": "Refunds are available within 30 days.",
+        "metadata": {"model": "gpt-4.1-mini", "latency_ms": 500}
+      },
+      "metrics": [
+        {
+          "key": "task_completion",
+          "name": "TaskCompletion",
+          "passed": false,
+          "error": "judge provider returned 429 rate limit",
+          "judge_evidence": {
+            "prompt_template_id": "task_completion_v1",
+            "prompt_template_version": "1.0.0",
+            "raw_output_redacted": "[REDACTED]",
+            "verdict": "error",
+            "retry_count": 2
+          }
+        }
+      ],
+      "duration_ms": 1500.0,
+      "error": "judge provider returned 429 rate limit"
+    }
+  ],
+  "provider_errors": [
+    {
+      "code": "rate_limit",
+      "message": "judge provider returned 429 rate limit",
+      "provider": "openai",
+      "retryable": true,
+      "case_id": "test_task_completion",
+      "metric_key": "task_completion"
+    }
+  ],
+  "exit_code": 3,
+  "duration_ms": 1500.0,
+  "total_cost_usd": 0
+}

--- a/testing/feat-eval-sdk-1106.md
+++ b/testing/feat-eval-sdk-1106.md
@@ -1,0 +1,35 @@
+# feat/eval-sdk-1106 — Test Contract
+
+## Functional Behavior
+
+- Versioned JSON schemas exist at `schemas/evaltest/agent-result.schema.json` and `schemas/evaltest/eval-report.schema.json`.
+- Report schema includes evidence for debugging failures without hosted AgentClash.
+- Report schema includes CI fields: pass/fail/skipped/errored counts, metric failures, duration, cost.
+- Report schema supports single-turn and multi-turn cases, tool calls, and retrieval context.
+- Report schema includes `schema_version`.
+- Exit codes 0–4 documented in `schemas/evaltest/README.md` and `cli/cmd/exit_codes.go`.
+- Golden fixtures exist for: all pass, metric failure, provider error, malformed config, multi-turn.
+
+## Unit Tests
+
+- `TestEvalReportSchemaAcceptsFixtures` — all golden fixtures validate against eval-report schema.
+- `TestEvalReportSchemaRejectsUnknownVersion` — unknown schema_version rejected.
+- `TestAgentResultSchemaAcceptsMultiTurnFixture` — agent-result schema accepts multi-turn shape.
+- `TestEvaltestExitCodesDocumented` — exit codes registered in documentedExitCodes for evaltest run.
+
+## Integration / Functional Tests
+
+- N/A — schema-only issue; CLI runner integration comes in #1110.
+
+## Smoke Tests
+
+- `cd cli && go test -short -race -count=1 ./cmd -run TestEvalReport`
+- `cd cli && go test -short -race -count=1 ./cmd -run TestEvaltestExitCodes`
+
+## E2E Tests
+
+- N/A — no runner yet.
+
+## Manual / cURL Tests
+
+- Reviewer validates fixtures with: `cd cli && go test -v ./cmd -run TestEvalReportSchemaAcceptsFixtures`


### PR DESCRIPTION
## Summary

- Adds versioned JSON schemas at `schemas/evaltest/` for agent results and eval reports.
- Adds golden fixtures: all-pass, metric-failure, provider-error, config-error, multi-turn.
- Documents exit codes 0–4 and registers them in `cli/cmd/exit_codes.go`.
- Adds CLI schema validation tests in `evaltest_schema_test.go`.

Closes #1106

## Test plan

- [x] `cd cli && go test -short -count=1 ./cmd -run TestEvalReport`
- [x] All golden fixtures validate against eval-report schema
- [x] Exit codes documented for `evaltest run`