### PR TITLE
fix(seo): lead homepage metadata with category, not just brand

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,9 +16,49 @@ import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import { isReturningVisitor } from "@/lib/auth/returning";
 import HomePage from "./landing";
 
+// Homepage title/meta lead with the category buyers search, not just the
+// brand. Brand-only titles give Google no reason to rank for "ai agent
+// evals", "agent benchmark", "agent workflow testing", "langsmith
+// alternative", etc. Keep the title under ~60 chars so it isn't truncated.
+const HOME_TITLE = "AgentClash - Open-source AI agent evals & benchmarks";
+const HOME_DESCRIPTION =
+  "Build, replay, score, and regression-test AI agents with open-source evals, traces, benchmarks, and CI gates. A LangSmith alternative for agent workflow testing and prompt regression testing.";
+
 export const metadata: Metadata = {
+  title: HOME_TITLE,
+  description: HOME_DESCRIPTION,
   alternates: {
     canonical: "/",
+  },
+  keywords: [
+    "AI agent evals",
+    "agent evaluation",
+    "LLM agent evaluation",
+    "agent benchmark",
+    "agent workflow testing",
+    "prompt regression testing",
+    "agent regression testing",
+    "agent testing CI",
+    "agent drift",
+    "trace replay",
+    "agent observability open source",
+    "evals for AI agents",
+    "LangSmith alternative",
+    "open-source agent evals",
+    "coding agent benchmark",
+  ],
+  openGraph: {
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    url: "/",
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
   },
 };
 


### PR DESCRIPTION
## Summary
- The homepage only set `canonical: "/"` and inherited the root layout title, so the strongest page carried none of the high-intent category keywords buyers actually search. Brand-only titles keep the site in brand-recognition mode rather than organic-acquisition mode (GSC shows brand signal, not category SEO).
- Adds a homepage-specific title, description, keywords, and OG/Twitter tags that lead with the category (`AI agent evals`, `agent benchmark`, `agent workflow testing`, `prompt regression testing`, `LangSmith alternative`, `trace replay`, `agent drift`, `evals for AI agents`, `agent observability open source`). Title stays under ~60 chars to avoid truncation.
- The category landing pages already exist (`/agent-evals`, `/llm-agent-evaluation`, `/ai-agent-benchmark`, `/ci-cd-agent-evaluation`, `/agent-trajectory-evaluation`, `/open-source-ai-agent-evaluation`, `/compare/agentclash-vs-langsmith`); this just makes the homepage itself signal what the site should rank for.

## Test plan
- [x] `pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts src/app/compare/compare-metadata.test.ts` (20/20 pass)
- [x] `npx tsc --noEmit` clean
- [ ] After deploy: apply GSC filter `Query does not contain agentclash` to confirm non-brand impressions start appearing for category queries