### PR TITLE
fix(tryouts): collapse the agent designer into the composer so it's one box

### DIFF
--- a/web/src/app/tryouts/agent-designer.tsx
+++ b/web/src/app/tryouts/agent-designer.tsx
@@ -92,6 +92,7 @@ export function AgentDesigner({
   taskLabel,
   onRun,
   running,
+  bare,
 }: {
   value: AgentDraft;
   onChange: (next: AgentDraft) => void;
@@ -100,6 +101,11 @@ export function AgentDesigner({
   taskLabel?: string;
   onRun?: () => void;
   running?: boolean;
+  /**
+   * Render without an outer card border/background so the designer can sit
+   * inside another container (e.g. the tryout composer) as one unified box.
+   */
+  bare?: boolean;
 }) {
   const grouped = tools.reduce<Record<string, AgentTool[]>>((acc, tool) => {
     (acc[tool.category] ??= []).push(tool);
@@ -115,10 +121,24 @@ export function AgentDesigner({
     onChange({ ...value, toolSlugs: [...next] });
   };
 
+  const padX = bare ? "px-2 sm:px-3" : "px-5 sm:px-6";
+
   return (
-    <div className="rounded-lg border border-white/10 bg-white/[0.015]">
+    <div
+      className={cn(
+        bare
+          ? "border-t border-white/[0.07]"
+          : "rounded-lg border border-white/10 bg-white/[0.015]",
+      )}
+    >
       {/* Identity header */}
-      <div className="flex items-center gap-3 border-b border-white/[0.07] px-5 py-4 sm:px-6">
+      <div
+        className={cn(
+          "flex items-center gap-3",
+          padX,
+          bare ? "pb-2 pt-3" : "border-b border-white/[0.07] py-4",
+        )}
+      >
         <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-white/15 bg-white/[0.04]">
           <Bot className="size-4 text-white/70" />
         </span>
@@ -135,7 +155,7 @@ export function AgentDesigner({
         </div>
       </div>
 
-      <div className="space-y-6 px-5 py-5 sm:px-6">
+      <div className={cn("space-y-6", padX, bare ? "pb-3 pt-1" : "py-5")}>
         {/* System prompt — the centerpiece */}
         <div>
           <Label hint="read before every run">Instructions</Label>

--- a/web/src/app/tryouts/agent-designer.tsx
+++ b/web/src/app/tryouts/agent-designer.tsx
@@ -146,6 +146,12 @@ export function AgentDesigner({
           <input
             value={value.name}
             onChange={(event) => onChange({ ...value, name: event.target.value })}
+            onKeyDown={(event) => {
+              // This input can sit inside the composer's <form> (bare mode), so
+              // block Enter from triggering the form's implicit submit and
+              // launching a run while the user is just naming their agent.
+              if (event.key === "Enter") event.preventDefault();
+            }}
             placeholder="Name your agent"
             className="w-full bg-transparent text-base font-medium text-white placeholder:text-white/30 focus:outline-none"
           />

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -1014,26 +1014,39 @@ function TryoutWelcome({
             submitting={launching}
             rows={2}
             aboveFooter={
-              attachments.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5 px-2 pb-1 sm:px-3">
-                  {attachments.map((attachment) => (
-                    <span
-                      key={attachment.id}
-                      className="inline-flex max-w-full items-center gap-1 rounded-sm border border-white/12 bg-white/[0.03] py-0.5 pl-2 pr-1 font-mono text-2xs text-white/65"
-                    >
-                      <span className="truncate">{attachment.filename}</span>
-                      <button
-                        type="button"
-                        aria-label={`Remove ${attachment.filename}`}
-                        onClick={() => onRemoveAttachment(attachment.id)}
-                        className="rounded-sm p-0.5 text-white/40 transition hover:text-white"
+              <>
+                {/* The agent designer lives inside the composer so the page has
+                    one box with one run button — design the agent, give it the
+                    task, send. */}
+                <AgentDesigner
+                  bare
+                  value={agentDraft}
+                  onChange={onAgentDraftChange}
+                  tools={tools}
+                  models={designerModels}
+                  taskLabel={template?.name}
+                />
+                {attachments.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5 px-2 pb-1 pt-2 sm:px-3">
+                    {attachments.map((attachment) => (
+                      <span
+                        key={attachment.id}
+                        className="inline-flex max-w-full items-center gap-1 rounded-sm border border-white/12 bg-white/[0.03] py-0.5 pl-2 pr-1 font-mono text-2xs text-white/65"
                       >
-                        <X className="size-3" />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              ) : null
+                        <span className="truncate">{attachment.filename}</span>
+                        <button
+                          type="button"
+                          aria-label={`Remove ${attachment.filename}`}
+                          onClick={() => onRemoveAttachment(attachment.id)}
+                          className="rounded-sm p-0.5 text-white/40 transition hover:text-white"
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </>
             }
             footerClassName="sm:flex-wrap"
             footer={
@@ -1135,18 +1148,6 @@ function TryoutWelcome({
             </div>
           ) : null}
         </form>
-
-        <div className="mt-6">
-          <AgentDesigner
-            value={agentDraft}
-            onChange={onAgentDraftChange}
-            tools={tools}
-            models={designerModels}
-            taskLabel={template?.name}
-            onRun={attemptLaunch}
-            running={launching}
-          />
-        </div>
       </div>
 
       <BarDialog


### PR DESCRIPTION
## What

The `/tryouts` welcome screen had **two stacked boxes**, each with its own text input and its own run button:

1. **Top** — the task composer (`ComposerShell`): the brief textarea + footer pills (attach, set the bar, template, judge) + a send button.
2. **Bottom** — the `AgentDesigner` card: agent name, an Instructions textarea, abilities picker, model picker, and a separate **"Run your agent"** button.

Two textareas and two ways to launch the same run — confusing.

## Change

Collapse the two boxes into **one box with one run button**:

- `AgentDesigner` gains a `bare` prop that drops its own card border/background and padding so it can sit inside another container.
- It's now rendered inside the composer (via the composer's `aboveFooter` slot), between the task textarea and the footer pills. The composer's existing send button is the single run trigger.
- The standalone bottom card and its duplicate "Run your agent" button are removed.

All functionality from the bottom box is preserved (agent name, instructions/system prompt, abilities, model) — it just lives inside the one composer now.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the changed files — no new warnings (the two existing warnings predate this change)
- Rendered locally against the production API and screenshotted: the page is now a single box, task brief at top → agent design → run-config pills + send.
