### PR TITLE
chore(release): remove release-as pin after v1.1.0 (⛔ hold until tagged)

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,8 +6,7 @@
     "cli": {
       "release-type": "simple",
       "package-name": "agentclash",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.1.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
⛔ **DO NOT MERGE until `v1.1.0` is tagged.** Kept as a draft so it can't merge early.

## Why this exists now

`release-as` (added in #1128) is **sticky**: once it forces `v1.1.0`, leaving it in `.github/release-please-config.json` pins every subsequent release back to `1.1.0` instead of computing `1.1.1` / `1.2.0` / etc. Per Greptile's review on #1128, opening the removal PR up front removes the dependency on someone remembering it under release-day pressure.

## What it does

Removes `"release-as": "1.1.0"` from the `cli` package, restoring normal semver computation.

## Stack / order

- Stacked on **#1128** (base = `fix/release-please-phantom-bump`) because `release-as` isn't on `main` until #1128 merges. GitHub auto-retargets this PR's base to `main` when #1128 merges (or retarget manually: `gh pr edit <n> --base main`).
- **Merge sequence:** merge #1128 → release-please re-cuts #1051 to `1.1.0` → merge #1051 (tags `v1.1.0`, publishes npm) → **then merge this PR.**

After merge, the next release-please run computes normally — the phantom `8fac07c` is before `v1.1.0`, so it's out of range and cannot recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
