### PR TITLE
chore(release): force CLI 1.1.0 (phantom 2.0.0 from reverted rename) + prevention docs

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,7 +6,8 @@
     "cli": {
       "release-type": "simple",
       "package-name": "agentclash",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "1.1.0"
     }
   }
 }

--- a/docs/cli-distribution.md
+++ b/docs/cli-distribution.md
@@ -137,6 +137,44 @@ Avoid it either way:
 
 - **At release time** — when reviewing the Release Please PR, delete the duplicate lines from the new `## [x.y.z]` block, keeping the non-merge (branch) commit of each pair.
 
+### Reviewing a Release Please PR
+
+Release Please computes the version automatically from conventional-commit types since the last tag (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` → major). Nobody picks the number by hand, so the release PR is the checkpoint where a human confirms it. Before merging one:
+
+- **Verify every `⚠ BREAKING CHANGES` entry is real.** Each line must map to a breaking change that is actually present in `main`. A `feat!:`/`refactor!:` commit that was later **reverted** still sits in history, and Release Please keeps counting it — so a net-zero change can drive a phantom major bump (see below).
+- **Confirm the version matches intent.** If the bump looks wrong (for example, an unintended major), do not merge — fix the version first.
+- **Dedupe merge-commit duplicates** in the new `## [x.y.z]` block (see Changelog hygiene above).
+
+### Forcing a version (phantom bumps from reverted breaking changes)
+
+When a breaking commit (`feat!:` / `refactor!:` / `BREAKING CHANGE:`) is merged and later reverted, the revert removes the change from the tree but not the breaking commit from history. Release Please still sees a breaking change in range and proposes a major bump that nothing in `main` justifies. Two things keep this in check:
+
+- **Revert with a conventional `revert:` commit** that references the original (`git revert` produces the right shape), so Release Please can try to cancel it. This is best-effort — the review checklist above is the backstop.
+- **Override the computed version** for one release with a per-package `release-as` in `.github/release-please-config.json`:
+
+  ```json
+  "cli": {
+    "release-type": "simple",
+    "package-name": "agentclash",
+    "changelog-path": "CHANGELOG.md",
+    "release-as": "1.1.0"
+  }
+  ```
+
+  Merging that config change re-cuts the open release PR at the forced version. `release-as` is **sticky** — remove it again right after the forced release tags, or every future release stays pinned to it. The `⚠ BREAKING CHANGES`/`Code Refactoring` lines for the reverted commit will still render in the changelog, so also scrub those from the release PR by hand.
+
+  Verify the override before merging by pointing a dry run at the branch that carries it:
+
+  ```bash
+  npx --yes release-please@latest release-pr \
+    --repo-url=https://github.com/agentclash/agentclash --target-branch=<your-branch> \
+    --config-file=.github/release-please-config.json \
+    --manifest-file=.github/.release-please-manifest.json \
+    --token="$(gh auth token)" --dry-run
+  ```
+
+  Release Please reads config, manifest, and changelog from the **target branch over the GitHub API**, not from your local files — so the change must be pushed and `--target-branch` must point at the branch that has it.
+
 ## Maintainer Setup
 
 Before advertising package-manager installs as live, make sure these external pieces exist:


### PR DESCRIPTION
## Problem

Release Please PR #1051 proposes **`chore(main): release 2.0.0`**, but the major bump is **phantom**.

The only `⚠ BREAKING CHANGES` entry is `rename challenge pack to eval pack everywhere` (commit `8fac07c`, `refactor!:`). That rename was reverted by #1121 / #1122 — `main` still uses "challenge pack" (no `cli/cmd/eval_pack.go`). But the breaking *commit* remains in history since `v1.0.0`, and #1122's title isn't a conventional `revert:`, so Release Please keeps counting it → 2.0.0 for a net-zero change.

Excluding the reverted rename, the real changes since v1.0.0 are `feat:` / `fix:` only → the correct bump is **minor, 1.1.0**.

## Fix

- Add `"release-as": "1.1.0"` to the `cli` package in `.github/release-please-config.json`. Merging this re-cuts #1051 at 1.1.0.
- Document a release-PR review checklist, the revert convention, and the `release-as` override (+ dry-run verification) in `docs/cli-distribution.md`.

## Verification (release-please dry-run, read-only)

| config | computed version |
|---|---|
| current `main` | `chore(main): release 2.0.0` (reproduces the phantom) |
| this branch (`release-as`) | `## [1.1.0]`, no `2.0.0`; log: `⚠ Setting version for cli from release-as configuration` |

Release Please reads config/manifest from the target branch over the GitHub API (not local files), so verification pointed `--target-branch` at this branch.

## After this merges — runbook

1. Release Please updates **#1051** to `chore(main): release 1.1.0` (manifest `1.0.0` → `1.1.0`).
2. Hand-clean the `## [1.1.0]` block on #1051 (`release-as` forces the *number* only; the changelog body is unchanged):
   - delete the `⚠ BREAKING CHANGES` section and the `Code Refactoring` rename line (both are the reverted `8fac07c`);
   - dedupe the merge-commit duplicate pairs — `#1110`, `#1106`, `eval-sdk #1111-1114`, `move billing to freemium`, `providers ConnectionService` (keep the branch commit of each).
3. Merge #1051 → tags `v1.1.0` → `release-cli.yml` publishes `agentclash@1.1.0` to npm.
4. **Merge #1129** (removes the sticky `release-as`) — already opened as a draft stacked on this PR; leaving `release-as` in place would pin every future release to 1.1.0.

⚠️ **Do not merge #1051 as-is** — it would publish a bogus 2.0.0 with a breaking change that isn't in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
