### PR TITLE
fix(scoring): allow single-model confidence in llm_judge_results constraint

### DIFF
--- a/backend/db/migrations/00064_llm_judge_results_single_model_confidence.sql
+++ b/backend/db/migrations/00064_llm_judge_results_single_model_confidence.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Fix: the llm_judge_results.confidence CHECK constraint was out of sync with
+-- the application. deriveJudgeConfidence (backend/internal/workflow/judges.go)
+-- emits "single-model" for single-model judges, and the scorecard UI renders it
+-- as a first-class confidence chip, but the original constraint from migration
+-- 00021 only permitted ('high','medium','low'). Persisting a single-model judge
+-- result therefore violated llm_judge_results_confidence_check (SQLSTATE 23514),
+-- which failed scoring and, in turn, the entire run. Widen the allowed set to
+-- include 'single-model'.
+ALTER TABLE llm_judge_results
+DROP CONSTRAINT IF EXISTS llm_judge_results_confidence_check;
+
+ALTER TABLE llm_judge_results
+ADD CONSTRAINT llm_judge_results_confidence_check
+CHECK (confidence IS NULL OR confidence IN ('high', 'medium', 'low', 'single-model'));
+
+-- +goose Down
+ALTER TABLE llm_judge_results
+DROP CONSTRAINT IF EXISTS llm_judge_results_confidence_check;
+
+ALTER TABLE llm_judge_results
+ADD CONSTRAINT llm_judge_results_confidence_check
+CHECK (confidence IS NULL OR confidence IN ('high', 'medium', 'low'));

--- a/backend/internal/repository/llm_judge_results_integration_test.go
+++ b/backend/internal/repository/llm_judge_results_integration_test.go
@@ -213,6 +213,45 @@ func TestUpsertLLMJudgeResult_HandlesNullableFields(t *testing.T) {
 	}
 }
 
+// TestUpsertLLMJudgeResult_AcceptsSingleModelConfidence is a regression test
+// for the stale confidence CHECK constraint. deriveJudgeConfidence emits
+// "single-model" for single-model judges and the scorecard UI renders it, but
+// the original constraint from migration 00021 only allowed high/medium/low,
+// so persisting such a result violated llm_judge_results_confidence_check and
+// failed the whole run. Migration 00064 widens the allowed set; this pins it.
+func TestUpsertLLMJudgeResult_AcceptsSingleModelConfidence(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "llm-judge-single-model", 1)
+
+	score := 1.0
+	confidence := "single-model"
+
+	params := repository.UpsertLLMJudgeResultParams{
+		RunAgentID:       fixture.primaryRunAgentID,
+		EvaluationSpecID: evaluationSpecID,
+		JudgeKey:         "no_hallucinated_fields",
+		Mode:             "assertion",
+		NormalizedScore:  &score,
+		Payload:          json.RawMessage(`{"mode":"assertion","model_scores":{"claude-haiku-4-5-20251001":1.0}}`),
+		Confidence:       &confidence,
+		Variance:         nil,
+		SampleCount:      3,
+		ModelCount:       1,
+	}
+
+	inserted, err := repo.UpsertLLMJudgeResult(ctx, params)
+	if err != nil {
+		t.Fatalf("UpsertLLMJudgeResult rejected single-model confidence: %v", err)
+	}
+	if inserted.Confidence == nil || *inserted.Confidence != "single-model" {
+		t.Errorf("Confidence = %v, want single-model", inserted.Confidence)
+	}
+}
+
 // TestListLLMJudgeResults_OrdersByJudgeKey pins the deterministic ordering
 // contract so downstream readers (dimension dispatch in Phase 4) can rely
 // on stable iteration without sorting again.


### PR DESCRIPTION
## Summary

Single-model LLM judges fail scoring — and take the **entire run** down with them — because the `llm_judge_results.confidence` CHECK constraint is out of sync with the application.

`deriveJudgeConfidence` (`backend/internal/workflow/judges.go`) emits `"single-model"` when a judge runs with exactly one model and no warnings, and the scorecard UI renders it as a first-class confidence chip (`judge-sample-card.tsx`). But the constraint from migration `00021` only permitted `('high','medium','low')`. Persisting a single-model judge result therefore violates `llm_judge_results_confidence_check` (SQLSTATE 23514), which fails scoring and marks the run `failed` — even though the agents completed and the deterministic validators were fine.

## How I found it

Dogfooding a `prompt_eval` challenge pack whose only LLM judge was a single-model assertion judge (`claude-haiku-4-5`). All three agents completed, then scoring crashed:

```
scoring.failed: persist evaluation results: upsert llm judge result no_hallucinated_fields:
  ERROR: new row for relation "llm_judge_results" violates check constraint
  "llm_judge_results_confidence_check" (SQLSTATE 23514)
```

Any pack with a single-model judge hits this. There is no graceful degradation — one judge-row write failure aborts the whole scoring transaction.

## Fix

Migration `00064` widens the constraint to include the legitimate fourth value:

```sql
CHECK (confidence IS NULL OR confidence IN ('high', 'medium', 'low', 'single-model'))
```

This keeps `single-model` (which the code and UI already treat as canonical) rather than removing it, and preserves rejection of unexpected values.

## Verification

Against a real Postgres:
- Reproduced the original `23514` violation on the old constraint.
- Applied the migration → `single-model` inserts cleanly; `'bogus'` is still rejected.
- Added regression test `TestUpsertLLMJudgeResult_AcceptsSingleModelConfidence`; full `./internal/repository` integration suite passes against the live DB.
- `go build ./...`, `go vet ./...`, and `./internal/workflow` unit tests pass.

## Notes / follow-ups (out of scope)

The deeper fragility — a single judge-persistence error failing the whole run instead of recording that judge as `errored` and continuing — is worth a separate issue. This PR fixes the immediate, reproducible crash.
