### PR TITLE
[codex] Agentic self-instruct phases 3-5

### DIFF
--- a/backend/internal/api/datasets.go
+++ b/backend/internal/api/datasets.go
@@ -64,6 +64,7 @@ type DatasetService interface {
 	SyncDatasetRegressionSuite(context.Context, Caller, SyncDatasetRegressionSuiteInput) (repository.SyncDatasetRegressionSuiteResult, error)
 	StartDatasetGeneration(context.Context, Caller, StartDatasetGenerationInput) (repository.DatasetGenerationJob, error)
 	GetDatasetGenerationJob(context.Context, Caller, GetDatasetGenerationJobInput) (repository.DatasetGenerationJob, error)
+	ListDatasetGenerationRejections(context.Context, Caller, ListDatasetGenerationRejectionsInput) (ListDatasetGenerationRejectionsResult, error)
 }
 
 type DatasetManager struct {
@@ -1348,4 +1349,7 @@ func (noopDatasetService) StartDatasetGeneration(context.Context, Caller, StartD
 }
 func (noopDatasetService) GetDatasetGenerationJob(context.Context, Caller, GetDatasetGenerationJobInput) (repository.DatasetGenerationJob, error) {
 	return repository.DatasetGenerationJob{}, errors.New("dataset service is not configured")
+}
+func (noopDatasetService) ListDatasetGenerationRejections(context.Context, Caller, ListDatasetGenerationRejectionsInput) (ListDatasetGenerationRejectionsResult, error) {
+	return ListDatasetGenerationRejectionsResult{}, errors.New("dataset service is not configured")
 }

--- a/backend/internal/api/datasets_generations.go
+++ b/backend/internal/api/datasets_generations.go
@@ -23,6 +23,9 @@ type DatasetGenerationRepository interface {
 	ListDatasetExamplesByDatasetID(context.Context, repository.ListDatasetExamplesParams) ([]repository.DatasetExample, error)
 	ListDatasetGenerationRejectionsByJobID(context.Context, repository.ListDatasetGenerationRejectionsParams) ([]repository.DatasetGenerationRejection, error)
 	CountDatasetGenerationRejectionsByJobID(context.Context, uuid.UUID) (int64, error)
+	ListRunnableDeploymentsWithLatestSnapshot(context.Context, uuid.UUID, []uuid.UUID) ([]repository.RunnableDeployment, error)
+	GetRunnableChallengePackVersionByID(context.Context, uuid.UUID) (repository.RunnableChallengePackVersion, error)
+	WorkspacePublicPacksEnabled(context.Context, uuid.UUID) (bool, error)
 }
 
 type DatasetGenerationWorkflowStarter interface {
@@ -117,7 +120,7 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 		return repository.DatasetGenerationJob{}, err
 	}
 	if input.TargetCount <= 0 || input.TargetCount > 100 {
-		return repository.DatasetGenerationJob{}, errors.New("target_count must be between 1 and 100")
+		return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("target_count must be between 1 and 100")
 	}
 	providerAccount, err := genRepo.GetProviderAccountByID(ctx, input.ProviderAccountID)
 	if err != nil {
@@ -127,7 +130,7 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 		return repository.DatasetGenerationJob{}, ErrForbidden
 	}
 	if strings.TrimSpace(input.Model) == "" {
-		return repository.DatasetGenerationJob{}, errors.New("model is required")
+		return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("model is required")
 	}
 	validateProviderAccount := func(accountID uuid.UUID) error {
 		account, accountErr := genRepo.GetProviderAccountByID(ctx, accountID)
@@ -141,16 +144,16 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	}
 	if strategy == datasetgeneration.StrategyAgenticSelfInstruct {
 		if input.JudgeProviderAccountID == nil || *input.JudgeProviderAccountID == uuid.Nil {
-			return repository.DatasetGenerationJob{}, errors.New("judge_provider_account_id is required for agentic_self_instruct")
+			return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("judge_provider_account_id is required for agentic_self_instruct")
 		}
 		if err := validateProviderAccount(*input.JudgeProviderAccountID); err != nil {
 			return repository.DatasetGenerationJob{}, err
 		}
 		if strings.TrimSpace(input.JudgeModel) == "" {
-			return repository.DatasetGenerationJob{}, errors.New("judge_model is required for agentic_self_instruct")
+			return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("judge_model is required for agentic_self_instruct")
 		}
 		if input.MaxRoundsPerExample < 0 || input.MaxRoundsPerExample > 15 {
-			return repository.DatasetGenerationJob{}, errors.New("max_rounds_per_example must be between 0 and 15")
+			return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("max_rounds_per_example must be between 0 and 15")
 		}
 		if datasetgeneration.NormalizeAgenticSolverMode(input.SolverMode) == datasetgeneration.SolverModeDirectProvider {
 			if input.WeakProviderAccountID != nil && *input.WeakProviderAccountID != uuid.Nil {
@@ -186,7 +189,7 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 		seedCount++
 	}
 	if seedCount == 0 {
-		return repository.DatasetGenerationJob{}, errors.New("dataset must have at least one active seed example")
+		return repository.DatasetGenerationJob{}, datasetgeneration.NewValidationError("dataset must have at least one active seed example")
 	}
 
 	rawConfig := datasetgeneration.JobConfig{
@@ -222,6 +225,14 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	decodedConfig, err := datasetgeneration.DecodeJobConfigForStrategy(config, strategy)
 	if err != nil {
 		return repository.DatasetGenerationJob{}, err
+	}
+	// Deployment context is persisted and surfaced in metadata regardless of
+	// strategy, so enforce workspace ownership whenever any of it is present —
+	// not only on the agentic path that structurally validates it.
+	if datasetgeneration.HasAgenticDeploymentContext(decodedConfig) {
+		if err := validateAgenticDeploymentContext(ctx, genRepo, input.WorkspaceID, decodedConfig); err != nil {
+			return repository.DatasetGenerationJob{}, err
+		}
 	}
 	config, err = json.Marshal(decodedConfig)
 	if err != nil {
@@ -426,6 +437,62 @@ func listDatasetGenerationRejectionsHandler(logger *slog.Logger, service Dataset
 	}
 }
 
+// validateAgenticDeploymentContext enforces that the optional AgentClash
+// deployment context references resources the caller's workspace actually owns,
+// mirroring the provider-account ownership checks. Deployment IDs and the
+// challenge pack version are stored in the job config and later surfaced in
+// example/job metadata, so unowned UUIDs must be rejected at creation time
+// rather than silently persisted.
+func validateAgenticDeploymentContext(ctx context.Context, repo DatasetGenerationRepository, workspaceID uuid.UUID, cfg datasetgeneration.JobConfig) error {
+	deploymentIDs := make([]uuid.UUID, 0, 2)
+	if cfg.WeakDeploymentID != nil && *cfg.WeakDeploymentID != uuid.Nil {
+		deploymentIDs = append(deploymentIDs, *cfg.WeakDeploymentID)
+	}
+	if cfg.StrongDeploymentID != nil && *cfg.StrongDeploymentID != uuid.Nil {
+		deploymentIDs = append(deploymentIDs, *cfg.StrongDeploymentID)
+	}
+	if len(deploymentIDs) > 0 {
+		deployments, err := repo.ListRunnableDeploymentsWithLatestSnapshot(ctx, workspaceID, deploymentIDs)
+		if err != nil {
+			return err
+		}
+		owned := make(map[uuid.UUID]struct{}, len(deployments))
+		for _, deployment := range deployments {
+			owned[deployment.ID] = struct{}{}
+		}
+		for _, id := range deploymentIDs {
+			if _, ok := owned[id]; !ok {
+				return ErrForbidden
+			}
+		}
+	}
+
+	if cfg.ChallengePackVersionID != nil && *cfg.ChallengePackVersionID != uuid.Nil {
+		version, err := repo.GetRunnableChallengePackVersionByID(ctx, *cfg.ChallengePackVersionID)
+		if err != nil {
+			if errors.Is(err, repository.ErrChallengePackVersionNotFound) {
+				return ErrForbidden
+			}
+			return err
+		}
+		switch {
+		case version.WorkspaceID != nil && *version.WorkspaceID != workspaceID:
+			return ErrForbidden
+		case version.WorkspaceID == nil:
+			// Global (shared) pack — only allowed when the workspace opted into
+			// public packs, matching run creation.
+			publicPacks, err := repo.WorkspacePublicPacksEnabled(ctx, workspaceID)
+			if err != nil {
+				return err
+			}
+			if !publicPacks {
+				return ErrForbidden
+			}
+		}
+	}
+	return nil
+}
+
 func handleDatasetGenerationError(w http.ResponseWriter, logger *slog.Logger, err error) {
 	switch {
 	case errors.Is(err, datasetgeneration.ErrUnsupportedStrategy):
@@ -444,15 +511,6 @@ func handleDatasetGenerationError(w http.ResponseWriter, logger *slog.Logger, er
 }
 
 func isDatasetGenerationValidationError(err error) bool {
-	if err == nil {
-		return false
-	}
-	message := err.Error()
-	if message == "target_count must be between 1 and 100" || message == "dataset must have at least one active seed example" || message == "model is required" {
-		return true
-	}
-	return strings.Contains(message, " is required") ||
-		strings.Contains(message, " must be ") ||
-		strings.Contains(message, "must be between") ||
-		strings.Contains(message, "must be valid JSON")
+	var validationErr *datasetgeneration.ValidationError
+	return errors.As(err, &validationErr)
 }

--- a/backend/internal/api/datasets_generations.go
+++ b/backend/internal/api/datasets_generations.go
@@ -39,22 +39,34 @@ func (e DatasetGenerationWorkflowStartError) Error() string {
 func (e DatasetGenerationWorkflowStartError) Unwrap() error { return e.Cause }
 
 type StartDatasetGenerationInput struct {
-	WorkspaceID            uuid.UUID
-	DatasetID              uuid.UUID
-	Strategy               string
-	TargetCount            int32
-	ProviderAccountID      uuid.UUID
-	Model                  string
-	SeedsTag               string
-	CreateVersion          bool
-	VersionLabel           string
-	JudgeProviderAccountID *uuid.UUID
-	JudgeModel             string
-	MaxRoundsPerExample    int
-	AcceptanceMode         string
-	MinGap                 *float64
-	MaxWeakScore           *float64
-	MinStrongScore         *float64
+	WorkspaceID             uuid.UUID
+	DatasetID               uuid.UUID
+	Strategy                string
+	TargetCount             int32
+	ProviderAccountID       uuid.UUID
+	Model                   string
+	SeedsTag                string
+	CreateVersion           bool
+	VersionLabel            string
+	JudgeProviderAccountID  *uuid.UUID
+	JudgeModel              string
+	MaxRoundsPerExample     int
+	AcceptanceMode          string
+	MinGap                  *float64
+	MaxWeakScore            *float64
+	MinStrongScore          *float64
+	SolverMode              string
+	WeakProviderAccountID   *uuid.UUID
+	WeakModel               string
+	StrongProviderAccountID *uuid.UUID
+	StrongModel             string
+	WeakRollouts            int
+	StrongRollouts          int
+	WeakDeploymentID        *uuid.UUID
+	StrongDeploymentID      *uuid.UUID
+	ChallengePackVersionID  *uuid.UUID
+	ChallengeKey            string
+	FieldMapping            json.RawMessage
 }
 
 type GetDatasetGenerationJobInput struct {
@@ -100,22 +112,40 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	if strings.TrimSpace(input.Model) == "" {
 		return repository.DatasetGenerationJob{}, errors.New("model is required")
 	}
+	validateProviderAccount := func(accountID uuid.UUID) error {
+		account, accountErr := genRepo.GetProviderAccountByID(ctx, accountID)
+		if accountErr != nil {
+			return accountErr
+		}
+		if account.WorkspaceID == nil || *account.WorkspaceID != input.WorkspaceID {
+			return ErrForbidden
+		}
+		return nil
+	}
 	if strategy == datasetgeneration.StrategyAgenticSelfInstruct {
 		if input.JudgeProviderAccountID == nil || *input.JudgeProviderAccountID == uuid.Nil {
 			return repository.DatasetGenerationJob{}, errors.New("judge_provider_account_id is required for agentic_self_instruct")
 		}
-		judgeProviderAccount, err := genRepo.GetProviderAccountByID(ctx, *input.JudgeProviderAccountID)
-		if err != nil {
+		if err := validateProviderAccount(*input.JudgeProviderAccountID); err != nil {
 			return repository.DatasetGenerationJob{}, err
-		}
-		if judgeProviderAccount.WorkspaceID == nil || *judgeProviderAccount.WorkspaceID != input.WorkspaceID {
-			return repository.DatasetGenerationJob{}, ErrForbidden
 		}
 		if strings.TrimSpace(input.JudgeModel) == "" {
 			return repository.DatasetGenerationJob{}, errors.New("judge_model is required for agentic_self_instruct")
 		}
 		if input.MaxRoundsPerExample < 0 || input.MaxRoundsPerExample > 15 {
 			return repository.DatasetGenerationJob{}, errors.New("max_rounds_per_example must be between 0 and 15")
+		}
+		if datasetgeneration.NormalizeAgenticSolverMode(input.SolverMode) == datasetgeneration.SolverModeDirectProvider {
+			if input.WeakProviderAccountID != nil && *input.WeakProviderAccountID != uuid.Nil {
+				if err := validateProviderAccount(*input.WeakProviderAccountID); err != nil {
+					return repository.DatasetGenerationJob{}, err
+				}
+			}
+			if input.StrongProviderAccountID != nil && *input.StrongProviderAccountID != uuid.Nil {
+				if err := validateProviderAccount(*input.StrongProviderAccountID); err != nil {
+					return repository.DatasetGenerationJob{}, err
+				}
+			}
 		}
 	}
 
@@ -142,24 +172,42 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 		return repository.DatasetGenerationJob{}, errors.New("dataset must have at least one active seed example")
 	}
 
-	config, err := json.Marshal(datasetgeneration.JobConfig{
-		ProviderAccountID:      input.ProviderAccountID,
-		Model:                  strings.TrimSpace(input.Model),
-		SeedsTag:               strings.TrimSpace(input.SeedsTag),
-		CreateVersion:          input.CreateVersion,
-		VersionLabel:           strings.TrimSpace(input.VersionLabel),
-		JudgeProviderAccountID: input.JudgeProviderAccountID,
-		JudgeModel:             strings.TrimSpace(input.JudgeModel),
-		MaxRoundsPerExample:    input.MaxRoundsPerExample,
-		AcceptanceMode:         strings.TrimSpace(input.AcceptanceMode),
-		MinGap:                 input.MinGap,
-		MaxWeakScore:           input.MaxWeakScore,
-		MinStrongScore:         input.MinStrongScore,
-	})
+	rawConfig := datasetgeneration.JobConfig{
+		ProviderAccountID:       input.ProviderAccountID,
+		Model:                   strings.TrimSpace(input.Model),
+		SeedsTag:                strings.TrimSpace(input.SeedsTag),
+		CreateVersion:           input.CreateVersion,
+		VersionLabel:            strings.TrimSpace(input.VersionLabel),
+		JudgeProviderAccountID:  input.JudgeProviderAccountID,
+		JudgeModel:              strings.TrimSpace(input.JudgeModel),
+		MaxRoundsPerExample:     input.MaxRoundsPerExample,
+		AcceptanceMode:          strings.TrimSpace(input.AcceptanceMode),
+		MinGap:                  input.MinGap,
+		MaxWeakScore:            input.MaxWeakScore,
+		MinStrongScore:          input.MinStrongScore,
+		SolverMode:              strings.TrimSpace(input.SolverMode),
+		WeakProviderAccountID:   input.WeakProviderAccountID,
+		WeakModel:               strings.TrimSpace(input.WeakModel),
+		StrongProviderAccountID: input.StrongProviderAccountID,
+		StrongModel:             strings.TrimSpace(input.StrongModel),
+		WeakRollouts:            input.WeakRollouts,
+		StrongRollouts:          input.StrongRollouts,
+		WeakDeploymentID:        input.WeakDeploymentID,
+		StrongDeploymentID:      input.StrongDeploymentID,
+		ChallengePackVersionID:  input.ChallengePackVersionID,
+		ChallengeKey:            strings.TrimSpace(input.ChallengeKey),
+		FieldMapping:            append(json.RawMessage(nil), input.FieldMapping...),
+	}
+	config, err := json.Marshal(rawConfig)
 	if err != nil {
 		return repository.DatasetGenerationJob{}, err
 	}
-	if _, err := datasetgeneration.DecodeJobConfigForStrategy(config, strategy); err != nil {
+	decodedConfig, err := datasetgeneration.DecodeJobConfigForStrategy(config, strategy)
+	if err != nil {
+		return repository.DatasetGenerationJob{}, err
+	}
+	config, err = json.Marshal(decodedConfig)
+	if err != nil {
 		return repository.DatasetGenerationJob{}, err
 	}
 
@@ -207,20 +255,32 @@ func startDatasetGenerationHandler(logger *slog.Logger, service DatasetService) 
 			return
 		}
 		var body struct {
-			Strategy               string     `json:"strategy"`
-			TargetCount            int32      `json:"target_count"`
-			ProviderAccountID      uuid.UUID  `json:"provider_account_id"`
-			Model                  string     `json:"model"`
-			SeedsTag               string     `json:"seeds_tag,omitempty"`
-			CreateVersion          bool       `json:"create_version,omitempty"`
-			VersionLabel           string     `json:"version_label,omitempty"`
-			JudgeProviderAccountID *uuid.UUID `json:"judge_provider_account_id,omitempty"`
-			JudgeModel             string     `json:"judge_model,omitempty"`
-			MaxRoundsPerExample    int        `json:"max_rounds_per_example,omitempty"`
-			AcceptanceMode         string     `json:"acceptance_mode,omitempty"`
-			MinGap                 *float64   `json:"min_gap,omitempty"`
-			MaxWeakScore           *float64   `json:"max_weak_score,omitempty"`
-			MinStrongScore         *float64   `json:"min_strong_score,omitempty"`
+			Strategy                string          `json:"strategy"`
+			TargetCount             int32           `json:"target_count"`
+			ProviderAccountID       uuid.UUID       `json:"provider_account_id"`
+			Model                   string          `json:"model"`
+			SeedsTag                string          `json:"seeds_tag,omitempty"`
+			CreateVersion           bool            `json:"create_version,omitempty"`
+			VersionLabel            string          `json:"version_label,omitempty"`
+			JudgeProviderAccountID  *uuid.UUID      `json:"judge_provider_account_id,omitempty"`
+			JudgeModel              string          `json:"judge_model,omitempty"`
+			MaxRoundsPerExample     int             `json:"max_rounds_per_example,omitempty"`
+			AcceptanceMode          string          `json:"acceptance_mode,omitempty"`
+			MinGap                  *float64        `json:"min_gap,omitempty"`
+			MaxWeakScore            *float64        `json:"max_weak_score,omitempty"`
+			MinStrongScore          *float64        `json:"min_strong_score,omitempty"`
+			SolverMode              string          `json:"solver_mode,omitempty"`
+			WeakProviderAccountID   *uuid.UUID      `json:"weak_provider_account_id,omitempty"`
+			WeakModel               string          `json:"weak_model,omitempty"`
+			StrongProviderAccountID *uuid.UUID      `json:"strong_provider_account_id,omitempty"`
+			StrongModel             string          `json:"strong_model,omitempty"`
+			WeakRollouts            int             `json:"weak_rollouts,omitempty"`
+			StrongRollouts          int             `json:"strong_rollouts,omitempty"`
+			WeakDeploymentID        *uuid.UUID      `json:"weak_deployment_id,omitempty"`
+			StrongDeploymentID      *uuid.UUID      `json:"strong_deployment_id,omitempty"`
+			ChallengePackVersionID  *uuid.UUID      `json:"challenge_pack_version_id,omitempty"`
+			ChallengeKey            string          `json:"challenge_key,omitempty"`
+			FieldMapping            json.RawMessage `json:"field_mapping,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
@@ -231,22 +291,34 @@ func startDatasetGenerationHandler(logger *slog.Logger, service DatasetService) 
 			return
 		}
 		job, err := service.StartDatasetGeneration(r.Context(), caller, StartDatasetGenerationInput{
-			WorkspaceID:            workspaceID,
-			DatasetID:              datasetID,
-			Strategy:               body.Strategy,
-			TargetCount:            body.TargetCount,
-			ProviderAccountID:      body.ProviderAccountID,
-			SeedsTag:               body.SeedsTag,
-			CreateVersion:          body.CreateVersion,
-			VersionLabel:           body.VersionLabel,
-			Model:                  body.Model,
-			JudgeProviderAccountID: body.JudgeProviderAccountID,
-			JudgeModel:             body.JudgeModel,
-			MaxRoundsPerExample:    body.MaxRoundsPerExample,
-			AcceptanceMode:         body.AcceptanceMode,
-			MinGap:                 body.MinGap,
-			MaxWeakScore:           body.MaxWeakScore,
-			MinStrongScore:         body.MinStrongScore,
+			WorkspaceID:             workspaceID,
+			DatasetID:               datasetID,
+			Strategy:                body.Strategy,
+			TargetCount:             body.TargetCount,
+			ProviderAccountID:       body.ProviderAccountID,
+			SeedsTag:                body.SeedsTag,
+			CreateVersion:           body.CreateVersion,
+			VersionLabel:            body.VersionLabel,
+			Model:                   body.Model,
+			JudgeProviderAccountID:  body.JudgeProviderAccountID,
+			JudgeModel:              body.JudgeModel,
+			MaxRoundsPerExample:     body.MaxRoundsPerExample,
+			AcceptanceMode:          body.AcceptanceMode,
+			MinGap:                  body.MinGap,
+			MaxWeakScore:            body.MaxWeakScore,
+			MinStrongScore:          body.MinStrongScore,
+			SolverMode:              body.SolverMode,
+			WeakProviderAccountID:   body.WeakProviderAccountID,
+			WeakModel:               body.WeakModel,
+			StrongProviderAccountID: body.StrongProviderAccountID,
+			StrongModel:             body.StrongModel,
+			WeakRollouts:            body.WeakRollouts,
+			StrongRollouts:          body.StrongRollouts,
+			WeakDeploymentID:        body.WeakDeploymentID,
+			StrongDeploymentID:      body.StrongDeploymentID,
+			ChallengePackVersionID:  body.ChallengePackVersionID,
+			ChallengeKey:            body.ChallengeKey,
+			FieldMapping:            body.FieldMapping,
 		})
 		if err != nil {
 			handleDatasetGenerationError(w, logger, err)
@@ -290,9 +362,23 @@ func handleDatasetGenerationError(w http.ResponseWriter, logger *slog.Logger, er
 		writeError(w, http.StatusNotFound, "provider_account_not_found", "provider account not found")
 	case errors.Is(err, ErrForbidden):
 		writeError(w, http.StatusForbidden, "forbidden", "forbidden")
-	case err != nil && (err.Error() == "target_count must be between 1 and 100" || err.Error() == "dataset must have at least one active seed example" || err.Error() == "model is required"):
+	case err != nil && isDatasetGenerationValidationError(err):
 		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 	default:
 		handleDatasetError(w, logger, err)
 	}
+}
+
+func isDatasetGenerationValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	if message == "target_count must be between 1 and 100" || message == "dataset must have at least one active seed example" || message == "model is required" {
+		return true
+	}
+	return strings.Contains(message, " is required") ||
+		strings.Contains(message, " must be ") ||
+		strings.Contains(message, "must be between") ||
+		strings.Contains(message, "must be valid JSON")
 }

--- a/backend/internal/api/datasets_generations.go
+++ b/backend/internal/api/datasets_generations.go
@@ -21,6 +21,8 @@ type DatasetGenerationRepository interface {
 	GetDatasetGenerationJobByID(context.Context, uuid.UUID) (repository.DatasetGenerationJob, error)
 	GetProviderAccountByID(context.Context, uuid.UUID) (repository.ProviderAccountRow, error)
 	ListDatasetExamplesByDatasetID(context.Context, repository.ListDatasetExamplesParams) ([]repository.DatasetExample, error)
+	ListDatasetGenerationRejectionsByJobID(context.Context, repository.ListDatasetGenerationRejectionsParams) ([]repository.DatasetGenerationRejection, error)
+	CountDatasetGenerationRejectionsByJobID(context.Context, uuid.UUID) (int64, error)
 }
 
 type DatasetGenerationWorkflowStarter interface {
@@ -73,6 +75,21 @@ type GetDatasetGenerationJobInput struct {
 	WorkspaceID uuid.UUID
 	DatasetID   uuid.UUID
 	JobID       uuid.UUID
+}
+
+type ListDatasetGenerationRejectionsInput struct {
+	WorkspaceID uuid.UUID
+	DatasetID   uuid.UUID
+	JobID       uuid.UUID
+	Limit       int32
+	Offset      int32
+}
+
+type ListDatasetGenerationRejectionsResult struct {
+	Items  []repository.DatasetGenerationRejection `json:"items"`
+	Total  int64                                   `json:"total"`
+	Limit  int32                                   `json:"limit"`
+	Offset int32                                   `json:"offset"`
 }
 
 func (m *DatasetManager) WithGenerationWorkflowStarter(starter DatasetGenerationWorkflowStarter) *DatasetManager {
@@ -248,6 +265,33 @@ func (m *DatasetManager) GetDatasetGenerationJob(ctx context.Context, caller Cal
 	return job, nil
 }
 
+func (m *DatasetManager) ListDatasetGenerationRejections(ctx context.Context, caller Caller, input ListDatasetGenerationRejectionsInput) (ListDatasetGenerationRejectionsResult, error) {
+	if _, err := m.GetDatasetGenerationJob(ctx, caller, GetDatasetGenerationJobInput{
+		WorkspaceID: input.WorkspaceID,
+		DatasetID:   input.DatasetID,
+		JobID:       input.JobID,
+	}); err != nil {
+		return ListDatasetGenerationRejectionsResult{}, err
+	}
+	genRepo, ok := m.repo.(DatasetGenerationRepository)
+	if !ok {
+		return ListDatasetGenerationRejectionsResult{}, errors.New("dataset generation repository not configured")
+	}
+	items, err := genRepo.ListDatasetGenerationRejectionsByJobID(ctx, repository.ListDatasetGenerationRejectionsParams{
+		JobID:  input.JobID,
+		Limit:  input.Limit,
+		Offset: input.Offset,
+	})
+	if err != nil {
+		return ListDatasetGenerationRejectionsResult{}, err
+	}
+	total, err := genRepo.CountDatasetGenerationRejectionsByJobID(ctx, input.JobID)
+	if err != nil {
+		return ListDatasetGenerationRejectionsResult{}, err
+	}
+	return ListDatasetGenerationRejectionsResult{Items: items, Total: total, Limit: input.Limit, Offset: input.Offset}, nil
+}
+
 func startDatasetGenerationHandler(logger *slog.Logger, service DatasetService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller, workspaceID, datasetID, ok := datasetPathContext(w, r)
@@ -349,6 +393,36 @@ func getDatasetGenerationJobHandler(logger *slog.Logger, service DatasetService)
 			return
 		}
 		writeJSON(w, http.StatusOK, job)
+	}
+}
+
+func listDatasetGenerationRejectionsHandler(logger *slog.Logger, service DatasetService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, datasetID, ok := datasetPathContext(w, r)
+		if !ok {
+			return
+		}
+		jobID, err := uuid.Parse(chi.URLParam(r, "jobID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_job_id", "jobID must be a UUID")
+			return
+		}
+		limit, offset, ok := paginationFromRequest(w, r)
+		if !ok {
+			return
+		}
+		result, err := service.ListDatasetGenerationRejections(r.Context(), caller, ListDatasetGenerationRejectionsInput{
+			WorkspaceID: workspaceID,
+			DatasetID:   datasetID,
+			JobID:       jobID,
+			Limit:       limit,
+			Offset:      offset,
+		})
+		if err != nil {
+			handleDatasetGenerationError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
 	}
 }
 

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -25,8 +25,9 @@ func (denyWorkspaceAccessAuthorizer) AuthorizeWorkspace(context.Context, Caller,
 
 type datasetGenerationFakeRepo struct {
 	*datasetImportFakeRepo
-	providerAccount repository.ProviderAccountRow
-	job             repository.DatasetGenerationJob
+	providerAccount  repository.ProviderAccountRow
+	providerAccounts map[uuid.UUID]repository.ProviderAccountRow
+	job              repository.DatasetGenerationJob
 }
 
 func (r *datasetGenerationFakeRepo) CreateDatasetGenerationJob(_ context.Context, params repository.CreateDatasetGenerationJobParams) (repository.DatasetGenerationJob, error) {
@@ -51,6 +52,11 @@ func (r *datasetGenerationFakeRepo) GetDatasetGenerationJobByID(_ context.Contex
 }
 
 func (r *datasetGenerationFakeRepo) GetProviderAccountByID(_ context.Context, id uuid.UUID) (repository.ProviderAccountRow, error) {
+	if r.providerAccounts != nil {
+		if account, ok := r.providerAccounts[id]; ok {
+			return account, nil
+		}
+	}
 	if r.providerAccount.ID == id {
 		return r.providerAccount, nil
 	}
@@ -179,6 +185,110 @@ func TestStartDatasetGenerationCreatesAgenticJobConfig(t *testing.T) {
 	}
 	if cfg["max_rounds_per_example"] != float64(rounds) {
 		t.Fatalf("max_rounds_per_example = %v", cfg["max_rounds_per_example"])
+	}
+}
+
+func TestStartDatasetGenerationCreatesDirectSolverConfig(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	judgeID := uuid.New()
+	weakID := uuid.New()
+	strongID := uuid.New()
+	account := func(id uuid.UUID) repository.ProviderAccountRow {
+		return repository.ProviderAccountRow{ID: id, WorkspaceID: &wsID, ProviderKey: "openai"}
+	}
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccounts: map[uuid.UUID]repository.ProviderAccountRow{
+			providerID: account(providerID),
+			judgeID:    account(judgeID),
+			weakID:     account(weakID),
+			strongID:   account(strongID),
+		},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	job, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:             wsID,
+		DatasetID:               datasetID,
+		Strategy:                "agentic-self-instruct",
+		TargetCount:             2,
+		ProviderAccountID:       providerID,
+		Model:                   "gpt-4.1-mini",
+		JudgeProviderAccountID:  &judgeID,
+		JudgeModel:              "gpt-4.1",
+		SolverMode:              "direct_provider",
+		WeakProviderAccountID:   &weakID,
+		WeakModel:               "gpt-4.1-nano",
+		StrongProviderAccountID: &strongID,
+		StrongModel:             "gpt-4.1",
+	})
+	if err != nil {
+		t.Fatalf("start generation: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(job.Config, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg["solver_mode"] != "direct_provider" {
+		t.Fatalf("solver_mode = %v", cfg["solver_mode"])
+	}
+	if cfg["weak_rollouts"] != float64(1) || cfg["strong_rollouts"] != float64(1) {
+		t.Fatalf("rollouts = %v/%v, want 1/1", cfg["weak_rollouts"], cfg["strong_rollouts"])
+	}
+}
+
+func TestStartDatasetGenerationCreatesDeploymentContextConfig(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	weakDeploymentID := uuid.New()
+	strongDeploymentID := uuid.New()
+	challengePackVersionID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	job, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:            wsID,
+		DatasetID:              datasetID,
+		Strategy:               "agentic-self-instruct",
+		TargetCount:            2,
+		ProviderAccountID:      providerID,
+		Model:                  "gpt-4.1-mini",
+		JudgeProviderAccountID: &providerID,
+		JudgeModel:             "gpt-4.1",
+		WeakDeploymentID:       &weakDeploymentID,
+		StrongDeploymentID:     &strongDeploymentID,
+		ChallengePackVersionID: &challengePackVersionID,
+		ChallengeKey:           "support-recovery",
+		FieldMapping:           json.RawMessage(`{"input":"prompt","expected":"answer"}`),
+	})
+	if err != nil {
+		t.Fatalf("start generation: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(job.Config, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg["challenge_key"] != "support-recovery" {
+		t.Fatalf("challenge_key = %v", cfg["challenge_key"])
+	}
+	if _, ok := cfg["field_mapping"].(map[string]any); !ok {
+		t.Fatalf("field_mapping = %#v, want object", cfg["field_mapping"])
 	}
 }
 

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -25,10 +25,13 @@ func (denyWorkspaceAccessAuthorizer) AuthorizeWorkspace(context.Context, Caller,
 
 type datasetGenerationFakeRepo struct {
 	*datasetImportFakeRepo
-	providerAccount  repository.ProviderAccountRow
-	providerAccounts map[uuid.UUID]repository.ProviderAccountRow
-	job              repository.DatasetGenerationJob
-	rejections       []repository.DatasetGenerationRejection
+	providerAccount       repository.ProviderAccountRow
+	providerAccounts      map[uuid.UUID]repository.ProviderAccountRow
+	job                   repository.DatasetGenerationJob
+	rejections            []repository.DatasetGenerationRejection
+	deployments           map[uuid.UUID]repository.RunnableDeployment
+	challengePackVersions map[uuid.UUID]repository.RunnableChallengePackVersion
+	publicPacksEnabled    bool
 }
 
 func (r *datasetGenerationFakeRepo) CreateDatasetGenerationJob(_ context.Context, params repository.CreateDatasetGenerationJobParams) (repository.DatasetGenerationJob, error) {
@@ -90,6 +93,29 @@ func (r *datasetGenerationFakeRepo) CountDatasetGenerationRejectionsByJobID(_ co
 		}
 	}
 	return count, nil
+}
+
+func (r *datasetGenerationFakeRepo) ListRunnableDeploymentsWithLatestSnapshot(_ context.Context, workspaceID uuid.UUID, ids []uuid.UUID) ([]repository.RunnableDeployment, error) {
+	out := make([]repository.RunnableDeployment, 0, len(ids))
+	for _, id := range ids {
+		deployment, ok := r.deployments[id]
+		if !ok || deployment.WorkspaceID != workspaceID {
+			continue
+		}
+		out = append(out, deployment)
+	}
+	return out, nil
+}
+
+func (r *datasetGenerationFakeRepo) GetRunnableChallengePackVersionByID(_ context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error) {
+	if version, ok := r.challengePackVersions[id]; ok {
+		return version, nil
+	}
+	return repository.RunnableChallengePackVersion{}, repository.ErrChallengePackVersionNotFound
+}
+
+func (r *datasetGenerationFakeRepo) WorkspacePublicPacksEnabled(_ context.Context, _ uuid.UUID) (bool, error) {
+	return r.publicPacksEnabled, nil
 }
 
 func TestStartDatasetGenerationRequiresManageDatasets(t *testing.T) {
@@ -283,6 +309,13 @@ func TestStartDatasetGenerationCreatesDeploymentContextConfig(t *testing.T) {
 	repo := &datasetGenerationFakeRepo{
 		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
 		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+		deployments: map[uuid.UUID]repository.RunnableDeployment{
+			weakDeploymentID:   {ID: weakDeploymentID, WorkspaceID: wsID},
+			strongDeploymentID: {ID: strongDeploymentID, WorkspaceID: wsID},
+		},
+		challengePackVersions: map[uuid.UUID]repository.RunnableChallengePackVersion{
+			challengePackVersionID: {ID: challengePackVersionID, WorkspaceID: &wsID},
+		},
 	}
 	repo.examples = []repository.DatasetExample{{
 		ID:        uuid.New(),
@@ -318,6 +351,52 @@ func TestStartDatasetGenerationCreatesDeploymentContextConfig(t *testing.T) {
 	}
 	if _, ok := cfg["field_mapping"].(map[string]any); !ok {
 		t.Fatalf("field_mapping = %#v, want object", cfg["field_mapping"])
+	}
+}
+
+func TestStartDatasetGenerationRejectsForeignDeploymentContext(t *testing.T) {
+	wsID := uuid.New()
+	otherWsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	weakDeploymentID := uuid.New()
+	strongDeploymentID := uuid.New()
+	challengePackVersionID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+		// Deployments and pack version belong to a different workspace.
+		deployments: map[uuid.UUID]repository.RunnableDeployment{
+			weakDeploymentID:   {ID: weakDeploymentID, WorkspaceID: otherWsID},
+			strongDeploymentID: {ID: strongDeploymentID, WorkspaceID: otherWsID},
+		},
+		challengePackVersions: map[uuid.UUID]repository.RunnableChallengePackVersion{
+			challengePackVersionID: {ID: challengePackVersionID, WorkspaceID: &otherWsID},
+		},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID:        uuid.New(),
+		DatasetID: datasetID,
+		Input:     json.RawMessage(`{"q":"seed"}`),
+		Status:    domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	_, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID:            wsID,
+		DatasetID:              datasetID,
+		Strategy:               "agentic-self-instruct",
+		TargetCount:            2,
+		ProviderAccountID:      providerID,
+		Model:                  "gpt-4.1-mini",
+		JudgeProviderAccountID: &providerID,
+		JudgeModel:             "gpt-4.1",
+		WeakDeploymentID:       &weakDeploymentID,
+		StrongDeploymentID:     &strongDeploymentID,
+		ChallengePackVersionID: &challengePackVersionID,
+		ChallengeKey:           "support-recovery",
+	})
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected forbidden for cross-workspace deployment context, got %v", err)
 	}
 }
 

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -28,6 +28,7 @@ type datasetGenerationFakeRepo struct {
 	providerAccount  repository.ProviderAccountRow
 	providerAccounts map[uuid.UUID]repository.ProviderAccountRow
 	job              repository.DatasetGenerationJob
+	rejections       []repository.DatasetGenerationRejection
 }
 
 func (r *datasetGenerationFakeRepo) CreateDatasetGenerationJob(_ context.Context, params repository.CreateDatasetGenerationJobParams) (repository.DatasetGenerationJob, error) {
@@ -61,6 +62,34 @@ func (r *datasetGenerationFakeRepo) GetProviderAccountByID(_ context.Context, id
 		return r.providerAccount, nil
 	}
 	return repository.ProviderAccountRow{}, repository.ErrProviderAccountNotFound
+}
+
+func (r *datasetGenerationFakeRepo) ListDatasetGenerationRejectionsByJobID(_ context.Context, params repository.ListDatasetGenerationRejectionsParams) ([]repository.DatasetGenerationRejection, error) {
+	items := make([]repository.DatasetGenerationRejection, 0)
+	for _, item := range r.rejections {
+		if item.JobID == params.JobID {
+			items = append(items, item)
+		}
+	}
+	start := int(params.Offset)
+	if start > len(items) {
+		return []repository.DatasetGenerationRejection{}, nil
+	}
+	end := start + int(params.Limit)
+	if params.Limit <= 0 || end > len(items) {
+		end = len(items)
+	}
+	return items[start:end], nil
+}
+
+func (r *datasetGenerationFakeRepo) CountDatasetGenerationRejectionsByJobID(_ context.Context, jobID uuid.UUID) (int64, error) {
+	var count int64
+	for _, item := range r.rejections {
+		if item.JobID == jobID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func TestStartDatasetGenerationRequiresManageDatasets(t *testing.T) {
@@ -320,5 +349,42 @@ func TestStartDatasetGenerationAgenticThresholdRequiresValues(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected missing threshold values error")
+	}
+}
+
+func TestListDatasetGenerationRejectionsReturnsJobHistory(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	jobID := uuid.New()
+	otherJobID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		job: repository.DatasetGenerationJob{
+			ID:          jobID,
+			WorkspaceID: wsID,
+			DatasetID:   datasetID,
+		},
+		rejections: []repository.DatasetGenerationRejection{
+			{ID: uuid.New(), JobID: jobID, ReasonCode: "solver_error", Metadata: json.RawMessage(`{"role":"weak_solver"}`)},
+			{ID: uuid.New(), JobID: otherJobID, ReasonCode: "parse_error", Metadata: json.RawMessage(`{}`)},
+			{ID: uuid.New(), JobID: jobID, ReasonCode: "quality_rejected", Metadata: json.RawMessage(`{"gap":0.1}`)},
+		},
+	}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	result, err := manager.ListDatasetGenerationRejections(context.Background(), Caller{UserID: uuid.New()}, ListDatasetGenerationRejectionsInput{
+		WorkspaceID: wsID,
+		DatasetID:   datasetID,
+		JobID:       jobID,
+		Limit:       10,
+		Offset:      0,
+	})
+	if err != nil {
+		t.Fatalf("list rejections: %v", err)
+	}
+	if result.Total != 2 || len(result.Items) != 2 {
+		t.Fatalf("history total/items = %d/%d, want 2/2", result.Total, len(result.Items))
+	}
+	if result.Items[0].ReasonCode != "solver_error" || result.Items[1].ReasonCode != "quality_rejected" {
+		t.Fatalf("items = %+v", result.Items)
 	}
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -138,6 +138,7 @@ func registerProtectedRoutes(
 	router.Post("/workspaces/{workspaceID}/datasets/{datasetID}/regression-suite/sync", syncDatasetRegressionSuiteHandler(logger, datasetService))
 	router.Post("/workspaces/{workspaceID}/datasets/{datasetID}/generate", startDatasetGenerationHandler(logger, datasetService))
 	router.Get("/workspaces/{workspaceID}/datasets/{datasetID}/generations/{jobID}", getDatasetGenerationJobHandler(logger, datasetService))
+	router.Get("/workspaces/{workspaceID}/datasets/{datasetID}/generations/{jobID}/rejections", listDatasetGenerationRejectionsHandler(logger, datasetService))
 	router.Post("/workspaces/{workspaceID}/datasets/{datasetID}/examples", addDatasetExampleHandler(logger, datasetService))
 	router.Get("/workspaces/{workspaceID}/datasets/{datasetID}/examples", listDatasetExamplesHandler(logger, datasetService))
 	router.Patch("/workspaces/{workspaceID}/datasets/{datasetID}/examples/{exampleID}", patchDatasetExampleHandler(logger, datasetService))

--- a/backend/internal/datasets/generation/agentic_self_instruct.go
+++ b/backend/internal/datasets/generation/agentic_self_instruct.go
@@ -17,8 +17,18 @@ const (
 )
 
 type AgenticJudgeInput struct {
-	Seeds     []SeedExample
-	Candidate Candidate
+	Seeds          []SeedExample
+	Candidate      Candidate
+	WeakAttempts   []AgenticSolverAttempt
+	StrongAttempts []AgenticSolverAttempt
+}
+
+type AgenticSolverAttempt struct {
+	Role              string `json:"role"`
+	Attempt           int    `json:"attempt"`
+	ProviderAccountID string `json:"provider_account_id,omitempty"`
+	Model             string `json:"model,omitempty"`
+	Output            string `json:"output"`
 }
 
 type AgenticJudgeVerdict struct {
@@ -48,10 +58,14 @@ func BuildAgenticJudgePrompt(input AgenticJudgeInput) string {
 	var b strings.Builder
 	b.WriteString("You are judging a synthetic AgentClash dataset example before it is accepted.\n")
 	b.WriteString("Decide whether the candidate is high-quality, realistic, non-duplicative in spirit, and useful for evaluating an agent.\n")
-	b.WriteString("This phase is judge-only: no weak or strong solver rollouts are available yet. Prefer rejecting vague, trivial, answer-leaking, impossible, or schema-inconsistent examples.\n")
+	if len(input.WeakAttempts) == 0 && len(input.StrongAttempts) == 0 {
+		b.WriteString("No weak or strong solver rollouts are available for this candidate. Prefer rejecting vague, trivial, answer-leaking, impossible, or schema-inconsistent examples.\n")
+	} else {
+		b.WriteString("Weak and strong solver attempts are provided. Reward examples where the strong solver clearly succeeds more often or more completely than the weak solver.\n")
+	}
 	b.WriteString("Respond with ONLY valid JSON in this exact shape:\n")
 	b.WriteString(`{"verdict":"accept|improve|reject","quality_verdict":"high|medium|low","weak_score":0.0,"strong_score":1.0,"gap":0.0,"weak_pattern":"","strong_pattern":"","gap_interpretation":"","rubric_concerns":[],"capability_tags":[],"grpo_suitability":"high|medium|low","suggestion_for_challenger":null}` + "\n")
-	b.WriteString("Use null or omit scores when solver scores are not available. If verdict is improve or reject, include a concrete suggestion_for_challenger.\n\n")
+	b.WriteString("Scores must be between 0 and 1. Use null or omit scores when solver evidence is insufficient. If verdict is improve or reject, include a concrete suggestion_for_challenger.\n\n")
 	b.WriteString("Seed examples:\n")
 	for i, seed := range input.Seeds {
 		b.WriteString(fmt.Sprintf("%d. input: %s\n", i+1, compactJSON(seed.Input)))
@@ -64,6 +78,24 @@ func BuildAgenticJudgePrompt(input AgenticJudgeInput) string {
 	if len(input.Candidate.Expected) > 0 && string(input.Candidate.Expected) != "null" {
 		b.WriteString(fmt.Sprintf("expected: %s\n", compactJSON(input.Candidate.Expected)))
 	}
+	writeSolverAttempts(&b, "Weak solver attempts", input.WeakAttempts)
+	writeSolverAttempts(&b, "Strong solver attempts", input.StrongAttempts)
+	return b.String()
+}
+
+func BuildAgenticSolverPrompt(role string, candidate Candidate) string {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		role = "solver"
+	}
+	var b strings.Builder
+	b.WriteString("You are acting as the ")
+	b.WriteString(role)
+	b.WriteString(" model in an AgentClash synthetic dataset calibration loop.\n")
+	b.WriteString("Solve the candidate task as directly as possible. Return your best final answer only; do not mention that this is a dataset generation review.\n\n")
+	b.WriteString("Candidate input:\n")
+	b.WriteString(compactJSON(candidate.Input))
+	b.WriteString("\n")
 	return b.String()
 }
 
@@ -158,6 +190,42 @@ func AgenticJudgeMetadata(verdict AgenticJudgeVerdict) json.RawMessage {
 		return json.RawMessage(`{}`)
 	}
 	return encoded
+}
+
+func AgenticJudgeMetadataWithSolvers(verdict AgenticJudgeVerdict, weakAttempts, strongAttempts []AgenticSolverAttempt) json.RawMessage {
+	var metadata map[string]any
+	if err := json.Unmarshal(AgenticJudgeMetadata(verdict), &metadata); err != nil {
+		metadata = map[string]any{}
+	}
+	if len(weakAttempts) > 0 {
+		metadata["weak_solver_attempts"] = weakAttempts
+	}
+	if len(strongAttempts) > 0 {
+		metadata["strong_solver_attempts"] = strongAttempts
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return encoded
+}
+
+func writeSolverAttempts(b *strings.Builder, title string, attempts []AgenticSolverAttempt) {
+	if len(attempts) == 0 {
+		return
+	}
+	b.WriteString("\n")
+	b.WriteString(title)
+	b.WriteString(":\n")
+	for _, attempt := range attempts {
+		b.WriteString(fmt.Sprintf("- attempt %d", attempt.Attempt))
+		if attempt.Model != "" {
+			b.WriteString(fmt.Sprintf(" (%s)", attempt.Model))
+		}
+		b.WriteString(": ")
+		b.WriteString(strings.TrimSpace(attempt.Output))
+		b.WriteString("\n")
+	}
 }
 
 func validateOptionalScore(name string, value *float64) error {

--- a/backend/internal/datasets/generation/generation_test.go
+++ b/backend/internal/datasets/generation/generation_test.go
@@ -130,6 +130,120 @@ func TestDecodeJobConfigForStrategyRequiresThresholdValues(t *testing.T) {
 	}
 }
 
+func TestDecodeJobConfigForStrategyValidatesDirectProviderSolvers(t *testing.T) {
+	providerID := uuid.New()
+	judgeID := uuid.New()
+	weakID := uuid.New()
+	strongID := uuid.New()
+	raw, _ := json.Marshal(map[string]any{
+		"provider_account_id":        providerID,
+		"model":                      "gpt-4.1-mini",
+		"judge_provider_account_id":  judgeID,
+		"judge_model":                "gpt-4.1",
+		"solver_mode":                "direct_provider",
+		"weak_provider_account_id":   weakID,
+		"weak_model":                 "gpt-4.1-nano",
+		"strong_provider_account_id": strongID,
+		"strong_model":               "gpt-4.1",
+	})
+	cfg, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct)
+	if err != nil {
+		t.Fatalf("decode direct provider config: %v", err)
+	}
+	if cfg.SolverMode != generation.SolverModeDirectProvider {
+		t.Fatalf("solver mode = %q", cfg.SolverMode)
+	}
+	if cfg.WeakRollouts != 1 || cfg.StrongRollouts != 1 {
+		t.Fatalf("default rollouts = %d/%d, want 1/1", cfg.WeakRollouts, cfg.StrongRollouts)
+	}
+
+	raw, _ = json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1",
+		"solver_mode":               "direct_provider",
+		"weak_provider_account_id":  weakID,
+		"weak_model":                "gpt-4.1-nano",
+		"strong_model":              "gpt-4.1",
+	})
+	if _, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct); err == nil {
+		t.Fatal("expected missing strong provider error")
+	}
+}
+
+func TestDecodeJobConfigForStrategyValidatesDeploymentContext(t *testing.T) {
+	providerID := uuid.New()
+	judgeID := uuid.New()
+	weakDeploymentID := uuid.New()
+	strongDeploymentID := uuid.New()
+	challengePackVersionID := uuid.New()
+	raw, _ := json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1",
+		"weak_deployment_id":        weakDeploymentID,
+		"strong_deployment_id":      strongDeploymentID,
+		"challenge_pack_version_id": challengePackVersionID,
+		"challenge_key":             "support-recovery",
+		"field_mapping":             map[string]string{"input": "prompt"},
+	})
+	cfg, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct)
+	if err != nil {
+		t.Fatalf("decode deployment context: %v", err)
+	}
+	if cfg.WeakDeploymentID == nil || *cfg.WeakDeploymentID != weakDeploymentID {
+		t.Fatalf("weak deployment = %+v", cfg.WeakDeploymentID)
+	}
+
+	raw, _ = json.Marshal(map[string]any{
+		"provider_account_id":       providerID,
+		"model":                     "gpt-4.1-mini",
+		"judge_provider_account_id": judgeID,
+		"judge_model":               "gpt-4.1",
+		"weak_deployment_id":        weakDeploymentID,
+	})
+	if _, err := generation.DecodeJobConfigForStrategy(raw, generation.StrategyAgenticSelfInstruct); err == nil {
+		t.Fatal("expected incomplete deployment context error")
+	}
+}
+
+func TestBuildAgenticSolverPromptOmitsExpectedAnswer(t *testing.T) {
+	prompt := generation.BuildAgenticSolverPrompt("weak_solver", generation.Candidate{
+		Input:    json.RawMessage(`{"prompt":"recover the account"}`),
+		Expected: json.RawMessage(`{"answer":"secret expected answer"}`),
+	})
+	if !containsAll(prompt, "weak_solver", "recover the account") {
+		t.Fatalf("solver prompt missing role/input: %q", prompt)
+	}
+	if contains(prompt, "secret expected answer") || contains(prompt, "expected") {
+		t.Fatalf("solver prompt leaked expected answer: %q", prompt)
+	}
+}
+
+func TestBuildAgenticJudgePromptIncludesSolverAttempts(t *testing.T) {
+	prompt := generation.BuildAgenticJudgePrompt(generation.AgenticJudgeInput{
+		Seeds:     []generation.SeedExample{{Input: json.RawMessage(`{"q":"seed"}`)}},
+		Candidate: generation.Candidate{Input: json.RawMessage(`{"q":"candidate"}`)},
+		WeakAttempts: []generation.AgenticSolverAttempt{{
+			Role:    "weak_solver",
+			Attempt: 1,
+			Model:   "gpt-4.1-nano",
+			Output:  "weak answer",
+		}},
+		StrongAttempts: []generation.AgenticSolverAttempt{{
+			Role:    "strong_solver",
+			Attempt: 1,
+			Model:   "gpt-4.1",
+			Output:  "strong answer",
+		}},
+	})
+	if !containsAll(prompt, "Weak solver attempts", "weak answer", "Strong solver attempts", "strong answer") {
+		t.Fatalf("judge prompt missing solver attempts: %q", prompt)
+	}
+}
+
 func TestParseAgenticJudgeResponse(t *testing.T) {
 	verdict, err := generation.ParseAgenticJudgeResponse(`{
 		"verdict":"accept",

--- a/backend/internal/datasets/generation/types.go
+++ b/backend/internal/datasets/generation/types.go
@@ -19,6 +19,21 @@ const (
 
 var ErrUnsupportedStrategy = errors.New("unsupported dataset generation strategy")
 
+// ValidationError marks an error as invalid user-supplied generation input. The
+// API layer maps it to an HTTP 400 validation_error response. Using a typed
+// error (rather than substring matching on the message) keeps wrapped database
+// or provider failures from being misreported to callers as bad input.
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+// NewValidationError builds a ValidationError with a formatted message.
+func NewValidationError(format string, args ...any) error {
+	return &ValidationError{Message: fmt.Sprintf(format, args...)}
+}
+
 type JobConfig struct {
 	ProviderAccountID uuid.UUID `json:"provider_account_id"`
 	// Model is the provider model id to generate with (e.g. "gpt-4.1-mini"),
@@ -85,17 +100,17 @@ func DecodeJobConfig(raw json.RawMessage) (JobConfig, error) {
 
 func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig, error) {
 	if len(raw) == 0 {
-		return JobConfig{}, errors.New("generation job config is required")
+		return JobConfig{}, NewValidationError("generation job config is required")
 	}
 	var cfg JobConfig
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return JobConfig{}, err
 	}
 	if cfg.ProviderAccountID == uuid.Nil {
-		return JobConfig{}, errors.New("provider_account_id is required")
+		return JobConfig{}, NewValidationError("provider_account_id is required")
 	}
 	if cfg.Model == "" {
-		return JobConfig{}, errors.New("model is required")
+		return JobConfig{}, NewValidationError("model is required")
 	}
 	parsedStrategy, err := ParseStrategy(strategy)
 	if err != nil {
@@ -103,20 +118,20 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 	}
 	if parsedStrategy == StrategyAgenticSelfInstruct {
 		if cfg.JudgeProviderAccountID == nil || *cfg.JudgeProviderAccountID == uuid.Nil {
-			return JobConfig{}, errors.New("judge_provider_account_id is required for agentic_self_instruct")
+			return JobConfig{}, NewValidationError("judge_provider_account_id is required for agentic_self_instruct")
 		}
 		if cfg.JudgeModel == "" {
-			return JobConfig{}, errors.New("judge_model is required for agentic_self_instruct")
+			return JobConfig{}, NewValidationError("judge_model is required for agentic_self_instruct")
 		}
 		if cfg.MaxRoundsPerExample < 0 || cfg.MaxRoundsPerExample > 15 {
-			return JobConfig{}, errors.New("max_rounds_per_example must be between 0 and 15")
+			return JobConfig{}, NewValidationError("max_rounds_per_example must be between 0 and 15")
 		}
 		if cfg.AcceptanceMode != "" && cfg.AcceptanceMode != AcceptanceModeJudge && cfg.AcceptanceMode != AcceptanceModeThreshold {
-			return JobConfig{}, errors.New("acceptance_mode must be judge or threshold")
+			return JobConfig{}, NewValidationError("acceptance_mode must be judge or threshold")
 		}
 		if cfg.AcceptanceMode == AcceptanceModeThreshold {
 			if cfg.MinGap == nil || cfg.MaxWeakScore == nil || cfg.MinStrongScore == nil {
-				return JobConfig{}, errors.New("min_gap, max_weak_score, and min_strong_score are all required when acceptance_mode is threshold")
+				return JobConfig{}, NewValidationError("min_gap, max_weak_score, and min_strong_score are all required when acceptance_mode is threshold")
 			}
 		}
 		cfg.SolverMode = NormalizeAgenticSolverMode(cfg.SolverMode)
@@ -130,16 +145,16 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 			}
 		case SolverModeDirectProvider:
 			if cfg.WeakProviderAccountID == nil || *cfg.WeakProviderAccountID == uuid.Nil {
-				return JobConfig{}, errors.New("weak_provider_account_id is required when solver_mode is direct_provider")
+				return JobConfig{}, NewValidationError("weak_provider_account_id is required when solver_mode is direct_provider")
 			}
 			if cfg.WeakModel == "" {
-				return JobConfig{}, errors.New("weak_model is required when solver_mode is direct_provider")
+				return JobConfig{}, NewValidationError("weak_model is required when solver_mode is direct_provider")
 			}
 			if cfg.StrongProviderAccountID == nil || *cfg.StrongProviderAccountID == uuid.Nil {
-				return JobConfig{}, errors.New("strong_provider_account_id is required when solver_mode is direct_provider")
+				return JobConfig{}, NewValidationError("strong_provider_account_id is required when solver_mode is direct_provider")
 			}
 			if cfg.StrongModel == "" {
-				return JobConfig{}, errors.New("strong_model is required when solver_mode is direct_provider")
+				return JobConfig{}, NewValidationError("strong_model is required when solver_mode is direct_provider")
 			}
 			if cfg.WeakRollouts == 0 {
 				cfg.WeakRollouts = 1
@@ -154,28 +169,28 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 				return JobConfig{}, err
 			}
 		default:
-			return JobConfig{}, errors.New("solver_mode must be judge_only or direct_provider")
+			return JobConfig{}, NewValidationError("solver_mode must be judge_only or direct_provider")
 		}
 		if HasAgenticDeploymentContext(cfg) {
 			if cfg.WeakDeploymentID == nil || *cfg.WeakDeploymentID == uuid.Nil {
-				return JobConfig{}, errors.New("weak_deployment_id is required when deployment context is provided")
+				return JobConfig{}, NewValidationError("weak_deployment_id is required when deployment context is provided")
 			}
 			if cfg.StrongDeploymentID == nil || *cfg.StrongDeploymentID == uuid.Nil {
-				return JobConfig{}, errors.New("strong_deployment_id is required when deployment context is provided")
+				return JobConfig{}, NewValidationError("strong_deployment_id is required when deployment context is provided")
 			}
 			if cfg.ChallengePackVersionID == nil || *cfg.ChallengePackVersionID == uuid.Nil {
-				return JobConfig{}, errors.New("challenge_pack_version_id is required when deployment context is provided")
+				return JobConfig{}, NewValidationError("challenge_pack_version_id is required when deployment context is provided")
 			}
 			if strings.TrimSpace(cfg.ChallengeKey) == "" {
-				return JobConfig{}, errors.New("challenge_key is required when deployment context is provided")
+				return JobConfig{}, NewValidationError("challenge_key is required when deployment context is provided")
 			}
 			if len(cfg.FieldMapping) > 0 {
 				if !json.Valid(cfg.FieldMapping) {
-					return JobConfig{}, errors.New("field_mapping must be valid JSON")
+					return JobConfig{}, NewValidationError("field_mapping must be valid JSON")
 				}
 				var fieldMapping map[string]any
 				if err := json.Unmarshal(cfg.FieldMapping, &fieldMapping); err != nil || fieldMapping == nil {
-					return JobConfig{}, errors.New("field_mapping must be a JSON object")
+					return JobConfig{}, NewValidationError("field_mapping must be a JSON object")
 				}
 			}
 		}
@@ -208,7 +223,7 @@ func validateOptionalRolloutCount(name string, value int) error {
 
 func validateRequiredRolloutCount(name string, value int) error {
 	if value < 1 || value > 5 {
-		return fmt.Errorf("%s must be between 1 and 5", name)
+		return NewValidationError("%s must be between 1 and 5", name)
 	}
 	return nil
 }

--- a/backend/internal/datasets/generation/types.go
+++ b/backend/internal/datasets/generation/types.go
@@ -3,6 +3,8 @@ package generation
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -10,23 +12,40 @@ import (
 const StrategySelfInstruct = "self_instruct"
 const StrategyAgenticSelfInstruct = "agentic_self_instruct"
 
+const (
+	SolverModeJudgeOnly      = "judge_only"
+	SolverModeDirectProvider = "direct_provider"
+)
+
 var ErrUnsupportedStrategy = errors.New("unsupported dataset generation strategy")
 
 type JobConfig struct {
 	ProviderAccountID uuid.UUID `json:"provider_account_id"`
 	// Model is the provider model id to generate with (e.g. "gpt-4.1-mini"),
 	// chosen directly from the provider connection's live model list.
-	Model                  string     `json:"model"`
-	SeedsTag               string     `json:"seeds_tag,omitempty"`
-	CreateVersion          bool       `json:"create_version,omitempty"`
-	VersionLabel           string     `json:"version_label,omitempty"`
-	JudgeProviderAccountID *uuid.UUID `json:"judge_provider_account_id,omitempty"`
-	JudgeModel             string     `json:"judge_model,omitempty"`
-	MaxRoundsPerExample    int        `json:"max_rounds_per_example,omitempty"`
-	AcceptanceMode         string     `json:"acceptance_mode,omitempty"`
-	MinGap                 *float64   `json:"min_gap,omitempty"`
-	MaxWeakScore           *float64   `json:"max_weak_score,omitempty"`
-	MinStrongScore         *float64   `json:"min_strong_score,omitempty"`
+	Model                   string          `json:"model"`
+	SeedsTag                string          `json:"seeds_tag,omitempty"`
+	CreateVersion           bool            `json:"create_version,omitempty"`
+	VersionLabel            string          `json:"version_label,omitempty"`
+	JudgeProviderAccountID  *uuid.UUID      `json:"judge_provider_account_id,omitempty"`
+	JudgeModel              string          `json:"judge_model,omitempty"`
+	MaxRoundsPerExample     int             `json:"max_rounds_per_example,omitempty"`
+	AcceptanceMode          string          `json:"acceptance_mode,omitempty"`
+	MinGap                  *float64        `json:"min_gap,omitempty"`
+	MaxWeakScore            *float64        `json:"max_weak_score,omitempty"`
+	MinStrongScore          *float64        `json:"min_strong_score,omitempty"`
+	SolverMode              string          `json:"solver_mode,omitempty"`
+	WeakProviderAccountID   *uuid.UUID      `json:"weak_provider_account_id,omitempty"`
+	WeakModel               string          `json:"weak_model,omitempty"`
+	StrongProviderAccountID *uuid.UUID      `json:"strong_provider_account_id,omitempty"`
+	StrongModel             string          `json:"strong_model,omitempty"`
+	WeakRollouts            int             `json:"weak_rollouts,omitempty"`
+	StrongRollouts          int             `json:"strong_rollouts,omitempty"`
+	WeakDeploymentID        *uuid.UUID      `json:"weak_deployment_id,omitempty"`
+	StrongDeploymentID      *uuid.UUID      `json:"strong_deployment_id,omitempty"`
+	ChallengePackVersionID  *uuid.UUID      `json:"challenge_pack_version_id,omitempty"`
+	ChallengeKey            string          `json:"challenge_key,omitempty"`
+	FieldMapping            json.RawMessage `json:"field_mapping,omitempty"`
 }
 
 type SeedExample struct {
@@ -44,6 +63,7 @@ const (
 	ReasonSchemaViolation = "schema_violation"
 	ReasonDuplicateInput  = "duplicate_input"
 	ReasonProviderError   = "provider_error"
+	ReasonSolverError     = "solver_error"
 	ReasonJudgeParseError = "judge_parse_error"
 	ReasonQualityRejected = "quality_rejected"
 )
@@ -99,6 +119,90 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 				return JobConfig{}, errors.New("min_gap, max_weak_score, and min_strong_score are all required when acceptance_mode is threshold")
 			}
 		}
+		cfg.SolverMode = NormalizeAgenticSolverMode(cfg.SolverMode)
+		switch cfg.SolverMode {
+		case SolverModeJudgeOnly:
+			if err := validateOptionalRolloutCount("weak_rollouts", cfg.WeakRollouts); err != nil {
+				return JobConfig{}, err
+			}
+			if err := validateOptionalRolloutCount("strong_rollouts", cfg.StrongRollouts); err != nil {
+				return JobConfig{}, err
+			}
+		case SolverModeDirectProvider:
+			if cfg.WeakProviderAccountID == nil || *cfg.WeakProviderAccountID == uuid.Nil {
+				return JobConfig{}, errors.New("weak_provider_account_id is required when solver_mode is direct_provider")
+			}
+			if cfg.WeakModel == "" {
+				return JobConfig{}, errors.New("weak_model is required when solver_mode is direct_provider")
+			}
+			if cfg.StrongProviderAccountID == nil || *cfg.StrongProviderAccountID == uuid.Nil {
+				return JobConfig{}, errors.New("strong_provider_account_id is required when solver_mode is direct_provider")
+			}
+			if cfg.StrongModel == "" {
+				return JobConfig{}, errors.New("strong_model is required when solver_mode is direct_provider")
+			}
+			if cfg.WeakRollouts == 0 {
+				cfg.WeakRollouts = 1
+			}
+			if cfg.StrongRollouts == 0 {
+				cfg.StrongRollouts = 1
+			}
+			if err := validateRequiredRolloutCount("weak_rollouts", cfg.WeakRollouts); err != nil {
+				return JobConfig{}, err
+			}
+			if err := validateRequiredRolloutCount("strong_rollouts", cfg.StrongRollouts); err != nil {
+				return JobConfig{}, err
+			}
+		default:
+			return JobConfig{}, errors.New("solver_mode must be judge_only or direct_provider")
+		}
+		if HasAgenticDeploymentContext(cfg) {
+			if cfg.WeakDeploymentID == nil || *cfg.WeakDeploymentID == uuid.Nil {
+				return JobConfig{}, errors.New("weak_deployment_id is required when deployment context is provided")
+			}
+			if cfg.StrongDeploymentID == nil || *cfg.StrongDeploymentID == uuid.Nil {
+				return JobConfig{}, errors.New("strong_deployment_id is required when deployment context is provided")
+			}
+			if cfg.ChallengePackVersionID == nil || *cfg.ChallengePackVersionID == uuid.Nil {
+				return JobConfig{}, errors.New("challenge_pack_version_id is required when deployment context is provided")
+			}
+			if strings.TrimSpace(cfg.ChallengeKey) == "" {
+				return JobConfig{}, errors.New("challenge_key is required when deployment context is provided")
+			}
+			if len(cfg.FieldMapping) > 0 && !json.Valid(cfg.FieldMapping) {
+				return JobConfig{}, errors.New("field_mapping must be valid JSON")
+			}
+		}
 	}
 	return cfg, nil
+}
+
+func NormalizeAgenticSolverMode(mode string) string {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return SolverModeJudgeOnly
+	}
+	return mode
+}
+
+func HasAgenticDeploymentContext(cfg JobConfig) bool {
+	return cfg.WeakDeploymentID != nil ||
+		cfg.StrongDeploymentID != nil ||
+		cfg.ChallengePackVersionID != nil ||
+		strings.TrimSpace(cfg.ChallengeKey) != "" ||
+		len(cfg.FieldMapping) > 0
+}
+
+func validateOptionalRolloutCount(name string, value int) error {
+	if value == 0 {
+		return nil
+	}
+	return validateRequiredRolloutCount(name, value)
+}
+
+func validateRequiredRolloutCount(name string, value int) error {
+	if value < 1 || value > 5 {
+		return fmt.Errorf("%s must be between 1 and 5", name)
+	}
+	return nil
 }

--- a/backend/internal/datasets/generation/types.go
+++ b/backend/internal/datasets/generation/types.go
@@ -169,8 +169,14 @@ func DecodeJobConfigForStrategy(raw json.RawMessage, strategy string) (JobConfig
 			if strings.TrimSpace(cfg.ChallengeKey) == "" {
 				return JobConfig{}, errors.New("challenge_key is required when deployment context is provided")
 			}
-			if len(cfg.FieldMapping) > 0 && !json.Valid(cfg.FieldMapping) {
-				return JobConfig{}, errors.New("field_mapping must be valid JSON")
+			if len(cfg.FieldMapping) > 0 {
+				if !json.Valid(cfg.FieldMapping) {
+					return JobConfig{}, errors.New("field_mapping must be valid JSON")
+				}
+				var fieldMapping map[string]any
+				if err := json.Unmarshal(cfg.FieldMapping, &fieldMapping); err != nil || fieldMapping == nil {
+					return JobConfig{}, errors.New("field_mapping must be a JSON object")
+				}
 			}
 		}
 	}

--- a/backend/internal/repository/dataset_generations.go
+++ b/backend/internal/repository/dataset_generations.go
@@ -117,13 +117,15 @@ type CreateDatasetGenerationRejectionParams struct {
 }
 
 type DatasetGenerationExecutionContext struct {
-	Job                  DatasetGenerationJob
-	Dataset              Dataset
-	Config               datasetgeneration.JobConfig
-	Seeds                []datasetgeneration.SeedExample
-	ExistingInputs       map[string]struct{}
-	ProviderAccount      ProviderAccountRow
-	JudgeProviderAccount *ProviderAccountRow
+	Job                   DatasetGenerationJob
+	Dataset               Dataset
+	Config                datasetgeneration.JobConfig
+	Seeds                 []datasetgeneration.SeedExample
+	ExistingInputs        map[string]struct{}
+	ProviderAccount       ProviderAccountRow
+	JudgeProviderAccount  *ProviderAccountRow
+	WeakProviderAccount   *ProviderAccountRow
+	StrongProviderAccount *ProviderAccountRow
 	// Model is the provider model id to generate with. Pricing is best-effort
 	// from the static fallback map (0 when unknown) and is used only for the
 	// job's cost estimate, never for scoring.
@@ -257,6 +259,22 @@ func (r *Repository) GetDatasetGenerationExecutionContextByID(ctx context.Contex
 		}
 		judgeProviderAccount = &account
 	}
+	var weakProviderAccount *ProviderAccountRow
+	if cfg.WeakProviderAccountID != nil {
+		account, accountErr := r.GetProviderAccountByID(ctx, *cfg.WeakProviderAccountID)
+		if accountErr != nil {
+			return DatasetGenerationExecutionContext{}, accountErr
+		}
+		weakProviderAccount = &account
+	}
+	var strongProviderAccount *ProviderAccountRow
+	if cfg.StrongProviderAccountID != nil {
+		account, accountErr := r.GetProviderAccountByID(ctx, *cfg.StrongProviderAccountID)
+		if accountErr != nil {
+			return DatasetGenerationExecutionContext{}, accountErr
+		}
+		strongProviderAccount = &account
+	}
 	// Pricing is best-effort: the static fallback map yields 0 when the model is
 	// unknown, which only affects the job's cost estimate.
 	inputCost, outputCost, _ := provider.StaticModelPrice(providerAccount.ProviderKey, cfg.Model)
@@ -294,6 +312,8 @@ func (r *Repository) GetDatasetGenerationExecutionContextByID(ctx context.Contex
 		ExistingInputs:             existing,
 		ProviderAccount:            providerAccount,
 		JudgeProviderAccount:       judgeProviderAccount,
+		WeakProviderAccount:        weakProviderAccount,
+		StrongProviderAccount:      strongProviderAccount,
 		Model:                      cfg.Model,
 		InputCostPerMillionTokens:  inputCost,
 		OutputCostPerMillionTokens: outputCost,

--- a/backend/internal/repository/dataset_generations.go
+++ b/backend/internal/repository/dataset_generations.go
@@ -116,6 +116,12 @@ type CreateDatasetGenerationRejectionParams struct {
 	Metadata          json.RawMessage
 }
 
+type ListDatasetGenerationRejectionsParams struct {
+	JobID  uuid.UUID
+	Limit  int32
+	Offset int32
+}
+
 type DatasetGenerationExecutionContext struct {
 	Job                   DatasetGenerationJob
 	Dataset               Dataset
@@ -232,6 +238,34 @@ func (r *Repository) CreateDatasetGenerationRejection(ctx context.Context, param
 		return DatasetGenerationRejection{}, fmt.Errorf("create dataset generation rejection: %w", err)
 	}
 	return mapDatasetGenerationRejection(row)
+}
+
+func (r *Repository) ListDatasetGenerationRejectionsByJobID(ctx context.Context, params ListDatasetGenerationRejectionsParams) ([]DatasetGenerationRejection, error) {
+	rows, err := r.queries.ListDatasetGenerationRejectionsByJobID(ctx, repositorysqlc.ListDatasetGenerationRejectionsByJobIDParams{
+		JobID:        params.JobID,
+		ResultLimit:  params.Limit,
+		ResultOffset: params.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list dataset generation rejections: %w", err)
+	}
+	items := make([]DatasetGenerationRejection, 0, len(rows))
+	for _, row := range rows {
+		item, mapErr := mapDatasetGenerationRejection(row)
+		if mapErr != nil {
+			return nil, mapErr
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (r *Repository) CountDatasetGenerationRejectionsByJobID(ctx context.Context, jobID uuid.UUID) (int64, error) {
+	count, err := r.queries.CountDatasetGenerationRejectionsByJobID(ctx, repositorysqlc.CountDatasetGenerationRejectionsByJobIDParams{JobID: jobID})
+	if err != nil {
+		return 0, fmt.Errorf("count dataset generation rejections: %w", err)
+	}
+	return count, nil
 }
 
 func (r *Repository) GetDatasetGenerationExecutionContextByID(ctx context.Context, jobID uuid.UUID) (DatasetGenerationExecutionContext, error) {

--- a/backend/internal/workflow/dataset_generation_activities.go
+++ b/backend/internal/workflow/dataset_generation_activities.go
@@ -74,6 +74,12 @@ type agenticJudgeUsage struct {
 	CostUSD      float64
 }
 
+type agenticSolverRolloutResult struct {
+	WeakAttempts   []datasetgeneration.AgenticSolverAttempt
+	StrongAttempts []datasetgeneration.AgenticSolverAttempt
+	Usage          agenticJudgeUsage
+}
+
 type agenticJudgeParseError struct {
 	err error
 }
@@ -147,6 +153,11 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 	var totalInputTokens = executionContext.Job.TotalInputTokens
 	var totalOutputTokens = executionContext.Job.TotalOutputTokens
 	var totalCostUSD = executionContext.Job.TotalCostUSD
+	rejectionReasonCounts := make(map[string]int)
+	var weakScoreTotal float64
+	var strongScoreTotal float64
+	var gapTotal float64
+	var scoreObservations int
 	maxAttempts := int(executionContext.Job.TargetCount) * 5
 	if executionContext.Job.Strategy == datasetgeneration.StrategyAgenticSelfInstruct && executionContext.Config.MaxRoundsPerExample > 0 {
 		maxAttempts = int(executionContext.Job.TargetCount) * executionContext.Config.MaxRoundsPerExample
@@ -180,6 +191,7 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		generatedCount++
 		if invokeErr != nil {
 			rejectedCount++
+			rejectionReasonCounts[datasetgeneration.ReasonProviderError]++
 			if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonProviderError, invokeErr.Error(), nil, nil); rejectErr != nil {
 				return wrapActivityError(rejectErr)
 			}
@@ -195,6 +207,7 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		candidate, parseErr := datasetgeneration.ParseSelfInstructResponse(response.OutputText)
 		if parseErr != nil {
 			rejectedCount++
+			rejectionReasonCounts[datasetgeneration.ReasonParseError]++
 			if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonParseError, parseErr.Error(), nil, nil); rejectErr != nil {
 				return wrapActivityError(rejectErr)
 			}
@@ -202,6 +215,7 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		}
 		if schemaErr := datasetgeneration.ValidateCandidateInput(executionContext.Dataset.InputSchema, executionContext.Dataset.InputSchemaEnforced, candidate.Input); schemaErr != nil {
 			rejectedCount++
+			rejectionReasonCounts[datasetgeneration.ReasonSchemaViolation]++
 			if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonSchemaViolation, schemaErr.Error(), candidate.Input, candidate.Expected); rejectErr != nil {
 				return wrapActivityError(rejectErr)
 			}
@@ -210,6 +224,7 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		hash, hashErr := datasetgeneration.CanonicalInputHash(candidate.Input)
 		if hashErr != nil {
 			rejectedCount++
+			rejectionReasonCounts[datasetgeneration.ReasonParseError]++
 			if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonParseError, hashErr.Error(), candidate.Input, candidate.Expected); rejectErr != nil {
 				return wrapActivityError(rejectErr)
 			}
@@ -217,6 +232,7 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		}
 		if _, exists := acceptedHashes[hash]; exists {
 			rejectedCount++
+			rejectionReasonCounts[datasetgeneration.ReasonDuplicateInput]++
 			if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonDuplicateInput, "duplicate input", candidate.Input, candidate.Expected); rejectErr != nil {
 				return wrapActivityError(rejectErr)
 			}
@@ -224,8 +240,32 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 		}
 
 		var judgeVerdict *datasetgeneration.AgenticJudgeVerdict
+		var weakAttempts []datasetgeneration.AgenticSolverAttempt
+		var strongAttempts []datasetgeneration.AgenticSolverAttempt
 		if executionContext.Job.Strategy == datasetgeneration.StrategyAgenticSelfInstruct {
-			verdict, usage, judgeErr := a.judgeAgenticCandidate(ctx, executionContext, seedBatch, candidate)
+			if datasetgeneration.NormalizeAgenticSolverMode(executionContext.Config.SolverMode) == datasetgeneration.SolverModeDirectProvider {
+				solverResult, solverErr := a.runAgenticSolverRollouts(ctx, executionContext, candidate)
+				if solverResult.Usage.InputTokens > 0 || solverResult.Usage.OutputTokens > 0 {
+					totalInputTokens += solverResult.Usage.InputTokens
+					totalOutputTokens += solverResult.Usage.OutputTokens
+					totalCostUSD += solverResult.Usage.CostUSD
+				}
+				weakAttempts = solverResult.WeakAttempts
+				strongAttempts = solverResult.StrongAttempts
+				if solverErr != nil {
+					rejectedCount++
+					rejectionReasonCounts[datasetgeneration.ReasonSolverError]++
+					if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonSolverError, solverErr.Error(), candidate.Input, candidate.Expected, mustMarshalJSON(map[string]any{
+						"solver_mode":     executionContext.Config.SolverMode,
+						"weak_attempts":   weakAttempts,
+						"strong_attempts": strongAttempts,
+					})); rejectErr != nil {
+						return wrapActivityError(rejectErr)
+					}
+					continue
+				}
+			}
+			verdict, usage, judgeErr := a.judgeAgenticCandidate(ctx, executionContext, seedBatch, candidate, weakAttempts, strongAttempts)
 			if usage.InputTokens > 0 || usage.OutputTokens > 0 {
 				totalInputTokens += usage.InputTokens
 				totalOutputTokens += usage.OutputTokens
@@ -237,8 +277,11 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 				if _, ok := judgeErr.(agenticJudgeParseError); ok {
 					reasonCode = datasetgeneration.ReasonJudgeParseError
 				}
+				rejectionReasonCounts[reasonCode]++
 				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, reasonCode, judgeErr.Error(), candidate.Input, candidate.Expected, mustMarshalJSON(map[string]any{
-					"role": "judge",
+					"role":            "judge",
+					"weak_attempts":   weakAttempts,
+					"strong_attempts": strongAttempts,
 				})); rejectErr != nil {
 					return wrapActivityError(rejectErr)
 				}
@@ -246,10 +289,17 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 			}
 			if verdict == nil {
 				rejectedCount++
+				rejectionReasonCounts[datasetgeneration.ReasonJudgeParseError]++
 				if _, rejectErr := a.recordRejection(ctx, input.JobID, datasetgeneration.ReasonJudgeParseError, "missing judge verdict", candidate.Input, candidate.Expected); rejectErr != nil {
 					return wrapActivityError(rejectErr)
 				}
 				continue
+			}
+			if verdict.WeakScore != nil && verdict.StrongScore != nil && verdict.Gap != nil {
+				weakScoreTotal += *verdict.WeakScore
+				strongScoreTotal += *verdict.StrongScore
+				gapTotal += *verdict.Gap
+				scoreObservations++
 			}
 			if !datasetgeneration.ShouldAcceptJudgeVerdict(*verdict, datasetgeneration.AgenticAcceptanceConfig{
 				Mode:           agenticAcceptanceMode(executionContext.Config.AcceptanceMode),
@@ -258,7 +308,8 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 				MinStrongScore: executionContext.Config.MinStrongScore,
 			}) {
 				rejectedCount++
-				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonQualityRejected, datasetgeneration.AgenticJudgeRejectionDetail(*verdict), candidate.Input, candidate.Expected, datasetgeneration.AgenticJudgeMetadata(*verdict)); rejectErr != nil {
+				rejectionReasonCounts[datasetgeneration.ReasonQualityRejected]++
+				if _, rejectErr := a.recordRejectionWithMetadata(ctx, input.JobID, datasetgeneration.ReasonQualityRejected, datasetgeneration.AgenticJudgeRejectionDetail(*verdict), candidate.Input, candidate.Expected, datasetgeneration.AgenticJudgeMetadataWithSolvers(*verdict, weakAttempts, strongAttempts)); rejectErr != nil {
 					return wrapActivityError(rejectErr)
 				}
 				continue
@@ -284,6 +335,28 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 			exampleMetadata["gap"] = judgeVerdict.Gap
 			exampleMetadata["capability_tags"] = judgeVerdict.CapabilityTags
 			exampleMetadata["judge_summary"] = judgeVerdict.GapInterpretation
+			exampleMetadata["solver_mode"] = datasetgeneration.NormalizeAgenticSolverMode(executionContext.Config.SolverMode)
+			if len(weakAttempts) > 0 {
+				exampleMetadata["weak_provider_account_id"] = executionContext.Config.WeakProviderAccountID
+				exampleMetadata["weak_model_id"] = executionContext.Config.WeakModel
+				exampleMetadata["weak_rollouts"] = executionContext.Config.WeakRollouts
+				exampleMetadata["weak_solver_attempts"] = weakAttempts
+			}
+			if len(strongAttempts) > 0 {
+				exampleMetadata["strong_provider_account_id"] = executionContext.Config.StrongProviderAccountID
+				exampleMetadata["strong_model_id"] = executionContext.Config.StrongModel
+				exampleMetadata["strong_rollouts"] = executionContext.Config.StrongRollouts
+				exampleMetadata["strong_solver_attempts"] = strongAttempts
+			}
+			if datasetgeneration.HasAgenticDeploymentContext(executionContext.Config) {
+				exampleMetadata["weak_deployment_id"] = executionContext.Config.WeakDeploymentID
+				exampleMetadata["strong_deployment_id"] = executionContext.Config.StrongDeploymentID
+				exampleMetadata["challenge_pack_version_id"] = executionContext.Config.ChallengePackVersionID
+				exampleMetadata["challenge_key"] = executionContext.Config.ChallengeKey
+				if len(executionContext.Config.FieldMapping) > 0 {
+					exampleMetadata["field_mapping"] = json.RawMessage(executionContext.Config.FieldMapping)
+				}
+			}
 			tags = append(tags, "agentic")
 		}
 		metadata := mustMarshalJSON(exampleMetadata)
@@ -317,8 +390,29 @@ func (a *DatasetGenerationActivities) ExecuteSyntheticDatasetGeneration(ctx cont
 	}
 
 	summary := map[string]any{
-		"strategy": executionContext.Job.Strategy,
-		"attempts": generatedCount,
+		"strategy":       executionContext.Job.Strategy,
+		"solver_mode":    datasetgeneration.NormalizeAgenticSolverMode(executionContext.Config.SolverMode),
+		"attempts":       generatedCount,
+		"accepted_count": acceptedCount,
+		"rejected_count": rejectedCount,
+	}
+	if len(rejectionReasonCounts) > 0 {
+		summary["rejection_reasons"] = rejectionReasonCounts
+	}
+	if scoreObservations > 0 {
+		summary["score_observations"] = scoreObservations
+		summary["avg_weak_score"] = weakScoreTotal / float64(scoreObservations)
+		summary["avg_strong_score"] = strongScoreTotal / float64(scoreObservations)
+		summary["avg_gap"] = gapTotal / float64(scoreObservations)
+	}
+	if datasetgeneration.HasAgenticDeploymentContext(executionContext.Config) {
+		summary["deployment_context"] = map[string]any{
+			"weak_deployment_id":        executionContext.Config.WeakDeploymentID,
+			"strong_deployment_id":      executionContext.Config.StrongDeploymentID,
+			"challenge_pack_version_id": executionContext.Config.ChallengePackVersionID,
+			"challenge_key":             executionContext.Config.ChallengeKey,
+			"field_mapping":             json.RawMessage(executionContext.Config.FieldMapping),
+		}
 	}
 	if acceptedCount < executionContext.Job.TargetCount {
 		summary["partial"] = true
@@ -372,14 +466,87 @@ func (a *DatasetGenerationActivities) recordRejectionWithMetadata(ctx context.Co
 	})
 }
 
-func (a *DatasetGenerationActivities) judgeAgenticCandidate(ctx context.Context, executionContext repository.DatasetGenerationExecutionContext, seedBatch []datasetgeneration.SeedExample, candidate datasetgeneration.Candidate) (*datasetgeneration.AgenticJudgeVerdict, agenticJudgeUsage, error) {
+func (a *DatasetGenerationActivities) runAgenticSolverRollouts(ctx context.Context, executionContext repository.DatasetGenerationExecutionContext, candidate datasetgeneration.Candidate) (agenticSolverRolloutResult, error) {
+	weakAttempts, weakUsage, weakErr := a.invokeAgenticSolverRollouts(ctx, executionContext, "weak_solver", executionContext.WeakProviderAccount, executionContext.Config.WeakModel, executionContext.Config.WeakRollouts, candidate)
+	result := agenticSolverRolloutResult{
+		WeakAttempts: weakAttempts,
+		Usage:        weakUsage,
+	}
+	if weakErr != nil {
+		return result, weakErr
+	}
+
+	strongAttempts, strongUsage, strongErr := a.invokeAgenticSolverRollouts(ctx, executionContext, "strong_solver", executionContext.StrongProviderAccount, executionContext.Config.StrongModel, executionContext.Config.StrongRollouts, candidate)
+	result.StrongAttempts = strongAttempts
+	result.Usage.InputTokens += strongUsage.InputTokens
+	result.Usage.OutputTokens += strongUsage.OutputTokens
+	result.Usage.CostUSD += strongUsage.CostUSD
+	if strongErr != nil {
+		return result, strongErr
+	}
+	return result, nil
+}
+
+func (a *DatasetGenerationActivities) invokeAgenticSolverRollouts(ctx context.Context, executionContext repository.DatasetGenerationExecutionContext, role string, account *repository.ProviderAccountRow, model string, rolloutCount int, candidate datasetgeneration.Candidate) ([]datasetgeneration.AgenticSolverAttempt, agenticJudgeUsage, error) {
+	if account == nil {
+		return nil, agenticJudgeUsage{}, fmt.Errorf("%s provider account is required", role)
+	}
+	if rolloutCount <= 0 {
+		rolloutCount = 1
+	}
+	attempts := make([]datasetgeneration.AgenticSolverAttempt, 0, rolloutCount)
+	var usage agenticJudgeUsage
+	for i := 0; i < rolloutCount; i++ {
+		prompt := datasetgeneration.BuildAgenticSolverPrompt(role, candidate)
+		response, invokeErr := a.client.InvokeModel(ctx, provider.Request{
+			ProviderKey:         account.ProviderKey,
+			ProviderAccountID:   account.ID.String(),
+			CredentialReference: account.CredentialReference,
+			Model:               model,
+			TraceMode:           "required",
+			StepTimeout:         120 * time.Second,
+			Messages:            []provider.Message{{Role: "user", Content: prompt}},
+			Metadata: mustMarshalJSON(map[string]any{
+				"dataset_generation_job_id": executionContext.Job.ID,
+				"dataset_id":                executionContext.Dataset.ID,
+				"strategy":                  executionContext.Job.Strategy,
+				"role":                      role,
+				"attempt":                   i + 1,
+			}),
+		})
+		if response.Usage.InputTokens > 0 || response.Usage.OutputTokens > 0 {
+			inputCost, outputCost, _ := provider.StaticModelPrice(account.ProviderKey, model)
+			usage.InputTokens += response.Usage.InputTokens
+			usage.OutputTokens += response.Usage.OutputTokens
+			usage.CostUSD += datasetgeneration.ComputeCostUSD(response.Usage.InputTokens, response.Usage.OutputTokens, datasetgeneration.ModelPricing{
+				InputCostPerMillionTokens:  inputCost,
+				OutputCostPerMillionTokens: outputCost,
+			})
+		}
+		if invokeErr != nil {
+			return attempts, usage, fmt.Errorf("%s attempt %d: %w", role, i+1, invokeErr)
+		}
+		attempts = append(attempts, datasetgeneration.AgenticSolverAttempt{
+			Role:              role,
+			Attempt:           i + 1,
+			ProviderAccountID: account.ID.String(),
+			Model:             model,
+			Output:            strings.TrimSpace(response.OutputText),
+		})
+	}
+	return attempts, usage, nil
+}
+
+func (a *DatasetGenerationActivities) judgeAgenticCandidate(ctx context.Context, executionContext repository.DatasetGenerationExecutionContext, seedBatch []datasetgeneration.SeedExample, candidate datasetgeneration.Candidate, weakAttempts, strongAttempts []datasetgeneration.AgenticSolverAttempt) (*datasetgeneration.AgenticJudgeVerdict, agenticJudgeUsage, error) {
 	if executionContext.JudgeProviderAccount == nil {
 		return nil, agenticJudgeUsage{}, fmt.Errorf("judge provider account is required")
 	}
 	judgeAccount := *executionContext.JudgeProviderAccount
 	prompt := datasetgeneration.BuildAgenticJudgePrompt(datasetgeneration.AgenticJudgeInput{
-		Seeds:     seedBatch,
-		Candidate: candidate,
+		Seeds:          seedBatch,
+		Candidate:      candidate,
+		WeakAttempts:   weakAttempts,
+		StrongAttempts: strongAttempts,
 	})
 	response, invokeErr := a.client.InvokeModel(ctx, provider.Request{
 		ProviderKey:         judgeAccount.ProviderKey,

--- a/backend/internal/workflow/dataset_generation_activities_test.go
+++ b/backend/internal/workflow/dataset_generation_activities_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -42,6 +43,88 @@ func TestExecuteSyntheticDatasetGenerationAgenticAcceptsJudgeApprovedCandidate(t
 	}
 	if fixture.repo.progress.TotalInputTokens != 21 || fixture.repo.progress.TotalOutputTokens != 11 {
 		t.Fatalf("usage = %d/%d", fixture.repo.progress.TotalInputTokens, fixture.repo.progress.TotalOutputTokens)
+	}
+}
+
+func TestExecuteSyntheticDatasetGenerationAgenticRunsDirectProviderSolvers(t *testing.T) {
+	fixture := newDatasetGenerationActivityFixture(t, []provider.Response{
+		{OutputText: `{"input":{"q":"candidate"},"expected":{"a":"ok"}}`, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+		{OutputText: `weak answer`, Usage: provider.Usage{InputTokens: 2, OutputTokens: 3}},
+		{OutputText: `strong answer`, Usage: provider.Usage{InputTokens: 4, OutputTokens: 5}},
+		{OutputText: `{"verdict":"accept","quality_verdict":"high","weak_score":0.3,"strong_score":0.9,"gap":0.6,"capability_tags":["recovery"],"gap_interpretation":"clear separation"}`, Usage: provider.Usage{InputTokens: 11, OutputTokens: 6}},
+	})
+	configureDirectProviderSolvers(&fixture)
+
+	if err := fixture.activities.ExecuteSyntheticDatasetGeneration(context.Background(), ExecuteSyntheticDatasetGenerationInput{JobID: fixture.jobID}); err != nil {
+		t.Fatalf("execute generation: %v", err)
+	}
+	if fixture.client.calls != 4 {
+		t.Fatalf("provider calls = %d, want 4", fixture.client.calls)
+	}
+	models := []string{
+		fixture.client.requests[0].Model,
+		fixture.client.requests[1].Model,
+		fixture.client.requests[2].Model,
+		fixture.client.requests[3].Model,
+	}
+	wantModels := []string{"gpt-4.1-mini", "gpt-4.1-nano", "gpt-4.1", "gpt-4.1-mini"}
+	for i := range wantModels {
+		if models[i] != wantModels[i] {
+			t.Fatalf("call %d model = %q, want %q", i, models[i], wantModels[i])
+		}
+	}
+	if strings.Contains(fixture.client.requests[1].Messages[0].Content, `"a":"ok"`) {
+		t.Fatalf("weak solver prompt leaked expected answer: %q", fixture.client.requests[1].Messages[0].Content)
+	}
+	if !strings.Contains(fixture.client.requests[3].Messages[0].Content, "weak answer") || !strings.Contains(fixture.client.requests[3].Messages[0].Content, "strong answer") {
+		t.Fatalf("judge prompt missing solver outputs: %q", fixture.client.requests[3].Messages[0].Content)
+	}
+	if len(fixture.repo.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(fixture.repo.upserts))
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(fixture.repo.upserts[0].Metadata, &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata["solver_mode"] != datasetgeneration.SolverModeDirectProvider {
+		t.Fatalf("solver_mode = %v", metadata["solver_mode"])
+	}
+	if _, ok := metadata["weak_solver_attempts"].([]any); !ok {
+		t.Fatalf("weak solver attempts missing from metadata: %+v", metadata)
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(fixture.repo.progress.Summary, &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary["avg_gap"] != 0.6 {
+		t.Fatalf("avg_gap = %v, want 0.6", summary["avg_gap"])
+	}
+}
+
+func TestExecuteSyntheticDatasetGenerationAgenticRecordsSolverFailure(t *testing.T) {
+	fixture := newDatasetGenerationActivityFixture(t, []provider.Response{
+		{OutputText: `{"input":{"q":"candidate"},"expected":{"a":"ok"}}`},
+		{},
+	})
+	configureDirectProviderSolvers(&fixture)
+	fixture.repo.context.Config.MaxRoundsPerExample = 1
+	fixture.client.errors = []error{nil, errors.New("weak model down")}
+
+	if err := fixture.activities.ExecuteSyntheticDatasetGeneration(context.Background(), ExecuteSyntheticDatasetGenerationInput{JobID: fixture.jobID}); err != nil {
+		t.Fatalf("execute generation: %v", err)
+	}
+	if len(fixture.repo.upserts) != 0 {
+		t.Fatalf("upserts = %d, want 0", len(fixture.repo.upserts))
+	}
+	if len(fixture.repo.rejections) == 0 {
+		t.Fatal("expected at least one rejection")
+	}
+	rejection := fixture.repo.rejections[0]
+	if rejection.ReasonCode != datasetgeneration.ReasonSolverError {
+		t.Fatalf("reason = %q", rejection.ReasonCode)
+	}
+	if rejection.ReasonDetail == nil || !strings.Contains(*rejection.ReasonDetail, "weak model down") {
+		t.Fatalf("reason detail = %v", rejection.ReasonDetail)
 	}
 }
 
@@ -99,6 +182,7 @@ func TestExecuteSyntheticDatasetGenerationAgenticRecordsMalformedJudgeOutput(t *
 type datasetGenerationActivityFixture struct {
 	jobID      uuid.UUID
 	repo       *fakeDatasetGenerationWorkflowRepo
+	client     *scriptedDatasetGenerationProvider
 	activities *DatasetGenerationActivities
 }
 
@@ -166,22 +250,56 @@ func newDatasetGenerationActivityFixture(t *testing.T, responses []provider.Resp
 	return datasetGenerationActivityFixture{
 		jobID:      jobID,
 		repo:       repo,
+		client:     client,
 		activities: NewDatasetGenerationActivities(repo, client, nil),
+	}
+}
+
+func configureDirectProviderSolvers(fixture *datasetGenerationActivityFixture) {
+	workspaceID := fixture.repo.context.Job.WorkspaceID
+	weakProviderAccountID := uuid.New()
+	strongProviderAccountID := uuid.New()
+	fixture.repo.context.Config.SolverMode = datasetgeneration.SolverModeDirectProvider
+	fixture.repo.context.Config.WeakProviderAccountID = &weakProviderAccountID
+	fixture.repo.context.Config.WeakModel = "gpt-4.1-nano"
+	fixture.repo.context.Config.WeakRollouts = 1
+	fixture.repo.context.Config.StrongProviderAccountID = &strongProviderAccountID
+	fixture.repo.context.Config.StrongModel = "gpt-4.1"
+	fixture.repo.context.Config.StrongRollouts = 1
+	fixture.repo.context.WeakProviderAccount = &repository.ProviderAccountRow{
+		ID:                  weakProviderAccountID,
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "secret://weak",
+	}
+	fixture.repo.context.StrongProviderAccount = &repository.ProviderAccountRow{
+		ID:                  strongProviderAccountID,
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "secret://strong",
 	}
 }
 
 type scriptedDatasetGenerationProvider struct {
 	responses []provider.Response
+	errors    []error
+	requests  []provider.Request
 	calls     int
 }
 
-func (c *scriptedDatasetGenerationProvider) InvokeModel(context.Context, provider.Request) (provider.Response, error) {
+func (c *scriptedDatasetGenerationProvider) InvokeModel(_ context.Context, request provider.Request) (provider.Response, error) {
+	c.requests = append(c.requests, request)
 	if c.calls >= len(c.responses) {
+		c.calls++
 		return provider.Response{}, nil
 	}
 	response := c.responses[c.calls]
+	var err error
+	if c.calls < len(c.errors) {
+		err = c.errors[c.calls]
+	}
 	c.calls++
-	return response, nil
+	return response, err
 }
 
 type fakeDatasetGenerationWorkflowRepo struct {

--- a/cli/cmd/dataset_generate.go
+++ b/cli/cmd/dataset_generate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -22,6 +23,18 @@ func init() {
 	datasetGenerateCmd.Flags().Float64("min-gap", 0, "Minimum strong-minus-weak score gap for agentic threshold guardrails")
 	datasetGenerateCmd.Flags().Float64("max-weak-score", 0, "Maximum weak score for agentic threshold guardrails")
 	datasetGenerateCmd.Flags().Float64("min-strong-score", 0, "Minimum strong score for agentic threshold guardrails")
+	datasetGenerateCmd.Flags().String("solver-mode", "", "Agentic solver mode (judge_only or direct_provider)")
+	datasetGenerateCmd.Flags().String("weak-provider-account", "", "Weak solver provider account ID for direct provider agentic generation")
+	datasetGenerateCmd.Flags().String("weak-model", "", "Weak solver model ID for direct provider agentic generation")
+	datasetGenerateCmd.Flags().String("strong-provider-account", "", "Strong solver provider account ID for direct provider agentic generation")
+	datasetGenerateCmd.Flags().String("strong-model", "", "Strong solver model ID for direct provider agentic generation")
+	datasetGenerateCmd.Flags().Int("weak-rollouts", 0, "Weak solver rollout count for direct provider agentic generation")
+	datasetGenerateCmd.Flags().Int("strong-rollouts", 0, "Strong solver rollout count for direct provider agentic generation")
+	datasetGenerateCmd.Flags().String("weak-deployment", "", "Weak AgentClash deployment ID to store with generated examples")
+	datasetGenerateCmd.Flags().String("strong-deployment", "", "Strong AgentClash deployment ID to store with generated examples")
+	datasetGenerateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID to store with generation deployment context")
+	datasetGenerateCmd.Flags().String("challenge-key", "", "Challenge key to store with generation deployment context")
+	datasetGenerateCmd.Flags().String("field-mapping", "", "JSON object mapping dataset fields to challenge inputs")
 	datasetGenerateCmd.Flags().String("seeds-tag", "", "Only use seed examples with this tag")
 	datasetGenerateCmd.Flags().Bool("create-version", false, "Snapshot a dataset version when generation completes")
 	datasetGenerateCmd.Flags().String("version-label", "", "Optional label for the generated dataset version")
@@ -64,6 +77,18 @@ var datasetGenerateCmd = &cobra.Command{
 		judgeModel, _ := cmd.Flags().GetString("judge-model")
 		maxRoundsPerExample, _ := cmd.Flags().GetInt("max-rounds-per-example")
 		acceptanceMode, _ := cmd.Flags().GetString("acceptance-mode")
+		solverMode, _ := cmd.Flags().GetString("solver-mode")
+		weakProviderAccount, _ := cmd.Flags().GetString("weak-provider-account")
+		weakModel, _ := cmd.Flags().GetString("weak-model")
+		strongProviderAccount, _ := cmd.Flags().GetString("strong-provider-account")
+		strongModel, _ := cmd.Flags().GetString("strong-model")
+		weakRollouts, _ := cmd.Flags().GetInt("weak-rollouts")
+		strongRollouts, _ := cmd.Flags().GetInt("strong-rollouts")
+		weakDeployment, _ := cmd.Flags().GetString("weak-deployment")
+		strongDeployment, _ := cmd.Flags().GetString("strong-deployment")
+		challengePackVersion, _ := cmd.Flags().GetString("challenge-pack-version")
+		challengeKey, _ := cmd.Flags().GetString("challenge-key")
+		fieldMapping, _ := cmd.Flags().GetString("field-mapping")
 
 		body := map[string]any{
 			"strategy":            strategy,
@@ -101,6 +126,49 @@ var datasetGenerateCmd = &cobra.Command{
 		if cmd.Flags().Changed("min-strong-score") {
 			minStrongScore, _ := cmd.Flags().GetFloat64("min-strong-score")
 			body["min_strong_score"] = minStrongScore
+		}
+		if solverMode != "" {
+			body["solver_mode"] = solverMode
+		}
+		if weakProviderAccount != "" {
+			body["weak_provider_account_id"] = weakProviderAccount
+		}
+		if weakModel != "" {
+			body["weak_model"] = weakModel
+		}
+		if strongProviderAccount != "" {
+			body["strong_provider_account_id"] = strongProviderAccount
+		}
+		if strongModel != "" {
+			body["strong_model"] = strongModel
+		}
+		if weakRollouts > 0 {
+			body["weak_rollouts"] = weakRollouts
+		}
+		if strongRollouts > 0 {
+			body["strong_rollouts"] = strongRollouts
+		}
+		if weakDeployment != "" {
+			body["weak_deployment_id"] = weakDeployment
+		}
+		if strongDeployment != "" {
+			body["strong_deployment_id"] = strongDeployment
+		}
+		if challengePackVersion != "" {
+			body["challenge_pack_version_id"] = challengePackVersion
+		}
+		if challengeKey != "" {
+			body["challenge_key"] = challengeKey
+		}
+		if fieldMapping != "" {
+			var mapping map[string]any
+			if err := json.Unmarshal([]byte(fieldMapping), &mapping); err != nil {
+				return fmt.Errorf("--field-mapping must be a JSON object: %w", err)
+			}
+			if mapping == nil {
+				return fmt.Errorf("--field-mapping must be a JSON object")
+			}
+			body["field_mapping"] = mapping
 		}
 
 		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/datasets/"+datasetID+"/generate", body)

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -1634,6 +1634,16 @@
               "type": "string"
             },
             {
+              "name": "challenge-key",
+              "usage": "Challenge key to store with generation deployment context",
+              "type": "string"
+            },
+            {
+              "name": "challenge-pack-version",
+              "usage": "Challenge pack version ID to store with generation deployment context",
+              "type": "string"
+            },
+            {
               "name": "count",
               "usage": "Target number of accepted synthetic examples",
               "type": "int",
@@ -1644,6 +1654,11 @@
               "usage": "Snapshot a dataset version when generation completes",
               "type": "bool",
               "default": "false"
+            },
+            {
+              "name": "field-mapping",
+              "usage": "JSON object mapping dataset fields to challenge inputs",
+              "type": "string"
             },
             {
               "name": "follow",
@@ -1707,10 +1722,36 @@
               "type": "string"
             },
             {
+              "name": "solver-mode",
+              "usage": "Agentic solver mode (judge_only or direct_provider)",
+              "type": "string"
+            },
+            {
               "name": "strategy",
               "usage": "Generation strategy (self-instruct, agentic-self-instruct)",
               "type": "string",
               "default": "self-instruct"
+            },
+            {
+              "name": "strong-deployment",
+              "usage": "Strong AgentClash deployment ID to store with generated examples",
+              "type": "string"
+            },
+            {
+              "name": "strong-model",
+              "usage": "Strong solver model ID for direct provider agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "strong-provider-account",
+              "usage": "Strong solver provider account ID for direct provider agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "strong-rollouts",
+              "usage": "Strong solver rollout count for direct provider agentic generation",
+              "type": "int",
+              "default": "0"
             },
             {
               "name": "timeout",
@@ -1722,6 +1763,27 @@
               "name": "version-label",
               "usage": "Optional label for the generated dataset version",
               "type": "string"
+            },
+            {
+              "name": "weak-deployment",
+              "usage": "Weak AgentClash deployment ID to store with generated examples",
+              "type": "string"
+            },
+            {
+              "name": "weak-model",
+              "usage": "Weak solver model ID for direct provider agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "weak-provider-account",
+              "usage": "Weak solver provider account ID for direct provider agentic generation",
+              "type": "string"
+            },
+            {
+              "name": "weak-rollouts",
+              "usage": "Weak solver rollout count for direct provider agentic generation",
+              "type": "int",
+              "default": "0"
             }
           ]
         },

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7315,6 +7315,45 @@ components:
           type: number
           minimum: 0
           maximum: 1
+        solver_mode:
+          type: string
+          enum: [judge_only, direct_provider]
+        weak_provider_account_id:
+          type: string
+          format: uuid
+          description: Required when solver_mode is direct_provider.
+        weak_model:
+          type: string
+          description: Required when solver_mode is direct_provider.
+        strong_provider_account_id:
+          type: string
+          format: uuid
+          description: Required when solver_mode is direct_provider.
+        strong_model:
+          type: string
+          description: Required when solver_mode is direct_provider.
+        weak_rollouts:
+          type: integer
+          minimum: 1
+          maximum: 5
+        strong_rollouts:
+          type: integer
+          minimum: 1
+          maximum: 5
+        weak_deployment_id:
+          type: string
+          format: uuid
+        strong_deployment_id:
+          type: string
+          format: uuid
+        challenge_pack_version_id:
+          type: string
+          format: uuid
+        challenge_key:
+          type: string
+        field_mapping:
+          type: object
+          additionalProperties: true
 
     DatasetGenerationJob:
       type: object

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4091,11 +4091,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          description: Dataset or generation job not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
+          $ref: "#/components/responses/NotFoundError"
 
   /v1/workspaces/{workspaceID}/datasets/{datasetID}/gate:
     post:

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4052,6 +4052,51 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /v1/workspaces/{workspaceID}/datasets/{datasetID}/generations/{jobID}/rejections:
+    get:
+      operationId: listDatasetGenerationRejections
+      tags: [Datasets]
+      summary: List rejection records for a synthetic dataset generation job
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/DatasetID"
+        - name: jobID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Generation rejection records
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetGenerationRejectionsResult"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          description: Dataset or generation job not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /v1/workspaces/{workspaceID}/datasets/{datasetID}/gate:
     post:
       operationId: evaluateDatasetGate
@@ -7404,6 +7449,31 @@ components:
         failed_at: { type: string, format: date-time }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+
+    DatasetGenerationRejection:
+      type: object
+      required: [id, job_id, reason_code, metadata, created_at]
+      properties:
+        id: { type: string, format: uuid }
+        job_id: { type: string, format: uuid }
+        reason_code: { type: string }
+        reason_detail: { type: string }
+        candidate_input: {}
+        candidate_expected: {}
+        metadata: { type: object, additionalProperties: true }
+        created_at: { type: string, format: date-time }
+
+    DatasetGenerationRejectionsResult:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DatasetGenerationRejection"
+        total: { type: integer, format: int64 }
+        limit: { type: integer }
+        offset: { type: integer }
 
     EvaluateDatasetGateInput:
       type: object

--- a/testing/codex-agentic-self-instruct-phases-3-5.md
+++ b/testing/codex-agentic-self-instruct-phases-3-5.md
@@ -1,0 +1,93 @@
+# Codex Agentic Self-Instruct Phases 3-5 — Test Contract
+
+## Functional Behavior
+- Phase 3 adds an optional direct solver loop for `agentic_self_instruct` generation:
+  - API/CLI/UI inputs can specify weak and strong provider accounts, models, and rollout counts.
+  - When `solver_mode` is `direct_provider`, each valid challenger candidate is solved by the configured weak and strong models before judging.
+  - The judge prompt includes the seed set, candidate, weak attempts, and strong attempts.
+  - Accepted examples persist solver metadata including model IDs, rollout counts, solver attempts, judge scores, and score gap.
+  - Rejected examples preserve structured metadata for provider failures, solver failures, judge parse failures, invalid candidates, duplicates, and quality gate failures.
+- Phase 4 adds AgentClash deployment-loop configuration at the product surface:
+  - API/CLI/UI inputs can capture weak/strong deployment IDs, challenge pack version ID, challenge key, and field mapping.
+  - The generation job config persists this deployment context for history and follow-up evaluation workflows.
+  - The workflow keeps per-candidate generation execution on the direct provider path; deployment-backed competitive runs remain handled by the existing dataset evaluation/run creation flow.
+- Phase 5 improves generation history and explainability:
+  - Job summaries include accepted counts, rejection counts by reason, average weak score, average strong score, average gap, and solver mode.
+  - A generation history endpoint returns structured rejection/attempt records for a job.
+  - The dataset generation UI surfaces recent job summary stats and lets the user inspect recent rejection reasons.
+
+## Unit Tests
+- `datasetgeneration.DecodeJobConfigForStrategy` accepts valid direct-provider solver config and rejects invalid solver modes or rollout counts.
+- `BuildAgenticSolverPrompt` omits the expected answer and contains only the candidate task plus role guidance.
+- `BuildAgenticJudgePrompt` includes weak/strong solver attempt sections when attempts are present.
+- `DatasetGenerationActivities.ExecuteSyntheticDatasetGeneration` invokes challenger, weak solver, strong solver, and judge in order for direct-provider jobs.
+- `DatasetGenerationActivities.ExecuteSyntheticDatasetGeneration` records solver metadata on accepted examples.
+- `DatasetGenerationActivities.ExecuteSyntheticDatasetGeneration` records a solver failure rejection when a weak/strong provider call fails.
+- API tests cover validation and persistence of new solver/deployment generation fields.
+- CLI command tests cover new generation flags and schema output.
+
+## Integration / Functional Tests
+- Backend package tests pass for generation, API, repository, and workflow packages.
+- CLI command tests pass and the schema golden snapshot is updated.
+- Web lint passes for the dataset generation dialog and shared API types.
+
+## Smoke Tests
+- Start generation with default judge-only settings still works for existing clients.
+- Start generation with direct weak/strong solver settings accepts the payload and stores the full config.
+- The generation history endpoint returns rejections for an existing generation job.
+- The dataset generation dialog renders without type or lint errors after adding solver and deployment fields.
+
+## E2E Tests
+- N/A — this PR does not introduce a browser-driven E2E suite. Manual UI verification is covered by the smoke checks and lint/type checks.
+
+## Manual / cURL Tests
+- Start a direct-provider agentic generation job:
+
+  ```bash
+  curl -X POST "$API/v1/workspaces/$WORKSPACE_ID/datasets/$DATASET_ID/generate" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "strategy": "agentic_self_instruct",
+      "targetCount": 5,
+      "providerAccountId": "'"$CHALLENGER_PROVIDER_ID"'",
+      "model": "gpt-4.1-mini",
+      "judgeProviderAccountId": "'"$JUDGE_PROVIDER_ID"'",
+      "judgeModel": "gpt-4.1",
+      "solverMode": "direct_provider",
+      "weakProviderAccountId": "'"$WEAK_PROVIDER_ID"'",
+      "weakModel": "gpt-4.1-nano",
+      "strongProviderAccountId": "'"$STRONG_PROVIDER_ID"'",
+      "strongModel": "gpt-4.1",
+      "weakRollouts": 1,
+      "strongRollouts": 1
+    }'
+  ```
+
+- Inspect generation history for a job:
+
+  ```bash
+  curl "$API/v1/workspaces/$WORKSPACE_ID/datasets/$DATASET_ID/generations/$JOB_ID/rejections" \
+    -H "Authorization: Bearer $TOKEN"
+  ```
+
+- Start a generation job with deployment context:
+
+  ```bash
+  agentclash dataset generate "$DATASET_ID" \
+    --strategy agentic_self_instruct \
+    --provider-account "$CHALLENGER_PROVIDER_ID" \
+    --model gpt-4.1-mini \
+    --judge-provider-account "$JUDGE_PROVIDER_ID" \
+    --judge-model gpt-4.1 \
+    --solver-mode direct_provider \
+    --weak-provider-account "$WEAK_PROVIDER_ID" \
+    --weak-model gpt-4.1-nano \
+    --strong-provider-account "$STRONG_PROVIDER_ID" \
+    --strong-model gpt-4.1 \
+    --weak-deployment "$WEAK_DEPLOYMENT_ID" \
+    --strong-deployment "$STRONG_DEPLOYMENT_ID" \
+    --challenge-pack-version "$CHALLENGE_PACK_VERSION_ID" \
+    --challenge-key "$CHALLENGE_KEY" \
+    --field-mapping '{"input":"prompt","expected":"answer"}'
+  ```

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
@@ -13,6 +13,9 @@ import {
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type {
+  AgentDeployment,
+  ChallengePack,
+  ChallengePackVersion,
   DatasetGenerationJob,
   ProviderConnectionModel,
   ProviderAccount,
@@ -55,6 +58,9 @@ export function StartGenerationDialog({
   const [providerAccounts, setProviderAccounts] = useState<ProviderAccount[]>(
     [],
   );
+  const [packs, setPacks] = useState<ChallengePack[]>([]);
+  const [packVersions, setPackVersions] = useState<ChallengePackVersion[]>([]);
+  const [deployments, setDeployments] = useState<AgentDeployment[]>([]);
   const [models, setModels] = useState<ProviderConnectionModel[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
   const [strategy, setStrategy] = useState<
@@ -71,6 +77,22 @@ export function StartGenerationDialog({
   const [minGap, setMinGap] = useState("0.2");
   const [maxWeakScore, setMaxWeakScore] = useState("0.65");
   const [minStrongScore, setMinStrongScore] = useState("0.75");
+  const [solverMode, setSolverMode] = useState<"judge_only" | "direct_provider">(
+    "judge_only",
+  );
+  const [weakProviderAccountId, setWeakProviderAccountId] = useState("");
+  const [weakModel, setWeakModel] = useState("");
+  const [strongProviderAccountId, setStrongProviderAccountId] = useState("");
+  const [strongModel, setStrongModel] = useState("");
+  const [weakRollouts, setWeakRollouts] = useState("1");
+  const [strongRollouts, setStrongRollouts] = useState("1");
+  const [weakDeploymentId, setWeakDeploymentId] = useState("");
+  const [strongDeploymentId, setStrongDeploymentId] = useState("");
+  const [packId, setPackId] = useState("");
+  const [packVersionId, setPackVersionId] = useState("");
+  const [challengeKey, setChallengeKey] = useState("");
+  const [fieldMappingJson, setFieldMappingJson] = useState("");
+  const [fieldMappingError, setFieldMappingError] = useState<string>();
   const [targetCount, setTargetCount] = useState("10");
   const [seedsTag, setSeedsTag] = useState("");
   const [createVersion, setCreateVersion] = useState(true);
@@ -91,12 +113,24 @@ export function StartGenerationDialog({
     try {
       const token = await getAccessToken();
       const api = createApiClient(token);
-      const accounts = await api.paginated<ProviderAccount>(
-        `/v1/workspaces/${workspaceId}/provider-accounts`,
-        { limit: 100 },
-      );
+      const [accounts, packsRes, deploymentsRes] = await Promise.all([
+        api.paginated<ProviderAccount>(
+          `/v1/workspaces/${workspaceId}/provider-accounts`,
+          { limit: 100 },
+        ),
+        api.get<{ items: ChallengePack[] }>(
+          `/v1/workspaces/${workspaceId}/challenge-packs`,
+        ),
+        api.get<{ items: AgentDeployment[] }>(
+          `/v1/workspaces/${workspaceId}/agent-deployments`,
+        ),
+      ]);
       setProviderAccounts(
         accounts.items.filter((a) => a.status === "active"),
+      );
+      setPacks(packsRes.items);
+      setDeployments(
+        deploymentsRes.items.filter((item) => item.status === "active"),
       );
     } catch (err) {
       toast.error(
@@ -106,6 +140,20 @@ export function StartGenerationDialog({
       setLoading(false);
     }
   }, [getAccessToken, workspaceId]);
+
+  useEffect(() => {
+    if (!packId) {
+      setPackVersions([]);
+      setPackVersionId("");
+      return;
+    }
+    const pack = packs.find((item) => item.id === packId);
+    const runnable = (pack?.versions ?? []).filter(
+      (item) => item.lifecycle_status === "runnable",
+    );
+    setPackVersions(runnable);
+    setPackVersionId(runnable.length > 0 ? runnable[runnable.length - 1].id : "");
+  }, [packId, packs]);
 
   const loadModels = useCallback(
     async (accountId: string) => {
@@ -248,6 +296,64 @@ export function StartGenerationDialog({
           return;
         }
       }
+      if (solverMode === "direct_provider") {
+        const rolloutValues = [Number(weakRollouts), Number(strongRollouts)];
+        if (
+          !weakProviderAccountId ||
+          !weakModel.trim() ||
+          !strongProviderAccountId ||
+          !strongModel.trim()
+        ) {
+          toast.error("Select weak and strong solver provider accounts and models");
+          return;
+        }
+        if (
+          rolloutValues.some(
+            (value) => !Number.isInteger(value) || value < 1 || value > 5,
+          )
+        ) {
+          toast.error("Solver rollouts must be between 1 and 5");
+          return;
+        }
+      }
+    }
+
+    const hasDeploymentContext =
+      strategy === "agentic_self_instruct" &&
+      (Boolean(weakDeploymentId) ||
+        Boolean(strongDeploymentId) ||
+        Boolean(packVersionId) ||
+        Boolean(challengeKey.trim()) ||
+        Boolean(fieldMappingJson.trim()));
+    let fieldMapping: Record<string, unknown> | undefined;
+    if (hasDeploymentContext) {
+      if (
+        !weakDeploymentId ||
+        !strongDeploymentId ||
+        !packVersionId ||
+        !challengeKey.trim()
+      ) {
+        toast.error("Select weak and strong deployments, pack version, and challenge key");
+        return;
+      }
+      if (fieldMappingJson.trim()) {
+        try {
+          const parsed = JSON.parse(fieldMappingJson) as unknown;
+          if (
+            parsed == null ||
+            typeof parsed !== "object" ||
+            Array.isArray(parsed)
+          ) {
+            setFieldMappingError("Mapping must be a JSON object");
+            return;
+          }
+          fieldMapping = parsed as Record<string, unknown>;
+          setFieldMappingError(undefined);
+        } catch {
+          setFieldMappingError("Invalid JSON");
+          return;
+        }
+      }
     }
 
     setSubmitting(true);
@@ -295,6 +401,58 @@ export function StartGenerationDialog({
             acceptanceMode === "threshold"
               ? Number(minStrongScore)
               : undefined,
+          solver_mode:
+            strategy === "agentic_self_instruct" ? solverMode : undefined,
+          weak_provider_account_id:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? weakProviderAccountId
+              : undefined,
+          weak_model:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? weakModel.trim()
+              : undefined,
+          strong_provider_account_id:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? strongProviderAccountId
+              : undefined,
+          strong_model:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? strongModel.trim()
+              : undefined,
+          weak_rollouts:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? Number(weakRollouts)
+              : undefined,
+          strong_rollouts:
+            strategy === "agentic_self_instruct" &&
+            solverMode === "direct_provider"
+              ? Number(strongRollouts)
+              : undefined,
+          weak_deployment_id:
+            strategy === "agentic_self_instruct" && hasDeploymentContext
+              ? weakDeploymentId
+              : undefined,
+          strong_deployment_id:
+            strategy === "agentic_self_instruct" && hasDeploymentContext
+              ? strongDeploymentId
+              : undefined,
+          challenge_pack_version_id:
+            strategy === "agentic_self_instruct" && hasDeploymentContext
+              ? packVersionId
+              : undefined,
+          challenge_key:
+            strategy === "agentic_self_instruct" && hasDeploymentContext
+              ? challengeKey.trim()
+              : undefined,
+          field_mapping:
+            strategy === "agentic_self_instruct" && hasDeploymentContext
+              ? fieldMapping
+              : undefined,
         },
       );
       setJob(queued);
@@ -317,7 +475,7 @@ export function StartGenerationDialog({
         <Sparkles data-icon="inline-start" className="size-4" />
         Generate
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Synthetic generation</DialogTitle>
           <DialogDescription>
@@ -358,7 +516,7 @@ export function StartGenerationDialog({
             <Loader2 className="size-6 animate-spin text-muted-foreground" />
           </div>
         ) : (
-          <div className="space-y-4">
+          <div className="max-h-[65vh] space-y-4 overflow-y-auto pr-1">
             {recentJobs.length > 0 ? (
               <div className="rounded-lg border border-border p-3">
                 <p className="text-sm font-medium">Recent jobs</p>
@@ -507,6 +665,119 @@ export function StartGenerationDialog({
                 </div>
                 <div>
                   <label className="mb-1.5 block text-sm font-medium">
+                    Solver mode
+                  </label>
+                  <select
+                    value={solverMode}
+                    onChange={(e) =>
+                      setSolverMode(
+                        e.target.value as "judge_only" | "direct_provider",
+                      )
+                    }
+                    className={inputClass}
+                  >
+                    <option value="judge_only">Judge only</option>
+                    <option value="direct_provider">Direct weak/strong</option>
+                  </select>
+                </div>
+                {solverMode === "direct_provider" ? (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-3">
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Weak provider account
+                        </label>
+                        <select
+                          value={weakProviderAccountId}
+                          onChange={(e) =>
+                            setWeakProviderAccountId(e.target.value)
+                          }
+                          className={inputClass}
+                        >
+                          <option value="">Select account...</option>
+                          {providerAccounts.map((a) => (
+                            <option key={a.id} value={a.id}>
+                              {a.name} ({a.provider_key})
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Weak model
+                        </label>
+                        <input
+                          value={weakModel}
+                          onChange={(e) => setWeakModel(e.target.value)}
+                          placeholder="e.g. gpt-4.1-nano"
+                          disabled={!weakProviderAccountId}
+                          className={inputClass}
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Weak rollouts
+                        </label>
+                        <input
+                          type="number"
+                          min={1}
+                          max={5}
+                          value={weakRollouts}
+                          onChange={(e) => setWeakRollouts(e.target.value)}
+                          className={inputClass}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-3">
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Strong provider account
+                        </label>
+                        <select
+                          value={strongProviderAccountId}
+                          onChange={(e) =>
+                            setStrongProviderAccountId(e.target.value)
+                          }
+                          className={inputClass}
+                        >
+                          <option value="">Select account...</option>
+                          {providerAccounts.map((a) => (
+                            <option key={a.id} value={a.id}>
+                              {a.name} ({a.provider_key})
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Strong model
+                        </label>
+                        <input
+                          value={strongModel}
+                          onChange={(e) => setStrongModel(e.target.value)}
+                          placeholder="e.g. gpt-4.1"
+                          disabled={!strongProviderAccountId}
+                          className={inputClass}
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1.5 block text-sm font-medium">
+                          Strong rollouts
+                        </label>
+                        <input
+                          type="number"
+                          min={1}
+                          max={5}
+                          value={strongRollouts}
+                          onChange={(e) => setStrongRollouts(e.target.value)}
+                          className={inputClass}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
                     Acceptance mode
                   </label>
                   <select
@@ -566,6 +837,111 @@ export function StartGenerationDialog({
                     </div>
                   </div>
                 ) : null}
+                <div className="space-y-3 rounded-md border border-border/70 p-3">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Weak deployment
+                      </label>
+                      <select
+                        value={weakDeploymentId}
+                        onChange={(e) => setWeakDeploymentId(e.target.value)}
+                        className={inputClass}
+                      >
+                        <option value="">Select deployment...</option>
+                        {deployments.map((deployment) => (
+                          <option key={deployment.id} value={deployment.id}>
+                            {deployment.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Strong deployment
+                      </label>
+                      <select
+                        value={strongDeploymentId}
+                        onChange={(e) => setStrongDeploymentId(e.target.value)}
+                        className={inputClass}
+                      >
+                        <option value="">Select deployment...</option>
+                        {deployments.map((deployment) => (
+                          <option key={deployment.id} value={deployment.id}>
+                            {deployment.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Challenge pack
+                      </label>
+                      <select
+                        value={packId}
+                        onChange={(e) => setPackId(e.target.value)}
+                        className={inputClass}
+                      >
+                        <option value="">Select pack...</option>
+                        {packs.map((pack) => (
+                          <option key={pack.id} value={pack.id}>
+                            {pack.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium">
+                        Pack version
+                      </label>
+                      <select
+                        value={packVersionId}
+                        onChange={(e) => setPackVersionId(e.target.value)}
+                        disabled={!packId}
+                        className={inputClass}
+                      >
+                        <option value="">Select version...</option>
+                        {packVersions.map((version) => (
+                          <option key={version.id} value={version.id}>
+                            v{version.version_number}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium">
+                      Challenge key
+                    </label>
+                    <input
+                      value={challengeKey}
+                      onChange={(e) => setChallengeKey(e.target.value)}
+                      placeholder="e.g. refund-recovery"
+                      className={inputClass}
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium">
+                      Field mapping
+                    </label>
+                    <textarea
+                      value={fieldMappingJson}
+                      onChange={(e) => {
+                        setFieldMappingJson(e.target.value);
+                        setFieldMappingError(undefined);
+                      }}
+                      rows={3}
+                      className={inputClass}
+                    />
+                    {fieldMappingError ? (
+                      <p className="mt-1 text-xs text-destructive">
+                        {fieldMappingError}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
               </div>
             ) : null}
             <div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
@@ -8,6 +8,7 @@ import { Loader2, Sparkles } from "lucide-react";
 
 import {
   getDatasetGenerationJob,
+  listDatasetGenerationRejections,
   startDatasetGeneration,
 } from "@/lib/api/datasets";
 import { createApiClient } from "@/lib/api/client";
@@ -17,6 +18,7 @@ import type {
   ChallengePack,
   ChallengePackVersion,
   DatasetGenerationJob,
+  DatasetGenerationRejection,
   ProviderConnectionModel,
   ProviderAccount,
 } from "@/lib/api/types";
@@ -98,6 +100,10 @@ export function StartGenerationDialog({
   const [createVersion, setCreateVersion] = useState(true);
   const [versionLabel, setVersionLabel] = useState("");
   const [job, setJob] = useState<DatasetGenerationJob | null>(null);
+  const [jobRejections, setJobRejections] = useState<
+    DatasetGenerationRejection[]
+  >([]);
+  const [loadingJobRejections, setLoadingJobRejections] = useState(false);
   const [recentJobs, setRecentJobs] = useState<DatasetGenerationJob[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
 
@@ -220,16 +226,48 @@ export function StartGenerationDialog({
     }
   }, [datasetId, getAccessToken, workspaceId]);
 
+  const loadJobRejections = useCallback(
+    async (jobId: string) => {
+      setLoadingJobRejections(true);
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const result = await listDatasetGenerationRejections(
+          api,
+          workspaceId,
+          datasetId,
+          jobId,
+        );
+        setJobRejections(result.items);
+      } catch {
+        setJobRejections([]);
+      } finally {
+        setLoadingJobRejections(false);
+      }
+    },
+    [datasetId, getAccessToken, workspaceId],
+  );
+
   useEffect(() => {
     if (open) {
       void loadOptions();
       void loadRecentJobs();
       setJob(null);
+      setJobRejections([]);
     } else {
       stopPolling();
     }
     return stopPolling;
   }, [loadOptions, loadRecentJobs, open, stopPolling]);
+
+  useEffect(() => {
+    const selectedJobId = job?.id;
+    if (!open || !selectedJobId) {
+      setJobRejections([]);
+      return;
+    }
+    void loadJobRejections(selectedJobId);
+  }, [job?.id, loadJobRejections, open]);
 
   function startPolling(jobId: string) {
     stopPolling();
@@ -246,6 +284,7 @@ export function StartGenerationDialog({
         setJob(next);
         if (next.status === "completed" || next.status === "failed") {
           stopPolling();
+          void loadJobRejections(next.id);
           if (next.status === "completed") {
             toast.success(
               `Generated ${next.accepted_count} examples (${next.rejected_count} rejected)`,
@@ -504,6 +543,59 @@ export function StartGenerationDialog({
                 ? ` (${job.rejected_count} rejected)`
                 : ""}
             </p>
+            {generationSummaryStats(job).length > 0 ? (
+              <div className="grid gap-2 sm:grid-cols-3">
+                {generationSummaryStats(job).map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="rounded-md border border-border/70 px-2 py-1.5"
+                  >
+                    <p className="text-[11px] font-medium uppercase text-muted-foreground">
+                      {stat.label}
+                    </p>
+                    <p className="mt-0.5 truncate text-sm">{stat.value}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {job.rejected_count > 0 ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  {loadingJobRejections ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : null}
+                  <span>Rejections</span>
+                </div>
+                {jobRejections.length > 0 ? (
+                  <div className="max-h-36 space-y-1 overflow-y-auto">
+                    {jobRejections.slice(0, 5).map((rejection) => (
+                      <div
+                        key={rejection.id}
+                        className="rounded-md border border-border/70 px-2 py-1.5"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium">
+                            {formatReasonCode(rejection.reason_code)}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {new Date(rejection.created_at).toLocaleTimeString()}
+                          </span>
+                        </div>
+                        {rejection.reason_detail ? (
+                          <p className="mt-1 line-clamp-2 text-muted-foreground">
+                            {rejection.reason_detail}
+                          </p>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : loadingJobRejections ? null : (
+                  <p className="text-muted-foreground">
+                    No rejection records yet.
+                  </p>
+                )}
+              </div>
+            ) : null}
             {(job.status === "queued" || job.status === "running") && (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="size-4 animate-spin" />
@@ -537,10 +629,25 @@ export function StartGenerationDialog({
                             startPolling(recentJob.id);
                           }
                         }}
-                        className="flex w-full items-center justify-between rounded-md border border-border/70 px-3 py-2 text-left text-sm hover:bg-muted/30"
+                        className="flex w-full items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-left text-sm hover:bg-muted/30"
                       >
-                        <span>{recentJob.id.slice(0, 8)}</span>
-                        <Badge variant="secondary">{recentJob.status}</Badge>
+                        <span>
+                          <span className="font-medium">
+                            {recentJob.id.slice(0, 8)}
+                          </span>
+                          <span className="mt-0.5 block text-xs text-muted-foreground">
+                            {recentJob.accepted_count}/{recentJob.target_count} accepted
+                            {recentJob.rejected_count > 0
+                              ? `, ${recentJob.rejected_count} rejected`
+                              : ""}
+                            {topRejectionReason(recentJob)
+                              ? `, ${topRejectionReason(recentJob)}`
+                              : ""}
+                          </span>
+                        </span>
+                        <Badge variant="secondary" className="shrink-0">
+                          {recentJob.status}
+                        </Badge>
                       </button>
                     ))
                   )}
@@ -1005,4 +1112,60 @@ export function StartGenerationDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function generationSummaryStats(job: DatasetGenerationJob) {
+  const stats: { label: string; value: string }[] = [];
+  const solverMode = summaryString(job, "solver_mode");
+  if (solverMode && solverMode !== "judge_only") {
+    stats.push({ label: "Solver", value: formatReasonCode(solverMode) });
+  }
+  const avgGap = summaryNumber(job, "avg_gap");
+  if (avgGap != null) {
+    stats.push({ label: "Avg gap", value: formatScore(avgGap) });
+  }
+  const avgWeak = summaryNumber(job, "avg_weak_score");
+  if (avgWeak != null) {
+    stats.push({ label: "Weak", value: formatScore(avgWeak) });
+  }
+  const avgStrong = summaryNumber(job, "avg_strong_score");
+  if (avgStrong != null) {
+    stats.push({ label: "Strong", value: formatScore(avgStrong) });
+  }
+  const topReason = topRejectionReason(job);
+  if (topReason) {
+    stats.push({ label: "Top reject", value: topReason });
+  }
+  return stats.slice(0, 6);
+}
+
+function summaryString(job: DatasetGenerationJob, key: string) {
+  const value = job.summary[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function summaryNumber(job: DatasetGenerationJob, key: string) {
+  const value = job.summary[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function topRejectionReason(job: DatasetGenerationJob) {
+  const reasons = job.summary["rejection_reasons"];
+  if (reasons == null || typeof reasons !== "object" || Array.isArray(reasons)) {
+    return undefined;
+  }
+  let top: { reason: string; count: number } | undefined;
+  for (const [reason, count] of Object.entries(reasons)) {
+    if (typeof count !== "number") continue;
+    if (!top || count > top.count) top = { reason, count };
+  }
+  return top ? `${formatReasonCode(top.reason)} x${top.count}` : undefined;
+}
+
+function formatReasonCode(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function formatScore(value: number) {
+  return value.toFixed(2);
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx
@@ -616,40 +616,41 @@ export function StartGenerationDialog({
                   {loadingHistory ? (
                     <Loader2 className="size-4 animate-spin text-muted-foreground" />
                   ) : (
-                    recentJobs.map((recentJob) => (
-                      <button
-                        key={recentJob.id}
-                        type="button"
-                        onClick={() => {
-                          setJob(recentJob);
-                          if (
-                            recentJob.status === "queued" ||
-                            recentJob.status === "running"
-                          ) {
-                            startPolling(recentJob.id);
-                          }
-                        }}
-                        className="flex w-full items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-left text-sm hover:bg-muted/30"
-                      >
-                        <span>
-                          <span className="font-medium">
-                            {recentJob.id.slice(0, 8)}
+                    recentJobs.map((recentJob) => {
+                      const topReason = topRejectionReason(recentJob);
+                      return (
+                        <button
+                          key={recentJob.id}
+                          type="button"
+                          onClick={() => {
+                            setJob(recentJob);
+                            if (
+                              recentJob.status === "queued" ||
+                              recentJob.status === "running"
+                            ) {
+                              startPolling(recentJob.id);
+                            }
+                          }}
+                          className="flex w-full items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-left text-sm hover:bg-muted/30"
+                        >
+                          <span>
+                            <span className="font-medium">
+                              {recentJob.id.slice(0, 8)}
+                            </span>
+                            <span className="mt-0.5 block text-xs text-muted-foreground">
+                              {recentJob.accepted_count}/{recentJob.target_count} accepted
+                              {recentJob.rejected_count > 0
+                                ? `, ${recentJob.rejected_count} rejected`
+                                : ""}
+                              {topReason ? `, ${topReason}` : ""}
+                            </span>
                           </span>
-                          <span className="mt-0.5 block text-xs text-muted-foreground">
-                            {recentJob.accepted_count}/{recentJob.target_count} accepted
-                            {recentJob.rejected_count > 0
-                              ? `, ${recentJob.rejected_count} rejected`
-                              : ""}
-                            {topRejectionReason(recentJob)
-                              ? `, ${topRejectionReason(recentJob)}`
-                              : ""}
-                          </span>
-                        </span>
-                        <Badge variant="secondary" className="shrink-0">
-                          {recentJob.status}
-                        </Badge>
-                      </button>
-                    ))
+                          <Badge variant="secondary" className="shrink-0">
+                            {recentJob.status}
+                          </Badge>
+                        </button>
+                      );
+                    })
                   )}
                 </div>
               </div>

--- a/web/src/lib/api/datasets.ts
+++ b/web/src/lib/api/datasets.ts
@@ -8,6 +8,7 @@ import type {
   DatasetBaseline,
   DatasetExample,
   DatasetGenerationJob,
+  DatasetGenerationRejectionsResult,
   DatasetImportMode,
   DatasetImportResponse,
   DatasetInteropFormat,
@@ -418,6 +419,17 @@ export function getDatasetGenerationJob(
 ): Promise<DatasetGenerationJob> {
   return api.get<DatasetGenerationJob>(
     `${datasetBase(workspaceId, datasetId)}/generations/${jobId}`,
+  );
+}
+
+export function listDatasetGenerationRejections(
+  api: ApiClient,
+  workspaceId: string,
+  datasetId: string,
+  jobId: string,
+): Promise<DatasetGenerationRejectionsResult> {
+  return api.get<DatasetGenerationRejectionsResult>(
+    `${datasetBase(workspaceId, datasetId)}/generations/${jobId}/rejections?limit=20`,
   );
 }
 

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2352,6 +2352,18 @@ export interface StartDatasetGenerationInput {
   min_gap?: number;
   max_weak_score?: number;
   min_strong_score?: number;
+  solver_mode?: "judge_only" | "direct_provider";
+  weak_provider_account_id?: string;
+  weak_model?: string;
+  strong_provider_account_id?: string;
+  strong_model?: string;
+  weak_rollouts?: number;
+  strong_rollouts?: number;
+  weak_deployment_id?: string;
+  strong_deployment_id?: string;
+  challenge_pack_version_id?: string;
+  challenge_key?: string;
+  field_mapping?: Record<string, unknown>;
 }
 
 export interface DatasetGenerationJob {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2394,6 +2394,24 @@ export interface DatasetGenerationJob {
   updated_at: string;
 }
 
+export interface DatasetGenerationRejection {
+  id: string;
+  job_id: string;
+  reason_code: string;
+  reason_detail?: string;
+  candidate_input?: unknown;
+  candidate_expected?: unknown;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface DatasetGenerationRejectionsResult {
+  items: DatasetGenerationRejection[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface EvaluateDatasetGateInput {
   baseline_id: string;
   run_id: string;


### PR DESCRIPTION
## What changed

Implements the next Agentic Self-Instruct dataset generation slice from #1142:

- Phase 3: direct-provider weak/strong solver loop before judging, with solver prompts that do not leak expected answers, solver-aware judge prompts, solver metadata, score summaries, and solver failure rejections.
- Phase 4: API, CLI, OpenAPI, and UI controls for direct solver config plus persisted AgentClash deployment context (weak/strong deployment, challenge pack version, challenge key, field mapping).
- Phase 5: generation history endpoint for rejection records, job summary stats, and UI history/rejection summaries in the dataset generation dialog.

The existing judge-only agentic mode remains the default for backwards compatibility. Deployment context is persisted and surfaced for follow-up eval workflows while the generation worker keeps per-candidate execution on the direct-provider path.

## Review contract

Locked before implementation in `testing/codex-agentic-self-instruct-phases-3-5.md`.

## Validation

- `cd backend && go test ./internal/datasets/generation ./internal/api ./internal/repository ./internal/workflow`
- `cd cli && go test ./cmd`
- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/datasets/[datasetId]/start-generation-dialog.tsx' src/lib/api/types.ts src/lib/api/datasets.ts`

Manual live cURL/UI smoke tests were not run because no live workspace/API credentials were used in this local verification.
