### PR TITLE
[codex] Add agentic self-instruct generation phases 1-2

### DIFF
--- a/backend/internal/api/datasets_generations.go
+++ b/backend/internal/api/datasets_generations.go
@@ -39,15 +39,22 @@ func (e DatasetGenerationWorkflowStartError) Error() string {
 func (e DatasetGenerationWorkflowStartError) Unwrap() error { return e.Cause }
 
 type StartDatasetGenerationInput struct {
-	WorkspaceID       uuid.UUID
-	DatasetID         uuid.UUID
-	Strategy          string
-	TargetCount       int32
-	ProviderAccountID uuid.UUID
-	Model             string
-	SeedsTag          string
-	CreateVersion     bool
-	VersionLabel      string
+	WorkspaceID            uuid.UUID
+	DatasetID              uuid.UUID
+	Strategy               string
+	TargetCount            int32
+	ProviderAccountID      uuid.UUID
+	Model                  string
+	SeedsTag               string
+	CreateVersion          bool
+	VersionLabel           string
+	JudgeProviderAccountID *uuid.UUID
+	JudgeModel             string
+	MaxRoundsPerExample    int
+	AcceptanceMode         string
+	MinGap                 *float64
+	MaxWeakScore           *float64
+	MinStrongScore         *float64
 }
 
 type GetDatasetGenerationJobInput struct {
@@ -93,6 +100,24 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	if strings.TrimSpace(input.Model) == "" {
 		return repository.DatasetGenerationJob{}, errors.New("model is required")
 	}
+	if strategy == datasetgeneration.StrategyAgenticSelfInstruct {
+		if input.JudgeProviderAccountID == nil || *input.JudgeProviderAccountID == uuid.Nil {
+			return repository.DatasetGenerationJob{}, errors.New("judge_provider_account_id is required for agentic_self_instruct")
+		}
+		judgeProviderAccount, err := genRepo.GetProviderAccountByID(ctx, *input.JudgeProviderAccountID)
+		if err != nil {
+			return repository.DatasetGenerationJob{}, err
+		}
+		if judgeProviderAccount.WorkspaceID == nil || *judgeProviderAccount.WorkspaceID != input.WorkspaceID {
+			return repository.DatasetGenerationJob{}, ErrForbidden
+		}
+		if strings.TrimSpace(input.JudgeModel) == "" {
+			return repository.DatasetGenerationJob{}, errors.New("judge_model is required for agentic_self_instruct")
+		}
+		if input.MaxRoundsPerExample < 0 || input.MaxRoundsPerExample > 15 {
+			return repository.DatasetGenerationJob{}, errors.New("max_rounds_per_example must be between 0 and 15")
+		}
+	}
 
 	active := domain.DatasetExampleStatusActive
 	examples, err := genRepo.ListDatasetExamplesByDatasetID(ctx, repository.ListDatasetExamplesParams{
@@ -118,13 +143,23 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	}
 
 	config, err := json.Marshal(datasetgeneration.JobConfig{
-		ProviderAccountID: input.ProviderAccountID,
-		Model:             strings.TrimSpace(input.Model),
-		SeedsTag:          strings.TrimSpace(input.SeedsTag),
-		CreateVersion:     input.CreateVersion,
-		VersionLabel:      strings.TrimSpace(input.VersionLabel),
+		ProviderAccountID:      input.ProviderAccountID,
+		Model:                  strings.TrimSpace(input.Model),
+		SeedsTag:               strings.TrimSpace(input.SeedsTag),
+		CreateVersion:          input.CreateVersion,
+		VersionLabel:           strings.TrimSpace(input.VersionLabel),
+		JudgeProviderAccountID: input.JudgeProviderAccountID,
+		JudgeModel:             strings.TrimSpace(input.JudgeModel),
+		MaxRoundsPerExample:    input.MaxRoundsPerExample,
+		AcceptanceMode:         strings.TrimSpace(input.AcceptanceMode),
+		MinGap:                 input.MinGap,
+		MaxWeakScore:           input.MaxWeakScore,
+		MinStrongScore:         input.MinStrongScore,
 	})
 	if err != nil {
+		return repository.DatasetGenerationJob{}, err
+	}
+	if _, err := datasetgeneration.DecodeJobConfigForStrategy(config, strategy); err != nil {
 		return repository.DatasetGenerationJob{}, err
 	}
 
@@ -172,13 +207,20 @@ func startDatasetGenerationHandler(logger *slog.Logger, service DatasetService) 
 			return
 		}
 		var body struct {
-			Strategy          string    `json:"strategy"`
-			TargetCount       int32     `json:"target_count"`
-			ProviderAccountID uuid.UUID `json:"provider_account_id"`
-			Model             string    `json:"model"`
-			SeedsTag          string    `json:"seeds_tag,omitempty"`
-			CreateVersion     bool      `json:"create_version,omitempty"`
-			VersionLabel      string    `json:"version_label,omitempty"`
+			Strategy               string     `json:"strategy"`
+			TargetCount            int32      `json:"target_count"`
+			ProviderAccountID      uuid.UUID  `json:"provider_account_id"`
+			Model                  string     `json:"model"`
+			SeedsTag               string     `json:"seeds_tag,omitempty"`
+			CreateVersion          bool       `json:"create_version,omitempty"`
+			VersionLabel           string     `json:"version_label,omitempty"`
+			JudgeProviderAccountID *uuid.UUID `json:"judge_provider_account_id,omitempty"`
+			JudgeModel             string     `json:"judge_model,omitempty"`
+			MaxRoundsPerExample    int        `json:"max_rounds_per_example,omitempty"`
+			AcceptanceMode         string     `json:"acceptance_mode,omitempty"`
+			MinGap                 *float64   `json:"min_gap,omitempty"`
+			MaxWeakScore           *float64   `json:"max_weak_score,omitempty"`
+			MinStrongScore         *float64   `json:"min_strong_score,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
@@ -189,15 +231,22 @@ func startDatasetGenerationHandler(logger *slog.Logger, service DatasetService) 
 			return
 		}
 		job, err := service.StartDatasetGeneration(r.Context(), caller, StartDatasetGenerationInput{
-			WorkspaceID:       workspaceID,
-			DatasetID:         datasetID,
-			Strategy:          body.Strategy,
-			TargetCount:       body.TargetCount,
-			ProviderAccountID: body.ProviderAccountID,
-			SeedsTag:          body.SeedsTag,
-			CreateVersion:     body.CreateVersion,
-			VersionLabel:      body.VersionLabel,
-			Model:             body.Model,
+			WorkspaceID:            workspaceID,
+			DatasetID:              datasetID,
+			Strategy:               body.Strategy,
+			TargetCount:            body.TargetCount,
+			ProviderAccountID:      body.ProviderAccountID,
+			SeedsTag:               body.SeedsTag,
+			CreateVersion:          body.CreateVersion,
+			VersionLabel:           body.VersionLabel,
+			Model:                  body.Model,
+			JudgeProviderAccountID: body.JudgeProviderAccountID,
+			JudgeModel:             body.JudgeModel,
+			MaxRoundsPerExample:    body.MaxRoundsPerExample,
+			AcceptanceMode:         body.AcceptanceMode,
+			MinGap:                 body.MinGap,
+			MaxWeakScore:           body.MaxWeakScore,
+			MinStrongScore:         body.MinStrongScore,
 		})
 		if err != nil {
 			handleDatasetGenerationError(w, logger, err)

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -107,3 +107,77 @@ func TestStartDatasetGenerationCreatesJob(t *testing.T) {
 		t.Fatalf("expected target_count 2, got %d", job.TargetCount)
 	}
 }
+
+func TestStartDatasetGenerationAgenticRequiresJudgeConfig(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	_, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:       wsID,
+		DatasetID:         datasetID,
+		Strategy:          "agentic-self-instruct",
+		TargetCount:       2,
+		ProviderAccountID: providerID,
+		Model:             "gpt-4.1",
+	})
+	if err == nil {
+		t.Fatal("expected missing judge config error")
+	}
+}
+
+func TestStartDatasetGenerationCreatesAgenticJobConfig(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	rounds := 3
+	job, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:            wsID,
+		DatasetID:              datasetID,
+		Strategy:               "agentic-self-instruct",
+		TargetCount:            2,
+		ProviderAccountID:      providerID,
+		Model:                  "gpt-4.1",
+		JudgeProviderAccountID: &providerID,
+		JudgeModel:             "gpt-4.1-mini",
+		MaxRoundsPerExample:    rounds,
+		AcceptanceMode:         "judge",
+	})
+	if err != nil {
+		t.Fatalf("start generation: %v", err)
+	}
+	if job.Strategy != "agentic_self_instruct" {
+		t.Fatalf("strategy = %q", job.Strategy)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(job.Config, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg["judge_model"] != "gpt-4.1-mini" {
+		t.Fatalf("judge_model = %v", cfg["judge_model"])
+	}
+	if cfg["max_rounds_per_example"] != float64(rounds) {
+		t.Fatalf("max_rounds_per_example = %v", cfg["max_rounds_per_example"])
+	}
+}

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -181,3 +181,34 @@ func TestStartDatasetGenerationCreatesAgenticJobConfig(t *testing.T) {
 		t.Fatalf("max_rounds_per_example = %v", cfg["max_rounds_per_example"])
 	}
 }
+
+func TestStartDatasetGenerationAgenticThresholdRequiresValues(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	_, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:            wsID,
+		DatasetID:              datasetID,
+		Strategy:               "agentic-self-instruct",
+		TargetCount:            2,
+		ProviderAccountID:      providerID,
+		Model:                  "gpt-4.1",
+		JudgeProviderAccountID: &providerID,
+		JudgeModel:             "gpt-4.1-mini",
+		AcceptanceMode:         "threshold",
+	})
+	if err == nil {
+		t.Fatal("expected missing threshold values error")
+	}
+}

--- a/backend/internal/datasets/generation/agentic_self_instruct.go
+++ b/backend/internal/datasets/generation/agentic_self_instruct.go
@@ -1,0 +1,171 @@
+package generation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	AcceptanceModeJudge     = "judge"
+	AcceptanceModeThreshold = "threshold"
+
+	JudgeVerdictAccept  = "accept"
+	JudgeVerdictImprove = "improve"
+	JudgeVerdictReject  = "reject"
+)
+
+type AgenticJudgeInput struct {
+	Seeds     []SeedExample
+	Candidate Candidate
+}
+
+type AgenticJudgeVerdict struct {
+	Verdict                 string          `json:"verdict"`
+	QualityVerdict          string          `json:"quality_verdict,omitempty"`
+	WeakScore               *float64        `json:"weak_score,omitempty"`
+	StrongScore             *float64        `json:"strong_score,omitempty"`
+	Gap                     *float64        `json:"gap,omitempty"`
+	WeakPattern             string          `json:"weak_pattern,omitempty"`
+	StrongPattern           string          `json:"strong_pattern,omitempty"`
+	GapInterpretation       string          `json:"gap_interpretation,omitempty"`
+	RubricConcerns          []string        `json:"rubric_concerns,omitempty"`
+	CapabilityTags          []string        `json:"capability_tags,omitempty"`
+	GRPOSuitability         string          `json:"grpo_suitability,omitempty"`
+	SuggestionForChallenger string          `json:"suggestion_for_challenger,omitempty"`
+	Raw                     json.RawMessage `json:"-"`
+}
+
+type AgenticAcceptanceConfig struct {
+	Mode           string
+	MinGap         *float64
+	MaxWeakScore   *float64
+	MinStrongScore *float64
+}
+
+func BuildAgenticJudgePrompt(input AgenticJudgeInput) string {
+	var b strings.Builder
+	b.WriteString("You are judging a synthetic AgentClash dataset example before it is accepted.\n")
+	b.WriteString("Decide whether the candidate is high-quality, realistic, non-duplicative in spirit, and useful for evaluating an agent.\n")
+	b.WriteString("This phase is judge-only: no weak or strong solver rollouts are available yet. Prefer rejecting vague, trivial, answer-leaking, impossible, or schema-inconsistent examples.\n")
+	b.WriteString("Respond with ONLY valid JSON in this exact shape:\n")
+	b.WriteString(`{"verdict":"accept|improve|reject","quality_verdict":"high|medium|low","weak_score":0.0,"strong_score":1.0,"gap":0.0,"weak_pattern":"","strong_pattern":"","gap_interpretation":"","rubric_concerns":[],"capability_tags":[],"grpo_suitability":"high|medium|low","suggestion_for_challenger":null}` + "\n")
+	b.WriteString("Use null or omit scores when solver scores are not available. If verdict is improve or reject, include a concrete suggestion_for_challenger.\n\n")
+	b.WriteString("Seed examples:\n")
+	for i, seed := range input.Seeds {
+		b.WriteString(fmt.Sprintf("%d. input: %s\n", i+1, compactJSON(seed.Input)))
+		if len(seed.Expected) > 0 && string(seed.Expected) != "null" {
+			b.WriteString(fmt.Sprintf("   expected: %s\n", compactJSON(seed.Expected)))
+		}
+	}
+	b.WriteString("\nCandidate:\n")
+	b.WriteString(fmt.Sprintf("input: %s\n", compactJSON(input.Candidate.Input)))
+	if len(input.Candidate.Expected) > 0 && string(input.Candidate.Expected) != "null" {
+		b.WriteString(fmt.Sprintf("expected: %s\n", compactJSON(input.Candidate.Expected)))
+	}
+	return b.String()
+}
+
+func ParseAgenticJudgeResponse(raw string) (AgenticJudgeVerdict, error) {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	var verdict AgenticJudgeVerdict
+	if err := json.Unmarshal([]byte(text), &verdict); err != nil {
+		return AgenticJudgeVerdict{}, fmt.Errorf("decode agentic judge response: %w", err)
+	}
+	verdict.Raw = json.RawMessage(text)
+	switch verdict.Verdict {
+	case JudgeVerdictAccept, JudgeVerdictImprove, JudgeVerdictReject:
+	default:
+		return AgenticJudgeVerdict{}, errors.New("agentic judge response has invalid verdict")
+	}
+	if err := validateOptionalScore("weak_score", verdict.WeakScore); err != nil {
+		return AgenticJudgeVerdict{}, err
+	}
+	if err := validateOptionalScore("strong_score", verdict.StrongScore); err != nil {
+		return AgenticJudgeVerdict{}, err
+	}
+	if err := validateOptionalScore("gap", verdict.Gap); err != nil {
+		return AgenticJudgeVerdict{}, err
+	}
+	return verdict, nil
+}
+
+func ShouldAcceptJudgeVerdict(verdict AgenticJudgeVerdict, cfg AgenticAcceptanceConfig) bool {
+	if verdict.Verdict != JudgeVerdictAccept {
+		return false
+	}
+	if cfg.Mode == AcceptanceModeThreshold {
+		if cfg.MinGap == nil || cfg.MaxWeakScore == nil || cfg.MinStrongScore == nil {
+			return false
+		}
+	}
+	if cfg.MinGap != nil {
+		if verdict.Gap == nil || *verdict.Gap < *cfg.MinGap {
+			return false
+		}
+	}
+	if cfg.MaxWeakScore != nil {
+		if verdict.WeakScore == nil || *verdict.WeakScore > *cfg.MaxWeakScore {
+			return false
+		}
+	}
+	if cfg.MinStrongScore != nil {
+		if verdict.StrongScore == nil || *verdict.StrongScore < *cfg.MinStrongScore {
+			return false
+		}
+	}
+	return true
+}
+
+func AgenticJudgeRejectionDetail(verdict AgenticJudgeVerdict) string {
+	if verdict.SuggestionForChallenger != "" {
+		return verdict.SuggestionForChallenger
+	}
+	if verdict.GapInterpretation != "" {
+		return verdict.GapInterpretation
+	}
+	if verdict.QualityVerdict != "" {
+		return "judge quality verdict: " + verdict.QualityVerdict
+	}
+	return "agentic judge did not accept candidate"
+}
+
+func AgenticJudgeMetadata(verdict AgenticJudgeVerdict) json.RawMessage {
+	metadata := map[string]any{
+		"verdict":            verdict.Verdict,
+		"quality_verdict":    verdict.QualityVerdict,
+		"weak_score":         verdict.WeakScore,
+		"strong_score":       verdict.StrongScore,
+		"gap":                verdict.Gap,
+		"weak_pattern":       verdict.WeakPattern,
+		"strong_pattern":     verdict.StrongPattern,
+		"gap_interpretation": verdict.GapInterpretation,
+		"rubric_concerns":    verdict.RubricConcerns,
+		"capability_tags":    verdict.CapabilityTags,
+		"grpo_suitability":   verdict.GRPOSuitability,
+	}
+	if verdict.SuggestionForChallenger != "" {
+		metadata["suggestion_for_challenger"] = verdict.SuggestionForChallenger
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return encoded
+}
+
+func validateOptionalScore(name string, value *float64) error {
+	if value == nil {
+		return nil
+	}
+	if *value < 0 || *value > 1 {
+		return fmt.Errorf("%s must be between 0 and 1", name)
+	}
+	return nil
+}

--- a/backend/internal/datasets/generation/generation_test.go
+++ b/backend/internal/datasets/generation/generation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/datasets/generation"
+	"github.com/google/uuid"
 )
 
 func TestBuildSelfInstructPromptIncludesSeeds(t *testing.T) {
@@ -57,6 +58,111 @@ func TestComputeCostUSD(t *testing.T) {
 	})
 	if cost != 6 {
 		t.Fatalf("expected cost 6, got %v", cost)
+	}
+}
+
+func TestParseStrategyAcceptsAgenticSelfInstructAliases(t *testing.T) {
+	for _, raw := range []string{"agentic_self_instruct", "agentic-self-instruct"} {
+		strategy, err := generation.ParseStrategy(raw)
+		if err != nil {
+			t.Fatalf("parse strategy %q: %v", raw, err)
+		}
+		if strategy != generation.StrategyAgenticSelfInstruct {
+			t.Fatalf("strategy = %q, want %q", strategy, generation.StrategyAgenticSelfInstruct)
+		}
+	}
+}
+
+func TestDecodeJobConfigForStrategyValidatesAgenticJudgeFields(t *testing.T) {
+	providerID := uuid.New()
+	raw, _ := json.Marshal(map[string]any{
+		"provider_account_id": providerID,
+		"model":               "gpt-4.1-mini",
+	})
+	if _, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct); err == nil {
+		t.Fatal("expected missing judge provider error")
+	}
+
+	judgeID := uuid.New()
+	raw, _ = json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1-mini",
+		"max_rounds_per_example":    3,
+		"acceptance_mode":           "judge",
+	})
+	cfg, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct)
+	if err != nil {
+		t.Fatalf("decode agentic config: %v", err)
+	}
+	if cfg.JudgeProviderAccountID == nil || *cfg.JudgeProviderAccountID != judgeID {
+		t.Fatalf("unexpected judge provider: %+v", cfg.JudgeProviderAccountID)
+	}
+}
+
+func TestParseAgenticJudgeResponse(t *testing.T) {
+	verdict, err := generation.ParseAgenticJudgeResponse(`{
+		"verdict":"accept",
+		"quality_verdict":"high",
+		"weak_score":0.4,
+		"strong_score":0.8,
+		"gap":0.4,
+		"capability_tags":["schema-following"]
+	}`)
+	if err != nil {
+		t.Fatalf("parse judge response: %v", err)
+	}
+	if verdict.Verdict != generation.JudgeVerdictAccept {
+		t.Fatalf("verdict = %q", verdict.Verdict)
+	}
+	if verdict.Gap == nil || *verdict.Gap != 0.4 {
+		t.Fatalf("gap = %+v", verdict.Gap)
+	}
+}
+
+func TestParseAgenticJudgeResponseRejectsInvalidResponses(t *testing.T) {
+	tests := []string{
+		`not json`,
+		`{"quality_verdict":"high"}`,
+		`{"verdict":"maybe"}`,
+		`{"verdict":"accept","weak_score":1.2}`,
+	}
+	for _, raw := range tests {
+		if _, err := generation.ParseAgenticJudgeResponse(raw); err == nil {
+			t.Fatalf("expected error for %s", raw)
+		}
+	}
+}
+
+func TestShouldAcceptJudgeVerdict(t *testing.T) {
+	weak := 0.4
+	strong := 0.8
+	gap := 0.4
+	verdict := generation.AgenticJudgeVerdict{
+		Verdict:     generation.JudgeVerdictAccept,
+		WeakScore:   &weak,
+		StrongScore: &strong,
+		Gap:         &gap,
+	}
+	minGap := 0.2
+	maxWeak := 0.65
+	minStrong := 0.75
+	if !generation.ShouldAcceptJudgeVerdict(verdict, generation.AgenticAcceptanceConfig{
+		Mode:           generation.AcceptanceModeThreshold,
+		MinGap:         &minGap,
+		MaxWeakScore:   &maxWeak,
+		MinStrongScore: &minStrong,
+	}) {
+		t.Fatal("expected threshold verdict to be accepted")
+	}
+	tooHighWeak := 0.9
+	verdict.WeakScore = &tooHighWeak
+	if generation.ShouldAcceptJudgeVerdict(verdict, generation.AgenticAcceptanceConfig{
+		Mode:         generation.AcceptanceModeJudge,
+		MaxWeakScore: &maxWeak,
+	}) {
+		t.Fatal("expected max weak guardrail to reject")
 	}
 }
 

--- a/backend/internal/datasets/generation/generation_test.go
+++ b/backend/internal/datasets/generation/generation_test.go
@@ -101,6 +101,35 @@ func TestDecodeJobConfigForStrategyValidatesAgenticJudgeFields(t *testing.T) {
 	}
 }
 
+func TestDecodeJobConfigForStrategyRequiresThresholdValues(t *testing.T) {
+	providerID := uuid.New()
+	judgeID := uuid.New()
+	raw, _ := json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1-mini",
+		"acceptance_mode":           "threshold",
+	})
+	if _, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct); err == nil {
+		t.Fatal("expected missing threshold values error")
+	}
+
+	raw, _ = json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1-mini",
+		"acceptance_mode":           "threshold",
+		"min_gap":                   0.2,
+		"max_weak_score":            0.65,
+		"min_strong_score":          0.75,
+	})
+	if _, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct); err != nil {
+		t.Fatalf("decode threshold config: %v", err)
+	}
+}
+
 func TestParseAgenticJudgeResponse(t *testing.T) {
 	verdict, err := generation.ParseAgenticJudgeResponse(`{
 		"verdict":"accept",

--- a/backend/internal/datasets/generation/types.go
+++ b/backend/internal/datasets/generation/types.go
@@ -94,6 +94,11 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 		if cfg.AcceptanceMode != "" && cfg.AcceptanceMode != AcceptanceModeJudge && cfg.AcceptanceMode != AcceptanceModeThreshold {
 			return JobConfig{}, errors.New("acceptance_mode must be judge or threshold")
 		}
+		if cfg.AcceptanceMode == AcceptanceModeThreshold {
+			if cfg.MinGap == nil || cfg.MaxWeakScore == nil || cfg.MinStrongScore == nil {
+				return JobConfig{}, errors.New("min_gap, max_weak_score, and min_strong_score are all required when acceptance_mode is threshold")
+			}
+		}
 	}
 	return cfg, nil
 }

--- a/backend/internal/datasets/generation/types.go
+++ b/backend/internal/datasets/generation/types.go
@@ -8,6 +8,7 @@ import (
 )
 
 const StrategySelfInstruct = "self_instruct"
+const StrategyAgenticSelfInstruct = "agentic_self_instruct"
 
 var ErrUnsupportedStrategy = errors.New("unsupported dataset generation strategy")
 
@@ -15,10 +16,17 @@ type JobConfig struct {
 	ProviderAccountID uuid.UUID `json:"provider_account_id"`
 	// Model is the provider model id to generate with (e.g. "gpt-4.1-mini"),
 	// chosen directly from the provider connection's live model list.
-	Model         string `json:"model"`
-	SeedsTag      string `json:"seeds_tag,omitempty"`
-	CreateVersion bool   `json:"create_version,omitempty"`
-	VersionLabel  string `json:"version_label,omitempty"`
+	Model                  string     `json:"model"`
+	SeedsTag               string     `json:"seeds_tag,omitempty"`
+	CreateVersion          bool       `json:"create_version,omitempty"`
+	VersionLabel           string     `json:"version_label,omitempty"`
+	JudgeProviderAccountID *uuid.UUID `json:"judge_provider_account_id,omitempty"`
+	JudgeModel             string     `json:"judge_model,omitempty"`
+	MaxRoundsPerExample    int        `json:"max_rounds_per_example,omitempty"`
+	AcceptanceMode         string     `json:"acceptance_mode,omitempty"`
+	MinGap                 *float64   `json:"min_gap,omitempty"`
+	MaxWeakScore           *float64   `json:"max_weak_score,omitempty"`
+	MinStrongScore         *float64   `json:"min_strong_score,omitempty"`
 }
 
 type SeedExample struct {
@@ -36,18 +44,26 @@ const (
 	ReasonSchemaViolation = "schema_violation"
 	ReasonDuplicateInput  = "duplicate_input"
 	ReasonProviderError   = "provider_error"
+	ReasonJudgeParseError = "judge_parse_error"
+	ReasonQualityRejected = "quality_rejected"
 )
 
 func ParseStrategy(raw string) (string, error) {
 	switch raw {
 	case StrategySelfInstruct, "self-instruct":
 		return StrategySelfInstruct, nil
+	case StrategyAgenticSelfInstruct, "agentic-self-instruct":
+		return StrategyAgenticSelfInstruct, nil
 	default:
 		return "", ErrUnsupportedStrategy
 	}
 }
 
 func DecodeJobConfig(raw json.RawMessage) (JobConfig, error) {
+	return DecodeJobConfigForStrategy(raw, StrategySelfInstruct)
+}
+
+func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig, error) {
 	if len(raw) == 0 {
 		return JobConfig{}, errors.New("generation job config is required")
 	}
@@ -60,6 +76,24 @@ func DecodeJobConfig(raw json.RawMessage) (JobConfig, error) {
 	}
 	if cfg.Model == "" {
 		return JobConfig{}, errors.New("model is required")
+	}
+	parsedStrategy, err := ParseStrategy(strategy)
+	if err != nil {
+		return JobConfig{}, err
+	}
+	if parsedStrategy == StrategyAgenticSelfInstruct {
+		if cfg.JudgeProviderAccountID == nil || *cfg.JudgeProviderAccountID == uuid.Nil {
+			return JobConfig{}, errors.New("judge_provider_account_id is required for agentic_self_instruct")
+		}
+		if cfg.JudgeModel == "" {
+			return JobConfig{}, errors.New("judge_model is required for agentic_self_instruct")
+		}
+		if cfg.MaxRoundsPerExample < 0 || cfg.MaxRoundsPerExample > 15 {
+			return JobConfig{}, errors.New("max_rounds_per_example must be between 0 and 15")
+		}
+		if cfg.AcceptanceMode != "" && cfg.AcceptanceMode != AcceptanceModeJudge && cfg.AcceptanceMode != AcceptanceModeThreshold {
+			return JobConfig{}, errors.New("acceptance_mode must be judge or threshold")
+		}
 	}
 	return cfg, nil
 }

--- a/backend/internal/repository/dataset_generations.go
+++ b/backend/internal/repository/dataset_generations.go
@@ -117,12 +117,13 @@ type CreateDatasetGenerationRejectionParams struct {
 }
 
 type DatasetGenerationExecutionContext struct {
-	Job             DatasetGenerationJob
-	Dataset         Dataset
-	Config          datasetgeneration.JobConfig
-	Seeds           []datasetgeneration.SeedExample
-	ExistingInputs  map[string]struct{}
-	ProviderAccount ProviderAccountRow
+	Job                  DatasetGenerationJob
+	Dataset              Dataset
+	Config               datasetgeneration.JobConfig
+	Seeds                []datasetgeneration.SeedExample
+	ExistingInputs       map[string]struct{}
+	ProviderAccount      ProviderAccountRow
+	JudgeProviderAccount *ProviderAccountRow
 	// Model is the provider model id to generate with. Pricing is best-effort
 	// from the static fallback map (0 when unknown) and is used only for the
 	// job's cost estimate, never for scoring.
@@ -240,13 +241,21 @@ func (r *Repository) GetDatasetGenerationExecutionContextByID(ctx context.Contex
 	if err != nil {
 		return DatasetGenerationExecutionContext{}, err
 	}
-	cfg, err := datasetgeneration.DecodeJobConfig(job.Config)
+	cfg, err := datasetgeneration.DecodeJobConfigForStrategy(job.Config, job.Strategy)
 	if err != nil {
 		return DatasetGenerationExecutionContext{}, err
 	}
 	providerAccount, err := r.GetProviderAccountByID(ctx, cfg.ProviderAccountID)
 	if err != nil {
 		return DatasetGenerationExecutionContext{}, err
+	}
+	var judgeProviderAccount *ProviderAccountRow
+	if cfg.JudgeProviderAccountID != nil {
+		account, accountErr := r.GetProviderAccountByID(ctx, *cfg.JudgeProviderAccountID)
+		if accountErr != nil {
+			return DatasetGenerationExecutionContext{}, accountErr
+		}
+		judgeProviderAccount = &account
 	}
 	// Pricing is best-effort: the static fallback map yields 0 when the model is
 	// unknown, which only affects the job's cost estimate.
@@ -284,6 +293,7 @@ func (r *Repository) GetDatasetGenerationExecutionContextByID(ctx context.Contex
 		Seeds:                      seeds,
 		ExistingInputs:             existing,
 		ProviderAccount:            providerAccount,
+		JudgeProviderAccount:       judgeProviderAccount,
 		Model:                      cfg.Model,
 		InputCostPerMillionTokens:  inputCost,
 		OutputCostPerMillionTokens: outputCost,

--- a/backend/internal/workflow/dataset_generation_activities.go
+++ b/backend/internal/workflow/dataset_generation_activities.go
@@ -74,6 +74,18 @@ type agenticJudgeUsage struct {
 	CostUSD      float64
 }
 
+type agenticJudgeParseError struct {
+	err error
+}
+
+func (e agenticJudgeParseError) Error() string {
+	return e.err.Error()
+}
+
+func (e agenticJudgeParseError) Unwrap() error {
+	return e.err
+}
+
 func NewDatasetGenerationActivities(repo DatasetGenerationWorkflowRepository, client provider.Client, secretsLookup DatasetGenerationSecretsLookup) *DatasetGenerationActivities {
 	return &DatasetGenerationActivities{repo: repo, client: client, secretsLookup: secretsLookup}
 }
@@ -221,7 +233,11 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 			}
 			if judgeErr != nil {
 				rejectedCount++
-				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonProviderError, judgeErr.Error(), candidate.Input, candidate.Expected, mustMarshalJSON(map[string]any{
+				reasonCode := datasetgeneration.ReasonProviderError
+				if _, ok := judgeErr.(agenticJudgeParseError); ok {
+					reasonCode = datasetgeneration.ReasonJudgeParseError
+				}
+				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, reasonCode, judgeErr.Error(), candidate.Input, candidate.Expected, mustMarshalJSON(map[string]any{
 					"role": "judge",
 				})); rejectErr != nil {
 					return wrapActivityError(rejectErr)
@@ -394,7 +410,7 @@ func (a *DatasetGenerationActivities) judgeAgenticCandidate(ctx context.Context,
 	}
 	verdict, parseErr := datasetgeneration.ParseAgenticJudgeResponse(response.OutputText)
 	if parseErr != nil {
-		return nil, usage, nil
+		return nil, usage, agenticJudgeParseError{err: parseErr}
 	}
 	return &verdict, usage, nil
 }

--- a/backend/internal/workflow/dataset_generation_activities.go
+++ b/backend/internal/workflow/dataset_generation_activities.go
@@ -19,7 +19,7 @@ import (
 const (
 	loadDatasetGenerationExecutionContextActivityName = "workflow.load_dataset_generation_execution_context"
 	setDatasetGenerationJobTemporalIDsActivityName    = "workflow.set_dataset_generation_job_temporal_ids"
-	updateDatasetGenerationJobStatusActivityName    = "workflow.update_dataset_generation_job_status"
+	updateDatasetGenerationJobStatusActivityName      = "workflow.update_dataset_generation_job_status"
 	executeSyntheticDatasetGenerationActivityName     = "workflow.execute_synthetic_dataset_generation"
 )
 
@@ -66,6 +66,12 @@ type UpdateDatasetGenerationJobStatusInput struct {
 
 type ExecuteSyntheticDatasetGenerationInput struct {
 	JobID uuid.UUID `json:"job_id"`
+}
+
+type agenticJudgeUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+	CostUSD      float64
 }
 
 func NewDatasetGenerationActivities(repo DatasetGenerationWorkflowRepository, client provider.Client, secretsLookup DatasetGenerationSecretsLookup) *DatasetGenerationActivities {
@@ -130,12 +136,15 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 	var totalOutputTokens = executionContext.Job.TotalOutputTokens
 	var totalCostUSD = executionContext.Job.TotalCostUSD
 	maxAttempts := int(executionContext.Job.TargetCount) * 5
+	if executionContext.Job.Strategy == datasetgeneration.StrategyAgenticSelfInstruct && executionContext.Config.MaxRoundsPerExample > 0 {
+		maxAttempts = int(executionContext.Job.TargetCount) * executionContext.Config.MaxRoundsPerExample
+	}
 	if maxAttempts < 10 {
 		maxAttempts = 10
 	}
 
 	for attempt := 0; attempt < maxAttempts && acceptedCount < executionContext.Job.TargetCount; attempt++ {
-		activity.RecordHeartbeat(ctx, map[string]any{
+		recordDatasetGenerationHeartbeat(ctx, map[string]any{
 			"attempt":  attempt + 1,
 			"accepted": acceptedCount,
 			"target":   executionContext.Job.TargetCount,
@@ -202,20 +211,73 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 			continue
 		}
 
+		var judgeVerdict *datasetgeneration.AgenticJudgeVerdict
+		if executionContext.Job.Strategy == datasetgeneration.StrategyAgenticSelfInstruct {
+			verdict, usage, judgeErr := a.judgeAgenticCandidate(ctx, executionContext, seedBatch, candidate)
+			if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+				totalInputTokens += usage.InputTokens
+				totalOutputTokens += usage.OutputTokens
+				totalCostUSD += usage.CostUSD
+			}
+			if judgeErr != nil {
+				rejectedCount++
+				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonProviderError, judgeErr.Error(), candidate.Input, candidate.Expected, mustMarshalJSON(map[string]any{
+					"role": "judge",
+				})); rejectErr != nil {
+					return wrapActivityError(rejectErr)
+				}
+				continue
+			}
+			if verdict == nil {
+				rejectedCount++
+				if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonJudgeParseError, "missing judge verdict", candidate.Input, candidate.Expected); rejectErr != nil {
+					return wrapActivityError(rejectErr)
+				}
+				continue
+			}
+			if !datasetgeneration.ShouldAcceptJudgeVerdict(*verdict, datasetgeneration.AgenticAcceptanceConfig{
+				Mode:           agenticAcceptanceMode(executionContext.Config.AcceptanceMode),
+				MinGap:         executionContext.Config.MinGap,
+				MaxWeakScore:   executionContext.Config.MaxWeakScore,
+				MinStrongScore: executionContext.Config.MinStrongScore,
+			}) {
+				rejectedCount++
+				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonQualityRejected, datasetgeneration.AgenticJudgeRejectionDetail(*verdict), candidate.Input, candidate.Expected, datasetgeneration.AgenticJudgeMetadata(*verdict)); rejectErr != nil {
+					return wrapActivityError(rejectErr)
+				}
+				continue
+			}
+			judgeVerdict = verdict
+		}
+
 		externalID := fmt.Sprintf("gen:%s:%s", executionContext.Job.ID, hash)
-		metadata := mustMarshalJSON(map[string]any{
+		exampleMetadata := map[string]any{
 			"generator":           executionContext.Job.Strategy,
 			"generation_job_id":   executionContext.Job.ID,
 			"provider_account_id": executionContext.Config.ProviderAccountID,
 			"provider_model_id":   executionContext.Model,
-		})
+		}
+		tags := []string{"synthetic"}
+		if judgeVerdict != nil {
+			exampleMetadata["judge_provider_account_id"] = executionContext.Config.JudgeProviderAccountID
+			exampleMetadata["judge_model_id"] = executionContext.Config.JudgeModel
+			exampleMetadata["judge_verdict"] = judgeVerdict.Verdict
+			exampleMetadata["judge_quality_verdict"] = judgeVerdict.QualityVerdict
+			exampleMetadata["weak_score"] = judgeVerdict.WeakScore
+			exampleMetadata["strong_score"] = judgeVerdict.StrongScore
+			exampleMetadata["gap"] = judgeVerdict.Gap
+			exampleMetadata["capability_tags"] = judgeVerdict.CapabilityTags
+			exampleMetadata["judge_summary"] = judgeVerdict.GapInterpretation
+			tags = append(tags, "agentic")
+		}
+		metadata := mustMarshalJSON(exampleMetadata)
 		if _, upsertErr := a.repo.UpsertDatasetExample(ctx, repository.UpsertDatasetExampleParams{
 			DatasetID:  executionContext.Dataset.ID,
 			ExternalID: &externalID,
 			Input:      candidate.Input,
 			Expected:   candidate.Expected,
 			Metadata:   metadata,
-			Tags:       []string{"synthetic"},
+			Tags:       tags,
 			Status:     domain.DatasetExampleStatusActive,
 			Source:     domain.DatasetExampleSourceSynthetic,
 			Actor:      executionContext.Job.CreatedBy,
@@ -279,6 +341,10 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 }
 
 func (a *DatasetGenerationActivities) recordRejection(ctx context.Context, jobID uuid.UUID, reasonCode, detail string, input, expected json.RawMessage) (repository.DatasetGenerationRejection, error) {
+	return a.recordRejectionWithMetadata(ctx, jobID, reasonCode, detail, input, expected, nil)
+}
+
+func (a *DatasetGenerationActivities) recordRejectionWithMetadata(ctx context.Context, jobID uuid.UUID, reasonCode, detail string, input, expected, metadata json.RawMessage) (repository.DatasetGenerationRejection, error) {
 	detailCopy := detail
 	return a.repo.CreateDatasetGenerationRejection(ctx, repository.CreateDatasetGenerationRejectionParams{
 		JobID:             jobID,
@@ -286,7 +352,65 @@ func (a *DatasetGenerationActivities) recordRejection(ctx context.Context, jobID
 		ReasonDetail:      &detailCopy,
 		CandidateInput:    input,
 		CandidateExpected: expected,
+		Metadata:          metadata,
 	})
+}
+
+func (a *DatasetGenerationActivities) judgeAgenticCandidate(ctx context.Context, executionContext repository.DatasetGenerationExecutionContext, seedBatch []datasetgeneration.SeedExample, candidate datasetgeneration.Candidate) (*datasetgeneration.AgenticJudgeVerdict, agenticJudgeUsage, error) {
+	if executionContext.JudgeProviderAccount == nil {
+		return nil, agenticJudgeUsage{}, fmt.Errorf("judge provider account is required")
+	}
+	judgeAccount := *executionContext.JudgeProviderAccount
+	prompt := datasetgeneration.BuildAgenticJudgePrompt(datasetgeneration.AgenticJudgeInput{
+		Seeds:     seedBatch,
+		Candidate: candidate,
+	})
+	response, invokeErr := a.client.InvokeModel(ctx, provider.Request{
+		ProviderKey:         judgeAccount.ProviderKey,
+		ProviderAccountID:   judgeAccount.ID.String(),
+		CredentialReference: judgeAccount.CredentialReference,
+		Model:               executionContext.Config.JudgeModel,
+		TraceMode:           "required",
+		StepTimeout:         120 * time.Second,
+		Messages:            []provider.Message{{Role: "user", Content: prompt}},
+		Metadata: mustMarshalJSON(map[string]any{
+			"dataset_generation_job_id": executionContext.Job.ID,
+			"dataset_id":                executionContext.Dataset.ID,
+			"strategy":                  executionContext.Job.Strategy,
+			"role":                      "judge",
+		}),
+	})
+	if invokeErr != nil {
+		return nil, agenticJudgeUsage{}, invokeErr
+	}
+	inputCost, outputCost, _ := provider.StaticModelPrice(judgeAccount.ProviderKey, executionContext.Config.JudgeModel)
+	usage := agenticJudgeUsage{
+		InputTokens:  response.Usage.InputTokens,
+		OutputTokens: response.Usage.OutputTokens,
+		CostUSD: datasetgeneration.ComputeCostUSD(response.Usage.InputTokens, response.Usage.OutputTokens, datasetgeneration.ModelPricing{
+			InputCostPerMillionTokens:  inputCost,
+			OutputCostPerMillionTokens: outputCost,
+		}),
+	}
+	verdict, parseErr := datasetgeneration.ParseAgenticJudgeResponse(response.OutputText)
+	if parseErr != nil {
+		return nil, usage, nil
+	}
+	return &verdict, usage, nil
+}
+
+func agenticAcceptanceMode(mode string) string {
+	if strings.TrimSpace(mode) == "" {
+		return datasetgeneration.AcceptanceModeJudge
+	}
+	return strings.TrimSpace(mode)
+}
+
+func recordDatasetGenerationHeartbeat(ctx context.Context, details any) {
+	defer func() {
+		_ = recover()
+	}()
+	activity.RecordHeartbeat(ctx, details)
 }
 
 func pickSeedBatch(seeds []datasetgeneration.SeedExample, rng *rand.Rand, size int) []datasetgeneration.SeedExample {

--- a/backend/internal/workflow/dataset_generation_activities_test.go
+++ b/backend/internal/workflow/dataset_generation_activities_test.go
@@ -91,6 +91,9 @@ func TestExecuteSyntheticDatasetGenerationAgenticRecordsMalformedJudgeOutput(t *
 	if fixture.repo.rejections[0].ReasonCode != datasetgeneration.ReasonJudgeParseError {
 		t.Fatalf("reason = %q", fixture.repo.rejections[0].ReasonCode)
 	}
+	if fixture.repo.rejections[0].ReasonDetail == nil || !strings.Contains(*fixture.repo.rejections[0].ReasonDetail, "decode agentic judge response") {
+		t.Fatalf("reason detail = %v", fixture.repo.rejections[0].ReasonDetail)
+	}
 }
 
 type datasetGenerationActivityFixture struct {

--- a/backend/internal/workflow/dataset_generation_activities_test.go
+++ b/backend/internal/workflow/dataset_generation_activities_test.go
@@ -1,0 +1,255 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	datasetgeneration "github.com/agentclash/agentclash/backend/internal/datasets/generation"
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestExecuteSyntheticDatasetGenerationAgenticAcceptsJudgeApprovedCandidate(t *testing.T) {
+	fixture := newDatasetGenerationActivityFixture(t, []provider.Response{
+		{OutputText: `{"input":{"q":"candidate"},"expected":{"a":"ok"}}`, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+		{OutputText: `{"verdict":"accept","quality_verdict":"high","weak_score":0.4,"strong_score":0.8,"gap":0.4,"capability_tags":["schema-following"],"gap_interpretation":"useful separation"}`, Usage: provider.Usage{InputTokens: 11, OutputTokens: 6}},
+	})
+
+	if err := fixture.activities.ExecuteSyntheticDatasetGeneration(context.Background(), ExecuteSyntheticDatasetGenerationInput{JobID: fixture.jobID}); err != nil {
+		t.Fatalf("execute generation: %v", err)
+	}
+	if len(fixture.repo.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(fixture.repo.upserts))
+	}
+	upsert := fixture.repo.upserts[0]
+	if !containsTag(upsert.Tags, "synthetic") || !containsTag(upsert.Tags, "agentic") {
+		t.Fatalf("tags = %v, want synthetic and agentic", upsert.Tags)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(upsert.Metadata, &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata["generator"] != datasetgeneration.StrategyAgenticSelfInstruct {
+		t.Fatalf("generator = %v", metadata["generator"])
+	}
+	if metadata["judge_verdict"] != datasetgeneration.JudgeVerdictAccept {
+		t.Fatalf("judge_verdict = %v", metadata["judge_verdict"])
+	}
+	if fixture.repo.progress.TotalInputTokens != 21 || fixture.repo.progress.TotalOutputTokens != 11 {
+		t.Fatalf("usage = %d/%d", fixture.repo.progress.TotalInputTokens, fixture.repo.progress.TotalOutputTokens)
+	}
+}
+
+func TestExecuteSyntheticDatasetGenerationAgenticRecordsJudgeRejection(t *testing.T) {
+	fixture := newDatasetGenerationActivityFixture(t, []provider.Response{
+		{OutputText: `{"input":{"q":"too easy"},"expected":{"a":"ok"}}`},
+		{OutputText: `{"verdict":"reject","quality_verdict":"low","gap_interpretation":"too easy","suggestion_for_challenger":"make it require tool recovery"}`},
+		{OutputText: `{"input":{"q":"accepted"},"expected":{"a":"ok"}}`},
+		{OutputText: `{"verdict":"accept","quality_verdict":"high"}`},
+	})
+
+	if err := fixture.activities.ExecuteSyntheticDatasetGeneration(context.Background(), ExecuteSyntheticDatasetGenerationInput{JobID: fixture.jobID}); err != nil {
+		t.Fatalf("execute generation: %v", err)
+	}
+	if len(fixture.repo.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(fixture.repo.upserts))
+	}
+	if len(fixture.repo.rejections) != 1 {
+		t.Fatalf("rejections = %d, want 1", len(fixture.repo.rejections))
+	}
+	rejection := fixture.repo.rejections[0]
+	if rejection.ReasonCode != datasetgeneration.ReasonQualityRejected {
+		t.Fatalf("reason = %q", rejection.ReasonCode)
+	}
+	if rejection.ReasonDetail == nil || !strings.Contains(*rejection.ReasonDetail, "tool recovery") {
+		t.Fatalf("reason detail = %v", rejection.ReasonDetail)
+	}
+}
+
+func TestExecuteSyntheticDatasetGenerationAgenticRecordsMalformedJudgeOutput(t *testing.T) {
+	fixture := newDatasetGenerationActivityFixture(t, []provider.Response{
+		{OutputText: `{"input":{"q":"bad judge"},"expected":{"a":"ok"}}`},
+		{OutputText: `not json`},
+		{OutputText: `{"input":{"q":"accepted"},"expected":{"a":"ok"}}`},
+		{OutputText: `{"verdict":"accept","quality_verdict":"high"}`},
+	})
+
+	if err := fixture.activities.ExecuteSyntheticDatasetGeneration(context.Background(), ExecuteSyntheticDatasetGenerationInput{JobID: fixture.jobID}); err != nil {
+		t.Fatalf("execute generation: %v", err)
+	}
+	if len(fixture.repo.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(fixture.repo.upserts))
+	}
+	if len(fixture.repo.rejections) != 1 {
+		t.Fatalf("rejections = %d, want 1", len(fixture.repo.rejections))
+	}
+	if fixture.repo.rejections[0].ReasonCode != datasetgeneration.ReasonJudgeParseError {
+		t.Fatalf("reason = %q", fixture.repo.rejections[0].ReasonCode)
+	}
+}
+
+type datasetGenerationActivityFixture struct {
+	jobID      uuid.UUID
+	repo       *fakeDatasetGenerationWorkflowRepo
+	activities *DatasetGenerationActivities
+}
+
+func newDatasetGenerationActivityFixture(t *testing.T, responses []provider.Response) datasetGenerationActivityFixture {
+	t.Helper()
+	workspaceID := uuid.New()
+	datasetID := uuid.New()
+	jobID := uuid.New()
+	providerAccountID := uuid.New()
+	judgeProviderAccountID := uuid.New()
+	createdBy := uuid.New()
+	cfg := datasetgeneration.JobConfig{
+		ProviderAccountID:      providerAccountID,
+		Model:                  "gpt-4.1-mini",
+		JudgeProviderAccountID: &judgeProviderAccountID,
+		JudgeModel:             "gpt-4.1-mini",
+		MaxRoundsPerExample:    3,
+		AcceptanceMode:         datasetgeneration.AcceptanceModeJudge,
+	}
+	config, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	providerAccount := repository.ProviderAccountRow{
+		ID:                  providerAccountID,
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "secret://challenger",
+	}
+	judgeProviderAccount := repository.ProviderAccountRow{
+		ID:                  judgeProviderAccountID,
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "secret://judge",
+	}
+	repo := &fakeDatasetGenerationWorkflowRepo{
+		context: repository.DatasetGenerationExecutionContext{
+			Job: repository.DatasetGenerationJob{
+				ID:             jobID,
+				DatasetID:      datasetID,
+				WorkspaceID:    workspaceID,
+				Strategy:       datasetgeneration.StrategyAgenticSelfInstruct,
+				Config:         config,
+				TargetCount:    1,
+				GeneratedCount: 0,
+				AcceptedCount:  0,
+				RejectedCount:  0,
+				CreatedBy:      createdBy,
+			},
+			Dataset: repository.Dataset{
+				ID:                  datasetID,
+				WorkspaceID:         workspaceID,
+				InputSchema:         json.RawMessage(`{"type":"object"}`),
+				InputSchemaEnforced: false,
+			},
+			Config:               cfg,
+			Seeds:                []datasetgeneration.SeedExample{{Input: json.RawMessage(`{"q":"seed"}`), Expected: json.RawMessage(`{"a":"seed"}`)}},
+			ExistingInputs:       map[string]struct{}{},
+			ProviderAccount:      providerAccount,
+			JudgeProviderAccount: &judgeProviderAccount,
+			Model:                cfg.Model,
+		},
+	}
+	client := &scriptedDatasetGenerationProvider{responses: responses}
+	return datasetGenerationActivityFixture{
+		jobID:      jobID,
+		repo:       repo,
+		activities: NewDatasetGenerationActivities(repo, client, nil),
+	}
+}
+
+type scriptedDatasetGenerationProvider struct {
+	responses []provider.Response
+	calls     int
+}
+
+func (c *scriptedDatasetGenerationProvider) InvokeModel(context.Context, provider.Request) (provider.Response, error) {
+	if c.calls >= len(c.responses) {
+		return provider.Response{}, nil
+	}
+	response := c.responses[c.calls]
+	c.calls++
+	return response, nil
+}
+
+type fakeDatasetGenerationWorkflowRepo struct {
+	context    repository.DatasetGenerationExecutionContext
+	progress   repository.UpdateDatasetGenerationJobProgressParams
+	rejections []repository.CreateDatasetGenerationRejectionParams
+	upserts    []repository.UpsertDatasetExampleParams
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) GetDatasetGenerationExecutionContextByID(context.Context, uuid.UUID) (repository.DatasetGenerationExecutionContext, error) {
+	return r.context, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) SetDatasetGenerationJobTemporalIDs(context.Context, repository.SetDatasetGenerationJobTemporalIDsParams) (repository.DatasetGenerationJob, error) {
+	return r.context.Job, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) UpdateDatasetGenerationJobStatus(context.Context, repository.UpdateDatasetGenerationJobStatusParams) (repository.DatasetGenerationJob, error) {
+	return r.context.Job, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) UpdateDatasetGenerationJobProgress(_ context.Context, params repository.UpdateDatasetGenerationJobProgressParams) (repository.DatasetGenerationJob, error) {
+	r.progress = params
+	r.context.Job.GeneratedCount = params.GeneratedCount
+	r.context.Job.AcceptedCount = params.AcceptedCount
+	r.context.Job.RejectedCount = params.RejectedCount
+	r.context.Job.TotalInputTokens = params.TotalInputTokens
+	r.context.Job.TotalOutputTokens = params.TotalOutputTokens
+	r.context.Job.TotalCostUSD = params.TotalCostUSD
+	return r.context.Job, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) CreateDatasetGenerationRejection(_ context.Context, params repository.CreateDatasetGenerationRejectionParams) (repository.DatasetGenerationRejection, error) {
+	r.rejections = append(r.rejections, params)
+	return repository.DatasetGenerationRejection{
+		ID:             uuid.New(),
+		JobID:          params.JobID,
+		ReasonCode:     params.ReasonCode,
+		ReasonDetail:   params.ReasonDetail,
+		CandidateInput: params.CandidateInput,
+		Metadata:       params.Metadata,
+		CreatedAt:      time.Now(),
+	}, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) UpsertDatasetExample(_ context.Context, params repository.UpsertDatasetExampleParams) (repository.DatasetExample, error) {
+	r.upserts = append(r.upserts, params)
+	return repository.DatasetExample{
+		ID:        uuid.New(),
+		DatasetID: params.DatasetID,
+		Input:     params.Input,
+		Expected:  params.Expected,
+		Metadata:  params.Metadata,
+		Tags:      params.Tags,
+		Status:    domain.DatasetExampleStatusActive,
+		Source:    domain.DatasetExampleSourceSynthetic,
+		CreatedBy: params.Actor,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func (r *fakeDatasetGenerationWorkflowRepo) CreateDatasetVersion(context.Context, repository.CreateDatasetVersionParams) (repository.DatasetVersion, error) {
+	return repository.DatasetVersion{ID: uuid.New(), DatasetID: r.context.Dataset.ID}, nil
+}
+
+func containsTag(tags []string, target string) bool {
+	for _, tag := range tags {
+		if tag == target {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/dataset_generate.go
+++ b/cli/cmd/dataset_generate.go
@@ -11,10 +11,17 @@ import (
 
 func init() {
 	datasetCmd.AddCommand(datasetGenerateCmd)
-	datasetGenerateCmd.Flags().String("strategy", "self-instruct", "Generation strategy (v1: self-instruct)")
+	datasetGenerateCmd.Flags().String("strategy", "self-instruct", "Generation strategy (self-instruct, agentic-self-instruct)")
 	datasetGenerateCmd.Flags().Int("count", 0, "Target number of accepted synthetic examples")
 	datasetGenerateCmd.Flags().String("provider-account", "", "Provider account ID")
 	datasetGenerateCmd.Flags().String("model", "", "Provider model ID")
+	datasetGenerateCmd.Flags().String("judge-provider-account", "", "Judge provider account ID for agentic generation")
+	datasetGenerateCmd.Flags().String("judge-model", "", "Judge provider model ID for agentic generation")
+	datasetGenerateCmd.Flags().Int("max-rounds-per-example", 0, "Maximum judge/improve rounds per generated example for agentic generation")
+	datasetGenerateCmd.Flags().String("acceptance-mode", "", "Agentic acceptance mode (judge or threshold)")
+	datasetGenerateCmd.Flags().Float64("min-gap", 0, "Minimum strong-minus-weak score gap for agentic threshold guardrails")
+	datasetGenerateCmd.Flags().Float64("max-weak-score", 0, "Maximum weak score for agentic threshold guardrails")
+	datasetGenerateCmd.Flags().Float64("min-strong-score", 0, "Minimum strong score for agentic threshold guardrails")
 	datasetGenerateCmd.Flags().String("seeds-tag", "", "Only use seed examples with this tag")
 	datasetGenerateCmd.Flags().Bool("create-version", false, "Snapshot a dataset version when generation completes")
 	datasetGenerateCmd.Flags().String("version-label", "", "Optional label for the generated dataset version")
@@ -53,6 +60,10 @@ var datasetGenerateCmd = &cobra.Command{
 		createVersion, _ := cmd.Flags().GetBool("create-version")
 		versionLabel, _ := cmd.Flags().GetString("version-label")
 		follow, _ := cmd.Flags().GetBool("follow")
+		judgeProviderAccount, _ := cmd.Flags().GetString("judge-provider-account")
+		judgeModel, _ := cmd.Flags().GetString("judge-model")
+		maxRoundsPerExample, _ := cmd.Flags().GetInt("max-rounds-per-example")
+		acceptanceMode, _ := cmd.Flags().GetString("acceptance-mode")
 
 		body := map[string]any{
 			"strategy":            strategy,
@@ -66,6 +77,30 @@ var datasetGenerateCmd = &cobra.Command{
 		}
 		if versionLabel != "" {
 			body["version_label"] = versionLabel
+		}
+		if judgeProviderAccount != "" {
+			body["judge_provider_account_id"] = judgeProviderAccount
+		}
+		if judgeModel != "" {
+			body["judge_model"] = judgeModel
+		}
+		if maxRoundsPerExample > 0 {
+			body["max_rounds_per_example"] = maxRoundsPerExample
+		}
+		if acceptanceMode != "" {
+			body["acceptance_mode"] = acceptanceMode
+		}
+		if cmd.Flags().Changed("min-gap") {
+			minGap, _ := cmd.Flags().GetFloat64("min-gap")
+			body["min_gap"] = minGap
+		}
+		if cmd.Flags().Changed("max-weak-score") {
+			maxWeakScore, _ := cmd.Flags().GetFloat64("max-weak-score")
+			body["max_weak_score"] = maxWeakScore
+		}
+		if cmd.Flags().Changed("min-strong-score") {
+			minStrongScore, _ := cmd.Flags().GetFloat64("min-strong-score")
+			body["min_strong_score"] = minStrongScore
 		}
 
 		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/datasets/"+datasetID+"/generate", body)

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -1629,6 +1629,11 @@
           ],
           "flags": [
             {
+              "name": "acceptance-mode",
+              "usage": "Agentic acceptance mode (judge or threshold)",
+              "type": "string"
+            },
+            {
               "name": "count",
               "usage": "Target number of accepted synthetic examples",
               "type": "int",
@@ -1645,6 +1650,40 @@
               "usage": "Poll generation job status until it finishes",
               "type": "bool",
               "default": "false"
+            },
+            {
+              "name": "judge-model",
+              "usage": "Judge provider model ID for agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "judge-provider-account",
+              "usage": "Judge provider account ID for agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "max-rounds-per-example",
+              "usage": "Maximum judge/improve rounds per generated example for agentic generation",
+              "type": "int",
+              "default": "0"
+            },
+            {
+              "name": "max-weak-score",
+              "usage": "Maximum weak score for agentic threshold guardrails",
+              "type": "float64",
+              "default": "0"
+            },
+            {
+              "name": "min-gap",
+              "usage": "Minimum strong-minus-weak score gap for agentic threshold guardrails",
+              "type": "float64",
+              "default": "0"
+            },
+            {
+              "name": "min-strong-score",
+              "usage": "Minimum strong score for agentic threshold guardrails",
+              "type": "float64",
+              "default": "0"
             },
             {
               "name": "model",
@@ -1669,7 +1708,7 @@
             },
             {
               "name": "strategy",
-              "usage": "Generation strategy (v1: self-instruct)",
+              "usage": "Generation strategy (self-instruct, agentic-self-instruct)",
               "type": "string",
               "default": "self-instruct"
             },

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7273,7 +7273,13 @@ components:
       properties:
         strategy:
           type: string
-          enum: [self_instruct, self-instruct]
+          enum:
+            [
+              self_instruct,
+              self-instruct,
+              agentic_self_instruct,
+              agentic-self-instruct,
+            ]
         target_count:
           type: integer
           minimum: 1
@@ -7283,6 +7289,32 @@ components:
         seeds_tag: { type: string }
         create_version: { type: boolean }
         version_label: { type: string }
+        judge_provider_account_id:
+          type: string
+          format: uuid
+          description: Required for agentic_self_instruct.
+        judge_model:
+          type: string
+          description: Required for agentic_self_instruct.
+        max_rounds_per_example:
+          type: integer
+          minimum: 0
+          maximum: 15
+        acceptance_mode:
+          type: string
+          enum: [judge, threshold]
+        min_gap:
+          type: number
+          minimum: 0
+          maximum: 1
+        max_weak_score:
+          type: number
+          minimum: 0
+          maximum: 1
+        min_strong_score:
+          type: number
+          minimum: 0
+          maximum: 1
 
     DatasetGenerationJob:
       type: object

--- a/testing/codex-agentic-self-instruct-phase-1-2.md
+++ b/testing/codex-agentic-self-instruct-phase-1-2.md
@@ -1,0 +1,73 @@
+# codex/agentic-self-instruct-phase-1-2 - Test Contract
+
+## Functional Behavior
+
+- Existing `self_instruct` / `self-instruct` generation requests remain backward compatible.
+- New `agentic_self_instruct` / `agentic-self-instruct` strategy is accepted at parsing/API/CLI/UI boundaries.
+- Agentic generation config supports judge-only semantic filtering fields:
+  - `judge_provider_account_id`
+  - `judge_model`
+  - `max_rounds_per_example`
+  - `acceptance_mode`
+  - `min_gap`
+  - `max_weak_score`
+  - `min_strong_score`
+- Phase 2 behavior is judge-only filtering before full weak/strong deployment execution:
+  - challenger generates a candidate using the existing generation provider/model.
+  - for `agentic_self_instruct`, a judge model evaluates candidate quality after parse/schema/duplicate checks.
+  - judge verdict `accept` allows upsert.
+  - judge verdict `improve` or `reject` records a semantic rejection and continues generation attempts.
+  - malformed judge output records a judge parse rejection and continues generation attempts.
+- Agentic accepted examples are tagged with `synthetic` and `agentic`.
+- Agentic accepted example metadata includes generator, job id, challenger model, judge model, verdict summary, scores, gap, and capability tags when available.
+- Existing schema, duplicate, provider error, and version snapshot behavior still works.
+
+## Unit Tests
+
+- `generation.ParseStrategy` accepts `agentic_self_instruct` and `agentic-self-instruct`.
+- `generation.DecodeJobConfig` validates judge fields for agentic mode while preserving self-instruct validation.
+- `generation.ParseAgenticJudgeResponse` accepts valid JSON with `accept`, `improve`, and `reject`.
+- `generation.ParseAgenticJudgeResponse` rejects malformed JSON, missing verdict, invalid verdict, and out-of-range scores.
+- `generation.ShouldAcceptJudgeVerdict` respects judge mode and threshold guardrails.
+- Existing self-instruct generation tests continue to pass.
+
+## Integration / Functional Tests
+
+- API generation tests cover:
+  - existing self-instruct request still succeeds.
+  - agentic request requires judge provider/model.
+  - agentic request writes the expected config JSON.
+- Workflow generation tests cover:
+  - agentic judge `accept` creates an example with `agentic` tag and metadata.
+  - judge `reject` records a semantic rejection and does not upsert that candidate.
+  - judge malformed output records a judge parse rejection.
+
+## Smoke Tests
+
+- `go test ./internal/datasets/generation ./internal/api ./internal/workflow` from `backend/` passes.
+- `go test ./cmd` from `cli/` passes or targeted dataset generate tests pass if full suite is too slow.
+- Relevant web type/test command passes for touched dataset generation UI files, or TypeScript typecheck passes.
+
+## E2E Tests
+
+N/A - Phase 1/2 does not execute full AgentClash weak/strong deployments. E2E coverage belongs to the later deployment-loop phase.
+
+## Manual / cURL Tests
+
+- Start self-instruct generation request still accepts:
+
+```bash
+curl -X POST "$API/v1/workspaces/$WS/datasets/$DATASET/generations" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"strategy":"self_instruct","target_count":1,"provider_account_id":"'$PROVIDER'","model":"gpt-4.1-mini"}'
+```
+
+- Start agentic judge-only generation request accepts:
+
+```bash
+curl -X POST "$API/v1/workspaces/$WS/datasets/$DATASET/generations" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"strategy":"agentic_self_instruct","target_count":1,"provider_account_id":"'$PROVIDER'","model":"gpt-4.1-mini","judge_provider_account_id":"'$PROVIDER'","judge_model":"gpt-4.1-mini","max_rounds_per_example":3,"acceptance_mode":"judge"}'
+```

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
@@ -68,6 +68,9 @@ export function StartGenerationDialog({
   const [acceptanceMode, setAcceptanceMode] = useState<"judge" | "threshold">(
     "judge",
   );
+  const [minGap, setMinGap] = useState("0.2");
+  const [maxWeakScore, setMaxWeakScore] = useState("0.65");
+  const [minStrongScore, setMinStrongScore] = useState("0.75");
   const [targetCount, setTargetCount] = useState("10");
   const [seedsTag, setSeedsTag] = useState("");
   const [createVersion, setCreateVersion] = useState(true);
@@ -230,6 +233,21 @@ export function StartGenerationDialog({
         toast.error("Max rounds per example must be between 1 and 15");
         return;
       }
+      if (acceptanceMode === "threshold") {
+        const thresholdValues = [
+          Number(minGap),
+          Number(maxWeakScore),
+          Number(minStrongScore),
+        ];
+        if (thresholdValues.some((value) => !Number.isFinite(value))) {
+          toast.error("Threshold values must be valid numbers");
+          return;
+        }
+        if (thresholdValues.some((value) => value < 0 || value > 1)) {
+          toast.error("Threshold values must be between 0 and 1");
+          return;
+        }
+      }
     }
 
     setSubmitting(true);
@@ -262,6 +280,21 @@ export function StartGenerationDialog({
               : undefined,
           acceptance_mode:
             strategy === "agentic_self_instruct" ? acceptanceMode : undefined,
+          min_gap:
+            strategy === "agentic_self_instruct" &&
+            acceptanceMode === "threshold"
+              ? Number(minGap)
+              : undefined,
+          max_weak_score:
+            strategy === "agentic_self_instruct" &&
+            acceptanceMode === "threshold"
+              ? Number(maxWeakScore)
+              : undefined,
+          min_strong_score:
+            strategy === "agentic_self_instruct" &&
+            acceptanceMode === "threshold"
+              ? Number(minStrongScore)
+              : undefined,
         },
       );
       setJob(queued);
@@ -487,6 +520,52 @@ export function StartGenerationDialog({
                     <option value="threshold">Threshold</option>
                   </select>
                 </div>
+                {acceptanceMode === "threshold" ? (
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Min gap
+                      </label>
+                      <input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={minGap}
+                        onChange={(e) => setMinGap(e.target.value)}
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Max weak
+                      </label>
+                      <input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={maxWeakScore}
+                        onChange={(e) => setMaxWeakScore(e.target.value)}
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Min strong
+                      </label>
+                      <input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={minStrongScore}
+                        onChange={(e) => setMinStrongScore(e.target.value)}
+                        className={inputClass}
+                      />
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
             <div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
@@ -57,8 +57,17 @@ export function StartGenerationDialog({
   );
   const [models, setModels] = useState<ProviderConnectionModel[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
+  const [strategy, setStrategy] = useState<
+    "self_instruct" | "agentic_self_instruct"
+  >("self_instruct");
   const [providerAccountId, setProviderAccountId] = useState("");
   const [model, setModel] = useState("");
+  const [judgeProviderAccountId, setJudgeProviderAccountId] = useState("");
+  const [judgeModel, setJudgeModel] = useState("");
+  const [maxRoundsPerExample, setMaxRoundsPerExample] = useState("3");
+  const [acceptanceMode, setAcceptanceMode] = useState<"judge" | "threshold">(
+    "judge",
+  );
   const [targetCount, setTargetCount] = useState("10");
   const [seedsTag, setSeedsTag] = useState("");
   const [createVersion, setCreateVersion] = useState(true);
@@ -211,6 +220,17 @@ export function StartGenerationDialog({
       toast.error("Target count must be between 1 and 100");
       return;
     }
+    if (strategy === "agentic_self_instruct") {
+      const rounds = Number(maxRoundsPerExample);
+      if (!judgeProviderAccountId || !judgeModel.trim()) {
+        toast.error("Select a judge provider account and model");
+        return;
+      }
+      if (!Number.isInteger(rounds) || rounds < 1 || rounds > 15) {
+        toast.error("Max rounds per example must be between 1 and 15");
+        return;
+      }
+    }
 
     setSubmitting(true);
     try {
@@ -221,13 +241,27 @@ export function StartGenerationDialog({
         workspaceId,
         datasetId,
         {
-          strategy: "self_instruct",
+          strategy,
           target_count: count,
           provider_account_id: providerAccountId,
           model: model.trim(),
           seeds_tag: seedsTag.trim() || undefined,
           create_version: createVersion,
           version_label: versionLabel.trim() || undefined,
+          judge_provider_account_id:
+            strategy === "agentic_self_instruct"
+              ? judgeProviderAccountId
+              : undefined,
+          judge_model:
+            strategy === "agentic_self_instruct"
+              ? judgeModel.trim()
+              : undefined,
+          max_rounds_per_example:
+            strategy === "agentic_self_instruct"
+              ? Number(maxRoundsPerExample)
+              : undefined,
+          acceptance_mode:
+            strategy === "agentic_self_instruct" ? acceptanceMode : undefined,
         },
       );
       setJob(queued);
@@ -254,7 +288,7 @@ export function StartGenerationDialog({
         <DialogHeader>
           <DialogTitle>Synthetic generation</DialogTitle>
           <DialogDescription>
-            Self-instruct generation using a provider connection model.
+            Generate examples from seeds, with optional agentic judge filtering.
           </DialogDescription>
         </DialogHeader>
         {job ? (
@@ -324,6 +358,27 @@ export function StartGenerationDialog({
             ) : null}
             <div>
               <label className="mb-1.5 block text-sm font-medium">
+                Generation mode
+              </label>
+              <select
+                value={strategy}
+                onChange={(e) =>
+                  setStrategy(
+                    e.target.value as
+                      | "self_instruct"
+                      | "agentic_self_instruct",
+                  )
+                }
+                className={inputClass}
+              >
+                <option value="self_instruct">Fast Self-Instruct</option>
+                <option value="agentic_self_instruct">
+                  Agentic Self-Instruct
+                </option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
                 Provider account
               </label>
               <select
@@ -373,6 +428,67 @@ export function StartGenerationDialog({
                 />
               )}
             </div>
+            {strategy === "agentic_self_instruct" ? (
+              <div className="space-y-4 rounded-lg border border-border p-3">
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
+                    Judge provider account
+                  </label>
+                  <select
+                    value={judgeProviderAccountId}
+                    onChange={(e) => setJudgeProviderAccountId(e.target.value)}
+                    className={inputClass}
+                  >
+                    <option value="">Select account...</option>
+                    {providerAccounts.map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.name} ({a.provider_key})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
+                    Judge model
+                  </label>
+                  <input
+                    value={judgeModel}
+                    onChange={(e) => setJudgeModel(e.target.value)}
+                    placeholder="e.g. gpt-4.1, claude-sonnet-4-6"
+                    disabled={!judgeProviderAccountId}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
+                    Max rounds per example
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={15}
+                    value={maxRoundsPerExample}
+                    onChange={(e) => setMaxRoundsPerExample(e.target.value)}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
+                    Acceptance mode
+                  </label>
+                  <select
+                    value={acceptanceMode}
+                    onChange={(e) =>
+                      setAcceptanceMode(e.target.value as "judge" | "threshold")
+                    }
+                    className={inputClass}
+                  >
+                    <option value="judge">Judge</option>
+                    <option value="threshold">Threshold</option>
+                  </select>
+                </div>
+              </div>
+            ) : null}
             <div>
               <label className="mb-1.5 block text-sm font-medium">
                 Target count

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2334,13 +2334,24 @@ export interface SyncDatasetRegressionSuiteResult {
 }
 
 export interface StartDatasetGenerationInput {
-  strategy: "self_instruct" | "self-instruct";
+  strategy:
+    | "self_instruct"
+    | "self-instruct"
+    | "agentic_self_instruct"
+    | "agentic-self-instruct";
   target_count: number;
   provider_account_id: string;
   model: string;
   seeds_tag?: string;
   create_version?: boolean;
   version_label?: string;
+  judge_provider_account_id?: string;
+  judge_model?: string;
+  max_rounds_per_example?: number;
+  acceptance_mode?: "judge" | "threshold";
+  min_gap?: number;
+  max_weak_score?: number;
+  min_strong_score?: number;
 }
 
 export interface DatasetGenerationJob {


### PR DESCRIPTION
## Summary

Implements Phase 1 and Phase 2 of #1142 for Agentic Self-Instruct synthetic dataset generation.

- Adds `agentic_self_instruct` / `agentic-self-instruct` strategy support and config validation.
- Adds provider-agnostic judge prompt, verdict parsing, and acceptance guardrails.
- Wires agentic judge config through API, repository execution context, CLI flags, OpenAPI, and the dataset generation UI.
- Adds Phase 2 judge-only semantic filtering in the dataset generation workflow before accepting candidates.
- Tags accepted agentic examples with `synthetic` and `agentic`, and stores judge diagnostics in metadata.
- Records judge rejections/malformed output through the existing generation rejection path.

## Notes

This intentionally does not implement the full weak/strong AgentClash deployment loop. Phase 2 is judge-only filtering so we can improve candidate quality without introducing child run orchestration yet.

The test contract for this PR is committed at `testing/codex-agentic-self-instruct-phase-1-2.md`.

## Validation

- `cd backend && go test ./internal/datasets/generation ./internal/api ./internal/repository ./internal/workflow`
- `cd cli && go test ./cmd`
- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx' src/lib/api/types.ts`

No disposable OpenAI key was needed; the workflow tests use scripted provider responses.
