### PR TITLE
Turn /tryouts into an eval-driven agent-improvement playground

### DIFF
--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -98,10 +98,19 @@ func parseTryoutModelPolicy(raw json.RawMessage) (tryoutModelPolicy, error) {
 }
 
 // RerunAgentTryoutInput requests a rerun of an existing workspace tryout with a
-// different model policy.
+// different model policy and, optionally, a different agent design.
 type RerunAgentTryoutInput struct {
 	SourceTryoutID      uuid.UUID
 	SelectedModelPolicy json.RawMessage
+
+	// Optional agent-design override. When AgentDesignProvided is true the rerun
+	// replaces the source's agent_design with these fields (after normalization),
+	// making the agent design — not just the model — the varied dimension. When
+	// false the rerun inherits the source's agent_design unchanged.
+	AgentDesignProvided bool
+	AgentInstructions   string
+	AgentToolSlugs      []string
+	AgentName           string
 }
 
 // RerunWorkspaceTryout creates a new tryout that reuses the source tryout's
@@ -136,6 +145,26 @@ func (m *AgentTryoutManager) RerunWorkspaceTryout(ctx context.Context, caller Ca
 		}
 	}
 
+	// Clone the source input, then optionally override the agent design so the
+	// rerun varies the agent (not just the model). When no override is supplied
+	// the cloned snapshot — including any inherited agent_design — is reused.
+	inputSnapshot := cloneRawJSON(source.InputSnapshot)
+	toolPolicySnapshot := template.ToolPolicy
+	if input.AgentDesignProvided {
+		design, designPresent, designErr := normalizeAgentDesign(agentDesignInput{
+			Name:         input.AgentName,
+			Instructions: input.AgentInstructions,
+			ToolSlugs:    input.AgentToolSlugs,
+		})
+		if designErr != nil {
+			return repository.AgentTryout{}, designErr
+		}
+		inputSnapshot = replaceAgentDesignInInput(inputSnapshot, design, designPresent)
+		if designPresent {
+			toolPolicySnapshot = toolPolicyWithAgentToolKinds(toolPolicySnapshot, design.ToolSlugs)
+		}
+	}
+
 	callerID := caller.UserID
 	parentID := source.ID
 	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
@@ -143,9 +172,9 @@ func (m *AgentTryoutManager) RerunWorkspaceTryout(ctx context.Context, caller Ca
 		WorkspaceID:            source.WorkspaceID,
 		TemplateSlug:           template.Slug,
 		Status:                 repository.AgentTryoutStatusQueued,
-		InputSnapshot:          cloneRawJSON(source.InputSnapshot),
+		InputSnapshot:          inputSnapshot,
 		TemplateSnapshot:       templateSnapshot(template),
-		ToolPolicySnapshot:     template.ToolPolicy,
+		ToolPolicySnapshot:     toolPolicySnapshot,
 		EvaluationSpecSnapshot: template.EvaluationSpec,
 		SelectedModelPolicy:    input.SelectedModelPolicy,
 		Summary:                json.RawMessage(`{}`),
@@ -375,6 +404,12 @@ func templateExpectedArtifacts(templateSnapshot json.RawMessage) []map[string]an
 
 type rerunAgentTryoutRequest struct {
 	SelectedModelPolicy json.RawMessage `json:"selected_model_policy"`
+	// Agent-design override. agent_design_provided gates whether the rerun
+	// replaces the source's design; when false the source design is inherited.
+	AgentDesignProvided bool     `json:"agent_design_provided,omitempty"`
+	AgentInstructions   string   `json:"agent_instructions,omitempty"`
+	AgentToolSlugs      []string `json:"agent_tool_slugs,omitempty"`
+	AgentName           string   `json:"agent_name,omitempty"`
 }
 
 func rerunAgentTryoutHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
@@ -397,6 +432,10 @@ func rerunAgentTryoutHandler(logger *slog.Logger, service AgentTryoutService) ht
 		tryout, err := service.RerunWorkspaceTryout(r.Context(), caller, RerunAgentTryoutInput{
 			SourceTryoutID:      id,
 			SelectedModelPolicy: req.SelectedModelPolicy,
+			AgentDesignProvided: req.AgentDesignProvided,
+			AgentInstructions:   req.AgentInstructions,
+			AgentToolSlugs:      req.AgentToolSlugs,
+			AgentName:           req.AgentName,
 		})
 		if err != nil {
 			writeAgentTryoutError(w, logger, err)

--- a/backend/internal/api/agent_tryout_design.go
+++ b/backend/internal/api/agent_tryout_design.go
@@ -1,0 +1,321 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
+)
+
+// Agent design lets a public tryout carry a user-authored agent (system prompt
+// + selected library tools + display name). It is stashed inside the existing
+// input_snapshot JSONB under a namespaced "agent_design" key so it travels with
+// the snapshot through create, rerun-clone, and the prompt builders without a
+// migration. The prompt builders read it back to make the instructions the
+// agent's primary behavioral directive.
+
+const (
+	// maxAgentInstructionsBytes caps the user-authored system prompt.
+	maxAgentInstructionsBytes = 8000
+	// maxAgentToolSlugs caps how many library tools a design may select.
+	maxAgentToolSlugs = 24
+	// maxAgentNameBytes caps the agent display name.
+	maxAgentNameBytes = 120
+)
+
+// agentDesignInput is the optional user-authored agent carried on create/rerun.
+type agentDesignInput struct {
+	Name         string
+	Instructions string
+	ToolSlugs    []string
+}
+
+// isEmpty reports whether the design carries nothing worth storing.
+func (d agentDesignInput) isEmpty() bool {
+	return strings.TrimSpace(d.Name) == "" &&
+		strings.TrimSpace(d.Instructions) == "" &&
+		len(d.ToolSlugs) == 0
+}
+
+// normalizeAgentDesign trims, caps, and validates the user-authored agent.
+// Unknown tool slugs are silently dropped (not a hard failure) but the count is
+// capped before resolution so a caller cannot smuggle an unbounded list. The
+// instructions length is enforced as a hard limit. Returns a zero design and
+// ok=false when nothing usable remains, so callers can leave input_snapshot
+// untouched and preserve existing behavior.
+func normalizeAgentDesign(in agentDesignInput) (agentDesignInput, bool, error) {
+	name := strings.TrimSpace(in.Name)
+	if len(name) > maxAgentNameBytes {
+		name = strings.TrimSpace(string([]rune(name)[:maxAgentNameBytes]))
+	}
+
+	instructions := strings.TrimSpace(in.Instructions)
+	if len(instructions) > maxAgentInstructionsBytes {
+		return agentDesignInput{}, false, errInvalidAgentDesignInstructionsTooLong
+	}
+
+	// Cap the slug count before touching the library so an oversized list is
+	// rejected regardless of how many resolve.
+	slugs := in.ToolSlugs
+	if len(slugs) > maxAgentToolSlugs {
+		return agentDesignInput{}, false, errInvalidAgentDesignTooManyTools
+	}
+	resolved := resolveAgentToolSlugs(slugs)
+
+	out := agentDesignInput{Name: name, Instructions: instructions, ToolSlugs: resolved}
+	if out.isEmpty() {
+		return agentDesignInput{}, false, nil
+	}
+	return out, true, nil
+}
+
+// resolveAgentToolSlugs keeps only slugs that exist in the tool library,
+// de-duplicating while preserving order. Unknown slugs are dropped.
+func resolveAgentToolSlugs(slugs []string) []string {
+	if len(slugs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		slug = strings.TrimSpace(slug)
+		if slug == "" || seen[slug] {
+			continue
+		}
+		if _, ok := toolspec.LibraryBySlug(slug); !ok {
+			continue
+		}
+		seen[slug] = true
+		out = append(out, slug)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeAgentDesignIntoInput folds the normalized agent design into an
+// input_snapshot under the "agent_design" key. A non-object snapshot is
+// replaced with a fresh object so the design is never silently lost. When the
+// design is empty the snapshot is returned unchanged.
+func mergeAgentDesignIntoInput(input json.RawMessage, design agentDesignInput, present bool) json.RawMessage {
+	if !present || design.isEmpty() {
+		return input
+	}
+	object := map[string]any{}
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &object); err != nil {
+			object = map[string]any{}
+		}
+	}
+	object["agent_design"] = agentDesignSnapshot(design)
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return input
+	}
+	return encoded
+}
+
+// replaceAgentDesignInInput overrides input_snapshot.agent_design for a rerun.
+// Unlike mergeAgentDesignIntoInput, an empty override removes the key so a
+// rerun can explicitly clear an inherited design rather than keep it.
+func replaceAgentDesignInInput(input json.RawMessage, design agentDesignInput, present bool) json.RawMessage {
+	object := map[string]any{}
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &object); err != nil {
+			object = map[string]any{}
+		}
+	}
+	if !present || design.isEmpty() {
+		delete(object, "agent_design")
+	} else {
+		object["agent_design"] = agentDesignSnapshot(design)
+	}
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return input
+	}
+	return encoded
+}
+
+// agentDesignSnapshot is the stored JSON shape under input_snapshot.agent_design.
+func agentDesignSnapshot(design agentDesignInput) map[string]any {
+	snapshot := map[string]any{}
+	if name := strings.TrimSpace(design.Name); name != "" {
+		snapshot["name"] = name
+	}
+	if instructions := strings.TrimSpace(design.Instructions); instructions != "" {
+		snapshot["instructions"] = instructions
+	}
+	if len(design.ToolSlugs) > 0 {
+		snapshot["tool_slugs"] = design.ToolSlugs
+	}
+	return snapshot
+}
+
+// agentDesignToolKinds maps the design's selected tool slugs to their library
+// tool kinds, de-duplicated. Used to augment a tryout's tool_policy snapshot.
+func agentDesignToolKinds(slugs []string) []string {
+	if len(slugs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		entry, ok := toolspec.LibraryBySlug(strings.TrimSpace(slug))
+		if !ok {
+			continue
+		}
+		kind := strings.TrimSpace(entry.ToolKind)
+		if kind == "" || seen[kind] {
+			continue
+		}
+		seen[kind] = true
+		out = append(out, kind)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// toolPolicyWithAgentToolKinds returns a copy of the tool_policy snapshot with
+// the design's tool kinds merged into allowed_tool_kinds. This is best-effort:
+// it records the operator's chosen abilities on the snapshot for any execution
+// path that honors per-kind tools. The no-tools case returns the policy
+// unchanged so existing behavior is preserved.
+func toolPolicyWithAgentToolKinds(policy json.RawMessage, slugs []string) json.RawMessage {
+	kinds := agentDesignToolKinds(slugs)
+	if len(kinds) == 0 {
+		return policy
+	}
+	object := map[string]any{}
+	if len(policy) > 0 {
+		if err := json.Unmarshal(policy, &object); err != nil {
+			object = map[string]any{}
+		}
+	}
+	existing := stringSliceFromAny(object["allowed_tool_kinds"])
+	merged := mergeStringSets(existing, kinds)
+	object["allowed_tool_kinds"] = merged
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return policy
+	}
+	return encoded
+}
+
+// agentDesignPromptLines renders the user-authored agent design as prompt
+// sections: a primary "AGENT INSTRUCTIONS (authored by the user)" block the
+// agent must follow, and an abilities list resolved from the selected tool
+// slugs. Returns nil when no design is present so the template-only prompt is
+// unchanged.
+//
+// NOTE: workflow/public_agent_tryout_workflow.go keeps a byte-for-byte
+// identical builder (the two packages cannot import one another for layering
+// reasons). Keep them in sync when this changes.
+func agentDesignPromptLines(input json.RawMessage) []string {
+	design, ok := parseStoredAgentDesign(input)
+	if !ok {
+		return nil
+	}
+	lines := make([]string, 0, 8)
+	if instructions := strings.TrimSpace(design.Instructions); instructions != "" {
+		lines = append(lines,
+			"",
+			"AGENT INSTRUCTIONS (authored by the user) — these are your PRIMARY behavioral directive. Follow them above any default behavior; the task framing, inputs, and expected deliverables below still apply:",
+			instructions,
+		)
+	}
+	if names := agentDesignToolNames(design.ToolSlugs); len(names) > 0 {
+		lines = append(lines,
+			"",
+			"ABILITIES the user equipped this agent with — prefer these capabilities when they fit the task:",
+		)
+		for _, name := range names {
+			lines = append(lines, "- "+name)
+		}
+	}
+	return lines
+}
+
+// agentDesignToolNames resolves selected tool slugs to their human-readable
+// library names, dropping unknown slugs and de-duplicating by name.
+func agentDesignToolNames(slugs []string) []string {
+	if len(slugs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		entry, ok := toolspec.LibraryBySlug(strings.TrimSpace(slug))
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(entry.Name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// storedAgentDesign mirrors the JSON stashed under input_snapshot.agent_design.
+type storedAgentDesign struct {
+	Name         string   `json:"name"`
+	Instructions string   `json:"instructions"`
+	ToolSlugs    []string `json:"tool_slugs"`
+}
+
+// parseStoredAgentDesign reads the agent_design block from an input_snapshot.
+// Returns ok=false when absent or when nothing usable (instructions/tools) is
+// present, so the name alone never forces a design section.
+func parseStoredAgentDesign(input json.RawMessage) (storedAgentDesign, bool) {
+	if len(input) == 0 {
+		return storedAgentDesign{}, false
+	}
+	var wrapper struct {
+		AgentDesign *storedAgentDesign `json:"agent_design"`
+	}
+	if err := json.Unmarshal(input, &wrapper); err != nil || wrapper.AgentDesign == nil {
+		return storedAgentDesign{}, false
+	}
+	design := *wrapper.AgentDesign
+	if strings.TrimSpace(design.Instructions) == "" && len(design.ToolSlugs) == 0 {
+		return storedAgentDesign{}, false
+	}
+	return design, true
+}
+
+func stringSliceFromAny(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+			out = append(out, strings.TrimSpace(s))
+		}
+	}
+	return out
+}
+
+func mergeStringSets(base, extra []string) []string {
+	seen := make(map[string]bool, len(base)+len(extra))
+	out := make([]string, 0, len(base)+len(extra))
+	for _, value := range append(append([]string(nil), base...), extra...) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}

--- a/backend/internal/api/agent_tryout_design.go
+++ b/backend/internal/api/agent_tryout_design.go
@@ -19,8 +19,8 @@ const (
 	maxAgentInstructionsBytes = 8000
 	// maxAgentToolSlugs caps how many library tools a design may select.
 	maxAgentToolSlugs = 24
-	// maxAgentNameBytes caps the agent display name.
-	maxAgentNameBytes = 120
+	// maxAgentNameRunes caps the agent display name, counted in characters.
+	maxAgentNameRunes = 120
 )
 
 // agentDesignInput is the optional user-authored agent carried on create/rerun.
@@ -45,8 +45,8 @@ func (d agentDesignInput) isEmpty() bool {
 // untouched and preserve existing behavior.
 func normalizeAgentDesign(in agentDesignInput) (agentDesignInput, bool, error) {
 	name := strings.TrimSpace(in.Name)
-	if len(name) > maxAgentNameBytes {
-		name = strings.TrimSpace(string([]rune(name)[:maxAgentNameBytes]))
+	if nameRunes := []rune(name); len(nameRunes) > maxAgentNameRunes {
+		name = strings.TrimSpace(string(nameRunes[:maxAgentNameRunes]))
 	}
 
 	instructions := strings.TrimSpace(in.Instructions)

--- a/backend/internal/api/agent_tryout_design_test.go
+++ b/backend/internal/api/agent_tryout_design_test.go
@@ -1,0 +1,345 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNormalizeAgentDesign(t *testing.T) {
+	longInstructions := strings.Repeat("a", maxAgentInstructionsBytes+1)
+	tooManyTools := make([]string, maxAgentToolSlugs+1)
+	for i := range tooManyTools {
+		tooManyTools[i] = "read-file"
+	}
+
+	tests := []struct {
+		name        string
+		in          agentDesignInput
+		wantPresent bool
+		wantErr     error
+		// assert lets each case inspect the normalized design.
+		assert func(t *testing.T, design agentDesignInput)
+	}{
+		{
+			name:        "empty design is absent",
+			in:          agentDesignInput{},
+			wantPresent: false,
+		},
+		{
+			name:        "instructions only",
+			in:          agentDesignInput{Instructions: "  Always cite sources.  "},
+			wantPresent: true,
+			assert: func(t *testing.T, design agentDesignInput) {
+				if design.Instructions != "Always cite sources." {
+					t.Fatalf("instructions = %q, want trimmed", design.Instructions)
+				}
+			},
+		},
+		{
+			name:        "instructions too long rejected",
+			in:          agentDesignInput{Instructions: longInstructions},
+			wantPresent: false,
+			wantErr:     ErrInvalidAgentTryoutInput,
+		},
+		{
+			name:        "unknown slugs stripped, known kept and deduped",
+			in:          agentDesignInput{ToolSlugs: []string{"read-file", "read-file", "not-a-real-tool", "web-search"}},
+			wantPresent: true,
+			assert: func(t *testing.T, design agentDesignInput) {
+				want := []string{"read-file", "web-search"}
+				if strings.Join(design.ToolSlugs, ",") != strings.Join(want, ",") {
+					t.Fatalf("tool_slugs = %v, want %v", design.ToolSlugs, want)
+				}
+			},
+		},
+		{
+			name:        "all-unknown slugs leave design empty",
+			in:          agentDesignInput{ToolSlugs: []string{"nope", "also-nope"}},
+			wantPresent: false,
+		},
+		{
+			name:        "too many tool slugs rejected (count capped before resolution)",
+			in:          agentDesignInput{ToolSlugs: tooManyTools},
+			wantPresent: false,
+			wantErr:     ErrInvalidAgentTryoutInput,
+		},
+		{
+			name:        "name only is present",
+			in:          agentDesignInput{Name: "My Analyst"},
+			wantPresent: true,
+			assert: func(t *testing.T, design agentDesignInput) {
+				if design.Name != "My Analyst" {
+					t.Fatalf("name = %q", design.Name)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			design, present, err := normalizeAgentDesign(tc.in)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if present != tc.wantPresent {
+				t.Fatalf("present = %v, want %v", present, tc.wantPresent)
+			}
+			if tc.assert != nil {
+				tc.assert(t, design)
+			}
+		})
+	}
+}
+
+func TestMergeAgentDesignIntoInput(t *testing.T) {
+	design := agentDesignInput{Name: "Analyst", Instructions: "Be concise.", ToolSlugs: []string{"read-file"}}
+
+	// Absent design leaves the snapshot byte-identical.
+	original := json.RawMessage(`{"notes":"x"}`)
+	if got := mergeAgentDesignIntoInput(original, agentDesignInput{}, false); string(got) != string(original) {
+		t.Fatalf("absent design changed input: %s", got)
+	}
+
+	merged := mergeAgentDesignIntoInput(json.RawMessage(`{"notes":"x"}`), design, true)
+	var decoded map[string]any
+	if err := json.Unmarshal(merged, &decoded); err != nil {
+		t.Fatalf("merged input is invalid JSON: %v", err)
+	}
+	if decoded["notes"] != "x" {
+		t.Fatalf("merge dropped existing keys: %s", merged)
+	}
+	ad, ok := decoded["agent_design"].(map[string]any)
+	if !ok {
+		t.Fatalf("agent_design missing: %s", merged)
+	}
+	if ad["name"] != "Analyst" || ad["instructions"] != "Be concise." {
+		t.Fatalf("agent_design fields = %v", ad)
+	}
+	slugs, _ := ad["tool_slugs"].([]any)
+	if len(slugs) != 1 || slugs[0] != "read-file" {
+		t.Fatalf("agent_design tool_slugs = %v", ad["tool_slugs"])
+	}
+
+	// A non-object snapshot is replaced with a fresh object carrying the design.
+	fromArray := mergeAgentDesignIntoInput(json.RawMessage(`[1,2,3]`), design, true)
+	if err := json.Unmarshal(fromArray, &decoded); err != nil {
+		t.Fatalf("non-object merge produced invalid JSON: %v", err)
+	}
+	if _, ok := decoded["agent_design"]; !ok {
+		t.Fatalf("non-object merge lost agent_design: %s", fromArray)
+	}
+}
+
+func TestReplaceAgentDesignInInput(t *testing.T) {
+	withDesign := json.RawMessage(`{"notes":"x","agent_design":{"instructions":"old"}}`)
+
+	// Empty override removes the inherited design.
+	cleared := replaceAgentDesignInInput(withDesign, agentDesignInput{}, false)
+	var decoded map[string]any
+	if err := json.Unmarshal(cleared, &decoded); err != nil {
+		t.Fatalf("invalid JSON after clear: %v", err)
+	}
+	if _, ok := decoded["agent_design"]; ok {
+		t.Fatalf("empty override should remove agent_design: %s", cleared)
+	}
+	if decoded["notes"] != "x" {
+		t.Fatalf("clear dropped other keys: %s", cleared)
+	}
+
+	// Present override replaces it.
+	replaced := replaceAgentDesignInInput(withDesign, agentDesignInput{Instructions: "new"}, true)
+	if err := json.Unmarshal(replaced, &decoded); err != nil {
+		t.Fatalf("invalid JSON after replace: %v", err)
+	}
+	ad, _ := decoded["agent_design"].(map[string]any)
+	if ad["instructions"] != "new" {
+		t.Fatalf("override not applied: %s", replaced)
+	}
+}
+
+func TestToolPolicyWithAgentToolKinds(t *testing.T) {
+	// No tools: policy is unchanged.
+	policy := json.RawMessage(`{"tools":["file_writer"]}`)
+	if got := toolPolicyWithAgentToolKinds(policy, nil); string(got) != string(policy) {
+		t.Fatalf("no-tools case changed policy: %s", got)
+	}
+
+	got := toolPolicyWithAgentToolKinds(policy, []string{"read-file", "web-search"})
+	var decoded map[string]any
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("invalid policy JSON: %v", err)
+	}
+	kinds, _ := decoded["allowed_tool_kinds"].([]any)
+	if len(kinds) != 1 || kinds[0] != "primitive" {
+		t.Fatalf("allowed_tool_kinds = %v, want [primitive]", decoded["allowed_tool_kinds"])
+	}
+	if _, ok := decoded["tools"]; !ok {
+		t.Fatalf("merge dropped existing policy keys: %s", got)
+	}
+}
+
+func TestAgentDesignPromptLines(t *testing.T) {
+	// No design -> no lines.
+	if lines := agentDesignPromptLines(json.RawMessage(`{"notes":"x"}`)); lines != nil {
+		t.Fatalf("expected nil lines without design, got %v", lines)
+	}
+
+	input := json.RawMessage(`{"notes":"x","agent_design":{"name":"Analyst","instructions":"Refuse to fabricate numbers.","tool_slugs":["read-file","web-search","ghost-tool"]}}`)
+	prompt := strings.Join(agentDesignPromptLines(input), "\n")
+	for _, want := range []string{
+		"AGENT INSTRUCTIONS (authored by the user)",
+		"PRIMARY behavioral directive",
+		"Refuse to fabricate numbers.",
+		"ABILITIES",
+		"Read a file",
+		"Search the web",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "ghost-tool") {
+		t.Fatalf("unknown slug leaked into prompt:\n%s", prompt)
+	}
+}
+
+func TestAgentTryoutTaskPromptIncludesAgentDesign(t *testing.T) {
+	template := AgentTryoutTemplate{
+		Slug:        "slide-deck",
+		Name:        "Brief to Slide Deck",
+		Description: "Turn a brief into a deck.",
+		Runtime:     json.RawMessage(`{"instructions":"Build deck.pptx.","expected_artifacts":[{"key":"presentation","type":"pptx","path":"deck.pptx"}]}`),
+	}
+	input := json.RawMessage(`{"brief":"Q3 results","agent_design":{"instructions":"Always include a risks slide.","tool_slugs":["read-file"]}}`)
+
+	prompt := agentTryoutTaskPrompt(template, input)
+	for _, want := range []string{
+		"AGENT INSTRUCTIONS (authored by the user)",
+		"Always include a risks slide.",
+		"Read a file",
+		// Template framing must still be present.
+		"DELIVERABLES",
+		"deck.pptx (pptx)",
+		"INSTRUCTIONS:",
+		"Build deck.pptx.",
+		"Q3 results",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+}
+
+func TestCreateAnonymousTryoutStoresAgentDesign(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"ship it"}`),
+		AnonymousFingerprint: "203.0.113.10",
+		AgentName:            "Minute Taker",
+		AgentInstructions:    "Group action items by owner.",
+		AgentToolSlugs:       []string{"read-file", "made-up-tool"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+
+	design, ok := parseStoredAgentDesign(tryout.InputSnapshot)
+	if !ok {
+		t.Fatalf("agent_design not stored: %s", tryout.InputSnapshot)
+	}
+	if design.Name != "Minute Taker" || design.Instructions != "Group action items by owner." {
+		t.Fatalf("stored design = %+v", design)
+	}
+	if strings.Join(design.ToolSlugs, ",") != "read-file" {
+		t.Fatalf("stored tool_slugs = %v, want [read-file] (unknown stripped)", design.ToolSlugs)
+	}
+	// Tool kind recorded on the policy snapshot (best-effort).
+	if !strings.Contains(string(tryout.ToolPolicySnapshot), `"allowed_tool_kinds"`) {
+		t.Fatalf("tool policy snapshot missing allowed_tool_kinds: %s", tryout.ToolPolicySnapshot)
+	}
+}
+
+func TestCreateAnonymousTryoutRejectsOversizeInstructions(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"ship it"}`),
+		AnonymousFingerprint: "203.0.113.10",
+		AgentInstructions:    strings.Repeat("x", maxAgentInstructionsBytes+1),
+	})
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("err = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+}
+
+func TestRerunWorkspaceTryoutOverridesAgentDesign(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	// Seed the source with an inherited design so we can prove the override.
+	source.InputSnapshot = json.RawMessage(`{"task":"fix a nil check","agent_design":{"instructions":"old directive"}}`)
+	repo.tryouts[source.ID] = source
+
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	rerun, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(workspaceID), RerunAgentTryoutInput{
+		SourceTryoutID:      source.ID,
+		SelectedModelPolicy: json.RawMessage(`{"mode":"hosted_default","models":[{"provider":"anthropic","model":"claude-opus-4-8"}]}`),
+		AgentDesignProvided: true,
+		AgentInstructions:   "new directive",
+		AgentToolSlugs:      []string{"web-search"},
+	})
+	if err != nil {
+		t.Fatalf("RerunWorkspaceTryout returned error: %v", err)
+	}
+	design, ok := parseStoredAgentDesign(rerun.InputSnapshot)
+	if !ok || design.Instructions != "new directive" {
+		t.Fatalf("override not applied; rerun input = %s", rerun.InputSnapshot)
+	}
+	if strings.Join(design.ToolSlugs, ",") != "web-search" {
+		t.Fatalf("override tool_slugs = %v", design.ToolSlugs)
+	}
+}
+
+func TestRerunWorkspaceTryoutInheritsAgentDesignWhenNotProvided(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	source.InputSnapshot = json.RawMessage(`{"task":"fix a nil check","agent_design":{"instructions":"inherited directive"}}`)
+	repo.tryouts[source.ID] = source
+
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	rerun, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(workspaceID), RerunAgentTryoutInput{
+		SourceTryoutID:      source.ID,
+		SelectedModelPolicy: json.RawMessage(`{"mode":"hosted_default","models":[{"provider":"anthropic","model":"claude-opus-4-8"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("RerunWorkspaceTryout returned error: %v", err)
+	}
+	if string(rerun.InputSnapshot) != string(source.InputSnapshot) {
+		t.Fatalf("rerun should inherit source design verbatim; got %s", rerun.InputSnapshot)
+	}
+	design, ok := parseStoredAgentDesign(rerun.InputSnapshot)
+	if !ok || design.Instructions != "inherited directive" {
+		t.Fatalf("inherited design lost: %s", rerun.InputSnapshot)
+	}
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -39,6 +39,10 @@ var (
 	ErrAgentTryoutCostCapExceeded           = errors.New("agent tryout cost cap exceeded")
 	ErrAgentTryoutRedactionNotReady         = errors.New("agent tryout redaction not ready")
 
+	// Agent-design validation errors (user-authored prompt + selected tools).
+	errInvalidAgentDesignInstructionsTooLong = fmt.Errorf("%w: agent instructions exceed %d characters", ErrInvalidAgentTryoutInput, maxAgentInstructionsBytes)
+	errInvalidAgentDesignTooManyTools        = fmt.Errorf("%w: select at most %d tools", ErrInvalidAgentTryoutInput, maxAgentToolSlugs)
+
 	// Conversion-flow errors (#947: rerun / compare / promote-to-eval).
 	ErrAgentTryoutSignInRequired             = errors.New("agent tryout sign-in required")
 	ErrAgentTryoutModelPolicyInvalid         = errors.New("agent tryout model policy invalid")
@@ -122,6 +126,14 @@ type CreateAnonymousAgentTryoutInput struct {
 	Judge                *AgentTryoutJudgeSelection
 	AnonymousFingerprint string
 	Now                  time.Time
+
+	// Optional user-authored agent design. When present, the instructions drive
+	// the run as the agent's primary directive, the selected tools are surfaced
+	// as the agent's abilities, and the name labels the design. Absent fields
+	// leave behavior identical to a template-only tryout.
+	AgentInstructions string
+	AgentToolSlugs    []string
+	AgentName         string
 }
 
 // SubmitAgentTryoutTurnInput is a user message in an interactive tryout chat.
@@ -301,8 +313,21 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	if err != nil {
 		return repository.AgentTryout{}, err
 	}
+	design, designPresent, err := normalizeAgentDesign(agentDesignInput{
+		Name:         input.AgentName,
+		Instructions: input.AgentInstructions,
+		ToolSlugs:    input.AgentToolSlugs,
+	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	resolvedInput = mergeAgentDesignIntoInput(resolvedInput, design, designPresent)
 	if int64(len(resolvedInput)) > template.MaxInputBytes {
 		return repository.AgentTryout{}, fmt.Errorf("%w: input exceeds %d bytes", ErrInvalidAgentTryoutInput, template.MaxInputBytes)
+	}
+	toolPolicySnapshot := template.ToolPolicy
+	if designPresent {
+		toolPolicySnapshot = toolPolicyWithAgentToolKinds(toolPolicySnapshot, design.ToolSlugs)
 	}
 	selectedHarness, err := normalizeSelectedHarnessKind(input.SelectedHarnessKind)
 	if err != nil {
@@ -329,7 +354,7 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		Status:                   repository.AgentTryoutStatusQueued,
 		InputSnapshot:            resolvedInput,
 		TemplateSnapshot:         templateSnapshot(template),
-		ToolPolicySnapshot:       template.ToolPolicy,
+		ToolPolicySnapshot:       toolPolicySnapshot,
 		EvaluationSpecSnapshot:   evaluationSpecWithPublicJudge(template.EvaluationSpec, judge, resolvedInput, template.Name),
 		SelectedModelPolicy:      selectedModelPolicy,
 		SelectedHarnessKind:      selectedHarness,
@@ -826,6 +851,7 @@ func agentTryoutTaskPrompt(template AgentTryoutTemplate, input json.RawMessage) 
 		"TASK: " + template.Name + " (" + template.Slug + ")",
 		"GOAL: " + template.Description,
 	}
+	lines = append(lines, agentDesignPromptLines(input)...)
 	if instructions != "" {
 		lines = append(lines, "", "INSTRUCTIONS:", instructions)
 	}
@@ -1098,6 +1124,9 @@ type createAgentTryoutRequest struct {
 	SelectedHarnessKind string                     `json:"selected_harness_kind,omitempty"`
 	SelectedModelPolicy json.RawMessage            `json:"selected_model_policy,omitempty"`
 	Judge               *AgentTryoutJudgeSelection `json:"judge,omitempty"`
+	AgentInstructions   string                     `json:"agent_instructions,omitempty"`
+	AgentToolSlugs      []string                   `json:"agent_tool_slugs,omitempty"`
+	AgentName           string                     `json:"agent_name,omitempty"`
 }
 
 type claimAgentTryoutRequest struct {
@@ -1215,6 +1244,9 @@ func createAnonymousAgentTryoutHandler(logger *slog.Logger, service AgentTryoutS
 			SelectedModelPolicy:  req.SelectedModelPolicy,
 			Judge:                req.Judge,
 			AnonymousFingerprint: anonymousFingerprintFromRequest(r),
+			AgentInstructions:    req.AgentInstructions,
+			AgentToolSlugs:       req.AgentToolSlugs,
+			AgentName:            req.AgentName,
 		})
 		if err != nil {
 			writeAgentTryoutError(w, logger, err)

--- a/backend/internal/workflow/public_agent_tryout_coach.go
+++ b/backend/internal/workflow/public_agent_tryout_coach.go
@@ -1,0 +1,364 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
+)
+
+// AI coaching for public tryouts. After a judge verdict exists, a small hosted
+// model reads the user's agent instructions, the judge's bar + verdict, a short
+// trace summary, and a truncated output preview, then proposes 1-3 specific,
+// applyable improvements. The result is stored under summary.coaching. The step
+// is strictly best-effort: any failure (no verdict, provider error, unparsable
+// output) omits coaching and never fails the run. Token/cost is bounded by
+// aggressive truncation and a single sample.
+
+const (
+	coachDefaultModel       = "gpt-5-mini"
+	coachTimeout            = 45 * time.Second
+	coachMaxInstructions    = 4_000
+	coachMaxOutputPreview   = 6_000
+	coachMaxReasoningPerKey = 600
+	coachMaxSuggestions     = 3
+)
+
+// coachSuggestion is one applyable improvement returned to summary.coaching.
+type coachSuggestion struct {
+	ID                   string   `json:"id"`
+	Title                string   `json:"title"`
+	Detail               string   `json:"detail"`
+	Kind                 string   `json:"kind"`
+	ProposedInstructions string   `json:"proposed_instructions,omitempty"`
+	AddToolSlugs         []string `json:"add_tool_slugs,omitempty"`
+}
+
+// generatePublicTryoutCoaching produces the summary.coaching block, or nil when
+// coaching cannot be produced. It never returns an error: failures degrade to
+// no coaching so the run still completes.
+func (a *Activities) generatePublicTryoutCoaching(
+	ctx context.Context,
+	tryout repository.AgentTryout,
+	outputs []map[string]any,
+	judgeSection map[string]any,
+) map[string]any {
+	if a.judgeClient == nil || judgeSection == nil {
+		return nil
+	}
+	verdict := strings.TrimSpace(stringFromAny(judgeSection["verdict"]))
+	// Only coach once a real verdict exists; "not_judged" carries no signal.
+	if verdict == "" || verdict == "not_judged" {
+		return nil
+	}
+
+	design, _ := parseStoredAgentDesign(tryout.InputSnapshot)
+	model := coachModel(judgeSection)
+	providerKey, credentialReference, ok := coachProviderTarget(model)
+	if !ok {
+		return nil
+	}
+
+	prompt := buildCoachPrompt(tryout, design, judgeSection, verdict, outputs)
+	request := provider.Request{
+		ProviderKey:         providerKey,
+		CredentialReference: credentialReference,
+		Model:               model,
+		StepTimeout:         coachTimeout,
+		Messages:            []provider.Message{{Role: "user", Content: prompt}},
+		Metadata: mustMarshalJSON(map[string]any{
+			"tryout_id": tryout.ID,
+			"purpose":   "agent_tryout_coaching",
+			"model":     model,
+		}),
+	}
+
+	response, err := a.judgeClient.InvokeModel(ctx, request)
+	if err != nil {
+		_ = a.recordPublicTryoutEvent(ctx, tryout.ID, runevents.EventTypeScoringFailed, map[string]any{
+			"status": "coaching_unavailable",
+		})
+		return nil
+	}
+	suggestions, ok := parseCoachSuggestions(response.OutputText)
+	if !ok || len(suggestions) == 0 {
+		return nil
+	}
+	return map[string]any{"suggestions": suggestions}
+}
+
+// coachModel picks the coaching model: reuse the judge model when it is a
+// hosted, inferable model, otherwise the cheap default. Keeping it consistent
+// with the judge models means coaching runs on the same platform keys.
+func coachModel(judgeSection map[string]any) string {
+	model := strings.TrimSpace(stringFromAny(judgeSection["model"]))
+	if model != "" && scoring.InferJudgeProviderKey(model) != "" {
+		return model
+	}
+	return coachDefaultModel
+}
+
+// coachProviderTarget resolves the provider key and platform credential
+// reference for a coaching model, mirroring judge credential resolution.
+func coachProviderTarget(model string) (string, string, bool) {
+	providerKey := scoring.InferJudgeProviderKey(model)
+	if providerKey == "" {
+		return "", "", false
+	}
+	credentialReference, ok := scoring.JudgeDefaultCredentialReference(providerKey)
+	if !ok {
+		return "", "", false
+	}
+	return providerKey, credentialReference, true
+}
+
+// buildCoachPrompt assembles the bounded coaching prompt. Everything is
+// truncated aggressively to cap token/cost. The output stays secret-free: it
+// only includes the agent's own instructions, judge labels/reasoning, and the
+// (already-redacted) output previews.
+func buildCoachPrompt(
+	tryout repository.AgentTryout,
+	design storedAgentDesign,
+	judgeSection map[string]any,
+	verdict string,
+	outputs []map[string]any,
+) string {
+	taskName := coachTaskName(tryout.TemplateSnapshot, tryout.TemplateSlug)
+
+	lines := []string{
+		"You are an expert coach helping a user improve an AI agent they designed for an office-work task.",
+		"Return ONLY valid JSON. Do not wrap the response in markdown fences.",
+		`Schema: {"suggestions":[{"id":"string","title":"string","detail":"string","kind":"prompt"|"tool"|"model","proposed_instructions":"string (optional, only for kind=prompt: the full revised agent instructions)","add_tool_slugs":["string (optional, only for kind=tool)"]}]}`,
+		fmt.Sprintf("Give 1-%d SPECIFIC, immediately applyable suggestions. Prefer the highest-leverage fixes. Each must be concrete enough to apply without further questions.", coachMaxSuggestions),
+		"",
+		"TASK: " + taskName,
+		"JUDGE VERDICT: " + verdict,
+	}
+
+	if instructions := truncateForCoach(strings.TrimSpace(design.Instructions), coachMaxInstructions); instructions != "" {
+		lines = append(lines,
+			"",
+			"THE AGENT INSTRUCTIONS THE USER WROTE (your suggestions should improve THESE; for kind=prompt return the full revised version in proposed_instructions):",
+			instructions,
+		)
+	} else {
+		lines = append(lines,
+			"",
+			"The user did not author custom instructions (the agent ran on the template defaults). A kind=prompt suggestion should propose a concrete instructions block to add.",
+		)
+	}
+
+	if bar := coachEvalBarLines(judgeSection); len(bar) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "WHAT THE JUDGE GRADED AGAINST (criteria + the judge's reasoning):")
+		lines = append(lines, bar...)
+	}
+
+	if trace := coachTraceSummary(outputs); trace != "" {
+		lines = append(lines, "", "TRACE SUMMARY (deliverables the agent produced): "+trace)
+	}
+	if preview := coachOutputPreview(outputs); preview != "" {
+		lines = append(lines, "", "OUTPUT PREVIEW (truncated):", preview)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// coachEvalBarLines summarizes the judge criteria + reasoning for the prompt,
+// truncating each reasoning block. Reads the criteria array produced by
+// runPublicTryoutJudges.
+func coachEvalBarLines(judgeSection map[string]any) []string {
+	rawCriteria, ok := judgeSection["criteria"].([]any)
+	if !ok || len(rawCriteria) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(rawCriteria))
+	for _, raw := range rawCriteria {
+		criterion, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		label := strings.TrimSpace(stringFromAny(criterion["label"]))
+		if label == "" {
+			label = strings.TrimSpace(stringFromAny(criterion["key"]))
+		}
+		if label == "" {
+			continue
+		}
+		status := strings.TrimSpace(stringFromAny(criterion["status"]))
+		entry := "- " + label
+		if status != "" {
+			entry += " [" + status + "]"
+		}
+		if reasoning := truncateForCoach(strings.TrimSpace(stringFromAny(criterion["reasoning"])), coachMaxReasoningPerKey); reasoning != "" {
+			entry += ": " + reasoning
+		}
+		lines = append(lines, entry)
+	}
+	return lines
+}
+
+// coachTraceSummary lists the produced deliverable paths/types as a short line.
+func coachTraceSummary(outputs []map[string]any) string {
+	if len(outputs) == 0 {
+		return "the agent produced no deliverable files"
+	}
+	parts := make([]string, 0, len(outputs))
+	for _, output := range outputs {
+		name := strings.TrimSpace(stringFromAny(output["relative_path"]))
+		if name == "" {
+			name = strings.TrimSpace(stringFromAny(output["key"]))
+		}
+		if name == "" {
+			continue
+		}
+		kind := strings.TrimSpace(stringFromAny(output["type"]))
+		if kind != "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", name, kind))
+		} else {
+			parts = append(parts, name)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// coachOutputPreview flattens text output previews into one aggressively
+// truncated block. Binary previews are summarized, not inlined.
+func coachOutputPreview(outputs []map[string]any) string {
+	sections := make([]string, 0, len(outputs))
+	total := 0
+	for _, output := range outputs {
+		preview := strings.TrimSpace(stringFromAny(output["preview"]))
+		if preview == "" {
+			continue
+		}
+		name := strings.TrimSpace(stringFromAny(output["relative_path"]))
+		if name == "" {
+			name = strings.TrimSpace(stringFromAny(output["key"]))
+		}
+		if strings.TrimSpace(stringFromAny(output["encoding"])) == "base64" {
+			kind := strings.TrimSpace(stringFromAny(output["type"]))
+			sections = append(sections, fmt.Sprintf("=== %s ===\n(binary %s artifact)", name, kind))
+			continue
+		}
+		remaining := coachMaxOutputPreview - total
+		if remaining <= 0 {
+			break
+		}
+		section := fmt.Sprintf("=== %s ===\n%s", name, truncateForCoach(preview, remaining))
+		total += len(section)
+		sections = append(sections, section)
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func coachTaskName(templateSnapshot json.RawMessage, fallbackSlug string) string {
+	var template struct {
+		Name string `json:"name"`
+	}
+	_ = json.Unmarshal(templateSnapshot, &template)
+	if name := strings.TrimSpace(template.Name); name != "" {
+		return name
+	}
+	return strings.TrimSpace(fallbackSlug)
+}
+
+func truncateForCoach(value string, limit int) string {
+	if limit <= 0 || value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit]) + "…(truncated)"
+}
+
+// parseCoachSuggestions decodes and sanitizes the model's JSON into bounded,
+// well-formed suggestions. Returns ok=false on parse failure or when no usable
+// suggestion remains.
+func parseCoachSuggestions(raw string) ([]coachSuggestion, bool) {
+	normalized := sanitizeJudgeJSON(raw)
+	var parsed struct {
+		Suggestions []coachSuggestion `json:"suggestions"`
+	}
+	if err := json.Unmarshal([]byte(normalized), &parsed); err != nil {
+		return nil, false
+	}
+	out := make([]coachSuggestion, 0, len(parsed.Suggestions))
+	for i, suggestion := range parsed.Suggestions {
+		title := strings.TrimSpace(suggestion.Title)
+		detail := strings.TrimSpace(suggestion.Detail)
+		if title == "" && detail == "" {
+			continue
+		}
+		kind := normalizeCoachKind(suggestion.Kind)
+		id := strings.TrimSpace(suggestion.ID)
+		if id == "" {
+			id = fmt.Sprintf("suggestion_%d", i+1)
+		}
+		clean := coachSuggestion{
+			ID:     id,
+			Title:  truncateForCoach(title, 160),
+			Detail: truncateForCoach(detail, 1_200),
+			Kind:   kind,
+		}
+		if kind == "prompt" {
+			clean.ProposedInstructions = truncateForCoach(strings.TrimSpace(suggestion.ProposedInstructions), coachMaxInstructions)
+		}
+		if kind == "tool" {
+			clean.AddToolSlugs = coachKnownToolSlugs(suggestion.AddToolSlugs)
+		}
+		out = append(out, clean)
+		if len(out) >= coachMaxSuggestions {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func normalizeCoachKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "tool":
+		return "tool"
+	case "model":
+		return "model"
+	default:
+		return "prompt"
+	}
+}
+
+// coachKnownToolSlugs keeps only slugs the tool library recognizes so a
+// suggestion never points the user at a non-existent tool.
+func coachKnownToolSlugs(slugs []string) []string {
+	if len(slugs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		slug = strings.TrimSpace(slug)
+		if slug == "" || seen[slug] {
+			continue
+		}
+		if _, ok := toolspec.LibraryBySlug(slug); !ok {
+			continue
+		}
+		seen[slug] = true
+		out = append(out, slug)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/backend/internal/workflow/public_agent_tryout_coach_test.go
+++ b/backend/internal/workflow/public_agent_tryout_coach_test.go
@@ -1,0 +1,199 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+func TestWorkflowAgentDesignPromptLinesMirrorsAPI(t *testing.T) {
+	// No design -> no lines (matches the api builder).
+	if lines := agentDesignPromptLines(json.RawMessage(`{"brief":"x"}`)); lines != nil {
+		t.Fatalf("expected nil without design, got %v", lines)
+	}
+
+	input := json.RawMessage(`{"brief":"x","agent_design":{"instructions":"Never invent figures.","tool_slugs":["read-file","ghost"]}}`)
+	prompt := strings.Join(agentDesignPromptLines(input), "\n")
+	for _, want := range []string{
+		"AGENT INSTRUCTIONS (authored by the user)",
+		"PRIMARY behavioral directive",
+		"Never invent figures.",
+		"ABILITIES",
+		"Read a file",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "ghost") {
+		t.Fatalf("unknown slug leaked: %s", prompt)
+	}
+}
+
+func TestPublicTryoutTaskPromptIncludesAgentDesign(t *testing.T) {
+	tryout := repository.AgentTryout{
+		TemplateSlug: "slide-deck",
+		TemplateSnapshot: json.RawMessage(`{"name":"Brief to Slide Deck","description":"Turn a brief into a deck.",` +
+			`"runtime":{"instructions":"Build deck.pptx.","expected_artifacts":[{"key":"presentation","type":"pptx","path":"deck.pptx"}]}}`),
+		InputSnapshot: json.RawMessage(`{"brief":"Q3 results","agent_design":{"instructions":"Always add a risks slide.","tool_slugs":["read-file"]}}`),
+	}
+	prompt := publicTryoutTaskPrompt(tryout)
+	for _, want := range []string{
+		"AGENT INSTRUCTIONS (authored by the user)",
+		"Always add a risks slide.",
+		"Read a file",
+		// Template framing intact.
+		"DELIVERABLES",
+		"deck.pptx (pptx)",
+		"Build deck.pptx.",
+		"Q3 results",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+}
+
+func TestCoachModelAndProviderTarget(t *testing.T) {
+	// Reuses an inferable judge model.
+	if got := coachModel(map[string]any{"model": "claude-haiku-4-5"}); got != "claude-haiku-4-5" {
+		t.Fatalf("coachModel = %q, want claude-haiku-4-5", got)
+	}
+	// Falls back to the default for a non-inferable model.
+	if got := coachModel(map[string]any{"model": "mystery-1"}); got != coachDefaultModel {
+		t.Fatalf("coachModel = %q, want %q", got, coachDefaultModel)
+	}
+	// Empty section model also falls back.
+	if got := coachModel(map[string]any{}); got != coachDefaultModel {
+		t.Fatalf("coachModel = %q, want %q", got, coachDefaultModel)
+	}
+
+	providerKey, credential, ok := coachProviderTarget("gpt-5-mini")
+	if !ok || providerKey != "openai" || credential != "env://OPENAI_API_KEY" {
+		t.Fatalf("provider target = %q/%q/%v", providerKey, credential, ok)
+	}
+	if _, _, ok := coachProviderTarget("mystery-1"); ok {
+		t.Fatalf("expected unknown model to have no provider target")
+	}
+}
+
+func TestParseCoachSuggestions(t *testing.T) {
+	t.Run("valid with prompt and tool kinds", func(t *testing.T) {
+		raw := `{"suggestions":[
+			{"id":"a","title":"Tighten the prompt","detail":"Spell out the JSON fields.","kind":"prompt","proposed_instructions":"Return strict JSON with fields x and y."},
+			{"id":"b","title":"Add a tool","detail":"Let it read files.","kind":"tool","add_tool_slugs":["read-file","not-real"]},
+			{"title":"Try a stronger model","detail":"Use a larger model.","kind":"model"}
+		]}`
+		got, ok := parseCoachSuggestions(raw)
+		if !ok || len(got) != 3 {
+			t.Fatalf("got %d suggestions ok=%v", len(got), ok)
+		}
+		if got[0].Kind != "prompt" || got[0].ProposedInstructions == "" {
+			t.Fatalf("prompt suggestion = %+v", got[0])
+		}
+		if got[1].Kind != "tool" || strings.Join(got[1].AddToolSlugs, ",") != "read-file" {
+			t.Fatalf("tool suggestion = %+v (unknown slug should be stripped)", got[1])
+		}
+		// Missing id is backfilled.
+		if got[2].ID == "" {
+			t.Fatalf("expected backfilled id, got empty")
+		}
+		// model kind must not carry proposed_instructions/add_tool_slugs.
+		if got[2].ProposedInstructions != "" || got[2].AddToolSlugs != nil {
+			t.Fatalf("model suggestion leaked fields: %+v", got[2])
+		}
+	})
+
+	t.Run("markdown-fenced JSON is recovered", func(t *testing.T) {
+		raw := "```json\n{\"suggestions\":[{\"title\":\"X\",\"detail\":\"Y\",\"kind\":\"prompt\"}]}\n```"
+		got, ok := parseCoachSuggestions(raw)
+		if !ok || len(got) != 1 {
+			t.Fatalf("fenced parse failed: ok=%v n=%d", ok, len(got))
+		}
+	})
+
+	t.Run("caps at three suggestions", func(t *testing.T) {
+		raw := `{"suggestions":[
+			{"title":"1","detail":"d","kind":"prompt"},
+			{"title":"2","detail":"d","kind":"prompt"},
+			{"title":"3","detail":"d","kind":"prompt"},
+			{"title":"4","detail":"d","kind":"prompt"}
+		]}`
+		got, ok := parseCoachSuggestions(raw)
+		if !ok || len(got) != coachMaxSuggestions {
+			t.Fatalf("got %d, want %d", len(got), coachMaxSuggestions)
+		}
+	})
+
+	t.Run("empty and invalid are rejected", func(t *testing.T) {
+		if _, ok := parseCoachSuggestions(`{"suggestions":[]}`); ok {
+			t.Fatalf("empty suggestions should be rejected")
+		}
+		if _, ok := parseCoachSuggestions(`not json at all`); ok {
+			t.Fatalf("garbage should be rejected")
+		}
+		if _, ok := parseCoachSuggestions(`{"suggestions":[{"kind":"prompt"}]}`); ok {
+			t.Fatalf("suggestion with no title/detail should be dropped, leaving none")
+		}
+	})
+}
+
+func TestBuildCoachPromptIsBoundedAndStructured(t *testing.T) {
+	tryout := repository.AgentTryout{
+		TemplateSlug:     "slide-deck",
+		TemplateSnapshot: json.RawMessage(`{"name":"Brief to Slide Deck"}`),
+	}
+	design := storedAgentDesign{Instructions: strings.Repeat("z", coachMaxInstructions+500)}
+	judgeSection := map[string]any{
+		"verdict": "needs_edits",
+		"criteria": []any{
+			map[string]any{"label": "Overall, against your bar", "status": "failed", "reasoning": "Missing the requested risks slide."},
+		},
+	}
+	outputs := []map[string]any{
+		{"relative_path": "deck.json", "type": "json", "encoding": "utf-8", "preview": strings.Repeat("p", coachMaxOutputPreview+500)},
+		{"relative_path": "deck.pptx", "type": "pptx", "encoding": "base64", "preview": "AAAA"},
+	}
+
+	prompt := buildCoachPrompt(tryout, design, judgeSection, "needs_edits", outputs)
+	for _, want := range []string{
+		"JUDGE VERDICT: needs_edits",
+		"Brief to Slide Deck",
+		"Overall, against your bar",
+		"Missing the requested risks slide.",
+		"OUTPUT PREVIEW",
+		"binary pptx artifact",
+		"…(truncated)", // long instructions + preview are truncated
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q\n---\n%.500s", want, prompt)
+		}
+	}
+}
+
+func TestCompletedSummaryEmbedsCoaching(t *testing.T) {
+	scorecard := map[string]any{"score": 0.8}
+	coaching := map[string]any{"suggestions": []coachSuggestion{{ID: "a", Title: "X", Detail: "Y", Kind: "prompt"}}}
+
+	withCoaching := publicTryoutCompletedSummary(nil, scorecard, coaching)
+	var decoded map[string]any
+	if err := json.Unmarshal(withCoaching, &decoded); err != nil {
+		t.Fatalf("invalid summary JSON: %v", err)
+	}
+	if _, ok := decoded["coaching"]; !ok {
+		t.Fatalf("summary missing coaching block: %s", withCoaching)
+	}
+
+	// Nil coaching omits the key entirely. Use a fresh map: json.Unmarshal does
+	// not delete keys already present in the destination map.
+	withoutCoaching := publicTryoutCompletedSummary(nil, scorecard, nil)
+	var decodedNoCoaching map[string]any
+	if err := json.Unmarshal(withoutCoaching, &decodedNoCoaching); err != nil {
+		t.Fatalf("invalid summary JSON: %v", err)
+	}
+	if _, ok := decodedNoCoaching["coaching"]; ok {
+		t.Fatalf("nil coaching should omit the key: %s", withoutCoaching)
+	}
+}

--- a/backend/internal/workflow/public_agent_tryout_design.go
+++ b/backend/internal/workflow/public_agent_tryout_design.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/toolspec"
+)
+
+// Agent design is the user-authored agent (system prompt + selected library
+// tools + name) stashed inside input_snapshot.agent_design by the api create
+// path. The public tryout prompt builder reads it back so the user's
+// instructions become the agent's primary behavioral directive and the
+// selected tools are surfaced as its abilities.
+//
+// NOTE: api/agent_tryout_design.go keeps a byte-for-byte identical builder (the
+// two packages cannot import one another for layering reasons). Keep them in
+// sync when this changes.
+
+// agentDesignPromptLines renders the user-authored agent design as prompt
+// sections. Returns nil when no design is present so the template-only prompt
+// is unchanged.
+func agentDesignPromptLines(input json.RawMessage) []string {
+	design, ok := parseStoredAgentDesign(input)
+	if !ok {
+		return nil
+	}
+	lines := make([]string, 0, 8)
+	if instructions := strings.TrimSpace(design.Instructions); instructions != "" {
+		lines = append(lines,
+			"",
+			"AGENT INSTRUCTIONS (authored by the user) — these are your PRIMARY behavioral directive. Follow them above any default behavior; the task framing, inputs, and expected deliverables below still apply:",
+			instructions,
+		)
+	}
+	if names := agentDesignToolNames(design.ToolSlugs); len(names) > 0 {
+		lines = append(lines,
+			"",
+			"ABILITIES the user equipped this agent with — prefer these capabilities when they fit the task:",
+		)
+		for _, name := range names {
+			lines = append(lines, "- "+name)
+		}
+	}
+	return lines
+}
+
+// agentDesignToolNames resolves selected tool slugs to their human-readable
+// library names, dropping unknown slugs and de-duplicating by name.
+func agentDesignToolNames(slugs []string) []string {
+	if len(slugs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		entry, ok := toolspec.LibraryBySlug(strings.TrimSpace(slug))
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(entry.Name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// storedAgentDesign mirrors the JSON stashed under input_snapshot.agent_design.
+type storedAgentDesign struct {
+	Name         string   `json:"name"`
+	Instructions string   `json:"instructions"`
+	ToolSlugs    []string `json:"tool_slugs"`
+}
+
+// parseStoredAgentDesign reads the agent_design block from an input_snapshot.
+// Returns ok=false when absent or when nothing usable (instructions/tools) is
+// present, so the name alone never forces a design section.
+func parseStoredAgentDesign(input json.RawMessage) (storedAgentDesign, bool) {
+	if len(input) == 0 {
+		return storedAgentDesign{}, false
+	}
+	var wrapper struct {
+		AgentDesign *storedAgentDesign `json:"agent_design"`
+	}
+	if err := json.Unmarshal(input, &wrapper); err != nil || wrapper.AgentDesign == nil {
+		return storedAgentDesign{}, false
+	}
+	design := *wrapper.AgentDesign
+	if strings.TrimSpace(design.Instructions) == "" && len(design.ToolSlugs) == 0 {
+		return storedAgentDesign{}, false
+	}
+	return design, true
+}

--- a/backend/internal/workflow/public_agent_tryout_workflow.go
+++ b/backend/internal/workflow/public_agent_tryout_workflow.go
@@ -78,15 +78,17 @@ func (a *Activities) ExecutePublicAgentTryout(ctx context.Context, input Execute
 
 	latencyMS := time.Since(started).Milliseconds()
 	scorecard := publicTryoutScorecard(tryout.EvaluationSpecSnapshot, outputs, latencyMS)
-	if judgeSection := a.runPublicTryoutJudges(ctx, tryout, outputs); judgeSection != nil {
-		scorecard["judge"] = judgeSection
+	var judgeSection map[string]any
+	if section := a.runPublicTryoutJudges(ctx, tryout, outputs); section != nil {
+		judgeSection = section
+		scorecard["judge"] = section
 	}
 	scoringPayload := map[string]any{
 		"passed": scorecard["passed_validators"],
 		"total":  scorecard["total_validators"],
 		"score":  scorecard["score"],
 	}
-	if judgeSection, ok := scorecard["judge"].(map[string]any); ok {
+	if judgeSection != nil {
 		if verdict, ok := judgeSection["verdict"].(string); ok {
 			scoringPayload["verdict"] = verdict
 		}
@@ -98,11 +100,16 @@ func (a *Activities) ExecutePublicAgentTryout(ctx context.Context, input Execute
 		return wrapActivityError(err)
 	}
 
+	// Best-effort AI coaching: only after a judge verdict exists. Any failure
+	// (no verdict, provider error, unparsable output) omits coaching and never
+	// fails the run.
+	coaching := a.generatePublicTryoutCoaching(ctx, tryout, outputs, judgeSection)
+
 	redaction := repository.AgentTryoutRedactionPassed
 	if _, err := a.publicTryoutRepo.UpdateAgentTryoutStatus(ctx, repository.UpdateAgentTryoutStatusParams{
 		ID:              tryout.ID,
 		Status:          repository.AgentTryoutStatusCompleted,
-		Summary:         publicTryoutCompletedSummary(outputs, scorecard),
+		Summary:         publicTryoutCompletedSummary(outputs, scorecard, coaching),
 		LatencyMS:       int64Ptr(latencyMS),
 		RedactionStatus: &redaction,
 	}); err != nil {
@@ -622,6 +629,7 @@ func renderAgentTryoutTaskPromptLines(name, slug, description string, runtime, i
 		"TASK: " + name + " (" + slug + ")",
 		"GOAL: " + description,
 	}
+	lines = append(lines, agentDesignPromptLines(input)...)
 	if instructions != "" {
 		lines = append(lines, "", "INSTRUCTIONS:", instructions)
 	}
@@ -888,13 +896,17 @@ func publicTryoutRunningSummary(outputs []map[string]any, harnessKind string, se
 	return payload
 }
 
-func publicTryoutCompletedSummary(outputs []map[string]any, scorecard map[string]any) json.RawMessage {
-	payload, _ := json.Marshal(map[string]any{
+func publicTryoutCompletedSummary(outputs []map[string]any, scorecard map[string]any, coaching map[string]any) json.RawMessage {
+	body := map[string]any{
 		"code":      "completed",
 		"message":   "The hosted agent finished this public tryout. Export the trace or sign in to save and rerun it.",
 		"outputs":   outputs,
 		"scorecard": scorecard,
-	})
+	}
+	if coaching != nil {
+		body["coaching"] = coaching
+	}
+	payload, _ := json.Marshal(body)
 	return payload
 }
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -14157,6 +14157,7 @@ components:
             agent_design.tool_slugs.
         agent_name:
           type: string
+          maxLength: 120
           description: >-
             Optional display name for the authored agent. Stored under
             agent_design.name.
@@ -14500,6 +14501,7 @@ components:
             true.
         agent_name:
           type: string
+          maxLength: 120
           description: >-
             Override agent display name for the rerun. Only applied when
             agent_design_provided is true.

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -14137,6 +14137,29 @@ components:
           description: Optional explicit model policy for the selected harness.
         judge:
           $ref: "#/components/schemas/AgentTryoutJudgeSelection"
+        agent_instructions:
+          type: string
+          maxLength: 8000
+          description: >-
+            Optional user-authored agent system prompt. When present it becomes
+            the agent's primary behavioral directive (the template still
+            supplies task framing, inputs, and expected deliverables). Stored in
+            input_snapshot under agent_design.instructions.
+        agent_tool_slugs:
+          type: array
+          items:
+            type: string
+          maxItems: 24
+          description: >-
+            Optional tool-library slugs the agent is equipped with. Unknown
+            slugs are dropped; the list is capped at 24. Surfaced in the prompt
+            as the agent's abilities and stored under
+            agent_design.tool_slugs.
+        agent_name:
+          type: string
+          description: >-
+            Optional display name for the authored agent. Stored under
+            agent_design.name.
 
     AgentTryoutJudgeSelection:
       type: object
@@ -14206,6 +14229,14 @@ components:
         summary:
           type: object
           additionalProperties: true
+          description: >-
+            Free-form status/result payload. On a completed tryout it carries
+            outputs and scorecard (with scorecard.judge), and — best-effort —
+            a coaching block matching AgentTryoutCoaching when AI coaching was
+            produced. Coaching is omitted on any failure.
+          properties:
+            coaching:
+              $ref: "#/components/schemas/AgentTryoutCoaching"
         redaction_status:
           type: string
           enum: [pending, passed, failed, not_required]
@@ -14280,6 +14311,14 @@ components:
         summary:
           type: object
           additionalProperties: true
+          description: >-
+            Free-form status/result payload. On a completed tryout it carries
+            outputs and scorecard (with scorecard.judge), and — best-effort —
+            a coaching block matching AgentTryoutCoaching when AI coaching was
+            produced. Coaching is omitted on any failure.
+          properties:
+            coaching:
+              $ref: "#/components/schemas/AgentTryoutCoaching"
         redaction_status:
           type: string
           enum: [pending, passed, failed, not_required]
@@ -14437,6 +14476,77 @@ components:
             The model policy to rerun under. Must set a `mode` or at least one
             explicit `models[]` entry; explicit models must name a known
             provider.
+        agent_design_provided:
+          type: boolean
+          description: >-
+            When true the rerun overrides the source tryout's agent design with
+            the agent_* fields below (after normalization), making the agent
+            design — not just the model — the varied dimension. When false or
+            omitted the rerun inherits the source's agent_design unchanged.
+        agent_instructions:
+          type: string
+          maxLength: 8000
+          description: >-
+            Override agent system prompt for the rerun. Only applied when
+            agent_design_provided is true.
+        agent_tool_slugs:
+          type: array
+          items:
+            type: string
+          maxItems: 24
+          description: >-
+            Override tool-library slugs for the rerun. Unknown slugs are
+            dropped; capped at 24. Only applied when agent_design_provided is
+            true.
+        agent_name:
+          type: string
+          description: >-
+            Override agent display name for the rerun. Only applied when
+            agent_design_provided is true.
+
+    AgentTryoutCoaching:
+      type: object
+      description: >-
+        Best-effort AI coaching produced after a judge verdict exists. Appears
+        under a completed tryout's summary.coaching. Omitted entirely on any
+        failure (no verdict, provider error, unparsable output).
+      required: [suggestions]
+      properties:
+        suggestions:
+          type: array
+          maxItems: 3
+          items:
+            $ref: "#/components/schemas/AgentTryoutCoachingSuggestion"
+
+    AgentTryoutCoachingSuggestion:
+      type: object
+      description: One specific, applyable improvement to the user's agent.
+      required: [id, title, detail, kind]
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        detail:
+          type: string
+        kind:
+          type: string
+          enum: [prompt, tool, model]
+          description: >-
+            Whether the suggestion changes the agent's prompt, its tools, or its
+            model.
+        proposed_instructions:
+          type: string
+          description: >-
+            For kind=prompt, the full revised agent instructions to apply.
+            Absent for other kinds.
+        add_tool_slugs:
+          type: array
+          items:
+            type: string
+          description: >-
+            For kind=tool, library tool slugs to add to the agent. Only slugs
+            recognized by the tool library are returned. Absent for other kinds.
 
     PromoteAgentTryoutRequest:
       type: object

--- a/web/src/app/tryouts/agent-designer.tsx
+++ b/web/src/app/tryouts/agent-designer.tsx
@@ -1,0 +1,225 @@
+import { Bot, Check, Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const MICRO = "font-mono text-2xs uppercase tracking-[0.22em]";
+
+/*
+ * "Design your agent" — the front of the playground loop.
+ *
+ * A user authors the agent's system prompt, picks the abilities (tools, drawn
+ * from the real tool library) it's allowed to use, and a model. The resulting
+ * draft is what gets run, graded, coached, and re-run — so the score delta is
+ * attributable to *their* choices, which is the whole point of the playground.
+ *
+ * Controlled + presentational: state lives in the parent (welcome flow / preview).
+ */
+
+export type AgentTool = {
+  slug: string;
+  name: string;
+  category: string;
+  /** Short verb-y blurb, e.g. "search the web". */
+  blurb?: string;
+};
+
+export type AgentModelChoice = {
+  key: string;
+  label: string;
+  hint?: string;
+};
+
+export type AgentDraft = {
+  name: string;
+  instructions: string;
+  toolSlugs: string[];
+  modelKey: string;
+};
+
+function Label({ children, hint }: { children: React.ReactNode; hint?: string }) {
+  return (
+    <div className="mb-2.5 flex items-baseline justify-between gap-3">
+      <span className={cn(MICRO, "text-white/45")}>{children}</span>
+      {hint ? <span className="text-2xs text-white/30">{hint}</span> : null}
+    </div>
+  );
+}
+
+function ToolChip({
+  tool,
+  selected,
+  onToggle,
+}: {
+  tool: AgentTool;
+  selected: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={selected}
+      className={cn(
+        "group flex items-center gap-2 rounded-sm border px-2.5 py-1.5 text-left transition",
+        selected
+          ? "border-white/40 bg-white/[0.06] text-white"
+          : "border-white/10 bg-transparent text-white/55 hover:border-white/25 hover:text-white/80",
+      )}
+    >
+      <span
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-[3px] border transition",
+          selected ? "border-white/50 bg-white text-black" : "border-white/20 text-transparent",
+        )}
+      >
+        <Check className="size-3" strokeWidth={3} />
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-sm leading-5">{tool.name}</span>
+        {tool.blurb ? (
+          <span className="block truncate text-2xs text-white/35">{tool.blurb}</span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+export function AgentDesigner({
+  value,
+  onChange,
+  tools,
+  models,
+  taskLabel,
+  onRun,
+  running,
+}: {
+  value: AgentDraft;
+  onChange: (next: AgentDraft) => void;
+  tools: AgentTool[];
+  models: AgentModelChoice[];
+  taskLabel?: string;
+  onRun?: () => void;
+  running?: boolean;
+}) {
+  const grouped = tools.reduce<Record<string, AgentTool[]>>((acc, tool) => {
+    (acc[tool.category] ??= []).push(tool);
+    return acc;
+  }, {});
+  const categories = Object.keys(grouped);
+  const selected = new Set(value.toolSlugs);
+
+  const toggleTool = (slug: string) => {
+    const next = new Set(selected);
+    if (next.has(slug)) next.delete(slug);
+    else next.add(slug);
+    onChange({ ...value, toolSlugs: [...next] });
+  };
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.015]">
+      {/* Identity header */}
+      <div className="flex items-center gap-3 border-b border-white/[0.07] px-5 py-4 sm:px-6">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-white/15 bg-white/[0.04]">
+          <Bot className="size-4 text-white/70" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <input
+            value={value.name}
+            onChange={(event) => onChange({ ...value, name: event.target.value })}
+            placeholder="Name your agent"
+            className="w-full bg-transparent text-base font-medium text-white placeholder:text-white/30 focus:outline-none"
+          />
+          <p className={cn(MICRO, "mt-0.5 text-white/35")}>
+            {taskLabel ? `Built for: ${taskLabel}` : "Your agent"}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-6 px-5 py-5 sm:px-6">
+        {/* System prompt — the centerpiece */}
+        <div>
+          <Label hint="read before every run">Instructions</Label>
+          <textarea
+            value={value.instructions}
+            onChange={(event) => onChange({ ...value, instructions: event.target.value })}
+            rows={6}
+            placeholder="Tell the agent how to behave. Be specific — vague prompts fail the bar."
+            className="w-full resize-y rounded-md border border-white/10 bg-black/20 p-3.5 text-sm leading-6 text-white/85 placeholder:text-white/25 focus:border-white/25 focus:bg-black/30 focus:outline-none"
+          />
+          <p className="mt-1.5 text-2xs leading-5 text-white/30">
+            This is your agent&apos;s system prompt. The judge grades what it produces against
+            your bar — tighten this and the score moves.
+          </p>
+        </div>
+
+        {/* Abilities — drawn from the tool library */}
+        <div>
+          <Label hint={`${selected.size} selected`}>Abilities</Label>
+          <div className="space-y-3">
+            {categories.map((category) => (
+              <div key={category}>
+                <p className="mb-2 text-2xs uppercase tracking-[0.16em] text-white/25">
+                  {category}
+                </p>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {grouped[category].map((tool) => (
+                    <ToolChip
+                      key={tool.slug}
+                      tool={tool}
+                      selected={selected.has(tool.slug)}
+                      onToggle={() => toggleTool(tool.slug)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Model */}
+        <div>
+          <Label hint="the brain">Model</Label>
+          <div className="flex flex-wrap gap-2">
+            {models.map((model) => {
+              const active = model.key === value.modelKey;
+              return (
+                <button
+                  key={model.key}
+                  type="button"
+                  onClick={() => onChange({ ...value, modelKey: model.key })}
+                  aria-pressed={active}
+                  className={cn(
+                    "rounded-sm border px-3 py-1.5 text-sm transition",
+                    active
+                      ? "border-white/40 bg-white/[0.06] text-white"
+                      : "border-white/10 text-white/55 hover:border-white/25 hover:text-white/80",
+                  )}
+                  title={model.hint}
+                >
+                  {model.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {onRun ? (
+        <div className="flex items-center justify-between gap-3 border-t border-white/[0.07] px-5 py-4 sm:px-6">
+          <p className="text-xs leading-5 text-white/40">
+            You&apos;ll watch it work, then a judge grades it against your bar.
+          </p>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={running}
+            className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-sm bg-white px-4 text-sm font-medium text-black transition hover:bg-white/90 disabled:opacity-60"
+          >
+            <Sparkles className="size-4" />
+            {running ? "Running…" : "Run your agent"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/app/tryouts/coach-card.tsx
+++ b/web/src/app/tryouts/coach-card.tsx
@@ -1,0 +1,106 @@
+import { Check, Cpu, PenLine, Sparkles, Wrench } from "lucide-react";
+import type { ComponentType } from "react";
+
+import type { TryoutCoaching, TryoutCoachingKind, TryoutCoachingSuggestion } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+const MICRO = "font-mono text-2xs uppercase tracking-[0.22em]";
+
+/*
+ * The coach. After a run is graded, the worker turns the judge's verdict +
+ * reasoning + trace into specific, applyable fixes (mostly prompt edits). This
+ * renders them with one-click Apply — the bridge from "it failed" to "here's
+ * how to make it pass", which is the whole point of running an eval.
+ */
+
+const KIND_ICON: Record<TryoutCoachingKind, ComponentType<{ className?: string }>> = {
+  prompt: PenLine,
+  tool: Wrench,
+  model: Cpu,
+};
+
+const KIND_LABEL: Record<TryoutCoachingKind, string> = {
+  prompt: "Prompt",
+  tool: "Tools",
+  model: "Model",
+};
+
+function canApply(suggestion: TryoutCoachingSuggestion): boolean {
+  if (suggestion.kind === "prompt") return Boolean(suggestion.proposed_instructions?.trim());
+  if (suggestion.kind === "tool") return (suggestion.add_tool_slugs?.length ?? 0) > 0;
+  return false;
+}
+
+export function CoachCard({
+  coaching,
+  appliedIds,
+  onApply,
+}: {
+  coaching: TryoutCoaching;
+  appliedIds?: string[];
+  onApply?: (suggestion: TryoutCoachingSuggestion) => void;
+}) {
+  if (!coaching.suggestions || coaching.suggestions.length === 0) return null;
+  const applied = new Set(appliedIds ?? []);
+
+  return (
+    <div className="rounded-lg border border-white/12 bg-white/[0.02]">
+      <div className="flex items-center gap-2.5 border-b border-white/[0.07] px-5 py-3.5">
+        <Sparkles className="size-4 text-white/70" />
+        <div>
+          <p className="text-sm font-medium text-white/90">Make it better</p>
+          <p className={cn(MICRO, "mt-0.5 text-white/35")}>What the eval says to fix</p>
+        </div>
+      </div>
+
+      <ul className="divide-y divide-white/[0.06]">
+        {coaching.suggestions.map((suggestion) => {
+          const Icon = KIND_ICON[suggestion.kind];
+          const isApplied = applied.has(suggestion.id);
+          const applyable = canApply(suggestion);
+          return (
+            <li key={suggestion.id} className="flex gap-3 px-5 py-4">
+              <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border border-white/12 text-white/55">
+                <Icon className="size-3.5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-3">
+                  <p className="text-sm leading-6 text-white/85">{suggestion.title}</p>
+                  <span className={cn(MICRO, "shrink-0 text-white/30")}>
+                    {KIND_LABEL[suggestion.kind]}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-white/45">{suggestion.detail}</p>
+
+                {onApply && applyable ? (
+                  <button
+                    type="button"
+                    onClick={() => onApply(suggestion)}
+                    disabled={isApplied}
+                    className={cn(
+                      "mt-2.5 inline-flex h-7 items-center gap-1.5 rounded-sm border px-2.5 text-xs transition",
+                      isApplied
+                        ? "border-white/15 text-white/45"
+                        : "border-white/25 text-white/80 hover:border-white/45 hover:text-white",
+                    )}
+                  >
+                    {isApplied ? (
+                      <>
+                        <Check className="size-3.5" strokeWidth={2.5} />
+                        Applied
+                      </>
+                    ) : suggestion.kind === "prompt" ? (
+                      "Apply to prompt"
+                    ) : (
+                      "Add to agent"
+                    )}
+                  </button>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/app/tryouts/delta-card.tsx
+++ b/web/src/app/tryouts/delta-card.tsx
@@ -1,0 +1,121 @@
+import { ArrowRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const SERIF = "[font-family:var(--font-race-display)]";
+const MICRO = "font-mono text-2xs uppercase tracking-[0.22em]";
+
+/*
+ * The payoff. Two runs of the user's agent — before their edit and after —
+ * side by side, so the score jump (e.g. Rejected 2.0 → Approved 4.5) is the
+ * thing they walk away with: "the eval made my agent measurably better."
+ */
+
+const VERDICT_WORDS: Record<string, string> = {
+  approved: "Approved",
+  needs_edits: "Needs edits",
+  rejected: "Rejected",
+  not_judged: "Not judged",
+};
+
+export type DeltaSide = {
+  label: string;
+  verdict?: string;
+  /** 1–5 grade, or null if not graded. */
+  grade?: number | null;
+};
+
+function Side({ side, dim }: { side: DeltaSide; dim?: boolean }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className={cn(MICRO, "text-white/35")}>{side.label}</p>
+      <p
+        className={cn(
+          SERIF,
+          "mt-2 font-light leading-none",
+          dim ? "text-white/45" : "text-white/95",
+        )}
+      >
+        {side.grade != null ? (
+          <>
+            {side.grade.toFixed(1)}
+            <span className="text-base text-white/30"> / 5</span>
+          </>
+        ) : (
+          <span className="text-2xl text-white/40">—</span>
+        )}
+      </p>
+      {side.verdict ? (
+        <p className="mt-1.5 text-xs text-white/45">{VERDICT_WORDS[side.verdict] ?? side.verdict}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function DeltaCard({
+  before,
+  after,
+  changes,
+}: {
+  before: DeltaSide;
+  after: DeltaSide;
+  changes?: string[];
+}) {
+  const delta =
+    before.grade != null && after.grade != null ? after.grade - before.grade : null;
+  const improved = delta != null && delta > 0.05;
+  const regressed = delta != null && delta < -0.05;
+  const flipped = before.verdict === "rejected" && after.verdict === "approved";
+
+  const headline = flipped
+    ? "Rejected → Approved. Your edit flipped the verdict."
+    : improved
+      ? "Your agent got measurably better."
+      : regressed
+        ? "That edit made it worse — keep tuning."
+        : "Same score — try a sharper change.";
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-5 sm:p-6",
+        improved || flipped ? "border-white/30 bg-white/[0.03]" : "border-white/12 bg-white/[0.015]",
+      )}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm leading-6 text-white/85">{headline}</p>
+        {delta != null ? (
+          <span
+            className={cn(
+              "font-mono text-xs tabular-nums",
+              improved ? "text-white/80" : regressed ? "text-[#e0a085]" : "text-white/35",
+            )}
+          >
+            {delta > 0 ? "+" : ""}
+            {delta.toFixed(1)}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-5 flex items-center gap-4">
+        <Side side={before} dim />
+        <ArrowRight className="size-5 shrink-0 text-white/30" />
+        <Side side={after} />
+      </div>
+
+      {changes && changes.length > 0 ? (
+        <div className="mt-5 border-t border-white/[0.07] pt-4">
+          <p className={cn(MICRO, "mb-2 text-white/30")}>What changed</p>
+          <ul className="space-y-1">
+            {changes.map((change, index) => (
+              <li key={index} className="flex items-baseline gap-2 text-xs text-white/55">
+                <span className="size-1 shrink-0 translate-y-1 rounded-full bg-white/30" aria-hidden />
+                {change}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/app/tryouts/run-timeline.tsx
+++ b/web/src/app/tryouts/run-timeline.tsx
@@ -1,0 +1,451 @@
+import {
+  Check,
+  Container,
+  FilePlus2,
+  Flag,
+  Loader2,
+  PackageCheck,
+  Scale,
+  ShieldCheck,
+  Sparkles,
+  SquareTerminal,
+  TriangleAlert,
+  Wrench,
+} from "lucide-react";
+import type { ComponentType } from "react";
+
+import type { TryoutTimelineEvent } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+const MICRO = "font-mono text-2xs uppercase tracking-[0.22em]";
+const MONO = "font-mono text-2xs tracking-tight";
+
+/*
+ * The agent-at-work timeline.
+ *
+ * The backend already ships rich, typed events (tool_name, exit_code,
+ * duration_ms, path, provider_model_id, verdict, score) in `event.payload`.
+ * This module folds the raw started/completed/failed pairs into settled steps
+ * and renders them as a single connected spine — so a tryout reads like
+ * "here is what the agent actually did", not a raw event log.
+ */
+
+type NodeStatus = "running" | "done" | "failed";
+
+type StepKind =
+  | "setup"
+  | "plan"
+  | "tool"
+  | "command"
+  | "files"
+  | "validation"
+  | "scoring"
+  | "finished"
+  | "activity";
+
+export type TimelineNode = {
+  id: string;
+  kind: StepKind;
+  title: string;
+  /** Mono technical detail rendered beside the title (tool name, judge model). */
+  detail?: string;
+  status: NodeStatus;
+  at: number;
+  durationMs?: number;
+  files?: string[];
+  exitCode?: number;
+  verdict?: string;
+  score?: number;
+  /** Optional per-node icon override (e.g. the output-finalized moment). */
+  icon?: ComponentType<{ className?: string }>;
+};
+
+const ICONS: Record<StepKind, ComponentType<{ className?: string }>> = {
+  setup: Container,
+  plan: Sparkles,
+  tool: Wrench,
+  command: SquareTerminal,
+  files: FilePlus2,
+  validation: ShieldCheck,
+  scoring: Scale,
+  finished: Flag,
+  activity: Sparkles,
+};
+
+function str(payload: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = payload?.[key];
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function num(payload: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = payload?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function pathOf(payload: Record<string, unknown> | undefined): string | undefined {
+  return str(payload, "path") ?? str(payload, "file_path") ?? str(payload, "relative_path");
+}
+
+function lifecycleOf(summary: string): "start" | "end" | "fail" {
+  const s = summary.toLowerCase();
+  if (s.includes("fail")) return "fail";
+  if (/(started|planning|is grading|grading against)/.test(s)) return "start";
+  return "end";
+}
+
+function prettyVerdict(verdict: string): string {
+  return verdict.replace(/_/g, " ");
+}
+
+/** Humanize a snake/camel tool name into a readable label, keeping it honest. */
+function prettyTool(name: string): string {
+  return name.replace(/[._-]+/g, " ").replace(/([a-z])([A-Z])/g, "$1 $2").trim();
+}
+
+export function formatDuration(ms: number | undefined): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = Math.round(seconds % 60);
+  return `${mins}m ${rem}s`;
+}
+
+/**
+ * Fold the raw event stream into settled timeline nodes. Started/completed
+ * pairs collapse into one node; consecutive file writes roll up into a single
+ * "created files" group; everything keeps its real technical substance.
+ */
+export function foldTimeline(events: TryoutTimelineEvent[]): TimelineNode[] {
+  const nodes: TimelineNode[] = [];
+  const openByKind = new Map<StepKind, number>();
+
+  const open = (kind: StepKind, node: Omit<TimelineNode, "status">) => {
+    nodes.push({ ...node, status: "running" });
+    openByKind.set(kind, nodes.length - 1);
+  };
+
+  const close = (
+    kind: StepKind,
+    status: NodeStatus,
+    at: number,
+    patch: Partial<TimelineNode>,
+    fallbackTitle: string,
+  ) => {
+    const index = openByKind.get(kind);
+    if (index != null) {
+      const node = nodes[index];
+      node.status = status;
+      node.durationMs = patch.durationMs ?? (at - node.at >= 0 ? at - node.at : undefined);
+      if (patch.title) node.title = patch.title;
+      if (patch.detail) node.detail = patch.detail;
+      if (patch.exitCode != null) node.exitCode = patch.exitCode;
+      if (patch.verdict) node.verdict = patch.verdict;
+      if (patch.score != null) node.score = patch.score;
+      openByKind.delete(kind);
+    } else {
+      nodes.push({
+        id: patch.id ?? `n${nodes.length}`,
+        kind,
+        title: patch.title ?? fallbackTitle,
+        detail: patch.detail,
+        status,
+        at,
+        durationMs: patch.durationMs,
+        exitCode: patch.exitCode,
+        verdict: patch.verdict,
+        score: patch.score,
+      });
+    }
+  };
+
+  for (const event of events) {
+    const at = new Date(event.occurred_at).getTime();
+    const id = `e${event.cursor}`;
+    const payload = event.payload;
+    const life = lifecycleOf(event.summary);
+
+    switch (event.type) {
+      case "started":
+        nodes.push({ id, kind: "setup", title: "Spun up a fresh sandbox", status: "done", at });
+        break;
+
+      case "planning": {
+        const model = str(payload, "provider_model_id");
+        if (life === "start") {
+          open("plan", { id, kind: "plan", title: "Reasoning about the task", detail: model, at });
+        } else {
+          close("plan", "done", at, { detail: model, durationMs: num(payload, "duration_ms") }, "Reasoned about the task");
+        }
+        break;
+      }
+
+      case "tool_call": {
+        const tool = str(payload, "tool_name");
+        if (life === "start") {
+          open("tool", { id, kind: "tool", title: tool ? prettyTool(tool) : "Used a tool", detail: tool, at });
+        } else {
+          close(
+            "tool",
+            life === "fail" ? "failed" : "done",
+            at,
+            { detail: tool, durationMs: num(payload, "duration_ms"), title: tool ? prettyTool(tool) : undefined },
+            tool ? prettyTool(tool) : "Used a tool",
+          );
+        }
+        break;
+      }
+
+      case "sandbox_command": {
+        if (life === "start") {
+          open("command", { id, kind: "command", title: "Ran a shell command", at });
+        } else {
+          close(
+            "command",
+            life === "fail" ? "failed" : "done",
+            at,
+            { exitCode: num(payload, "exit_code"), durationMs: num(payload, "duration_ms") },
+            "Ran a shell command",
+          );
+        }
+        break;
+      }
+
+      case "file_written":
+      case "file_activity": {
+        const file = pathOf(payload);
+        const last = nodes[nodes.length - 1];
+        if (last && last.kind === "files" && last.status === "done") {
+          if (file && !last.files?.includes(file)) last.files = [...(last.files ?? []), file];
+          last.at = at;
+        } else {
+          nodes.push({
+            id,
+            kind: "files",
+            title: "Wrote files",
+            status: "done",
+            at,
+            files: file ? [file] : [],
+          });
+        }
+        break;
+      }
+
+      case "validation":
+        nodes.push({ id, kind: "validation", title: "Checked the output against rules", status: "done", at });
+        break;
+
+      case "scoring": {
+        const model = str(payload, "provider_model_id");
+        const verdict = str(payload, "verdict");
+        const score = num(payload, "score");
+        if (life === "start") {
+          open("scoring", { id, kind: "scoring", title: "Judge is grading against your bar", detail: model, at });
+        } else {
+          close(
+            "scoring",
+            "done",
+            at,
+            {
+              title: verdict ? "Judge reached a verdict" : "Scoring complete",
+              detail: model,
+              verdict,
+              score,
+              durationMs: num(payload, "duration_ms"),
+            },
+            "Scoring complete",
+          );
+        }
+        break;
+      }
+
+      case "finished":
+        nodes.push({
+          id,
+          kind: "finished",
+          title: event.summary.toLowerCase().includes("fail") ? "Run ended early" : "Run complete",
+          status: event.summary.toLowerCase().includes("fail") ? "failed" : "done",
+          at,
+        });
+        break;
+
+      default: {
+        const isFinal = /final/i.test(event.summary);
+        const title = isFinal ? "Finalized the outputs" : event.summary || "Working";
+        nodes.push({ id, kind: "activity", title, status: "done", at, icon: isFinal ? PackageCheck : undefined });
+      }
+    }
+  }
+
+  return nodes;
+}
+
+function statusTone(status: NodeStatus): string {
+  if (status === "failed") return "border-[#d97757]/40 text-[#e0a085]";
+  if (status === "running") return "border-white/35 text-white";
+  return "border-white/12 text-white/55";
+}
+
+function NodeIcon({ node }: { node: TimelineNode }) {
+  const Icon = node.icon ?? ICONS[node.kind];
+  return (
+    <span
+      className={cn(
+        "relative z-10 flex size-7 shrink-0 items-center justify-center rounded-full border bg-[#131312]",
+        statusTone(node.status),
+      )}
+    >
+      {node.status === "running" ? (
+        <>
+          <span className="absolute inline-flex size-7 animate-ping rounded-full bg-white/10 motion-reduce:hidden" />
+          <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+        </>
+      ) : node.kind === "finished" && node.status === "done" ? (
+        <Check className="size-3.5" />
+      ) : node.status === "failed" ? (
+        <TriangleAlert className="size-3.5" />
+      ) : (
+        <Icon className="size-3.5" />
+      )}
+    </span>
+  );
+}
+
+function fileName(path: string): string {
+  const parts = path.split("/");
+  return parts[parts.length - 1] || path;
+}
+
+function TimelineNodeRow({ node, isLast }: { node: TimelineNode; isLast: boolean }) {
+  const duration = formatDuration(node.durationMs);
+  const grade = node.score != null ? (1 + node.score * 4).toFixed(1) : null;
+  const singleFile = node.kind === "files" && node.files?.length === 1 ? node.files[0] : null;
+  const title =
+    node.kind === "files" && node.files && node.files.length > 0
+      ? node.files.length === 1
+        ? `Wrote ${fileName(node.files[0])}`
+        : `Wrote ${node.files.length} files`
+      : node.title;
+
+  return (
+    <li className="relative flex gap-3 pb-5 last:pb-0">
+      {!isLast ? (
+        <span aria-hidden className="absolute left-[13.5px] top-7 bottom-0 w-px bg-white/12" />
+      ) : null}
+      <NodeIcon node={node} />
+      <div className="min-w-0 flex-1 pt-0.5">
+        <div className="flex items-baseline justify-between gap-3">
+          <p
+            className={cn(
+              "text-sm leading-6",
+              node.status === "running" ? "text-white/90" : node.status === "failed" ? "text-[#e0a085]" : "text-white/75",
+            )}
+          >
+            {title}
+            {node.detail && node.detail !== title ? (
+              <span className={cn(MONO, "ml-2 align-middle text-white/40")}>{node.detail}</span>
+            ) : null}
+          </p>
+          {duration ? (
+            <span className={cn(MONO, "shrink-0 tabular-nums text-white/30")}>{duration}</span>
+          ) : null}
+        </div>
+
+        {node.exitCode != null ? (
+          <span
+            className={cn(
+              MONO,
+              "mt-1.5 inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5",
+              node.exitCode === 0
+                ? "border-white/12 text-white/45"
+                : "border-[#d97757]/40 text-[#e0a085]",
+            )}
+          >
+            exit {node.exitCode}
+          </span>
+        ) : null}
+
+        {node.verdict ? (
+          <div className="mt-2 flex items-center gap-2">
+            <span
+              className={cn(
+                MICRO,
+                "rounded-sm border px-2 py-1",
+                node.verdict === "approved"
+                  ? "border-white/30 text-white/85"
+                  : node.verdict === "rejected"
+                    ? "border-[#d97757]/40 text-[#e0a085]"
+                    : "border-white/15 text-white/55",
+              )}
+            >
+              {prettyVerdict(node.verdict)}
+            </span>
+            {grade ? <span className="text-xs text-white/40">{grade} / 5</span> : null}
+          </div>
+        ) : null}
+
+        {singleFile && singleFile.includes("/") ? (
+          <p className={cn(MONO, "mt-1 truncate text-white/30")} title={singleFile}>
+            {singleFile}
+          </p>
+        ) : null}
+
+        {node.files && node.files.length > 1 ? (
+          <ul className="mt-2 space-y-1">
+            {node.files.map((file) => (
+              <li key={file} className="flex items-baseline gap-2 text-xs text-white/45">
+                <span className="size-1 shrink-0 translate-y-1 rounded-full bg-white/25" aria-hidden />
+                <span className={cn(MONO, "shrink-0 text-white/55")} title={file}>
+                  {fileName(file)}
+                </span>
+                {file.includes("/") ? (
+                  <span className="truncate text-2xs text-white/25">{file}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export function RunTimeline({
+  events,
+  active,
+  thinkingLabel,
+}: {
+  events: TryoutTimelineEvent[];
+  active?: boolean;
+  thinkingLabel?: string | null;
+}) {
+  const nodes = foldTimeline(events);
+
+  if (active && !nodes.some((node) => node.status === "running")) {
+    nodes.push({
+      id: "live",
+      kind: "activity",
+      title: thinkingLabel || "Working",
+      status: "running",
+      at: Number.MAX_SAFE_INTEGER,
+    });
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="flex items-center gap-2 py-1 text-sm text-white/45">
+        <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+        {thinkingLabel || "Waiting for the agent…"}
+      </div>
+    );
+  }
+
+  return (
+    <ol className="relative">
+      {nodes.map((node, index) => (
+        <TimelineNodeRow key={node.id} node={node} isLast={index === nodes.length - 1} />
+      ))}
+    </ol>
+  );
+}

--- a/web/src/app/tryouts/run-timeline.tsx
+++ b/web/src/app/tryouts/run-timeline.tsx
@@ -119,11 +119,16 @@ export function formatDuration(ms: number | undefined): string | null {
  */
 export function foldTimeline(events: TryoutTimelineEvent[]): TimelineNode[] {
   const nodes: TimelineNode[] = [];
-  const openByKind = new Map<StepKind, number>();
+  // Per-kind queue of indices for nodes still "running" — a queue, not a single
+  // slot, so interleaved/parallel events of the same kind (e.g. concurrent tool
+  // calls) don't strand the earlier node at status "running" forever.
+  const openByKind = new Map<StepKind, number[]>();
 
   const open = (kind: StepKind, node: Omit<TimelineNode, "status">) => {
     nodes.push({ ...node, status: "running" });
-    openByKind.set(kind, nodes.length - 1);
+    const queue = openByKind.get(kind);
+    if (queue) queue.push(nodes.length - 1);
+    else openByKind.set(kind, [nodes.length - 1]);
   };
 
   const close = (
@@ -133,7 +138,21 @@ export function foldTimeline(events: TryoutTimelineEvent[]): TimelineNode[] {
     patch: Partial<TimelineNode>,
     fallbackTitle: string,
   ) => {
-    const index = openByKind.get(kind);
+    // Match the completing event to an open node of the same kind — prefer one
+    // whose detail (e.g. tool name) matches, otherwise close the oldest. Either
+    // way the slot is consumed, so no node is left stranded as "running".
+    const queue = openByKind.get(kind);
+    let index: number | undefined;
+    if (queue && queue.length > 0) {
+      let pick = 0;
+      if (patch.detail) {
+        const matched = queue.findIndex((openIndex) => nodes[openIndex].detail === patch.detail);
+        if (matched >= 0) pick = matched;
+      }
+      index = queue[pick];
+      queue.splice(pick, 1);
+      if (queue.length === 0) openByKind.delete(kind);
+    }
     if (index != null) {
       const node = nodes[index];
       node.status = status;
@@ -143,7 +162,6 @@ export function foldTimeline(events: TryoutTimelineEvent[]): TimelineNode[] {
       if (patch.exitCode != null) node.exitCode = patch.exitCode;
       if (patch.verdict) node.verdict = patch.verdict;
       if (patch.score != null) node.score = patch.score;
-      openByKind.delete(kind);
     } else {
       nodes.push({
         id: patch.id ?? `n${nodes.length}`,

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -17,7 +17,6 @@ import {
   ChevronDown,
   Download,
   FileText,
-  Gauge,
   ListChecks,
   Loader2,
   Paperclip,
@@ -45,6 +44,7 @@ import type {
   AgentTryoutJudgeStrictness,
   AgentTryoutModelPolicy,
   AgentTryoutTemplate,
+  TryoutCoachingSuggestion,
   TryoutTimelineEvent,
 } from "@/lib/api/types";
 import {
@@ -74,6 +74,11 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+
+import { AgentDesigner, type AgentDraft, type AgentTool } from "./agent-designer";
+import { CoachCard } from "./coach-card";
+import { DeltaCard } from "./delta-card";
+import { RunTimeline } from "./run-timeline";
 
 // Analytics helpers for the public tryouts funnel. Privacy: derive email_domain
 // only — never send raw email or company name to PostHog.
@@ -264,7 +269,18 @@ type RerunPrefill = {
   judgeModel?: string;
   judgeStrictness?: AgentTryoutJudgeStrictness;
   selectedModelKey?: string;
+  agentInstructions?: string;
+  agentToolSlugs?: string[];
+  agentName?: string;
 };
+
+// Turn a tool-library description into a short blurb for the abilities picker.
+function toolBlurb(description?: string): string | undefined {
+  if (!description) return undefined;
+  const first = description.split(/[.\n]/)[0]?.trim();
+  if (!first) return undefined;
+  return first.length > 48 ? `${first.slice(0, 46)}…` : first;
+}
 
 function readRerunPrefill(): RerunPrefill | null {
   if (typeof window === "undefined") return null;
@@ -284,6 +300,95 @@ function writeRerunPrefill(prefill: RerunPrefill) {
   } catch {
     // best-effort
   }
+}
+
+// The user-authored agent (prompt + tools + name) lives under input_snapshot.agent_design.
+function readAgentDesign(input: unknown): {
+  name?: string;
+  instructions?: string;
+  tool_slugs?: string[];
+} {
+  if (!input || typeof input !== "object") return {};
+  const design = (input as { agent_design?: unknown }).agent_design;
+  if (!design || typeof design !== "object") return {};
+  const record = design as Record<string, unknown>;
+  return {
+    name: typeof record.name === "string" ? record.name : undefined,
+    instructions: typeof record.instructions === "string" ? record.instructions : undefined,
+    tool_slugs: Array.isArray(record.tool_slugs)
+      ? record.tool_slugs.filter((slug): slug is string => typeof slug === "string")
+      : undefined,
+  };
+}
+
+// Rebuild the welcome-screen state from a finished tryout so a re-run keeps the
+// same task, bar, model, and agent design — only the edited dimension changes.
+function buildRerunPrefill(tryout: AgentTryout, judge: TryoutJudgeSection): RerunPrefill {
+  const fieldValues: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tryout.input_snapshot ?? {})) {
+    if (key === "eval_setup" || key === "agent_design") continue;
+    if (typeof value === "string") fieldValues[key] = value;
+    else if (typeof value === "number") fieldValues[key] = String(value);
+  }
+  const setup = evalSetupFromInput(tryout.input_snapshot);
+  const design = readAgentDesign(tryout.input_snapshot);
+  return {
+    templateSlug: tryout.template_slug,
+    fieldValues,
+    evalSetup: setup
+      ? {
+          unacceptableMistakes: setup.unacceptable_mistakes,
+          reviewer: setup.human_reviewer,
+          priority: setup.business_priority,
+          style: setup.output_style,
+          monthlyVolume: setup.monthly_volume,
+        }
+      : undefined,
+    selectedModelKey: modelKeyFromPolicy(tryout.selected_model_policy),
+    judgeModel: judge.model,
+    judgeStrictness:
+      judge.strictness === "lenient" || judge.strictness === "harsh"
+        ? judge.strictness
+        : "standard",
+    agentInstructions: design.instructions,
+    agentToolSlugs: design.tool_slugs,
+    agentName: design.name,
+  };
+}
+
+// Carries the previous run's verdict across the re-run handoff so the next
+// session can render the before/after delta once it finishes.
+const COMPARISON_STORAGE_KEY = "agentclash.tryout.comparison";
+
+type TryoutComparison = {
+  beforeVerdict?: TryoutJudgeSection["verdict"];
+  beforeGrade?: number | null;
+  changes?: string[];
+};
+
+function writeComparison(comparison: TryoutComparison) {
+  try {
+    window.sessionStorage.setItem(COMPARISON_STORAGE_KEY, JSON.stringify(comparison));
+  } catch {
+    // best-effort
+  }
+}
+
+function readComparison(): TryoutComparison | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(COMPARISON_STORAGE_KEY);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(COMPARISON_STORAGE_KEY);
+    return JSON.parse(raw) as TryoutComparison;
+  } catch {
+    return null;
+  }
+}
+
+function judgeGrade(judge: TryoutJudgeSection | null | undefined): number | null {
+  if (!judge || judge.score == null) return null;
+  return 1 + judge.score * 4;
 }
 
 function agentLabel(value: string): string {
@@ -342,6 +447,10 @@ export function PublicTryoutsClient() {
     useState<AgentTryoutJudgeStrictness>("standard");
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [evalSetup, setEvalSetup] = useState<EvalSetupValues>(DEFAULT_EVAL_SETUP);
+  const [agentName, setAgentName] = useState("");
+  const [agentInstructions, setAgentInstructions] = useState("");
+  const [agentToolSlugs, setAgentToolSlugs] = useState<string[]>([]);
+  const [toolLibrary, setToolLibrary] = useState<AgentTool[]>([]);
   const prefillRef = useRef<RerunPrefill | null>(null);
 
   // Apply a rerun handoff (same brief, different agent/judge) exactly once.
@@ -358,7 +467,37 @@ export function PublicTryoutsClient() {
     if (prefill.judgeStrictness) setJudgeStrictness(prefill.judgeStrictness);
     if (prefill.selectedModelKey) setSelectedModelKey(prefill.selectedModelKey);
     if (prefill.fieldValues) setFieldValues(prefill.fieldValues);
+    if (prefill.agentInstructions !== undefined) setAgentInstructions(prefill.agentInstructions);
+    if (prefill.agentToolSlugs) setAgentToolSlugs(prefill.agentToolSlugs);
+    if (prefill.agentName !== undefined) setAgentName(prefill.agentName);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Tool library powers the "abilities" picker in the agent designer. Public,
+  // best-effort — if it fails the picker just stays empty.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get<{ items: Array<{ slug: string; name: string; category?: string; description?: string }> }>(
+        "/v1/tool-library",
+      )
+      .then((data) => {
+        if (cancelled) return;
+        setToolLibrary(
+          (data.items ?? []).map((entry) => ({
+            slug: entry.slug,
+            name: entry.name,
+            category: entry.category || "Tools",
+            blurb: toolBlurb(entry.description),
+          })),
+        );
+      })
+      .catch(() => {
+        // best-effort — the abilities picker simply stays empty.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
   const [templatesLoading, setTemplatesLoading] = useState(true);
   const [launching, setLaunching] = useState(false);
@@ -589,6 +728,9 @@ export function PublicTryoutsClient() {
         ...(selectedModel.value ? { selected_harness_kind: selectedModel.value } : {}),
         ...(selectedPolicy ? { selected_model_policy: selectedPolicy } : {}),
         judge: { model: judgeModel, strictness: judgeStrictness },
+        ...(agentInstructions.trim() ? { agent_instructions: agentInstructions.trim() } : {}),
+        ...(agentToolSlugs.length > 0 ? { agent_tool_slugs: agentToolSlugs } : {}),
+        ...(agentName.trim() ? { agent_name: agentName.trim() } : {}),
       };
       let nextTryout: AgentTryout;
       try {
@@ -713,8 +855,6 @@ export function PublicTryoutsClient() {
           templates={templates}
           templateSlug={templateSlug}
           setTemplateSlug={setTemplateSlug}
-          selectedModelKey={selectedModelKey}
-          setSelectedModelKey={setSelectedModelKey}
           judgeModel={judgeModel}
           setJudgeModel={setJudgeModel}
           judgeStrictness={judgeStrictness}
@@ -739,6 +879,19 @@ export function PublicTryoutsClient() {
           fileInputRef={fileInputRef}
           onAttachFiles={handleAttachFiles}
           onRemoveAttachment={removeAttachment}
+          agentDraft={{
+            name: agentName,
+            instructions: agentInstructions,
+            toolSlugs: agentToolSlugs,
+            modelKey: selectedModelKey,
+          }}
+          onAgentDraftChange={(next) => {
+            setAgentName(next.name);
+            setAgentInstructions(next.instructions);
+            setAgentToolSlugs(next.toolSlugs);
+            setSelectedModelKey(next.modelKey);
+          }}
+          tools={toolLibrary}
         />
       )}
     </main>
@@ -750,8 +903,6 @@ function TryoutWelcome({
   templates,
   templateSlug,
   setTemplateSlug,
-  selectedModelKey,
-  setSelectedModelKey,
   judgeModel,
   setJudgeModel,
   judgeStrictness,
@@ -776,13 +927,14 @@ function TryoutWelcome({
   fileInputRef,
   onAttachFiles,
   onRemoveAttachment,
+  agentDraft,
+  onAgentDraftChange,
+  tools,
 }: {
   template: AgentTryoutTemplate | null;
   templates: AgentTryoutTemplate[];
   templateSlug: string;
   setTemplateSlug: (value: string) => void;
-  selectedModelKey: string;
-  setSelectedModelKey: (value: string) => void;
   judgeModel: string;
   setJudgeModel: (value: string) => void;
   judgeStrictness: AgentTryoutJudgeStrictness;
@@ -810,14 +962,16 @@ function TryoutWelcome({
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   onAttachFiles: (files: FileList | null) => void;
   onRemoveAttachment: (id: string) => void;
+  agentDraft: AgentDraft;
+  onAgentDraftChange: (next: AgentDraft) => void;
+  tools: AgentTool[];
 }) {
   const [barOpen, setBarOpen] = useState(false);
   // True when the bar dialog was opened by a send attempt: confirming the bar
   // should immediately launch the run instead of dropping back to the page.
   const [launchAfterBar, setLaunchAfterBar] = useState(false);
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  function attemptLaunch() {
     if (!canRun) return;
     if (!evalReady) {
       setLaunchAfterBar(true);
@@ -826,6 +980,17 @@ function TryoutWelcome({
     }
     onLaunch();
   }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    attemptLaunch();
+  }
+
+  const designerModels = MODEL_OPTIONS.map((option) => ({
+    key: modelOptionKey(option),
+    label: option.label,
+    hint: option.hint,
+  }));
 
   return (
     <div className="relative min-h-0 flex-1 overflow-y-auto">
@@ -907,15 +1072,6 @@ function TryoutWelcome({
                   options={templates.map((t) => ({ value: t.slug, label: t.name }))}
                 />
                 <AnimatedPillSelect
-                  icon={<Gauge className="size-3.5" />}
-                  value={selectedModelKey}
-                  onChange={setSelectedModelKey}
-                  options={MODEL_OPTIONS.map((option) => ({
-                    value: modelOptionKey(option),
-                    label: option.label,
-                  }))}
-                />
-                <AnimatedPillSelect
                   icon={<Scale className="size-3.5" />}
                   value={judgeModel}
                   onChange={setJudgeModel}
@@ -979,6 +1135,18 @@ function TryoutWelcome({
             </div>
           ) : null}
         </form>
+
+        <div className="mt-6">
+          <AgentDesigner
+            value={agentDraft}
+            onChange={onAgentDraftChange}
+            tools={tools}
+            models={designerModels}
+            taskLabel={template?.name}
+            onRun={attemptLaunch}
+            running={launching}
+          />
+        </div>
       </div>
 
       <BarDialog
@@ -1318,31 +1486,7 @@ function TryoutSidebar({
         </div>
       ) : null}
 
-      <div className="mt-5 flex min-h-0 flex-1 flex-col px-1">
-        <p className={cn(MICRO, "mb-3 text-white/35")}>Raw event log</p>
-        <ol className="ml-1 min-h-0 flex-1 space-y-3 overflow-y-auto border-l border-white/10 pl-4">
-          {events.length === 0 ? (
-            <li className="text-xs text-white/40">
-              {tryoutIsActive(tryout.status)
-                ? "Waiting for events…"
-                : "No events recorded."}
-            </li>
-          ) : (
-            events.map((event) => (
-              <li key={event.cursor} className="relative">
-                <span
-                  aria-hidden
-                  className="absolute -left-[19px] top-[5px] size-[5px] rounded-full bg-white/25"
-                />
-                <p className="text-xs leading-5 text-white/60">{event.summary}</p>
-                <time className="mt-0.5 block font-mono text-2xs uppercase tracking-[0.1em] text-white/25">
-                  {new Date(event.occurred_at).toLocaleTimeString()}
-                </time>
-              </li>
-            ))
-          )}
-        </ol>
-      </div>
+      <div className="min-h-0 flex-1" />
 
       <Link
         href={loginHref}
@@ -1376,6 +1520,9 @@ function TryoutChatThread({
   const [ending, setEnding] = useState(false);
   const [followUps, setFollowUps] = useState<{ id: string; text: string; at: number }[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const [comparison] = useState(() => readComparison());
+  const [appliedIds, setAppliedIds] = useState<string[]>([]);
 
   const active = tryoutIsActive(tryout.status);
   const finished = !active;
@@ -1395,54 +1542,62 @@ function TryoutChatThread({
     [tryout.input_snapshot],
   );
 
-  const timeline = useMemo(() => {
-    const items: ChatItem[] = [];
-
+  const userMessages = useMemo(() => {
+    const msgs: { id: string; text: string; at: number }[] = [];
     if (initialUserText) {
-      items.push({
-        kind: "user",
+      msgs.push({
         id: "initial",
         text: initialUserText,
         at: new Date(tryout.created_at).getTime(),
       });
     }
-
     for (const msg of followUps) {
-      items.push({
-        kind: "user",
-        id: msg.id,
-        text: msg.text,
+      msgs.push({ id: msg.id, text: msg.text, at: msg.at });
+    }
+    return msgs;
+  }, [initialUserText, followUps, tryout.created_at]);
+
+  // Interleave user turns with the agent's events on a single timeline, then
+  // group consecutive events into agent segments. Each agent segment renders as
+  // a RunTimeline so the trace reads as "what the agent did", not a flat log.
+  const segments = useMemo(() => {
+    const merged = [
+      ...userMessages.map((msg, index) => ({
         at: msg.at,
-      });
-    }
-
-    for (const event of events) {
-      if (event.type === "started") continue;
-      items.push({
-        kind: "agent",
-        id: `e${event.cursor}`,
-        text: friendlyTraceSummary(event),
+        seq: index - 1_000_000,
+        user: msg as { id: string; text: string; at: number } | undefined,
+        event: undefined as TryoutTimelineEvent | undefined,
+      })),
+      ...events.map((event) => ({
         at: new Date(event.occurred_at).getTime(),
-      });
-    }
+        seq: event.sequence,
+        user: undefined as { id: string; text: string; at: number } | undefined,
+        event: event as TryoutTimelineEvent | undefined,
+      })),
+    ].sort((a, b) => a.at - b.at || a.seq - b.seq);
 
-    return items.sort((a, b) => a.at - b.at);
-  }, [initialUserText, followUps, events, tryout.created_at]);
-
-  const blocks = useMemo(() => {
-    const out: ChatBlock[] = [];
-    for (const item of timeline) {
-      const last = out[out.length - 1];
-      if (item.kind === "user") {
-        out.push({ kind: "user", item });
-      } else if (last?.kind === "steps") {
-        last.items.push(item);
-      } else {
-        out.push({ kind: "steps", id: item.id, items: [item] });
+    const out: TryoutSegment[] = [];
+    for (const entry of merged) {
+      if (entry.user) {
+        out.push({ kind: "user", id: entry.user.id, text: entry.user.text });
+      } else if (entry.event) {
+        const last = out[out.length - 1];
+        if (last?.kind === "agent") {
+          last.events.push(entry.event);
+        } else {
+          out.push({ kind: "agent", id: `seg-${entry.event.cursor}`, events: [entry.event] });
+        }
       }
     }
     return out;
-  }, [timeline]);
+  }, [userMessages, events]);
+
+  const lastAgentIndex = useMemo(() => {
+    for (let i = segments.length - 1; i >= 0; i -= 1) {
+      if (segments[i].kind === "agent") return i;
+    }
+    return -1;
+  }, [segments]);
 
   const lastEvent = events[events.length - 1];
   const judging =
@@ -1455,13 +1610,11 @@ function TryoutChatThread({
         ? null
         : events.length === 0
           ? "Starting"
-          : timeline[timeline.length - 1]?.kind === "agent"
-            ? "Working"
-            : null;
+          : "Working";
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [timeline.length, outputs.length, scorecard, finished]);
+  }, [segments.length, outputs.length, scorecard, finished]);
 
   async function send() {
     const text = draft.trim();
@@ -1501,28 +1654,57 @@ function TryoutChatThread({
     }
   }
 
+  // Apply a coaching fix: carry the edited agent design + the current verdict
+  // into a fresh run via the prefill funnel, so the next session shows the delta.
+  function applyCoaching(suggestion: TryoutCoachingSuggestion) {
+    if (!scorecard?.judge) return;
+    const design = readAgentDesign(tryout.input_snapshot);
+    const instructions =
+      suggestion.kind === "prompt" && suggestion.proposed_instructions
+        ? suggestion.proposed_instructions
+        : design.instructions;
+    const toolSlugs =
+      suggestion.kind === "tool" && suggestion.add_tool_slugs
+        ? Array.from(new Set([...(design.tool_slugs ?? []), ...suggestion.add_tool_slugs]))
+        : design.tool_slugs;
+    writeRerunPrefill({
+      ...buildRerunPrefill(tryout, scorecard.judge),
+      agentInstructions: instructions,
+      agentToolSlugs: toolSlugs,
+    });
+    writeComparison({
+      beforeVerdict: scorecard.judge.verdict,
+      beforeGrade: judgeGrade(scorecard.judge),
+      changes: [suggestion.title],
+    });
+    setAppliedIds((prev) => [...prev, suggestion.id]);
+    router.push("/tryouts");
+  }
+
   return (
     <>
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-6 sm:px-8">
         <div className="mx-auto flex max-w-3xl flex-col gap-5">
-          {blocks.map((block, index) =>
-            block.kind === "user" ? (
+          {segments.map((segment, index) =>
+            segment.kind === "user" ? (
               <UserBubble
-                key={block.item.id}
-                text={block.item.text}
-                animate={index === blocks.length - 1}
+                key={segment.id}
+                text={segment.text}
+                animate={index === segments.length - 1}
               />
             ) : (
-              <TraceBlock
-                key={block.id}
-                items={block.items}
-                thinking={index === blocks.length - 1 ? thinkingLabel : null}
+              <RunTimeline
+                key={segment.id}
+                events={segment.events}
+                active={active && index === lastAgentIndex}
+                thinkingLabel={index === lastAgentIndex ? thinkingLabel : null}
               />
             ),
           )}
 
-          {thinkingLabel && blocks[blocks.length - 1]?.kind !== "steps" ? (
-            <TraceBlock items={[]} thinking={thinkingLabel} />
+          {thinkingLabel &&
+          (segments.length === 0 || segments[segments.length - 1]?.kind === "user") ? (
+            <RunTimeline events={[]} active thinkingLabel={thinkingLabel} />
           ) : null}
 
           {outputs
@@ -1540,6 +1722,34 @@ function TryoutChatThread({
           {scorecard && finished ? (
             <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
               <VerdictCard scorecard={scorecard} />
+            </div>
+          ) : null}
+
+          {finished && comparison && scorecard?.judge ? (
+            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
+              <DeltaCard
+                before={{
+                  label: "Your last agent",
+                  verdict: comparison.beforeVerdict,
+                  grade: comparison.beforeGrade ?? null,
+                }}
+                after={{
+                  label: "This agent",
+                  verdict: scorecard.judge.verdict,
+                  grade: judgeGrade(scorecard.judge),
+                }}
+                changes={comparison.changes}
+              />
+            </div>
+          ) : null}
+
+          {finished && tryout.summary.coaching ? (
+            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
+              <CoachCard
+                coaching={tryout.summary.coaching}
+                appliedIds={appliedIds}
+                onApply={applyCoaching}
+              />
             </div>
           ) : null}
 
@@ -1613,16 +1823,9 @@ function TryoutChatThread({
   );
 }
 
-type ChatItem = {
-  kind: "user" | "agent";
-  id: string;
-  text: string;
-  at: number;
-};
-
-type ChatBlock =
-  | { kind: "user"; item: ChatItem }
-  | { kind: "steps"; id: string; items: ChatItem[] };
+type TryoutSegment =
+  | { kind: "user"; id: string; text: string }
+  | { kind: "agent"; id: string; events: TryoutTimelineEvent[] };
 
 function UserBubble({ text, animate }: { text: string; animate?: boolean }) {
   return (
@@ -1640,44 +1843,6 @@ function UserBubble({ text, animate }: { text: string; animate?: boolean }) {
   );
 }
 
-function TraceBlock({
-  items,
-  thinking,
-}: {
-  items: ChatItem[];
-  thinking?: string | null;
-}) {
-  return (
-    <div className="ml-1 border-l border-white/10 py-0.5 pl-5">
-      <div className="flex flex-col gap-2.5">
-        {items.map((item) => (
-          <div
-            key={item.id}
-            className="relative text-sm leading-6 text-white/55 animate-in fade-in duration-300 motion-reduce:animate-none"
-          >
-            <span
-              aria-hidden
-              className="absolute -left-[23px] top-[9.5px] size-[5px] rounded-full bg-white/30"
-            />
-            <span className="whitespace-pre-wrap">{item.text}</span>
-          </div>
-        ))}
-        {thinking ? (
-          <div className="relative flex h-6 items-center animate-in fade-in duration-300 motion-reduce:animate-none">
-            <span
-              aria-hidden
-              className="absolute -left-[24.5px] flex size-2"
-            >
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-white/25 motion-reduce:animate-none" />
-              <span className="relative inline-flex size-2 rounded-full bg-white/45" />
-            </span>
-            <span className={cn(MICRO, "text-white/35")}>{thinking}</span>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 function ArtifactChatCard({ output }: { output: TryoutOutputPreview }) {
   const label = output.relative_path || output.key || "Artifact";
@@ -1748,12 +1913,22 @@ function ArtifactPreviewBody({ output }: { output: TryoutOutputPreview }) {
   }
 
   if (isBinaryArtifact(output)) {
+    const sizeLabel =
+      typeof output.size_bytes === "number"
+        ? `${Math.max(1, Math.round(output.size_bytes / 1024))} KB`
+        : null;
     return (
-      <div className="px-4 py-6 text-sm leading-7 text-white/60">
-        <p>
-          {artifactKindLabel(output)} ready. Download to open it in PowerPoint, Keynote, or
-          Preview.
-        </p>
+      <div className="flex items-center gap-3 bg-black/20 px-4 py-5">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-md border border-white/12 bg-white/[0.03]">
+          <FileText className="size-5 text-white/55" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm text-white/80">{artifactKindLabel(output)} ready</p>
+          <p className="truncate text-2xs text-white/40">
+            {output.relative_path || "output"}
+            {sizeLabel ? ` · ${sizeLabel}` : ""} · download to open
+          </p>
+        </div>
       </div>
     );
   }
@@ -2096,37 +2271,8 @@ function RerunStrip({
 }) {
   const router = useRouter();
 
-  function basePrefill(): RerunPrefill {
-    const fieldValues: Record<string, string> = {};
-    for (const [key, value] of Object.entries(tryout.input_snapshot ?? {})) {
-      if (key === "eval_setup") continue;
-      if (typeof value === "string") fieldValues[key] = value;
-      else if (typeof value === "number") fieldValues[key] = String(value);
-    }
-    const setup = evalSetupFromInput(tryout.input_snapshot);
-    return {
-      templateSlug: tryout.template_slug,
-      fieldValues,
-      evalSetup: setup
-        ? {
-            unacceptableMistakes: setup.unacceptable_mistakes,
-            reviewer: setup.human_reviewer,
-            priority: setup.business_priority,
-            style: setup.output_style,
-            monthlyVolume: setup.monthly_volume,
-          }
-        : undefined,
-      selectedModelKey: modelKeyFromPolicy(tryout.selected_model_policy),
-      judgeModel: judge.model,
-      judgeStrictness:
-        judge.strictness === "lenient" || judge.strictness === "harsh"
-          ? judge.strictness
-          : "standard",
-    };
-  }
-
   function rerun(overrides: Partial<RerunPrefill>) {
-    writeRerunPrefill({ ...basePrefill(), ...overrides });
+    writeRerunPrefill({ ...buildRerunPrefill(tryout, judge), ...overrides });
     router.push("/tryouts");
   }
 
@@ -2648,30 +2794,6 @@ function priorityRubricChecks(priority: EvalPriority): string[] {
 
 function styleLabel(style: EvalStyle): string {
   return STYLE_OPTIONS.find((option) => option.value === style)?.label ?? "Same every time";
-}
-
-function friendlyTraceSummary(event: TryoutTimelineEvent): string {
-  const summary = event.summary.trim();
-  const lower = summary.toLowerCase();
-  switch (event.type) {
-    case "planning":
-      return "Planned the next step";
-    case "tool_call":
-      return lower.includes("complete") ? "Finished a tool step" : "Used a tool";
-    case "sandbox_command":
-      return lower.includes("soffice") || lower.includes("libreoffice")
-        ? "Exported the deck preview"
-        : "Ran a sandbox command";
-    case "file_written":
-    case "file_activity":
-      return summary.replace(/^wrote file:?/i, "Created").replace(/^file written:?/i, "Created");
-    case "validation":
-      return "Checked the output against validators";
-    case "scoring":
-      return summary.startsWith("Judge") ? summary : "Updated the eval scorecard";
-    default:
-      return summary || "Working";
-  }
 }
 
 const FIELD_LABELS: Record<string, string> = {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2701,7 +2701,32 @@ export interface AgentTryout {
 export interface AgentTryoutSummary {
   code?: string;
   message?: string;
+  coaching?: TryoutCoaching;
   [key: string]: unknown;
+}
+
+/** A user-authored agent design, stashed in input_snapshot.agent_design. */
+export interface TryoutAgentDesign {
+  name?: string;
+  instructions?: string;
+  tool_slugs?: string[];
+}
+
+export type TryoutCoachingKind = "prompt" | "tool" | "model";
+
+export interface TryoutCoachingSuggestion {
+  id: string;
+  title: string;
+  detail: string;
+  kind: TryoutCoachingKind;
+  /** Full revised instructions to apply, for kind === "prompt". */
+  proposed_instructions?: string;
+  /** Tool slugs to add to the agent, for kind === "tool". */
+  add_tool_slugs?: string[];
+}
+
+export interface TryoutCoaching {
+  suggestions: TryoutCoachingSuggestion[];
 }
 
 export type TryoutTimelineEventType =
@@ -2774,10 +2799,21 @@ export interface CreateAgentTryoutInput {
   selected_harness_kind?: AgentHarnessKind;
   selected_model_policy?: AgentTryoutModelPolicy;
   judge?: AgentTryoutJudgeSelection;
+  /** User-authored agent design (the system prompt that drives the run). */
+  agent_instructions?: string;
+  /** Tool-library slugs the agent is allowed to use. */
+  agent_tool_slugs?: string[];
+  /** Cosmetic name for the agent. */
+  agent_name?: string;
 }
 
 export interface RerunAgentTryoutInput {
-  selected_model_policy: AgentTryoutModelPolicy;
+  /** Optional: vary the model. Omit to keep the source model. */
+  selected_model_policy?: AgentTryoutModelPolicy;
+  /** Optional: vary the agent design so the re-run is attributable to the edit. */
+  agent_instructions?: string;
+  agent_tool_slugs?: string[];
+  agent_name?: string;
 }
 
 export interface PromoteAgentTryoutInput {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2810,7 +2810,12 @@ export interface CreateAgentTryoutInput {
 export interface RerunAgentTryoutInput {
   /** Optional: vary the model. Omit to keep the source model. */
   selected_model_policy?: AgentTryoutModelPolicy;
-  /** Optional: vary the agent design so the re-run is attributable to the edit. */
+  /**
+   * Must be true for the agent-design fields below to take effect. When false or
+   * omitted, the re-run inherits the source tryout's agent design unchanged.
+   */
+  agent_design_provided?: boolean;
+  /** Applied only when agent_design_provided is true. */
   agent_instructions?: string;
   agent_tool_slugs?: string[];
   agent_name?: string;


### PR DESCRIPTION
## What & why

`/tryouts` was a passive "watch an agent run" demo with a raw event log, locked
templates, and invisible outputs. This rebuilds it into the core loop that
shows *why evals matter*: **design an agent → watch it work → get judged → get
coached → re-run → see the score jump.**

## The loop

1. **Design your agent** — author the system prompt, pick abilities from the
   tool library, choose a model (`agent-designer.tsx`, wired into the welcome).
2. **Watch it work** — a real "agent at work" timeline built from the structured
   event payload the API already shipped: tool names, exit codes, durations,
   grouped file writes, the verdict. Replaces the "Raw event log" and the vague
   summary bubbles (`run-timeline.tsx`).
3. **Verdict + coaching** — the worker turns the judge's verdict + per-criterion
   reasoning into applyable fixes, stored in `summary.coaching`. The coach card
   surfaces them; **Apply** carries the edited agent + the current verdict into a
   fresh run (`coach-card.tsx`).
4. **Before/after delta** — the follow-up run shows the jump, e.g. `Rejected 2.0
   → Approved 4.5` (`delta-card.tsx`).

## Backend

- Anonymous create + re-run accept a user-authored agent design (instructions +
  tools + name), stored under `input_snapshot.agent_design` (**no migration**)
  and merged into the task prompt. Tool kinds recorded on `tool_policy`
  best-effort (the sandbox CLIs use their own tools, so the prompt is the lever).
- LLM coach runs in the worker after scoring; best-effort, omitted on failure.
- OpenAPI updated for the new fields + the coaching shape.

## Verification

- Backend: `go build` / `go vet` / `go test -short -race` all green.
- Web: `tsc --noEmit` clean, `eslint` clean (2 pre-existing warnings unrelated),
  production `pnpm build` succeeds.
- Components verified rendering in a throwaway preview route (removed before commit).
- Not exercised end-to-end against a live sandbox/worker locally (no E2B stack
  here) — the create/coaching contract is type-matched across both sides.
