### PR TITLE
fix(cli,web): finish eval-platform vocabulary reposition

### DIFF
--- a/cli/cmd/eval.go
+++ b/cli/cmd/eval.go
@@ -20,8 +20,7 @@ func init() {
 	evalStartCmd.Flags().String("scope", "full", "Run scope: full or suite_only")
 	evalStartCmd.Flags().StringSlice("suite", nil, "Regression suite ID or exact name (repeatable)")
 	evalStartCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
-	evalStartCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
-	evalStartCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
+	registerPeerStandingsFlags(evalStartCmd)
 	evalStartCmd.Flags().Int("repetitions", 1, "Repeat the eval N times in a multi-run eval session, [1, 100]. >=2 routes through /v1/eval-sessions and unlocks pass@K + pass^K aggregation.")
 
 	evalScorecardCmd.Flags().String("agent", "", "Run agent ID or label (optional)")

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -41,7 +41,7 @@ func buildEvalSessionBody(workspaceID string, request runCreateRequest, repetiti
 		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --repetitions >= 2")
 	}
 	if request.RaceContext || request.RaceContextCadence > 0 {
-		return nil, fmt.Errorf("--race-context flags are not supported with --repetitions >= 2")
+		return nil, peerStandingsFlagsUnsupportedError("--repetitions >= 2")
 	}
 	if request.Mode != "" {
 		return nil, fmt.Errorf("--mode is not supported with --repetitions >= 2 or --seeds")

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -232,12 +232,12 @@ func TestBuildEvalSessionBody_RejectsUnsupportedFlags(t *testing.T) {
 		{
 			name:    "race_context",
 			mutate:  func(r *runCreateRequest) { r.RaceContext = true },
-			wantErr: "race-context",
+			wantErr: "peer-standings",
 		},
 		{
 			name:    "race_context_cadence",
 			mutate:  func(r *runCreateRequest) { r.RaceContextCadence = 5 },
-			wantErr: "race-context",
+			wantErr: "peer-standings",
 		},
 		{
 			name:    "max_iterations",
@@ -526,7 +526,7 @@ func TestRunSeriesReportRendersAggregateScoreCostCorrectness(t *testing.T) {
 	}
 	for _, snippet := range []string{
 		"Eval Session ID",
-		"Race Series Report",
+		"Eval Series Report",
 		"COMPOSITE",
 		"smoke",
 		"default",
@@ -657,7 +657,7 @@ func TestBuildSeededEvalSessionBodyRejectsInvalidFlagRanges(t *testing.T) {
 				RaceContextCadence:     -1,
 				Seeds:                  2,
 			},
-			want: "--race-context-cadence",
+			want: "--peer-standings-cadence",
 		},
 	}
 	for _, tc := range cases {

--- a/cli/cmd/peer_standings_flags.go
+++ b/cli/cmd/peer_standings_flags.go
@@ -32,15 +32,17 @@ func registerPeerStandingsFlags(cmd *cobra.Command) {
 }
 
 func peerStandingsFromFlags(cmd *cobra.Command) (enabled bool, cadence int) {
-	enabled, _ = cmd.Flags().GetBool(peerStandingsFlagName)
-	if legacy, _ := cmd.Flags().GetBool(legacyRaceContextFlagName); legacy {
+	flags := cmd.Flags()
+	if flags.Changed(peerStandingsFlagName) {
+		enabled, _ = flags.GetBool(peerStandingsFlagName)
+	} else if legacy, _ := flags.GetBool(legacyRaceContextFlagName); legacy {
 		enabled = true
 	}
 
-	cadence, _ = cmd.Flags().GetInt(peerStandingsCadenceFlagName)
-	if cmd.Flags().Changed(legacyRaceContextCadenceName) {
-		legacyCadence, _ := cmd.Flags().GetInt(legacyRaceContextCadenceName)
-		cadence = legacyCadence
+	if flags.Changed(peerStandingsCadenceFlagName) {
+		cadence, _ = flags.GetInt(peerStandingsCadenceFlagName)
+	} else if flags.Changed(legacyRaceContextCadenceName) {
+		cadence, _ = flags.GetInt(legacyRaceContextCadenceName)
 	}
 	return enabled, cadence
 }
@@ -58,8 +60,9 @@ func validatePeerStandingsCadence(cadence int) error {
 
 func peerStandingsFlagsUnsupportedError(context string) error {
 	return fmt.Errorf(
-		"--%s flags are not supported with %s",
+		"--%s / --%s are not supported with %s",
 		peerStandingsFlagName,
+		peerStandingsCadenceFlagName,
 		context,
 	)
 }

--- a/cli/cmd/peer_standings_flags.go
+++ b/cli/cmd/peer_standings_flags.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	peerStandingsFlagName        = "peer-standings"
+	peerStandingsCadenceFlagName = "peer-standings-cadence"
+	legacyRaceContextFlagName    = "race-context"
+	legacyRaceContextCadenceName = "race-context-cadence"
+)
+
+func registerPeerStandingsFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.Bool(
+		peerStandingsFlagName,
+		false,
+		"Enable live peer-standings injection during the run (requires 2+ agents)",
+	)
+	flags.Int(
+		peerStandingsCadenceFlagName,
+		0,
+		"Override peer-standings cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.",
+	)
+	flags.Bool(legacyRaceContextFlagName, false, "Deprecated: use --peer-standings")
+	flags.Int(legacyRaceContextCadenceName, 0, "Deprecated: use --peer-standings-cadence")
+	_ = flags.MarkDeprecated(legacyRaceContextFlagName, "use --peer-standings instead")
+	_ = flags.MarkDeprecated(legacyRaceContextCadenceName, "use --peer-standings-cadence instead")
+}
+
+func peerStandingsFromFlags(cmd *cobra.Command) (enabled bool, cadence int) {
+	enabled, _ = cmd.Flags().GetBool(peerStandingsFlagName)
+	if legacy, _ := cmd.Flags().GetBool(legacyRaceContextFlagName); legacy {
+		enabled = true
+	}
+
+	cadence, _ = cmd.Flags().GetInt(peerStandingsCadenceFlagName)
+	if cmd.Flags().Changed(legacyRaceContextCadenceName) {
+		legacyCadence, _ := cmd.Flags().GetInt(legacyRaceContextCadenceName)
+		cadence = legacyCadence
+	}
+	return enabled, cadence
+}
+
+func validatePeerStandingsCadence(cadence int) error {
+	if cadence == 0 || (cadence >= 1 && cadence <= 10) {
+		return nil
+	}
+	return fmt.Errorf(
+		"--%s must be 0 (backend default) or between 1 and 10, got %d",
+		peerStandingsCadenceFlagName,
+		cadence,
+	)
+}
+
+func peerStandingsFlagsUnsupportedError(context string) error {
+	return fmt.Errorf(
+		"--%s flags are not supported with %s",
+		peerStandingsFlagName,
+		context,
+	)
+}

--- a/cli/cmd/quota.go
+++ b/cli/cmd/quota.go
@@ -40,8 +40,8 @@ var quotaCmd = &cobra.Command{
 		if status := mapString(quota, "status"); status != "" {
 			rc.Output.PrintDetail("Status", output.StatusColor(status))
 		}
-		rc.Output.PrintDetail("Monthly races", quotaCounterLine(mapObject(quota, "monthly_races")))
-		rc.Output.PrintDetail("Concurrent races", quotaCounterLine(mapObject(quota, "concurrent_races")))
+		rc.Output.PrintDetail("Monthly evals", quotaCounterLine(mapObject(quota, "monthly_races")))
+		rc.Output.PrintDetail("Concurrent evals", quotaCounterLine(mapObject(quota, "concurrent_races")))
 		if resetAt := mapString(mapObject(quota, "monthly_races"), "reset_at"); resetAt != "" {
 			rc.Output.PrintDetail("Quota resets", resetAt)
 		}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -36,7 +36,7 @@ func init() {
 	runCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().StringSlice("deployments", nil, "Agent deployment IDs (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().String("deployment-lineup", "", "Challenge pack deployment lineup to use when --deployments is omitted (default: default)")
-	runCreateCmd.Flags().StringSlice("deployment-lineups", nil, "Challenge pack deployment lineups to cross with --seeds for a race series")
+	runCreateCmd.Flags().StringSlice("deployment-lineups", nil, "Challenge pack deployment lineups to cross with --seeds for an eval series")
 	runCreateCmd.Flags().String("name", "", "Run name (optional)")
 	runCreateCmd.Flags().String("input-set", "", "Challenge input set ID (optional)")
 	runCreateCmd.Flags().Bool("follow", false, "Follow run events after creation")
@@ -44,8 +44,7 @@ func init() {
 	runCreateCmd.Flags().StringSlice("suite", nil, "Regression suite IDs (repeatable; required with --scope suite_only unless --case is used)")
 	runCreateCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
 	runCreateCmd.Flags().Bool("include-proposed-regressions", false, "Include proposed regression cases for validation runs")
-	runCreateCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
-	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
+	registerPeerStandingsFlags(runCreateCmd)
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
 	runCreateCmd.Flags().String("mode", "", "Voice eval mode: text-sim (future: audio-sim, live-call, replay-import)")
@@ -84,12 +83,12 @@ var runCmd = &cobra.Command{
 
 var runSeriesCmd = &cobra.Command{
 	Use:   "series",
-	Short: "Manage durable race series",
+	Short: "Manage durable eval series",
 }
 
 var runSeriesCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a race series from deployment lineups and seeds",
+	Short: "Create an eval series from deployment lineups and seeds",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
 		wsID := RequireWorkspace(cmd)
@@ -120,7 +119,7 @@ var runSeriesCreateCmd = &cobra.Command{
 
 var runSeriesReportCmd = &cobra.Command{
 	Use:   "report <eval-session-id>",
-	Short: "Show aggregate score, correctness, and cost for a race series",
+	Short: "Show aggregate score, correctness, and cost for an eval series",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
@@ -230,12 +229,12 @@ func renderRunSeriesReport(rc *RunContext, result map[string]any) {
 	report := mapObject(aggregate, "series_report")
 	rowsRaw := mapSlice(report, "rows")
 	if len(rowsRaw) == 0 {
-		rc.Output.PrintWarning("Aggregate result does not include a race series report.")
+		rc.Output.PrintWarning("Aggregate result does not include an eval series report.")
 		renderEvalSessionEvidenceWarnings(rc, result)
 		return
 	}
 
-	fmt.Fprintf(rc.Output.Writer(), "\n%s\n", output.Bold("Race Series Report"))
+	fmt.Fprintf(rc.Output.Writer(), "\n%s\n", output.Bold("Eval Series Report"))
 	reportUsesComposite := mapString(report, "rank_metric") == "composite_agent_score"
 	cols := []output.Column{
 		{Header: "Rank"},

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -97,11 +97,9 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 	includeProposed, _ := cmd.Flags().GetBool("include-proposed-regressions")
 	request.IncludeProposedRegressions = includeProposed
 
-	raceContext, _ := cmd.Flags().GetBool("race-context")
+	raceContext, raceContextCadence := peerStandingsFromFlags(cmd)
 	request.RaceContext = raceContext
-
-	cadence, _ := cmd.Flags().GetInt("race-context-cadence")
-	request.RaceContextCadence = cadence
+	request.RaceContextCadence = raceContextCadence
 
 	maxIterations, _ := cmd.Flags().GetInt("max-iter")
 	request.MaxIterations = maxIterations
@@ -153,8 +151,8 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	if request.OfficialPackMode == "suite_only" && len(request.RegressionSuiteIDs) == 0 && len(request.RegressionCaseIDs) == 0 {
 		return nil, fmt.Errorf("--scope suite_only requires at least one regression suite or regression case")
 	}
-	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
-		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	if err := validatePeerStandingsCadence(request.RaceContextCadence); err != nil {
+		return nil, err
 	}
 	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
 		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
@@ -206,8 +204,8 @@ func buildSeededEvalSessionBody(workspaceID string, request runCreateRequest) (m
 	if request.Seeds < 1 || request.Seeds > maxRunCreateSeeds {
 		return nil, fmt.Errorf("--seeds must be between 1 and %d, got %d", maxRunCreateSeeds, request.Seeds)
 	}
-	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
-		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	if err := validatePeerStandingsCadence(request.RaceContextCadence); err != nil {
+		return nil, err
 	}
 	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
 		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
@@ -216,7 +214,7 @@ func buildSeededEvalSessionBody(workspaceID string, request runCreateRequest) (m
 		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --seeds")
 	}
 	if request.RaceContext || request.RaceContextCadence > 0 {
-		return nil, fmt.Errorf("--race-context flags are not supported with --seeds")
+		return nil, peerStandingsFlagsUnsupportedError("--seeds")
 	}
 	sessionRequest := request
 	sessionRequest.MaxIterations = 0
@@ -256,8 +254,8 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 	if repetitions > evalSessionMaxRepetitions {
 		return nil, fmt.Errorf("--deployment-lineups × --seeds must create at most %d child runs, got %d", evalSessionMaxRepetitions, repetitions)
 	}
-	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
-		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	if err := validatePeerStandingsCadence(request.RaceContextCadence); err != nil {
+		return nil, err
 	}
 	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
 		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
@@ -266,7 +264,7 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --deployment-lineups")
 	}
 	if request.RaceContext || request.RaceContextCadence > 0 {
-		return nil, fmt.Errorf("--race-context flags are not supported with --deployment-lineups")
+		return nil, peerStandingsFlagsUnsupportedError("--deployment-lineups")
 	}
 	if request.Mode != "" {
 		return nil, fmt.Errorf("--mode is not supported with --deployment-lineups")

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -2266,14 +2266,14 @@
               "type": "string"
             },
             {
-              "name": "race-context",
+              "name": "peer-standings",
               "usage": "Enable live peer-standings injection during the run (requires 2+ agents)",
               "type": "bool",
               "default": "false"
             },
             {
-              "name": "race-context-cadence",
-              "usage": "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.",
+              "name": "peer-standings-cadence",
+              "usage": "Override peer-standings cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.",
               "type": "int",
               "default": "0"
             },
@@ -4009,7 +4009,7 @@
             },
             {
               "name": "deployment-lineups",
-              "usage": "Challenge pack deployment lineups to cross with --seeds for a race series",
+              "usage": "Challenge pack deployment lineups to cross with --seeds for an eval series",
               "type": "stringSlice",
               "default": "[]"
             },
@@ -4053,14 +4053,14 @@
               "type": "string"
             },
             {
-              "name": "race-context",
+              "name": "peer-standings",
               "usage": "Enable live peer-standings injection during the run (requires 2+ agents)",
               "type": "bool",
               "default": "false"
             },
             {
-              "name": "race-context-cadence",
-              "usage": "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.",
+              "name": "peer-standings-cadence",
+              "usage": "Override peer-standings cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.",
               "type": "int",
               "default": "0"
             },
@@ -4322,13 +4322,13 @@
         {
           "name": "series",
           "path": "agentclash run series",
-          "short": "Manage durable race series",
+          "short": "Manage durable eval series",
           "runnable": false,
           "subcommands": [
             {
               "name": "create",
               "path": "agentclash run series create",
-              "short": "Create a race series from deployment lineups and seeds",
+              "short": "Create an eval series from deployment lineups and seeds",
               "runnable": true,
               "flags": [
                 {
@@ -4369,7 +4369,7 @@
             {
               "name": "report",
               "path": "agentclash run series report",
-              "short": "Show aggregate score, correctness, and cost for a race series",
+              "short": "Show aggregate score, correctness, and cost for an eval series",
               "runnable": true,
               "args": [
                 {

--- a/cli/internal/skills/snapshot/agentclash-eval-runner/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-eval-runner/SKILL.md
@@ -77,8 +77,8 @@ Exact `eval start` flags:
 - `--scope`: `full` or `suite_only`; default is `full`.
 - `--suite`: regression suite ID or exact name. Repeatable.
 - `--case`: regression case IDs. Repeatable.
-- `--race-context`: enable live peer-standings injection during the run.
-- `--race-context-cadence`: 0 for backend default, otherwise 1 through 10.
+- `--peer-standings`: enable live peer-standings injection during the run.
+- `--peer-standings-cadence`: 0 for backend default, otherwise 1 through 10.
 - `--repetitions`: repeat the eval 1 through 100 times; values 2 or greater use `/v1/eval-sessions`.
 
 Selector behavior:
@@ -115,7 +115,7 @@ Exact `run create` notes:
 - In non-interactive mode, `--challenge-pack-version` and `--deployments` are required.
 - In a TTY, missing challenge pack version, input set, or deployments can open pickers.
 - `run create` does not resolve pack slugs, input set keys, or deployment names. Use `eval start` for that.
-- `--scope`, `--suite`, `--case`, `--race-context`, and `--race-context-cadence` behave like `eval start`, but suite and case flags are ID-first.
+- `--scope`, `--suite`, `--case`, `--peer-standings`, and `--peer-standings-cadence` behave like `eval start`, but suite and case flags are ID-first.
 
 The run create request body sent by the CLI contains:
 
@@ -202,7 +202,7 @@ Exact repetition behavior:
 - `--repetitions 1` creates a normal run through `/v1/runs`.
 - `--repetitions >= 2` posts to `/v1/eval-sessions`.
 - `--follow` is not supported with `--repetitions >= 2`; tail individual child runs with `agentclash run events <RUN_ID>`.
-- `--scope suite_only`, `--suite`, `--case`, and race-context flags are not supported with `--repetitions >= 2`.
+- `--scope suite_only`, `--suite`, `--case`, and peer-standings flags are not supported with `--repetitions >= 2`.
 - The eval-session response is `{ "eval_session": {...}, "run_ids": [...] }`.
 
 In human output, the CLI prints eval session ID, status, repetitions, and child run IDs. In structured output, it prints the raw response envelope.
@@ -228,7 +228,7 @@ Behavior:
 Use `eval session follow` after creating a multi-repetition eval when you need aggregated results before reading scorecards or comparisons.
 
 ## Run Series Commands
-`run series` crosses deployment lineups with seeds for race-style series evals:
+`run series` crosses deployment lineups with seeds for multi-run comparison series:
 
 ```bash
 agentclash run series create \
@@ -307,8 +307,8 @@ Read command notes:
 - `invalid_agent_deployment_ids`: deployment IDs must be active deployments with snapshots in the selected workspace, with no duplicates.
 - `invalid_challenge_pack_version_id`: the version must be runnable and visible to the selected workspace.
 - `invalid_challenge_input_set_id`: the input set must belong to the selected challenge pack version.
-- `invalid_race_context`: race context requires at least two agents.
-- `--race-context-cadence must be 0 (backend default) or between 1 and 10`: fix the cadence value.
+- `invalid_race_context`: peer standings require at least two agents.
+- `--peer-standings-cadence must be 0 (backend default) or between 1 and 10`: fix the cadence value.
 - `--follow is not supported with --repetitions >= 2`: create the eval session, then use `eval session follow` or stream individual child runs with `run events`.
 - `--scope suite_only requires at least one --suite or --case`: add a suite or case selection.
 - Scorecard pending or errored: report the state, then collect `run events`, `run agents`, and `run failures`.

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "5674fc82b113",
+  "snapshot_version": "ebfdcf026705",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -95,7 +95,7 @@
       "name": "agentclash-eval-runner",
       "role": "running",
       "requires_cli": true,
-      "sha256": "77867733082836e249a3c45fa3648035eb59d1449a1f797b8ebf18d231be2acb"
+      "sha256": "8cb10a6d1d295af1bd35cbc4fe4503eb53e0a32677366ed67474c7301360ccb0"
     },
     {
       "name": "agentclash-hub",

--- a/docs/cli-workflow-handoff.md
+++ b/docs/cli-workflow-handoff.md
@@ -39,7 +39,7 @@ they need: `run`, `challenge-pack`, `deployment`, `build`, `infra`, `artifact`,
   `run create`, `run agents`, `run ranking`, `run scorecard`, `run failures`,
   `run compare`, `run replay`, `run transcript`, and `run promote-failure`.
 - Repeated eval creation: `eval start --repetitions N` creates eval sessions.
-- Durable race series: `run series create` and `run series report` expose
+- Durable eval series: `run series create` and `run series report` expose
   lineup/seed aggregate reporting.
 - Prompt evals and quota: `prompt-eval` manages prompt-eval configs and
   playground experiments; `quota` shows workspace usage.
@@ -78,7 +78,7 @@ they need: `run`, `challenge-pack`, `deployment`, `build`, `infra`, `artifact`,
 3. `eval session follow` polls session status until aggregation completes.
 4. `eval session get` shows child runs, run counts, aggregate metrics, pass@K,
    pass^K, winner/leader information, and evidence warnings when available.
-5. For race-series sessions, `agentclash run series report <eval-session-id>`
+5. For eval-series sessions, `agentclash run series report <eval-session-id>`
    remains the focused aggregate report for lineup, seed, correctness, cost, and
    token totals.
 
@@ -121,7 +121,7 @@ they need: `run`, `challenge-pack`, `deployment`, `build`, `infra`, `artifact`,
   - Uses existing eval-session read APIs.
   - Makes repeated eval sessions inspectable from the CLI after
     `eval start --repetitions N`.
-  - Complements the existing `run series report` view for durable race series.
+  - Complements the existing `run series report` view for durable eval series.
 - `agentclash compare latest`
   - Compares the local baseline bookmark against the latest non-baseline run.
   - Supports `--agent`, `--baseline-agent`, `--candidate-agent`, `--gate`, and

--- a/docs/marketing/model-benchmark-workflow.md
+++ b/docs/marketing/model-benchmark-workflow.md
@@ -1,6 +1,6 @@
 # Model Benchmark Workflow (Monthly Public Report Runbook)
 
-Repeatable process for turning an AgentClash race into a **monthly public benchmark**:
+Repeatable process for turning an AgentClash comparison eval into a **monthly public benchmark**:
 a measured report on `/benchmarks/<slug>`, a shareable blog summary, and a changelog
 entry. Run it when major models ship and on a **monthly reliability cadence**.
 
@@ -10,7 +10,7 @@ Reference implementation: [Coding agent benchmark — June 2026](https://www.age
 
 | Role | Responsibility |
 | ---- | ---------------- |
-| **Monthly owner** | Picks the pack, runs the race, exports ranking JSON, drafts MDX + blog |
+| **Monthly owner** | Picks the pack, runs the eval, exports ranking JSON, drafts MDX + blog |
 | **Review approver** | Verifies numbers against replay, checks caveats and sample size honesty |
 | **Distribution** | Posts share URL to X / HN / LinkedIn on publish day; pings benchmarks RSS |
 
@@ -19,7 +19,7 @@ Reference implementation: [Coding agent benchmark — June 2026](https://www.age
 **Checklist (copy each cycle):**
 
 - [ ] Pin challenge pack version **and** git commit SHA in the report appendix
-- [ ] Race every candidate on the same pack (tools, sandbox, budgets)
+- [ ] Evaluate every candidate on the same pack (tools, sandbox, budgets)
 - [ ] Export ranking JSON and attach replay / validator evidence per lane
 - [ ] Set `sample: false` only when numbers are measured
 - [ ] Write narrative + methodology appendix; add monthly blog summary
@@ -44,7 +44,7 @@ Other packs suitable for future months (rotate or expand field size):
 Record in every report:
 
 - `pack.slug`, `evaluation_spec.name`, execution mode, tool policy, runtime limits
-- Git commit SHA of the repo when the race ran
+- Git commit SHA of the repo when the eval ran
 
 ## One-time setup
 
@@ -59,7 +59,7 @@ Record in every report:
 
 ## Per-report steps
 
-### 1. Run the race
+### 1. Run the eval
 
 ```bash
 cd cli
@@ -91,7 +91,7 @@ The scaffold accepts either the full response (`{ state, ranking: {...} }`) or t
 ```bash
 node scripts/benchmarks/scaffold.mjs \
   --ranking ranking.json \
-  --title "We raced <Model> on <task headline>" \
+  --title "We compared <Model> on <task headline>" \
   --model "<Model>" \
   --slug <kebab-slug> \
   --share-url "https://www.agentclash.dev/share/<token>"   # optional
@@ -101,13 +101,13 @@ Writes `web/content/benchmarks/<slug>.mdx` with `sample: false` and a prose skel
 
 ### 4. Public share link (recommended)
 
-Create a public share of the run scorecard and set `runShareUrl` in frontmatter. The report page renders "View the live race scorecard".
+Create a public share of the run scorecard and set `runShareUrl` in frontmatter. The report page renders "View the live comparison scorecard".
 
 ### 5. Edit narrative + methodology appendix
 
 In the MDX body, include:
 
-- How the race worked (lineup, constraints, n per model)
+- How the comparison worked (lineup, constraints, n per model)
 - Task description and why it was chosen
 - What we saw (story behind the scoreboard)
 - Caveats (sample size, provider scope, judge variance)

--- a/npm/cli/AGENTS.md
+++ b/npm/cli/AGENTS.md
@@ -6,7 +6,7 @@ AgentClash. It is not the AgentClash source repo.
 
 ## What AgentClash is
 
-AgentClash is a race engine: it pits AI models/agents against each other on real
+AgentClash is an agent evaluation platform: it compares AI models and agents on real
 tasks with live scoring. You define a **challenge pack** (the eval workload), run
 **agents** (model + runtime + tools) against it, and read a **scorecard**. There
 are **no built-in packs** — every workspace authors its own.

--- a/web/content/agent-skills/agentclash-eval-runner/SKILL.md
+++ b/web/content/agent-skills/agentclash-eval-runner/SKILL.md
@@ -77,8 +77,8 @@ Exact `eval start` flags:
 - `--scope`: `full` or `suite_only`; default is `full`.
 - `--suite`: regression suite ID or exact name. Repeatable.
 - `--case`: regression case IDs. Repeatable.
-- `--race-context`: enable live peer-standings injection during the run.
-- `--race-context-cadence`: 0 for backend default, otherwise 1 through 10.
+- `--peer-standings`: enable live peer-standings injection during the run.
+- `--peer-standings-cadence`: 0 for backend default, otherwise 1 through 10.
 - `--repetitions`: repeat the eval 1 through 100 times; values 2 or greater use `/v1/eval-sessions`.
 
 Selector behavior:
@@ -115,7 +115,7 @@ Exact `run create` notes:
 - In non-interactive mode, `--challenge-pack-version` and `--deployments` are required.
 - In a TTY, missing challenge pack version, input set, or deployments can open pickers.
 - `run create` does not resolve pack slugs, input set keys, or deployment names. Use `eval start` for that.
-- `--scope`, `--suite`, `--case`, `--race-context`, and `--race-context-cadence` behave like `eval start`, but suite and case flags are ID-first.
+- `--scope`, `--suite`, `--case`, `--peer-standings`, and `--peer-standings-cadence` behave like `eval start`, but suite and case flags are ID-first.
 
 The run create request body sent by the CLI contains:
 
@@ -202,7 +202,7 @@ Exact repetition behavior:
 - `--repetitions 1` creates a normal run through `/v1/runs`.
 - `--repetitions >= 2` posts to `/v1/eval-sessions`.
 - `--follow` is not supported with `--repetitions >= 2`; tail individual child runs with `agentclash run events <RUN_ID>`.
-- `--scope suite_only`, `--suite`, `--case`, and race-context flags are not supported with `--repetitions >= 2`.
+- `--scope suite_only`, `--suite`, `--case`, and peer-standings flags are not supported with `--repetitions >= 2`.
 - The eval-session response is `{ "eval_session": {...}, "run_ids": [...] }`.
 
 In human output, the CLI prints eval session ID, status, repetitions, and child run IDs. In structured output, it prints the raw response envelope.
@@ -228,7 +228,7 @@ Behavior:
 Use `eval session follow` after creating a multi-repetition eval when you need aggregated results before reading scorecards or comparisons.
 
 ## Run Series Commands
-`run series` crosses deployment lineups with seeds for race-style series evals:
+`run series` crosses deployment lineups with seeds for multi-run comparison series:
 
 ```bash
 agentclash run series create \
@@ -307,8 +307,8 @@ Read command notes:
 - `invalid_agent_deployment_ids`: deployment IDs must be active deployments with snapshots in the selected workspace, with no duplicates.
 - `invalid_challenge_pack_version_id`: the version must be runnable and visible to the selected workspace.
 - `invalid_challenge_input_set_id`: the input set must belong to the selected challenge pack version.
-- `invalid_race_context`: race context requires at least two agents.
-- `--race-context-cadence must be 0 (backend default) or between 1 and 10`: fix the cadence value.
+- `invalid_race_context`: peer standings require at least two agents.
+- `--peer-standings-cadence must be 0 (backend default) or between 1 and 10`: fix the cadence value.
 - `--follow is not supported with --repetitions >= 2`: create the eval session, then use `eval session follow` or stream individual child runs with `run events`.
 - `--scope suite_only requires at least one --suite or --case`: add a suite or case selection.
 - Scorecard pending or errored: report the state, then collect `run events`, `run agents`, and `run failures`.

--- a/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
+++ b/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
@@ -1,7 +1,7 @@
 ---
 title: "We raced four GPT generations on a real coding task — GPT-5.4 won on efficiency"
 date: "2026-06-07"
-description: "A head-to-head AgentClash race of GPT-4.1, GPT-5, GPT-5.4, and GPT-5.5 on a real agentic coding task — building an integer expression evaluator with truncating division — scored on correctness, reliability, and token efficiency."
+description: "A head-to-head AgentClash comparison of GPT-4.1, GPT-5, GPT-5.4, and GPT-5.5 on a real agentic coding task — building an integer expression evaluator with truncating division — scored on correctness, reliability, and token efficiency."
 author: "AgentClash"
 featuredModel: "GPT-5.4"
 verdict: "GPT-5.4 solved the task in 2 turns and ~8K tokens; GPT-5 and GPT-5.5 also passed, while GPT-4.1 thrashed for its full budget and failed to submit."
@@ -43,7 +43,7 @@ results:
     cost: 0.2
 ---
 
-## How the race worked
+## How the comparison worked
 
 All four models got the **same task, the same sandbox, and the same tools** — a
 shell and a filesystem, a ten-iteration budget, no network. The task is a real
@@ -101,7 +101,7 @@ the leanest run (fewer tokens → higher); we don't assert dollar prices here.
 
 ## Caveats
 
-This is a deliberately small first race: **one task, a single run per model**
+This is a deliberately small first comparison: **one task, a single run per model**
 (n=1), and an OpenAI-only field. The LLM-judge dimensions carry per-run variance,
 and one task can't rank models in general. Read it as a worked example of the
 format and a real, reproducible result — not a verdict on the models. Wider
@@ -112,7 +112,7 @@ backend grows to support them.
 
 A single benchmark number hides the trade-off that actually decides which model
 you ship. On this task every passing model was "correct" — but one solved it in
-two turns and another couldn't solve it at all. Race them on *your* tasks, with
+two turns and another couldn't solve it at all. Compare them on *your* tasks, with
 your tools, and read the whole scoreboard before you pick.
 
 For the shareable monthly summary and full methodology appendix, see [Coding agent benchmark — June 2026](/blog/coding-agent-benchmark-june-2026).
@@ -141,4 +141,4 @@ go run . run ranking <run-id> --json
 
 Monthly checklist and ownership: [`docs/marketing/model-benchmark-workflow.md`](https://github.com/agentclash/agentclash/blob/main/docs/marketing/model-benchmark-workflow.md).
 
-[Run your own race →](/try)
+[Run your own eval →](/try)

--- a/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
+++ b/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
@@ -55,7 +55,7 @@ A pattern we see on platform teams:
 
 1. **Trace in production** with LangSmith (or your APM) to find failures.
 2. **Score prompt changes** with Braintrust while iterating copy and judges.
-3. **Promote failures into challenge packs** and race agents before merge.
+3. **Promote failures into challenge packs** and evaluate agents before merge.
 4. **Gate CI** when the candidate regresses against baseline.
 
 AgentClash owns steps 3–4. It does not replace your tracing or prompt lab.

--- a/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
+++ b/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
@@ -21,7 +21,7 @@ Each job becomes a [challenge pack](/docs/guides/write-a-challenge-pack) case: i
 
 ## Step 2: Freeze the benchmark
 
-Version the pack before you race candidates. If the task drifts every week, you are comparing runs that never met on the same track.
+Version the pack before you compare candidates. If the task drifts every week, you are comparing runs that never met on the same track.
 
 Freeze:
 
@@ -36,7 +36,7 @@ This is the same discipline public benchmarks use — except the workload is you
 
 Run baseline and candidate agents concurrently on the same pack. Staggered comparisons leak cache warmth, provider weather, and prompt drift into the verdict.
 
-AgentClash races agents on the same task at the same time in isolated sandboxes. See [why we race agents head-to-head](/blog/why-agentclash-races-agents-head-to-head).
+AgentClash compares agents on the same task at the same time in isolated sandboxes. See [why we compare agents head-to-head](/blog/why-agentclash-races-agents-head-to-head).
 
 ## Step 4: Capture replay, not just scores
 

--- a/web/content/blog/coding-agent-benchmark-june-2026.mdx
+++ b/web/content/blog/coding-agent-benchmark-june-2026.mdx
@@ -5,7 +5,7 @@ description: "Our first measured public benchmark: four GPT generations on a rea
 author: "AgentClash"
 ---
 
-This is the first monthly coding-agent benchmark we publish on [/benchmarks](/benchmarks): a head-to-head race on a frozen challenge pack, scored on the full trajectory, with numbers you can reproduce.
+This is the first monthly coding-agent benchmark we publish on [/benchmarks](/benchmarks): a head-to-head comparison on a frozen challenge pack, scored on the full trajectory, with numbers you can reproduce.
 
 **Headline:** GPT-5.4 solved an integer expression evaluator in two model calls and about 8K tokens. GPT-5 and GPT-5.5 also passed. GPT-4.1 burned its full ten-iteration budget and never submitted a valid solution.
 
@@ -30,7 +30,7 @@ Every passing model was "correct" on the hidden tests. The separation showed up 
 
 ## Methodology appendix
 
-Use this block when you cite the report or rerun the race internally.
+Use this block when you cite the report or rerun the eval internally.
 
 ### Frozen challenge pack
 
@@ -74,7 +74,7 @@ Reliability reflects run completion. **Cost** on the public scoreboard is token-
 - Latency and token totals per run
 - Gate verdict (`pass_threshold: 0.5` on the pack)
 
-### Reproduce the race
+### Reproduce the eval
 
 Hosted path (recommended):
 
@@ -107,6 +107,6 @@ Full monthly checklist, ownership, and syndication steps live in the repo runboo
 
 ## What we do next month
 
-We follow the same five-step cadence on [/benchmarks](/benchmarks): pin the pack, race every candidate on identical constraints, export scorecards, attach replay evidence, summarize on the hub and RSS feed. Subscribe at [/benchmarks/feed.xml](/benchmarks/feed.xml).
+We follow the same five-step cadence on [/benchmarks](/benchmarks): pin the pack, evaluate every candidate on identical constraints, export scorecards, attach replay evidence, summarize on the hub and RSS feed. Subscribe at [/benchmarks/feed.xml](/benchmarks/feed.xml).
 
-Want the same discipline on your workloads? [Book an eval workshop](/enterprise) or [run your own race](/try).
+Want the same discipline on your workloads? [Book an eval workshop](/enterprise) or [run your own eval](/try).

--- a/web/content/blog/do-ai-models-cheat-by-brand.mdx
+++ b/web/content/blog/do-ai-models-cheat-by-brand.mdx
@@ -83,10 +83,10 @@ I'm 22 and just graduated, and this is one small pilot — so take these as hypo
 
 ## The honest caveats
 
-n=192 is small, and I know it. The runs came in two batches: a first pass of one run per pack per model (6 × 8 = **48**), then a hardened second pass of three runs per pack per model (6 × 8 × 3 = **144**) — **192** in total. I used neutral race labels to avoid tipping the models off, and validated everything locally first. The qualitative patterns held across repetitions, and the quantitative signal was consistent across the first batch (n=48), the second (n=144), and combined (n=192). But more data would absolutely help, and I could be wrong about any of this.
+n=192 is small, and I know it. The runs came in two batches: a first pass of one run per pack per model (6 × 8 = **48**), then a hardened second pass of three runs per pack per model (6 × 8 × 3 = **144**) — **192** in total. I used neutral agent labels to avoid tipping the models off, and validated everything locally first. The qualitative patterns held across repetitions, and the quantitative signal was consistent across the first batch (n=48), the second (n=144), and combined (n=192). But more data would absolutely help, and I could be wrong about any of this.
 
 This is also exactly the kind of thing AgentClash was built to surface — because it scores the *whole trajectory*, not just the final answer. (If you're curious how that scoring works, I wrote about it in [How AgentClash Scores Agent Trajectories](/blog/how-agentclash-scores-agent-trajectories).)
 
 The full code, the six challenge packs, and the raw data are open: see [agentclash/agentclash#858](https://github.com/agentclash/agentclash/pull/858). The original thread is [here](https://x.com/attharrva15/status/2059001263208202502).
 
-Want to see how your favorite model behaves when no one's checking the receipts? [Run your own race →](/try)
+Want to see how your favorite model behaves when no one's checking the receipts? [Run your own eval →](/try)

--- a/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
+++ b/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
@@ -60,7 +60,7 @@ Hybrid scorecards can gate on policy validators first, then score language quali
 
 ## Compare baselines per language lane
 
-Race candidate and baseline agents on the **same pack version** with the same tool policy. The compare view should answer:
+Compare candidate and baseline agents on the **same pack version** with the same tool policy. The compare view should answer:
 
 - Did Arabic lane correctness regress while English improved?
 - Did cost or latency spike on multi-turn cases?

--- a/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
+++ b/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
@@ -55,7 +55,7 @@ Replay should show *what changed in the repo*, not just the agent's summary mess
 
 ## 5. Compare harnesses, not just models
 
-The same model with different harnesses (CLI, IDE agent, custom orchestrator) is a different product surface. Race harnesses head-to-head on the same pack before you standardize on one.
+The same model with different harnesses (CLI, IDE agent, custom orchestrator) is a different product surface. Compare harnesses head-to-head on the same pack before you standardize on one.
 
 ## 6. Promote every production failure
 

--- a/web/content/blog/how-agentclash-scores-agent-trajectories.mdx
+++ b/web/content/blog/how-agentclash-scores-agent-trajectories.mdx
@@ -39,7 +39,7 @@ The result is a [scorecard](/docs/guides/interpret-results) that makes a run leg
 
 ## Why this is the whole point
 
-Scoring the trajectory instead of the string is what lets AgentClash do the things a final-answer benchmark can't: race models [head-to-head on the same task](/platform/agent-evaluation), explain *why* one won, and turn a specific failure into a permanent [regression test](/platform/agent-regression-testing) instead of a vibe.
+Scoring the trajectory instead of the string is what lets AgentClash do the things a final-answer benchmark can't: compare models [head-to-head on the same task](/platform/agent-evaluation), explain *why* one won, and turn a specific failure into a permanent [regression test](/platform/agent-regression-testing) instead of a vibe.
 
 You don't just learn *which* agent was better. You learn how, on what evidence, and at what cost — and you keep that evidence for the next time the question comes up.
 

--- a/web/content/blog/why-agentclash-races-agents-head-to-head.mdx
+++ b/web/content/blog/why-agentclash-races-agents-head-to-head.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Why AgentClash Races Agents Head-to-Head"
+title: "Why AgentClash Compares Agents Head-to-Head"
 date: "2026-06-03"
-description: "Staggered, one-at-a-time evals compare runs that never faced the same conditions. AgentClash runs every model on the same task at the same time on the same budget — here is why concurrent racing produces a fairer verdict."
+description: "Staggered, one-at-a-time evals compare runs that never faced the same conditions. AgentClash runs every model on the same task at the same time on the same budget — here is why concurrent comparison produces a fairer verdict."
 author: "Atharva"
 ---
 
@@ -9,7 +9,7 @@ If you want to know which agent is better for your task, the worst way to find o
 
 That is how most model comparisons actually happen. You run model A this week, eyeball the result, run model B next week against a slightly different prompt, a warmer cache, a different sandbox image, maybe a different time-of-day for the provider's latency. Then you compare two numbers that were never produced under the same conditions and call it a decision.
 
-AgentClash is built around the opposite default: a **head-to-head race**. Every model runs the same task, at the same time, on the same budget, in the same kind of fresh environment.
+AgentClash is built around the opposite default: a **head-to-head comparison eval**. Every model runs the same task, at the same time, on the same budget, in the same kind of fresh environment.
 
 ## What "staggered" quietly hides
 
@@ -24,7 +24,7 @@ None of these are model capability. All of them leak into a staggered comparison
 
 ## Same task, same time, same budget
 
-A race controls the variables that staggered evals leave floating. Every competitor in a race gets:
+A controlled comparison eval holds the variables that staggered runs leave floating. Every candidate in the eval gets:
 
 - the **same task** — identical inputs, fixtures, and tool/network policy
 - the **same starting point** — a fresh sandbox per agent, so nobody inherits another run's warm state or side effects
@@ -33,9 +33,9 @@ A race controls the variables that staggered evals leave floating. Every competi
 
 Because each agent gets its own fresh, sandboxed microVM with real files, a real shell, and real network, the side effects of one agent never contaminate another. The only thing left varying is the thing you're actually trying to measure.
 
-## A fair race needs a fair judge
+## A fair comparison needs a fair judge
 
-Running concurrently is only half of it. The race produces trajectories, and those trajectories are scored the same way for everyone — deterministic checks, numeric metrics like cost and latency, behavioral signals like tool-choice efficiency, and LLM judges where needed — then aggregated into one verdict. (We go deep on that in [how AgentClash scores agent trajectories](/blog/how-agentclash-scores-agent-trajectories).)
+Running concurrently is only half of it. The eval produces trajectories, and those trajectories are scored the same way for everyone — deterministic checks, numeric metrics like cost and latency, behavioral signals like tool-choice efficiency, and LLM judges where needed — then aggregated into one verdict. (We go deep on that in [how AgentClash scores agent trajectories](/blog/how-agentclash-scores-agent-trajectories).)
 
 Identical conditions plus identical scoring is what makes the outcome defensible. When one model wins, you can point at *why* it won — and at the [replay](/docs/concepts/replay-and-scorecards) evidence behind every dimension of the score.
 
@@ -43,8 +43,8 @@ Identical conditions plus identical scoring is what makes the outcome defensible
 
 Public leaderboards answer a different question: which model is generally popular or generally strong on a shared static benchmark that has probably leaked into training data. That's a fine first filter. It is not an answer to "which agent should *I* ship for *this* job."
 
-A head-to-head race on your own [challenge pack](/docs/guides/write-a-challenge-pack) answers the question you actually have, on the task you actually run, under conditions you actually control. And because the losing trajectories are real, captured runs, you can promote the interesting failures straight into a [regression gate](/platform/agent-regression-testing) so the next candidate has to prove it didn't get worse.
+A head-to-head comparison on your own [challenge pack](/docs/guides/write-a-challenge-pack) answers the question you actually have, on the task you actually run, under conditions you actually control. And because the losing trajectories are real, captured runs, you can promote the interesting failures straight into a [regression gate](/platform/agent-regression-testing) so the next candidate has to prove it didn't get worse.
 
-Stop comparing runs that never met. Put your models on the same track and let them race.
+Stop comparing runs that never met. Put your models on the same workload and evaluate them together.
 
 Start from the [quickstart](/docs/getting-started/quickstart), or see [how AgentClash compares](/compare) to prompt-evaluation tools.

--- a/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
+++ b/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
@@ -41,7 +41,7 @@ Use the enterprise buyer loop as your pilot template:
 
 1. **Monday problem:** name the release decision (for example, coding agent RC vs production baseline).
 2. **Freeze once:** challenge pack version, input set, tool policy, gate thresholds.
-3. **Race fairly:** baseline, candidate, and any vendors under the same sandbox contract.
+3. **Compare fairly:** baseline, candidate, and any vendors under the same sandbox contract.
 4. **Watch live:** routing fallbacks, tool efficiency, cost drift, sandbox failures.
 5. **Decide with replay:** open divergences, attach scorecard, export evidence bundle.
 6. **Close the loop:** block or ship with a named reason; promote failures into regression cases.

--- a/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
+++ b/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
@@ -40,7 +40,7 @@ Key flags (defined in `cli/cmd/eval.go`; resolution logic in `eval_resolve.go`):
 | `--follow` | Stream run events after creation |
 | `--scope` | `full` vs `suite_only` regression scoping |
 | `--suite` / `--case` | Target regression fixtures |
-| `--race-context` | Peer standings injection (multi-agent) |
+| `--peer-standings` | Peer standings injection (multi-agent) |
 
 Non-interactive environments must supply enough disambiguators—resolver errors spell out what’s missing.
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/quick-create-agent-dialog.tsx
@@ -183,7 +183,7 @@ export function QuickCreateAgentDialog({
           <DialogTitle>New agent</DialogTitle>
           <DialogDescription>
             Name it, tell it what to do, and pick a model. We build, version, and
-            deploy it for you — ready to race.
+            deploy it for you — ready to evaluate.
           </DialogDescription>
         </DialogHeader>
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-eval-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-eval-dialog.tsx
@@ -201,7 +201,7 @@ export function StartEvalDialog({
         <DialogHeader>
           <DialogTitle>Run dataset eval</DialogTitle>
           <DialogDescription>
-            Queue a race over a pinned dataset version and challenge pack.
+            Queue an eval over a pinned dataset version and challenge pack.
           </DialogDescription>
         </DialogHeader>
         {activeRun && submitting ? (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -410,21 +410,21 @@ export function RunDetailClient({
               Commentary {showCommentary ? "On" : "Off"}
             </Button>
             <Button
-              variant={arenaMode === "race" ? "default" : "outline"}
+              variant={arenaMode === "broadcast" ? "default" : "outline"}
               size="sm"
-              className={arenaMode === "race" ? "" : "bg-transparent border-white/10 text-white/70 hover:bg-white/5 hover:text-white"}
+              className={arenaMode === "broadcast" ? "" : "bg-transparent border-white/10 text-white/70 hover:bg-white/5 hover:text-white"}
               onClick={() =>
-                setArenaMode(arenaMode === "race" ? "dev" : "race")
+                setArenaMode(arenaMode === "broadcast" ? "dev" : "broadcast")
               }
-              aria-pressed={arenaMode === "race"}
+              aria-pressed={arenaMode === "broadcast"}
               title={
-                arenaMode === "race"
+                arenaMode === "broadcast"
                   ? "Switch to development (classic) view"
-                  : "Switch to race mode — the broadcast view"
+                  : "Switch to broadcast mode — the live comparison view"
               }
             >
               <Flag className="size-3.5 mr-1.5" />
-              {arenaMode === "race" ? "Race Mode" : "Dev Mode"}
+              {arenaMode === "broadcast" ? "Broadcast Mode" : "Dev Mode"}
             </Button>
             <Link
               href={`/workspaces/${workspaceId}/runs/${run.id}/failures`}
@@ -539,7 +539,7 @@ export function RunDetailClient({
       {/* === Agent Lanes === */}
       <div>
         <h2 className="text-2xs leading-none text-white/75 uppercase tracking-[0.22em] font-medium mb-4">Agent Lanes</h2>
-        {arenaMode === "race" ? (
+        {arenaMode === "broadcast" ? (
           <RaceModeArena
             agents={sortedAgents}
             lanes={arenaLanes}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -845,11 +845,11 @@ export function CreateRunDialog({
             )}
           </div>
 
-          {/* Race Context */}
+          {/* Peer standings */}
           <div className="flex items-start gap-3 rounded-lg border border-border p-3">
             <input
               type="checkbox"
-              id="race-context"
+              id="peer-standings"
               checked={raceContext}
               onChange={(e) => setRaceContext(e.target.checked)}
               disabled={selectedDeploymentIds.length < 2}
@@ -857,10 +857,10 @@ export function CreateRunDialog({
             />
             <div className="space-y-1">
               <label
-                htmlFor="race-context"
+                htmlFor="peer-standings"
                 className={`text-sm font-medium ${selectedDeploymentIds.length < 2 ? "opacity-50" : "cursor-pointer"}`}
               >
-                Race context (agents see live peer standings)
+                Peer standings (agents see live comparison updates)
               </label>
               <p className={`text-xs text-muted-foreground ${selectedDeploymentIds.length < 2 ? "opacity-50" : ""}`}>
                 Injects live peer progress updates into the agent&apos;s prompt mid-run. Requires at least 2 agents.

--- a/web/src/app/landing-2/page.tsx
+++ b/web/src/app/landing-2/page.tsx
@@ -173,7 +173,7 @@ export default function Landing2() {
                   desc: "A challenge pack with tasks, validators, and expected outputs. Versioned and immutable — the same version produces the same scores forever.",
                 },
                 {
-                  title: "Race your agents",
+                  title: "Compare your agents",
                   desc: "Run 2–8 models in parallel. Each gets its own sandbox with real tool execution. Every decision captured as a canonical event.",
                 },
                 {
@@ -207,7 +207,7 @@ export default function Landing2() {
         {/* Product preview — centered comparison table */}
         <section style={{ maxWidth: "640px", margin: "0 auto", padding: "64px 32px" }}>
           <p style={{ fontSize: "11px", fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--text-4)", marginBottom: "24px", textAlign: "center" }}>
-            What you see after a race
+            What you see after an eval
           </p>
 
           <div style={{

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -57,7 +57,7 @@ const workflow = [
   },
   {
     icon: Play,
-    title: "Race the agents",
+    title: "Run the eval",
     text: "Run every candidate against the same task at the same time with the same constraints.",
   },
   {
@@ -299,7 +299,7 @@ export default function AgentEvaluationPage() {
                 AI agent evaluation platform for real tasks
               </h1>
               <p className="mt-8 max-w-[58ch] text-base leading-8 text-white/62 sm:text-lg">
-                Race agents against the same workload with the same tools and
+                Compare agents against the same workload with the same tools and
                 same constraints. AgentClash captures replay evidence,
                 scorecards, artifacts, and release-gate verdicts so evals turn
                 into decisions instead of dashboard archaeology.

--- a/web/src/components/arena/live-event-ticker.tsx
+++ b/web/src/components/arena/live-event-ticker.tsx
@@ -16,6 +16,7 @@ import type {
   ArenaEventKind,
   TickerEntry,
 } from "@/lib/arena/event-formatter";
+import { PEER_STANDINGS_INJECTED_HEADLINE } from "@/lib/arena/constants";
 
 const KIND_ICON: Record<
   ArenaEventKind,
@@ -114,7 +115,7 @@ export function LiveEventTicker({
                 >
                   {entry.headline}
                 </span>
-                {entry.kind !== "system" || entry.headline !== "Race standings injected" ? (
+                {entry.kind !== "system" || entry.headline !== PEER_STANDINGS_INJECTED_HEADLINE ? (
                   entry.detail && (
                     <span className="hidden sm:inline truncate max-w-[40%] text-muted-foreground">
                       {entry.detail}
@@ -122,7 +123,7 @@ export function LiveEventTicker({
                   )
                 ) : null}
               </div>
-              {entry.kind === "system" && entry.headline === "Race standings injected" && entry.detail && (
+              {entry.kind === "system" && entry.headline === PEER_STANDINGS_INJECTED_HEADLINE && entry.detail && (
                 <div className="pl-[4.5rem] w-full">
                   <pre className="text-2xs text-muted-foreground whitespace-pre-wrap break-words font-[family-name:var(--font-mono)] bg-muted/30 p-2 rounded border border-border/50">
                     {entry.detail}

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -6,6 +6,7 @@ import { Play, CheckCircle2, Upload } from "lucide-react";
 
 import type { RunAgent, RunAgentStatus } from "@/lib/api/types";
 import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+import { PEER_STANDINGS_INJECTED_HEADLINE } from "@/lib/arena/constants";
 
 const ACTIVE_STATUSES: RunAgentStatus[] = [
   "queued",
@@ -183,10 +184,10 @@ export function RaceLane({
           <div className="rm-stream">{lane.streamingOutput}</div>
         )}
 
-        {lane.ticker.filter(e => e.kind === "system" && e.headline === "Race standings injected").slice(-1).map(e => (
+        {lane.ticker.filter(e => e.kind === "system" && e.headline === PEER_STANDINGS_INJECTED_HEADLINE).slice(-1).map(e => (
           <div key={e.id} className="rm-stream !bg-emerald-500/[0.03] !border-emerald-500/20 !text-emerald-500/70 !max-h-none">
             <div className="text-2xs uppercase tracking-[0.16em] text-emerald-500/50 mb-1.5 font-sans">
-              Latest Race Standings Injected
+              Latest peer standings injected
             </div>
             {e.detail}
           </div>

--- a/web/src/components/arena/race-mode/race-track.tsx
+++ b/web/src/components/arena/race-mode/race-track.tsx
@@ -38,7 +38,7 @@ export function RaceTrack({
   );
 
   return (
-    <section className="rm-track" aria-label="Race track">
+    <section className="rm-track" aria-label="Comparison track">
       <div className="rm-track__head">
         <h2 className="rm-track__title">Lap progress</h2>
         <div className="rm-track__meta">

--- a/web/src/components/onboarding/activation-checklist.tsx
+++ b/web/src/components/onboarding/activation-checklist.tsx
@@ -47,7 +47,7 @@ export function ActivationChecklist({
       </div>
       <p className="mb-5 text-sm text-muted-foreground">
         A few one-time steps connect your models and agents. Knock these out and
-        you can race.
+        you can compare.
       </p>
 
       <ol className="space-y-1">

--- a/web/src/hooks/use-arena-mode.ts
+++ b/web/src/hooks/use-arena-mode.ts
@@ -3,20 +3,26 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-export type ArenaMode = "dev" | "race";
+export type ArenaMode = "dev" | "broadcast";
 
 const STORAGE_KEY = "agentclash:arena-mode";
 const STORAGE_EVENT = "agentclash:arena-mode:changed";
 
-function isArenaMode(v: unknown): v is ArenaMode {
-  return v === "dev" || v === "race";
+function isBroadcastModeAlias(v: unknown): boolean {
+  return v === "broadcast" || v === "race";
+}
+
+function normalizeArenaMode(v: unknown): ArenaMode | null {
+  if (v === "dev") return "dev";
+  if (isBroadcastModeAlias(v)) return "broadcast";
+  return null;
 }
 
 function readStoredMode(): ArenaMode | null {
   if (typeof window === "undefined") return null;
   try {
     const v = window.localStorage.getItem(STORAGE_KEY);
-    return isArenaMode(v) ? v : null;
+    return normalizeArenaMode(v);
   } catch {
     return null;
   }
@@ -36,10 +42,10 @@ function subscribeStorage(cb: () => void): () => void {
 /**
  * Resolves arena mode with URL > localStorage > "dev" precedence.
  *
- * URL param (?mode=race) is the shareable source of truth; localStorage
- * carries the user's preference across sessions. Setting the mode updates
- * both — and dispatches a same-tab event so peer consumers of this hook
- * re-render.
+ * URL param (?mode=broadcast, legacy ?mode=race) is the shareable source of
+ * truth; localStorage carries the user's preference across sessions. Setting
+ * the mode updates both — and dispatches a same-tab event so peer consumers
+ * of this hook re-render.
  */
 export function useArenaMode(): [ArenaMode, (next: ArenaMode) => void] {
   const searchParams = useSearchParams();
@@ -53,9 +59,7 @@ export function useArenaMode(): [ArenaMode, (next: ArenaMode) => void] {
   );
 
   const urlMode = searchParams.get("mode");
-  const mode: ArenaMode = isArenaMode(urlMode)
-    ? urlMode
-    : (storedMode ?? "dev");
+  const mode: ArenaMode = normalizeArenaMode(urlMode) ?? storedMode ?? "dev";
 
   const setMode = useCallback(
     (next: ArenaMode) => {
@@ -66,7 +70,7 @@ export function useArenaMode(): [ArenaMode, (next: ArenaMode) => void] {
         // localStorage unavailable — URL is still the source of truth.
       }
       const params = new URLSearchParams(searchParams.toString());
-      if (next === "race") params.set("mode", "race");
+      if (next === "broadcast") params.set("mode", "broadcast");
       else params.delete("mode");
       const query = params.toString();
       router.replace(query ? `${pathname}?${query}` : pathname, {

--- a/web/src/lib/arena/constants.ts
+++ b/web/src/lib/arena/constants.ts
@@ -1,0 +1,2 @@
+/** User-facing headline for live peer-standings injection events. */
+export const PEER_STANDINGS_INJECTED_HEADLINE = "Peer standings injected";

--- a/web/src/lib/arena/event-formatter.ts
+++ b/web/src/lib/arena/event-formatter.ts
@@ -12,6 +12,7 @@
  */
 
 import type { RunEvent } from "@/hooks/use-run-events";
+import { PEER_STANDINGS_INJECTED_HEADLINE } from "@/lib/arena/constants";
 import type {
   ModelCallCompletedPayload,
   ModelCallStartedPayload,
@@ -230,7 +231,7 @@ export function summarizeEvent(event: RunEvent): TickerEntry | null {
       const p = payload<{ tokens_added?: number; triggered_by?: string; standings_snapshot?: string }>(event);
       return {
         ...base,
-        headline: "Race standings injected",
+        headline: PEER_STANDINGS_INJECTED_HEADLINE,
         detail: p.standings_snapshot || (p.triggered_by ? `Trigger: ${p.triggered_by.replace(/_/g, " ")}` : undefined),
       };
     }

--- a/web/src/lib/benchmarks.test.ts
+++ b/web/src/lib/benchmarks.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseBenchmarkReport } from "./benchmarks";
 
 const VALID = `---
-title: "Race report"
+title: "Comparison report"
 date: "2026-06-06"
-description: "A head-to-head race."
+description: "A head-to-head comparison."
 author: "AgentClash"
 featuredModel: "Claude Opus 4.8"
 verdict: "Opus 4.8 won 4 of 5."
@@ -48,7 +48,7 @@ describe("parseBenchmarkReport", () => {
   it("parses valid frontmatter and body", () => {
     const report = parseBenchmarkReport("race-report", VALID);
     expect(report).not.toBeNull();
-    expect(report?.title).toBe("Race report");
+    expect(report?.title).toBe("Comparison report");
     expect(report?.featuredModel).toBe("Claude Opus 4.8");
     expect(report?.sample).toBe(true);
     expect(report?.runShareUrl).toBe("https://www.agentclash.dev/share/abc");
@@ -91,9 +91,9 @@ describe("parseBenchmarkReport", () => {
 
   it("returns null when the results array is empty", () => {
     const noResults = `---
-title: "Race report"
+title: "Comparison report"
 date: "2026-06-06"
-description: "A head-to-head race."
+description: "A head-to-head comparison."
 author: "AgentClash"
 featuredModel: "Claude Opus 4.8"
 verdict: "Nobody raced."

--- a/web/src/lib/benchmarks.ts
+++ b/web/src/lib/benchmarks.ts
@@ -5,7 +5,7 @@ import matter from "gray-matter";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "benchmarks");
 
-// A single task in the head-to-head race (e.g. "Fix the auth bug").
+// A single task in a head-to-head comparison (e.g. "Fix the auth bug").
 export type BenchmarkTask = {
   id: string;
   name: string;
@@ -37,7 +37,7 @@ export type BenchmarkReport = {
   verdict: string;
   challengePack: string;
   // True when the scoreboard holds representative/illustrative data rather than
-  // numbers from a real race. Drives the disclaimer banner on the report page.
+  // numbers from a real comparison eval. Drives the disclaimer banner on the report page.
   sample: boolean;
   runShareUrl: string;
   tasks: BenchmarkTask[];

--- a/web/src/lib/blog-related-resources.ts
+++ b/web/src/lib/blog-related-resources.ts
@@ -48,7 +48,7 @@ const LINKS = {
   agentEvaluationFramework: {
     href: "/agent-evaluation-framework",
     label: "Agent evaluation framework",
-    description: "Framework for real-task races, replay, and scorecards.",
+    description: "Framework for real-task evals, replay, and scorecards.",
   },
   agentTrajectoryEvaluation: {
     href: "/agent-trajectory-evaluation",

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -105,11 +105,11 @@ export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
     startDate: "2026-04-25",
     endDate: "2026-05-04",
     label: "Apr 25 – May 04, 2026",
-    headline: "Race context, CLI distribution, and a redesigned public site",
+    headline: "Peer standings, CLI distribution, and a redesigned public site",
     summary:
-      "Live race standings injected into running agents, the CLI shipped through npm with production defaults, and the marketing site got a full redesign — /why, pricing, docs foundation, and arena-style run views.",
+      "Live peer standings injected into running agents, the CLI shipped through npm with production defaults, and the marketing site got a full redesign — /why, pricing, docs foundation, and broadcast-style run views.",
     themes: [
-      "Race context",
+      "Peer standings",
       "CLI & npm",
       "Public site redesign",
       "Docs foundation",
@@ -117,11 +117,11 @@ export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
     entries: [
       {
         category: "added",
-        text: "Live race context — standings injection at step boundaries, newswire formatting, and token split between agents vs race context.",
+        text: "Live peer standings — injection at step boundaries, newswire formatting, and token split between agents vs comparison context.",
       },
       {
         category: "added",
-        text: "CLI `--race-context` flags and UI toggle for race standings during live runs.",
+        text: "CLI `--peer-standings` flags and UI toggle for live comparison standings during runs.",
       },
       {
         category: "added",
@@ -388,7 +388,7 @@ export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
       },
       {
         category: "added",
-        text: "/benchmarks hub summarizes the measured GPT generations race with replay-backed scoreboard and methodology appendix.",
+        text: "/benchmarks hub summarizes the measured GPT generations comparison with replay-backed scoreboard and methodology appendix.",
         href: "/benchmarks/gpt-generations-expression-evaluator",
       },
     ],

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -189,6 +189,7 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("agentclash eval scorecard <RUN_ID> --agent");
     expect(doc?.content).toContain("`eval scorecard --json` returns an envelope");
     expect(doc?.content).toContain("missing_challenge_input_set_id");
+    expect(doc?.content).toContain("--peer-standings");
     expect(doc?.content).toContain("invalid_race_context");
   });
 

--- a/web/src/lib/rss.test.ts
+++ b/web/src/lib/rss.test.ts
@@ -87,7 +87,7 @@ describe("rss feed", () => {
 describe("benchmark rss feed", () => {
   const base = {
     date: "2026-06-06",
-    description: "Head-to-head race.",
+    description: "Head-to-head comparison.",
     author: "AgentClash",
     featuredModel: "Claude Opus 4.8",
     verdict: "Opus won.",

--- a/web/src/lib/workspace-readiness.ts
+++ b/web/src/lib/workspace-readiness.ts
@@ -106,7 +106,7 @@ export function useWorkspaceReadiness(workspaceId: string): WorkspaceReadiness {
     {
       key: "first_run",
       label: "Run your first eval",
-      description: "Race your deployments against a challenge pack.",
+      description: "Compare your deployments against a challenge pack.",
       href: `/workspaces/${workspaceId}/runs`,
       cta: "Create run",
       done: hasRun,


### PR DESCRIPTION
## Summary
- Renames user-facing CLI surface from race to eval/comparison vocabulary: `--peer-standings` / `--peer-standings-cadence` (with deprecated `--race-context` aliases), eval series help/output, and quota labels ("Monthly evals", "Concurrent evals").
- Updates workspace UI copy: peer standings toggle, Broadcast Mode arena (legacy `?mode=race` still works), and billing labels already on runs/models wording.
- Aligns docs, agent skills, blog/benchmark content, and npm AGENTS.md with agent-evals positioning; backend/schema/API field names unchanged.

## Test plan
- [x] `cd cli && go test ./cmd -run 'TestEvalSession|TestRunCreate|TestSchema|TestQuota'`
- [x] Regenerated `cli/cmd/testdata/schema_snapshot.json`
- [ ] `cd web && pnpm exec vitest run src/lib/docs.test.ts src/lib/benchmarks.test.ts`
- [ ] Spot-check run detail Broadcast Mode toggle and create-run peer standings checkbox
- [ ] Verify `agentclash eval start --peer-standings --help` and legacy `--race-context` still accepted