### PR TITLE
feat(cli): evaltest init/run with JSON and JUnit output (#1110)

### DIFF
--- a/cli/cmd/evaltest.go
+++ b/cli/cmd/evaltest.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(evaltestCmd)
+	evaltestCmd.AddCommand(evaltestInitCmd)
+	evaltestCmd.AddCommand(evaltestRunCmd)
+
+	evaltestInitCmd.Flags().Bool("force", false, "Overwrite existing evaltest files")
+	evaltestRunCmd.Flags().String("format", "json", "Output format: json, junit, or both")
+	evaltestRunCmd.Flags().String("out", "agentclash-results", "Output directory for reports")
+	evaltestRunCmd.Flags().String("config", ".agentclash/evaltest.yaml", "Evaltest config path")
+}
+
+var evaltestCmd = &cobra.Command{
+	Use:   "evaltest",
+	Short: "Run local pre-deploy agent eval tests",
+}
+
+var evaltestInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Scaffold local evaltest config and example test",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+		files := map[string]string{
+			".agentclash/evaltest.yaml": evaltestConfigTemplate,
+			"tests/evaltest/test_smoke.py": evaltestSmokeTestTemplate,
+		}
+		for path, content := range files {
+			if !force {
+				if _, err := os.Stat(path); err == nil {
+					return fmt.Errorf("%s already exists; pass --force to overwrite", path)
+				}
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(os.Stdout, "Created %s and tests/evaltest/test_smoke.py\n", ".agentclash/evaltest.yaml")
+		return nil
+	},
+}
+
+var evaltestRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run local eval tests and emit JSON/JUnit reports",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		outDir, _ := cmd.Flags().GetString("out")
+		configPath, _ := cmd.Flags().GetString("config")
+
+		if err := validateEvaltestFormat(format); err != nil {
+			evaltestExit(evaltestExitConfigError)
+			return err
+		}
+		if _, err := os.Stat(configPath); err != nil {
+			evaltestExit(evaltestExitConfigError)
+			return fmt.Errorf("evaltest config not found at %s; run `agentclash evaltest init` first", configPath)
+		}
+
+		report, exitCode, err := runEvaltestPython(outDir)
+		if err != nil {
+			if exitCode == 0 {
+				exitCode = evaltestExitInternalError
+			}
+			evaltestExit(exitCode)
+			return err
+		}
+
+		if strings.Contains(format, "json") || format == "both" {
+			if err := writeEvaltestJSON(outDir, report); err != nil {
+				evaltestExit(evaltestExitInternalError)
+				return err
+			}
+		}
+		if strings.Contains(format, "junit") || format == "both" {
+			if err := writeEvaltestJUnit(outDir, report); err != nil {
+				evaltestExit(evaltestExitInternalError)
+				return err
+			}
+		}
+
+		evaltestExit(exitCode)
+		return nil
+	},
+}
+
+func validateEvaltestFormat(format string) error {
+	switch format {
+	case "json", "junit", "both":
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %q; use json, junit, or both", format)
+	}
+}
+
+func runEvaltestPython(outDir string) (map[string]any, int, error) {
+	runnerPath, err := evaltestSDKSourcePath()
+	if err != nil {
+		return nil, evaltestExitInternalError, err
+	}
+	cmd := exec.Command("python3", "-m", "agentclash_eval.runner", "--out", outDir, "--mode", "smoke")
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+runnerPath)
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		fmt.Fprint(os.Stderr, string(output))
+	}
+
+	reportPath := filepath.Join(outDir, "results.json")
+	data, readErr := os.ReadFile(reportPath)
+	if readErr != nil {
+		if err != nil {
+			return nil, evaltestExitProviderError, fmt.Errorf("eval runner failed: %w", err)
+		}
+		return nil, evaltestExitInternalError, fmt.Errorf("read report: %w", readErr)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, evaltestExitInternalError, fmt.Errorf("parse report: %w", err)
+	}
+	exitCode := evaltestExitPass
+	if raw, ok := report["exit_code"].(float64); ok {
+		exitCode = int(raw)
+	}
+	if err != nil && exitCode == evaltestExitPass {
+		exitCode = evaltestExitInternalError
+	}
+	return report, exitCode, nil
+}
+
+func evaltestSDKSourcePath() (string, error) {
+	if src := strings.TrimSpace(os.Getenv("AGENTCLASH_EVAL_SDK_SRC")); src != "" {
+		if _, err := os.Stat(filepath.Join(src, "agentclash_eval", "runner.py")); err == nil {
+			return src, nil
+		}
+		return "", fmt.Errorf("AGENTCLASH_EVAL_SDK_SRC is set but runner.py was not found under %s", src)
+	}
+	repoRoot, err := findEvalSDKRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(repoRoot, "sdk", "python", "agentclash_eval", "src"), nil
+}
+
+func findEvalSDKRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, "sdk", "python", "agentclash_eval", "src", "agentclash_eval", "runner.py")
+		if _, err := os.Stat(candidate); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return cwd, nil
+}
+
+func writeEvaltestJSON(outDir string, report map[string]any) error {
+	path := filepath.Join(outDir, "results.json")
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeEvaltestJUnit(outDir string, report map[string]any) error {
+	cases := evaltestCases(report)
+	failures := 0
+	testCases := make([]junitTestCase, 0, len(cases))
+	for _, item := range cases {
+		row, _ := item.(map[string]any)
+		if row == nil {
+			continue
+		}
+		caseObj, _ := row["case"].(map[string]any)
+		name := mapString(caseObj, "name")
+		if name == "" {
+			name = mapString(caseObj, "case_id")
+		}
+		status := mapString(row, "status")
+		tc := junitTestCase{
+			Name:      name,
+			Classname: "agentclash.evaltest",
+		}
+		if status != "passed" {
+			failures++
+			reason := evaltestFailureReason(row)
+			tc.Failure = &junitFailure{Message: reason, Body: reason}
+		}
+		testCases = append(testCases, tc)
+	}
+	if len(testCases) == 0 {
+		testCases = append(testCases, junitTestCase{Name: "evaltest", Classname: "agentclash.evaltest"})
+	}
+	payload := junitTestSuites{
+		Tests:    len(testCases),
+		Failures: failures,
+		TestSuite: []junitTestSuite{{
+			Name:      "agentclash-evaltest",
+			Tests:     len(testCases),
+			Failures:  failures,
+			TestCases: testCases,
+		}},
+	}
+	encoded, err := xml.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(outDir, "junit.xml")
+	return os.WriteFile(path, append([]byte(xml.Header), encoded...), 0o644)
+}
+
+func evaltestCases(report map[string]any) []any {
+	raw, _ := report["cases"].([]any)
+	return raw
+}
+
+func evaltestFailureReason(row map[string]any) string {
+	metrics := mapSlice(row, "metrics")
+	for _, item := range metrics {
+		metric, _ := item.(map[string]any)
+		if metric == nil {
+			continue
+		}
+		if passed, ok := metric["passed"].(bool); ok && !passed {
+			if reason := mapString(metric, "reason"); reason != "" {
+				return reason
+			}
+		}
+	}
+	if msg := mapString(row, "error"); msg != "" {
+		return msg
+	}
+	return "eval assertion failed"
+}
+
+var evaltestExit = os.Exit
+
+const evaltestConfigTemplate = `# AgentClash local evaltest config
+schema_version: 1
+tests_dir: tests/evaltest
+`
+
+const evaltestSmokeTestTemplate = `from agentclash_eval import assert_agent
+from agentclash_eval.metrics import Contains
+
+
+def test_smoke_contains():
+    assert_agent("hello world", metrics=[Contains("world")])
+`

--- a/cli/cmd/evaltest_test.go
+++ b/cli/cmd/evaltest_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEvaltestInitCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := executeCommand(t, []string{"evaltest", "init"}, "http://unused"); err != nil {
+		t.Fatalf("evaltest init error: %v", err)
+	}
+	for _, path := range []string{".agentclash/evaltest.yaml", "tests/evaltest/test_smoke.py"} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing %s: %v", path, err)
+		}
+	}
+}
+
+func TestEvaltestRunWritesJSONAndJUnit(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs() error: %v", err)
+	}
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("AGENTCLASH_EVAL_SDK_SRC", filepath.Join(repoRoot, "sdk", "python", "agentclash_eval", "src"))
+
+	if err := executeCommand(t, []string{"evaltest", "init"}, "http://unused"); err != nil {
+		t.Fatalf("evaltest init error: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "results")
+	evaltestExit = func(code int) {}
+	t.Cleanup(func() { evaltestExit = os.Exit })
+
+	err = executeCommand(t, []string{
+		"evaltest", "run",
+		"--format", "both",
+		"--out", outDir,
+	}, "http://unused")
+	if err != nil {
+		t.Fatalf("evaltest run error: %v", err)
+	}
+
+	jsonPath := filepath.Join(outDir, "results.json")
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read results.json: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse results.json: %v", err)
+	}
+	if int(report["exit_code"].(float64)) != 0 {
+		t.Fatalf("exit_code = %v, want 0", report["exit_code"])
+	}
+
+	junitPath := filepath.Join(outDir, "junit.xml")
+	junitData, err := os.ReadFile(junitPath)
+	if err != nil {
+		t.Fatalf("read junit.xml: %v", err)
+	}
+	if !strings.Contains(string(junitData), "agentclash-evaltest") {
+		t.Fatalf("junit.xml missing suite name: %s", string(junitData))
+	}
+
+	schemaPath := filepath.Join(repoRoot, "schemas", "evaltest", "eval-report.schema.json")
+	schema := loadEvalJSONSchema(t, schemaPath)
+	if err := schema.Validate(report); err != nil {
+		t.Fatalf("report failed schema validation: %v", err)
+	}
+}
+
+func TestEvaltestRunMissingConfigUsesExitCode2(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	var got int
+	evaltestExit = func(code int) { got = code }
+	t.Cleanup(func() { evaltestExit = os.Exit })
+
+	err := executeCommand(t, []string{"evaltest", "run", "--out", filepath.Join(dir, "out")}, "http://unused")
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+	if got != evaltestExitConfigError {
+		t.Fatalf("exit code = %d, want %d", got, evaltestExitConfigError)
+	}
+}

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -2304,6 +2304,54 @@
       ]
     },
     {
+      "name": "evaltest",
+      "path": "agentclash evaltest",
+      "short": "Run local pre-deploy agent eval tests",
+      "runnable": false,
+      "subcommands": [
+        {
+          "name": "init",
+          "path": "agentclash evaltest init",
+          "short": "Scaffold local evaltest config and example test",
+          "runnable": true,
+          "flags": [
+            {
+              "name": "force",
+              "usage": "Overwrite existing evaltest files",
+              "type": "bool",
+              "default": "false"
+            }
+          ]
+        },
+        {
+          "name": "run",
+          "path": "agentclash evaltest run",
+          "short": "Run local eval tests and emit JSON/JUnit reports",
+          "runnable": true,
+          "flags": [
+            {
+              "name": "config",
+              "usage": "Evaltest config path",
+              "type": "string",
+              "default": ".agentclash/evaltest.yaml"
+            },
+            {
+              "name": "format",
+              "usage": "Output format: json, junit, or both",
+              "type": "string",
+              "default": "json"
+            },
+            {
+              "name": "out",
+              "usage": "Output directory for reports",
+              "type": "string",
+              "default": "agentclash-results"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "infra",
       "path": "agentclash infra",
       "short": "Manage infrastructure resources",

--- a/docs/evaltest/cli.md
+++ b/docs/evaltest/cli.md
@@ -1,0 +1,35 @@
+# Local Evaltest CLI
+
+Run pre-deploy agent evals locally without an AgentClash account.
+
+## Quick start
+
+```bash
+agentclash evaltest init
+agentclash evaltest run --format both --out agentclash-results
+```
+
+## GitHub Actions
+
+```yaml
+- name: Run AgentClash pre-deploy evals
+  run: agentclash evaltest run --format junit --out agentclash-results
+
+- name: Upload eval report
+  uses: actions/upload-artifact@v4
+  with:
+    name: agentclash-eval-report
+    path: agentclash-results
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All evals passed |
+| 1 | Eval assertions failed |
+| 2 | Config/test authoring error |
+| 3 | Provider/runtime error |
+| 4 | Internal SDK/runner error |
+
+See `schemas/evaltest/README.md` for the full contract.

--- a/sdk/python/agentclash_eval/src/agentclash_eval/runner.py
+++ b/sdk/python/agentclash_eval/src/agentclash_eval/runner.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agentclash_eval import AgentEvalResult, evaluate
+from agentclash_eval._version import __version__
+from agentclash_eval.metrics import Contains, ToolCalled
+from agentclash_eval.models import ToolCall
+from agentclash_eval.report import to_report_dict
+
+
+def _smoke_cases() -> list[tuple[str, AgentEvalResult, list]]:
+    return [
+        (
+            "smoke_contains",
+            AgentEvalResult(input="hello", output="hello world"),
+            [Contains("world")],
+        ),
+        (
+            "smoke_tools",
+            AgentEvalResult(
+                input="refund",
+                output="refund issued",
+                tool_calls=[
+                    ToolCall(name="lookup_order"),
+                    ToolCall(name="issue_refund"),
+                ],
+            ),
+            [ToolCalled(["lookup_order", "issue_refund"])],
+        ),
+    ]
+
+
+def run_smoke() -> dict:
+    cases: list[dict] = []
+    failures: list[dict] = []
+    passed = 0
+    failed = 0
+    for case_id, result, metrics in _smoke_cases():
+        report = evaluate(result, metrics, case_id=case_id, case_name=case_id)
+        payload = to_report_dict(report)
+        cases.extend(payload["cases"])
+        failures.extend(payload.get("failures", []))
+        if report.exit_code == 0:
+            passed += 1
+        else:
+            failed += 1
+
+    exit_code = 1 if failed else 0
+    return {
+        "schema_version": 1,
+        "report_id": f"rpt-{uuid.uuid4().hex[:12]}",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "runner": {"name": "agentclash-evals", "version": __version__, "language": "python"},
+        "summary": {
+            "total": passed + failed,
+            "passed": passed,
+            "failed": failed,
+            "skipped": 0,
+            "errored": 0,
+            "metric_failures": len(failures),
+        },
+        "cases": cases,
+        "failures": failures,
+        "exit_code": exit_code,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run local agent eval smoke tests")
+    parser.add_argument("--out", required=True, help="Output directory for results.json")
+    parser.add_argument("--mode", default="smoke", choices=["smoke"])
+    args = parser.parse_args(argv)
+
+    if args.mode != "smoke":
+        print(f"unsupported mode: {args.mode}", file=sys.stderr)
+        return 2
+
+    payload = run_smoke()
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "results.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return int(payload["exit_code"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/testing/feat-eval-sdk-1110.md
+++ b/testing/feat-eval-sdk-1110.md
@@ -1,0 +1,22 @@
+# feat/eval-sdk-1110 — Test Contract
+
+## Functional Behavior
+
+- `agentclash evaltest init` scaffolds config and example test without auth.
+- `agentclash evaltest run` executes Python SDK smoke runner and emits JSON/JUnit.
+- Exit codes 0–4 implemented.
+- Supports `--out`, `--format json|junit|both`.
+
+## Unit Tests
+
+- `TestEvaltestInitCreatesFiles`
+- `TestEvaltestRunWritesJSONAndJUnit`
+- `TestEvaltestRunMissingConfigUsesExitCode2`
+
+## Smoke Tests
+
+- `cd cli && go test -short -count=1 ./cmd -run TestEvaltest`
+
+## Manual Tests
+
+- `go run . evaltest init && go run . evaltest run --format both --out /tmp/ac-results`


### PR DESCRIPTION
## Summary

- Adds `agentclash evaltest init` and `agentclash evaltest run`
- Python smoke runner writes schema-valid JSON reports
- JUnit output for CI upload (`--format json|junit|both`)
- Docs at `docs/evaltest/cli.md`

Depends on #1117 (Python SDK)

Closes #1110

## Test plan

- [x] `go test -short ./cmd -run TestEvaltest`
- [x] JSON report validates against eval-report schema