### PR TITLE
fix(scoring): stop single-model judges from claiming high confidence

### DIFF
--- a/backend/internal/scoring/judge_providers.go
+++ b/backend/internal/scoring/judge_providers.go
@@ -5,6 +5,10 @@ import "strings"
 // InferJudgeProviderKey maps a judge model identifier to the provider key
 // used for credential resolution. Unknown prefixes return "" so callers can
 // reject the model at config time instead of failing silently at run time.
+//
+// Validation uses this map without deployment context, so models that rely
+// on a deployment provider-account fallback at runtime must still be
+// inferable here to pass pack validation.
 func InferJudgeProviderKey(model string) string {
 	trimmed := strings.ToLower(strings.TrimSpace(model))
 	switch {
@@ -20,6 +24,10 @@ func InferJudgeProviderKey(model string) string {
 		return "gemini"
 	case strings.HasPrefix(trimmed, "grok-"):
 		return "xai"
+	case strings.HasPrefix(trimmed, "mistral-"):
+		return "mistral"
+	case strings.Contains(trimmed, "/"):
+		return "openrouter"
 	default:
 		return ""
 	}
@@ -39,6 +47,10 @@ func JudgeDefaultCredentialReference(providerKey string) (string, bool) {
 		return "env://GEMINI_API_KEY", true
 	case "xai":
 		return "env://XAI_API_KEY", true
+	case "mistral":
+		return "env://MISTRAL_API_KEY", true
+	case "openrouter":
+		return "env://OPENROUTER_API_KEY", true
 	default:
 		return "", false
 	}

--- a/backend/internal/scoring/judge_providers.go
+++ b/backend/internal/scoring/judge_providers.go
@@ -1,0 +1,56 @@
+package scoring
+
+import "strings"
+
+// InferJudgeProviderKey maps a judge model identifier to the provider key
+// used for credential resolution. Unknown prefixes return "" so callers can
+// reject the model at config time instead of failing silently at run time.
+func InferJudgeProviderKey(model string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.HasPrefix(trimmed, "claude-"):
+		return "anthropic"
+	case strings.HasPrefix(trimmed, "gpt-"),
+		strings.HasPrefix(trimmed, "o1"),
+		strings.HasPrefix(trimmed, "o3"),
+		strings.HasPrefix(trimmed, "o4"),
+		strings.HasPrefix(trimmed, "text-embedding"):
+		return "openai"
+	case strings.HasPrefix(trimmed, "gemini-"):
+		return "gemini"
+	case strings.HasPrefix(trimmed, "grok-"):
+		return "xai"
+	default:
+		return ""
+	}
+}
+
+// JudgeDefaultCredentialReference returns the platform default credential
+// reference for a judge provider when no deployment-scoped provider account
+// matches. Packs must declare models whose provider is known here so
+// credential resolution is explicit at validation time.
+func JudgeDefaultCredentialReference(providerKey string) (string, bool) {
+	switch strings.TrimSpace(providerKey) {
+	case "anthropic":
+		return "env://ANTHROPIC_API_KEY", true
+	case "openai":
+		return "env://OPENAI_API_KEY", true
+	case "gemini":
+		return "env://GEMINI_API_KEY", true
+	case "xai":
+		return "env://XAI_API_KEY", true
+	default:
+		return "", false
+	}
+}
+
+// ValidateJudgeModelCredential checks that a judge model maps to a known
+// provider with a resolvable default credential reference.
+func ValidateJudgeModelCredential(model string) (providerKey string, ok bool) {
+	providerKey = InferJudgeProviderKey(model)
+	if providerKey == "" {
+		return "", false
+	}
+	_, ok = JudgeDefaultCredentialReference(providerKey)
+	return providerKey, ok
+}

--- a/backend/internal/scoring/judge_providers_test.go
+++ b/backend/internal/scoring/judge_providers_test.go
@@ -1,0 +1,45 @@
+package scoring
+
+import "testing"
+
+func TestInferJudgeProviderKeyRecognizesKnownModels(t *testing.T) {
+	cases := map[string]string{
+		"claude-sonnet-4-6":           "anthropic",
+		"gpt-4.1-mini":                "openai",
+		"o3-mini":                     "openai",
+		"gemini-2.5-flash":            "gemini",
+		"grok-4-1-fast-reasoning":     "xai",
+		"unknown-model":               "",
+	}
+	for model, want := range cases {
+		if got := InferJudgeProviderKey(model); got != want {
+			t.Fatalf("InferJudgeProviderKey(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestValidateJudgeModelCredentialAcceptsKnownProviders(t *testing.T) {
+	providerKey, ok := ValidateJudgeModelCredential("claude-haiku-4-5-20251001")
+	if !ok {
+		t.Fatal("expected known judge model to validate")
+	}
+	if providerKey != "anthropic" {
+		t.Fatalf("provider key = %q, want anthropic", providerKey)
+	}
+}
+
+func TestValidateJudgeModelCredentialRejectsUnknownModel(t *testing.T) {
+	if _, ok := ValidateJudgeModelCredential("llama-3.1-70b"); ok {
+		t.Fatal("expected unknown judge model to be rejected")
+	}
+}
+
+func TestJudgeDefaultCredentialReferenceSupportsXAI(t *testing.T) {
+	got, ok := JudgeDefaultCredentialReference("xai")
+	if !ok {
+		t.Fatal("expected xai credential reference")
+	}
+	if got != "env://XAI_API_KEY" {
+		t.Fatalf("credential reference = %q, want env://XAI_API_KEY", got)
+	}
+}

--- a/backend/internal/scoring/judge_providers_test.go
+++ b/backend/internal/scoring/judge_providers_test.go
@@ -9,6 +9,8 @@ func TestInferJudgeProviderKeyRecognizesKnownModels(t *testing.T) {
 		"o3-mini":                     "openai",
 		"gemini-2.5-flash":            "gemini",
 		"grok-4-1-fast-reasoning":     "xai",
+		"mistral-large-latest":        "mistral",
+		"openai/gpt-4.1-mini":         "openrouter",
 		"unknown-model":               "",
 	}
 	for model, want := range cases {
@@ -31,6 +33,21 @@ func TestValidateJudgeModelCredentialAcceptsKnownProviders(t *testing.T) {
 func TestValidateJudgeModelCredentialRejectsUnknownModel(t *testing.T) {
 	if _, ok := ValidateJudgeModelCredential("llama-3.1-70b"); ok {
 		t.Fatal("expected unknown judge model to be rejected")
+	}
+}
+
+func TestJudgeDefaultCredentialReferenceSupportsOpenRouterAndMistral(t *testing.T) {
+	for providerKey, want := range map[string]string{
+		"openrouter": "env://OPENROUTER_API_KEY",
+		"mistral":    "env://MISTRAL_API_KEY",
+	} {
+		got, ok := JudgeDefaultCredentialReference(providerKey)
+		if !ok {
+			t.Fatalf("expected credential reference for %q", providerKey)
+		}
+		if got != want {
+			t.Fatalf("provider %q credential = %q, want %q", providerKey, got, want)
+		}
 	}
 }
 

--- a/backend/internal/scoring/judge_spec_test.go
+++ b/backend/internal/scoring/judge_spec_test.go
@@ -347,6 +347,14 @@ func TestLoadEvaluationSpec_JudgeRejections(t *testing.T) {
 			needle:    "must be at most 10",
 		},
 		{
+			name: "unknown judge model provider",
+			judgesBlock: `[
+				{"mode": "rubric", "key": "persuasiveness", "rubric": "Rate the output 1-5 on clarity and correctness", "model": "llama-3.1-70b"}
+			]`,
+			scorecard: defaultScorecard,
+			needle:    "must be inferable to a known judge provider",
+		},
+		{
 			name: "multi-model without consensus",
 			judgesBlock: `[
 				{"mode": "rubric", "key": "persuasiveness", "rubric": "Rate the output 1-5 on clarity and correctness", "models": ["claude-sonnet-4-6", "gpt-4o"]}

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -585,8 +585,10 @@ type LLMJudgeDeclaration struct {
 
 	// Prompt is the cross-agent ranking prompt for n_wise mode.
 	Prompt string `json:"prompt,omitempty"`
-	// PositionDebiasing enables cyclic-shift ordering across samples so no
-	// agent is consistently shown in the same position.
+	// PositionDebiasing enables cyclic rotation across samples, guaranteeing
+	// each candidate appears in every position when samples >= len(candidates).
+	// When false (default), candidates are shuffled per sample — weaker than
+	// rotation but still breaks stable positional bias.
 	PositionDebiasing bool `json:"position_debiasing,omitempty"`
 
 	// ReferenceFrom names an evidence reference that resolves to the

--- a/backend/internal/scoring/validation_judges.go
+++ b/backend/internal/scoring/validation_judges.go
@@ -125,8 +125,12 @@ func validateLLMJudges(
 						Field:   fmt.Sprintf("%s.models[%d]", path, j),
 						Message: "must be a non-empty model identifier",
 					})
+					continue
 				}
+				errs = append(errs, validateJudgeModelCredential(fmt.Sprintf("%s.models[%d]", path, j), m)...)
 			}
+		case hasSingleModel:
+			errs = append(errs, validateJudgeModelCredential(path+".model", judge.Model)...)
 		}
 
 		// Rule 5: samples range [0, JudgeMaxSamplesCeiling]. 0 is
@@ -249,6 +253,22 @@ func validateLLMJudges(
 	}
 
 	return judgeKeys, errs
+}
+
+func validateJudgeModelCredential(field, model string) ValidationErrors {
+	if _, ok := ValidateJudgeModelCredential(model); ok {
+		return nil
+	}
+	if InferJudgeProviderKey(model) == "" {
+		return ValidationErrors{{
+			Field: field,
+			Message: "must be inferable to a known judge provider (claude-*, gpt-*, gemini-*, grok-*, o1*, o3*, o4*)",
+		}}
+	}
+	return ValidationErrors{{
+		Field:   field,
+		Message: "maps to a provider with no default credential reference",
+	}}
 }
 
 // validateConsensusForMode enforces that the aggregation strategy matches the

--- a/backend/internal/scoring/validation_judges.go
+++ b/backend/internal/scoring/validation_judges.go
@@ -262,7 +262,7 @@ func validateJudgeModelCredential(field, model string) ValidationErrors {
 	if InferJudgeProviderKey(model) == "" {
 		return ValidationErrors{{
 			Field: field,
-			Message: "must be inferable to a known judge provider (claude-*, gpt-*, gemini-*, grok-*, o1*, o3*, o4*)",
+			Message: "must be inferable to a known judge provider (claude-*, gpt-*, gemini-*, grok-*, mistral-*, openrouter/* slugs)",
 		}}
 	}
 	return ValidationErrors{{

--- a/backend/internal/workflow/judges.go
+++ b/backend/internal/workflow/judges.go
@@ -316,7 +316,7 @@ func evaluateSingleNWiseJudge(
 
 		perModelScores := make([]float64, 0, judge.Samples)
 		for sampleIdx := 0; sampleIdx < judge.Samples; sampleIdx++ {
-			orderedCandidates := orderNWiseCandidates(candidates, executionContext.Run.ID, sampleIdx, judge.PositionDebiasing)
+			orderedCandidates := orderNWiseCandidates(candidates, executionContext.Run.ID, judge.Key, sampleIdx, judge.PositionDebiasing)
 			request := provider.Request{
 				ProviderKey:         providerKey,
 				ProviderAccountID:   providerAccountID,
@@ -455,7 +455,7 @@ func buildNWiseCandidates(
 	return candidates, "", nil
 }
 
-func orderNWiseCandidates(candidates []nwiseCandidate, runID uuid.UUID, sampleIdx int, positionDebiasing bool) []nwiseCandidate {
+func orderNWiseCandidates(candidates []nwiseCandidate, runID uuid.UUID, judgeKey string, sampleIdx int, positionDebiasing bool) []nwiseCandidate {
 	ordered := append([]nwiseCandidate(nil), candidates...)
 	if len(ordered) <= 1 {
 		return ordered
@@ -468,7 +468,7 @@ func orderNWiseCandidates(candidates []nwiseCandidate, runID uuid.UUID, sampleId
 		return ordered
 	}
 
-	seed := nwiseCandidateShuffleSeed(runID, sampleIdx)
+	seed := nwiseCandidateShuffleSeed(runID, judgeKey, sampleIdx)
 	rng := rand.New(rand.NewSource(seed))
 	rng.Shuffle(len(ordered), func(i, j int) {
 		ordered[i], ordered[j] = ordered[j], ordered[i]
@@ -476,9 +476,10 @@ func orderNWiseCandidates(candidates []nwiseCandidate, runID uuid.UUID, sampleId
 	return ordered
 }
 
-func nwiseCandidateShuffleSeed(runID uuid.UUID, sampleIdx int) int64 {
+func nwiseCandidateShuffleSeed(runID uuid.UUID, judgeKey string, sampleIdx int) int64 {
 	hasher := fnv.New64a()
 	_, _ = hasher.Write(runID[:])
+	_, _ = hasher.Write([]byte(judgeKey))
 	_, _ = hasher.Write([]byte{byte(sampleIdx), byte(sampleIdx >> 8), byte(sampleIdx >> 16), byte(sampleIdx >> 24)})
 	return int64(hasher.Sum64())
 }
@@ -613,6 +614,8 @@ func judgeModels(judge scoring.LLMJudgeDeclaration) []string {
 
 func resolveJudgeTarget(model string, executionContext repository.RunAgentExecutionContext) (string, string, string, error) {
 	providerKey := scoring.InferJudgeProviderKey(model)
+	// Pack validation requires inferable models, so this fallback only applies
+	// to unvalidated snapshots (harnesses, legacy packs) at runtime.
 	if providerKey == "" && executionContext.Deployment.ProviderAccount != nil {
 		providerKey = executionContext.Deployment.ProviderAccount.ProviderKey
 	}
@@ -629,14 +632,6 @@ func resolveJudgeTarget(model string, executionContext repository.RunAgentExecut
 		return providerKey, "", "", fmt.Errorf("no default credential reference configured for judge provider %q", providerKey)
 	}
 	return providerKey, "", credentialReference, nil
-}
-
-func inferJudgeProviderKey(model string) string {
-	return scoring.InferJudgeProviderKey(model)
-}
-
-func defaultJudgeCredentialReference(providerKey string) (string, bool) {
-	return scoring.JudgeDefaultCredentialReference(providerKey)
 }
 
 func judgeTimeout(judge scoring.LLMJudgeDeclaration) time.Duration {
@@ -845,6 +840,9 @@ func deriveJudgeConfidence(judge scoring.LLMJudgeDeclaration, modelScores map[st
 		return ""
 	}
 	if len(values) == 1 {
+		if hadWarnings {
+			return "low"
+		}
 		return "single-model"
 	}
 

--- a/backend/internal/workflow/judges.go
+++ b/backend/internal/workflow/judges.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/google/uuid"
 )
 
 const defaultJudgeTimeout = 60 * time.Second
@@ -217,7 +220,7 @@ func evaluateSingleLLMJudge(
 	if variance, ok := sampleVariance(successfulScores); ok {
 		result.Variance = &variance
 	}
-	if confidence := deriveJudgeConfidence(judge, modelScores, successfulScores, len(warnings) > 0); confidence != "" {
+	if confidence := deriveJudgeConfidence(judge, modelScores, len(warnings) > 0); confidence != "" {
 		result.Confidence = &confidence
 	}
 	result.Payload = mustMarshalJSON(map[string]any{
@@ -313,7 +316,7 @@ func evaluateSingleNWiseJudge(
 
 		perModelScores := make([]float64, 0, judge.Samples)
 		for sampleIdx := 0; sampleIdx < judge.Samples; sampleIdx++ {
-			orderedCandidates := rotateNWiseCandidates(candidates, sampleIdx, judge.PositionDebiasing)
+			orderedCandidates := orderNWiseCandidates(candidates, executionContext.Run.ID, sampleIdx, judge.PositionDebiasing)
 			request := provider.Request{
 				ProviderKey:         providerKey,
 				ProviderAccountID:   providerAccountID,
@@ -385,7 +388,7 @@ func evaluateSingleNWiseJudge(
 	if variance, ok := sampleVariance(successfulScores); ok {
 		result.Variance = &variance
 	}
-	if confidence := deriveJudgeConfidence(judge, modelScores, successfulScores, len(warnings) > 0); confidence != "" {
+	if confidence := deriveJudgeConfidence(judge, modelScores, len(warnings) > 0); confidence != "" {
 		result.Confidence = &confidence
 	}
 	result.Payload = mustMarshalJSON(map[string]any{
@@ -452,16 +455,32 @@ func buildNWiseCandidates(
 	return candidates, "", nil
 }
 
-func rotateNWiseCandidates(candidates []nwiseCandidate, sampleIdx int, enabled bool) []nwiseCandidate {
-	rotated := append([]nwiseCandidate(nil), candidates...)
-	if !enabled || len(rotated) == 0 {
-		return rotated
+func orderNWiseCandidates(candidates []nwiseCandidate, runID uuid.UUID, sampleIdx int, positionDebiasing bool) []nwiseCandidate {
+	ordered := append([]nwiseCandidate(nil), candidates...)
+	if len(ordered) <= 1 {
+		return ordered
 	}
-	shift := sampleIdx % len(rotated)
-	if shift == 0 {
-		return rotated
+	if positionDebiasing {
+		shift := sampleIdx % len(ordered)
+		if shift > 0 {
+			return append(ordered[shift:], ordered[:shift]...)
+		}
+		return ordered
 	}
-	return append(rotated[shift:], rotated[:shift]...)
+
+	seed := nwiseCandidateShuffleSeed(runID, sampleIdx)
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(ordered), func(i, j int) {
+		ordered[i], ordered[j] = ordered[j], ordered[i]
+	})
+	return ordered
+}
+
+func nwiseCandidateShuffleSeed(runID uuid.UUID, sampleIdx int) int64 {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write(runID[:])
+	_, _ = hasher.Write([]byte{byte(sampleIdx), byte(sampleIdx >> 8), byte(sampleIdx >> 16), byte(sampleIdx >> 24)})
+	return int64(hasher.Sum64())
 }
 
 func buildNWiseJudgeMessages(judge scoring.LLMJudgeDeclaration, candidates []nwiseCandidate) []provider.Message {
@@ -593,7 +612,7 @@ func judgeModels(judge scoring.LLMJudgeDeclaration) []string {
 }
 
 func resolveJudgeTarget(model string, executionContext repository.RunAgentExecutionContext) (string, string, string, error) {
-	providerKey := inferJudgeProviderKey(model)
+	providerKey := scoring.InferJudgeProviderKey(model)
 	if providerKey == "" && executionContext.Deployment.ProviderAccount != nil {
 		providerKey = executionContext.Deployment.ProviderAccount.ProviderKey
 	}
@@ -605,7 +624,7 @@ func resolveJudgeTarget(model string, executionContext repository.RunAgentExecut
 		return providerKey, account.ID.String(), account.CredentialReference, nil
 	}
 
-	credentialReference, ok := defaultJudgeCredentialReference(providerKey)
+	credentialReference, ok := scoring.JudgeDefaultCredentialReference(providerKey)
 	if !ok {
 		return providerKey, "", "", fmt.Errorf("no default credential reference configured for judge provider %q", providerKey)
 	}
@@ -613,38 +632,11 @@ func resolveJudgeTarget(model string, executionContext repository.RunAgentExecut
 }
 
 func inferJudgeProviderKey(model string) string {
-	trimmed := strings.ToLower(strings.TrimSpace(model))
-	switch {
-	case strings.HasPrefix(trimmed, "claude-"):
-		return "anthropic"
-	case strings.HasPrefix(trimmed, "gpt-"),
-		strings.HasPrefix(trimmed, "o1"),
-		strings.HasPrefix(trimmed, "o3"),
-		strings.HasPrefix(trimmed, "o4"),
-		strings.HasPrefix(trimmed, "text-embedding"):
-		return "openai"
-	case strings.HasPrefix(trimmed, "gemini-"):
-		return "gemini"
-	case strings.HasPrefix(trimmed, "grok-"):
-		return "xai"
-	default:
-		return ""
-	}
+	return scoring.InferJudgeProviderKey(model)
 }
 
 func defaultJudgeCredentialReference(providerKey string) (string, bool) {
-	switch strings.TrimSpace(providerKey) {
-	case "anthropic":
-		return "env://ANTHROPIC_API_KEY", true
-	case "openai":
-		return "env://OPENAI_API_KEY", true
-	case "gemini":
-		return "env://GEMINI_API_KEY", true
-	case "xai":
-		return "env://XAI_API_KEY", true
-	default:
-		return "", false
-	}
+	return scoring.JudgeDefaultCredentialReference(providerKey)
 }
 
 func judgeTimeout(judge scoring.LLMJudgeDeclaration) time.Duration {
@@ -844,7 +836,7 @@ func aggregateModelScores(judge scoring.LLMJudgeDeclaration, modelScores map[str
 	}
 }
 
-func deriveJudgeConfidence(judge scoring.LLMJudgeDeclaration, modelScores map[string]float64, allScores []float64, hadWarnings bool) string {
+func deriveJudgeConfidence(judge scoring.LLMJudgeDeclaration, modelScores map[string]float64, hadWarnings bool) string {
 	values := make([]float64, 0, len(modelScores))
 	for _, value := range modelScores {
 		values = append(values, value)
@@ -852,10 +844,11 @@ func deriveJudgeConfidence(judge scoring.LLMJudgeDeclaration, modelScores map[st
 	if len(values) == 0 {
 		return ""
 	}
-	spread := max(values) - min(values)
-	if len(values) == 1 && len(allScores) > 1 {
-		spread = max(allScores) - min(allScores)
+	if len(values) == 1 {
+		return "single-model"
 	}
+
+	spread := max(values) - min(values)
 	threshold := 0.25
 	if judge.Consensus != nil && judge.Consensus.MinAgreementThreshold > 0 {
 		threshold = judge.Consensus.MinAgreementThreshold

--- a/backend/internal/workflow/judges_test.go
+++ b/backend/internal/workflow/judges_test.go
@@ -86,6 +86,9 @@ func TestEvaluateLLMJudges_UsesInferredProviderCredential(t *testing.T) {
 	if results[0].SampleCount != 2 {
 		t.Fatalf("sample count = %d, want 2", results[0].SampleCount)
 	}
+	if results[0].Confidence == nil || *results[0].Confidence != "single-model" {
+		t.Fatalf("confidence = %v, want single-model", results[0].Confidence)
+	}
 	if len(client.Requests) != 2 {
 		t.Fatalf("request count = %d, want 2", len(client.Requests))
 	}
@@ -216,6 +219,64 @@ func TestEvaluateLLMJudges_SupportsNWiseRankingForNormalRuns(t *testing.T) {
 	}
 	if got := client.Requests[0].Messages[0].Content; !containsAll(got, firstRunAgentID.String(), secondRunAgentID.String(), "Escalated to pager immediately", "Restarted a random service") {
 		t.Fatalf("n_wise prompt did not include both candidates: %q", got)
+	}
+}
+
+func TestDeriveJudgeConfidenceRequiresMultipleModelsForConsensus(t *testing.T) {
+	judge := scoring.LLMJudgeDeclaration{}
+	single := map[string]float64{"claude": 0.9}
+	if got := deriveJudgeConfidence(judge, single, false); got != "single-model" {
+		t.Fatalf("single-model confidence = %q, want single-model", got)
+	}
+
+	multiAgree := map[string]float64{"claude": 0.9, "gpt": 0.9}
+	if got := deriveJudgeConfidence(judge, multiAgree, false); got != "high" {
+		t.Fatalf("agreeing multi-model confidence = %q, want high", got)
+	}
+
+	multiDisagree := map[string]float64{"claude": 0.1, "gpt": 0.9}
+	if got := deriveJudgeConfidence(judge, multiDisagree, false); got != "low" {
+		t.Fatalf("disagreeing multi-model confidence = %q, want low", got)
+	}
+}
+
+func TestOrderNWiseCandidatesShufflesByDefault(t *testing.T) {
+	runID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	candidates := []nwiseCandidate{
+		{RunAgentID: "a", Label: "A"},
+		{RunAgentID: "b", Label: "B"},
+		{RunAgentID: "c", Label: "C"},
+	}
+	ordered := orderNWiseCandidates(candidates, runID, 0, false)
+	if len(ordered) != len(candidates) {
+		t.Fatalf("candidate count = %d, want %d", len(ordered), len(candidates))
+	}
+	seen := make(map[string]struct{}, len(ordered))
+	for _, candidate := range ordered {
+		seen[candidate.RunAgentID] = struct{}{}
+	}
+	for _, candidate := range candidates {
+		if _, ok := seen[candidate.RunAgentID]; !ok {
+			t.Fatalf("missing candidate %q after shuffle", candidate.RunAgentID)
+		}
+	}
+	if ordered[0].RunAgentID == candidates[0].RunAgentID &&
+		ordered[1].RunAgentID == candidates[1].RunAgentID &&
+		ordered[2].RunAgentID == candidates[2].RunAgentID {
+		t.Fatal("expected default n_wise ordering to shuffle candidates")
+	}
+}
+
+func TestOrderNWiseCandidatesRotatesWhenPositionDebiasingEnabled(t *testing.T) {
+	runID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	candidates := []nwiseCandidate{
+		{RunAgentID: "a", Label: "A"},
+		{RunAgentID: "b", Label: "B"},
+		{RunAgentID: "c", Label: "C"},
+	}
+	ordered := orderNWiseCandidates(candidates, runID, 1, true)
+	if ordered[0].RunAgentID != "b" || ordered[1].RunAgentID != "c" || ordered[2].RunAgentID != "a" {
+		t.Fatalf("rotated order = [%s %s %s], want [b c a]", ordered[0].RunAgentID, ordered[1].RunAgentID, ordered[2].RunAgentID)
 	}
 }
 

--- a/backend/internal/workflow/judges_test.go
+++ b/backend/internal/workflow/judges_test.go
@@ -100,27 +100,6 @@ func TestEvaluateLLMJudges_UsesInferredProviderCredential(t *testing.T) {
 	}
 }
 
-func TestInferJudgeProviderKeyRecognizesGrokModels(t *testing.T) {
-	for _, model := range []string{
-		"grok-4-1-fast-reasoning",
-		"  Grok-4-1-Fast-Reasoning  ",
-	} {
-		if got := inferJudgeProviderKey(model); got != "xai" {
-			t.Fatalf("model %q inferred provider key %q, want xai", model, got)
-		}
-	}
-}
-
-func TestDefaultJudgeCredentialReferenceSupportsXAI(t *testing.T) {
-	got, ok := defaultJudgeCredentialReference("xai")
-	if !ok {
-		t.Fatalf("expected xai credential reference")
-	}
-	if got != "env://XAI_API_KEY" {
-		t.Fatalf("credential reference = %q, want env://XAI_API_KEY", got)
-	}
-}
-
 func TestEvaluateLLMJudges_SupportsNWiseRankingForNormalRuns(t *testing.T) {
 	runID := uuid.New()
 	firstRunAgentID := uuid.New()
@@ -228,6 +207,9 @@ func TestDeriveJudgeConfidenceRequiresMultipleModelsForConsensus(t *testing.T) {
 	if got := deriveJudgeConfidence(judge, single, false); got != "single-model" {
 		t.Fatalf("single-model confidence = %q, want single-model", got)
 	}
+	if got := deriveJudgeConfidence(judge, single, true); got != "low" {
+		t.Fatalf("single-model confidence with warnings = %q, want low", got)
+	}
 
 	multiAgree := map[string]float64{"claude": 0.9, "gpt": 0.9}
 	if got := deriveJudgeConfidence(judge, multiAgree, false); got != "high" {
@@ -247,7 +229,7 @@ func TestOrderNWiseCandidatesShufflesByDefault(t *testing.T) {
 		{RunAgentID: "b", Label: "B"},
 		{RunAgentID: "c", Label: "C"},
 	}
-	ordered := orderNWiseCandidates(candidates, runID, 0, false)
+	ordered := orderNWiseCandidates(candidates, runID, "overall_preference", 0, false)
 	if len(ordered) != len(candidates) {
 		t.Fatalf("candidate count = %d, want %d", len(ordered), len(candidates))
 	}
@@ -267,6 +249,22 @@ func TestOrderNWiseCandidatesShufflesByDefault(t *testing.T) {
 	}
 }
 
+func TestOrderNWiseCandidatesDecorrelatesAcrossJudgeKeys(t *testing.T) {
+	runID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	candidates := []nwiseCandidate{
+		{RunAgentID: "a", Label: "A"},
+		{RunAgentID: "b", Label: "B"},
+		{RunAgentID: "c", Label: "C"},
+	}
+	first := orderNWiseCandidates(candidates, runID, "judge_a", 0, false)
+	second := orderNWiseCandidates(candidates, runID, "judge_b", 0, false)
+	if first[0].RunAgentID == second[0].RunAgentID &&
+		first[1].RunAgentID == second[1].RunAgentID &&
+		first[2].RunAgentID == second[2].RunAgentID {
+		t.Fatal("expected different judge keys to produce different shuffle order")
+	}
+}
+
 func TestOrderNWiseCandidatesRotatesWhenPositionDebiasingEnabled(t *testing.T) {
 	runID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 	candidates := []nwiseCandidate{
@@ -274,9 +272,28 @@ func TestOrderNWiseCandidatesRotatesWhenPositionDebiasingEnabled(t *testing.T) {
 		{RunAgentID: "b", Label: "B"},
 		{RunAgentID: "c", Label: "C"},
 	}
-	ordered := orderNWiseCandidates(candidates, runID, 1, true)
+	ordered := orderNWiseCandidates(candidates, runID, "overall_preference", 1, true)
 	if ordered[0].RunAgentID != "b" || ordered[1].RunAgentID != "c" || ordered[2].RunAgentID != "a" {
 		t.Fatalf("rotated order = [%s %s %s], want [b c a]", ordered[0].RunAgentID, ordered[1].RunAgentID, ordered[2].RunAgentID)
+	}
+}
+
+func TestOrderNWiseCandidatesRotationCoversEveryPosition(t *testing.T) {
+	runID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	candidates := []nwiseCandidate{
+		{RunAgentID: "a", Label: "A"},
+		{RunAgentID: "b", Label: "B"},
+		{RunAgentID: "c", Label: "C"},
+	}
+	firstPositions := make(map[string]int)
+	for sampleIdx := range candidates {
+		ordered := orderNWiseCandidates(candidates, runID, "overall_preference", sampleIdx, true)
+		firstPositions[ordered[0].RunAgentID] = sampleIdx
+	}
+	for _, candidate := range candidates {
+		if _, ok := firstPositions[candidate.RunAgentID]; !ok {
+			t.Fatalf("candidate %q never appeared first during rotation cycle", candidate.RunAgentID)
+		}
 	}
 }
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
@@ -499,7 +499,7 @@ function VerdictChip({
 function ConfidenceChip({ value }: { value: string }) {
   const v = value.toLowerCase();
   const tone =
-    v === "single-model" || v === "ungrounded"
+    v === "single-model"
       ? "text-white/45 border-white/10"
       : v.includes("high")
         ? "text-emerald-300/85 border-emerald-500/20"

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
@@ -498,11 +498,14 @@ function VerdictChip({
 
 function ConfidenceChip({ value }: { value: string }) {
   const v = value.toLowerCase();
-  const tone = v.includes("high")
-    ? "text-emerald-300/85 border-emerald-500/20"
-    : v.includes("low")
-      ? "text-red-300/85 border-red-500/20"
-      : "text-amber-300/85 border-amber-500/20";
+  const tone =
+    v === "single-model" || v === "ungrounded"
+      ? "text-white/45 border-white/10"
+      : v.includes("high")
+        ? "text-emerald-300/85 border-emerald-500/20"
+        : v.includes("low")
+          ? "text-red-300/85 border-red-500/20"
+          : "text-amber-300/85 border-amber-500/20";
   return (
     <span
       className={cn(


### PR DESCRIPTION
## Summary
- Single-model LLM judges now report `confidence=single-model` instead of `high`; consensus confidence (`high`/`medium`/`low`) requires at least two distinct judge models.
- N-wise grading shuffles candidate order by default (deterministic per run + sample); explicit `position_debiasing: true` keeps cyclic rotation.
- Challenge pack validation rejects judge models that cannot be mapped to a known provider/credential at config time.

Fixes #1045

## Test plan
- [x] `go test -short -race -count=1 ./internal/workflow/... ./internal/scoring/...`
- [x] Added unit tests for `deriveJudgeConfidence`, n-wise ordering, and judge model credential validation
- [ ] Manual: run a single-model judge pack and confirm scorecard shows `single-model` confidence
- [ ] Manual: publish a pack with an unknown judge model (e.g. `llama-3.1-70b`) and confirm validation rejects it