### PR TITLE
feat(web): DataSmith launch marketing, SEO, and docs

### DIFF
--- a/web/content/blog/introducing-datasmith-synthetic-agent-data.mdx
+++ b/web/content/blog/introducing-datasmith-synthetic-agent-data.mdx
@@ -1,0 +1,102 @@
+---
+title: "Introducing DataSmith: High-Signal Synthetic Data for AI Agents"
+date: "2026-07-01"
+description: "DataSmith is an open-source Python SDK for weak-vs-strong synthetic dataset generation. Use it locally for SFT and DPO export, or inside AgentClash for eval-ready datasets and regression tests."
+author: "Atharva"
+---
+
+Most self-instruct pipelines produce volume, not signal. You get thousands of prompt-completion pairs where the weak model already succeeds or the task is impossible to learn from. That noise shows up later as flat fine-tunes and eval sets that do not match production.
+
+DataSmith fixes the loop. It implements the practical weak-vs-strong Agentic Self-Instruct pattern from [Meta FAIR's Autodata work](https://arxiv.org/abs/2606.25996): a challenger proposes examples, weak and strong solvers attempt them, and a judge accepts only when the gap is useful for training.
+
+## The problem with prompt-only synthetic data
+
+Classic self-instruct assumes you already have seed examples and that bulk generation is good enough. In practice:
+
+- Seeds are thin or off-domain without web grounding.
+- Generated tasks are too easy (weak model passes) or too hard (strong model fails).
+- Rejected examples disappear instead of feeding the next attempt.
+- Export stops at JSONL instead of trainer-ready SFT, DPO, or Hugging Face formats.
+
+DataSmith treats data generation as a **repeatable pipeline**, not a one-shot prompt.
+
+## Two stages: seeds, then generation
+
+**Stage 1: Seed construction**
+
+Start from a domain brief. DataSmith's seed constructor can use web-search signals to bootstrap grounded seed examples. A seed judge filters for specificity and usefulness before anything enters the generation loop.
+
+**Stage 2: Weak-vs-strong generation**
+
+For each seed, a challenger proposes a candidate example. Weak and strong solvers attempt it. A judge scores quality and separation. Accepted rows land in `accepted.jsonl`; rejections keep reason codes, solver attempts, and feedback for the next round.
+
+```bash
+pip install datasmith
+
+datasmith construct-seeds --brief "customer support refund policy" --output seeds.jsonl
+datasmith run --seeds seeds.jsonl --output-dir ./artifacts
+datasmith export --input ./artifacts/accepted.jsonl --format sharegpt --output train.jsonl
+```
+
+The Python import is `asi` for compatibility. The CLI answers to both `datasmith` and `asi`.
+
+## Provider-agnostic by design
+
+DataSmith works with any model that implements a simple `complete()` protocol:
+
+- OpenAI-compatible APIs (OpenAI, Groq, Together, local vLLM)
+- Your own wrapper for Anthropic, Gemini, or internal gateways
+- Deterministic demo models for tests and tutorials
+
+No vendor lock-in. Swap weak and strong solvers per domain without rewriting the loop.
+
+## Turn production traces into training seeds
+
+Real agent runs are often the best seed material. DataSmith ingests OpenTelemetry JSON and flattened span JSONL:
+
+```bash
+datasmith ingest-otel --input traces.jsonl --output seeds.jsonl
+```
+
+That closes the loop between observability and fine-tuning: production failures become curated training examples instead of dashboard noise.
+
+## Export for SFT, DPO, and Hugging Face
+
+Accepted artifacts export to formats trainers actually consume:
+
+- ShareGPT and ChatML for supervised fine-tuning
+- DPO preference pairs when weak and strong outputs diverge
+- Prompt-completion JSONL for simpler pipelines
+- Direct push to Hugging Face Hub with the optional `[hf]` extra
+
+See the [GSM8K + Qwen DPO benchmark writeup](https://github.com/Atharva-Kanherkar/datasmith/blob/main/docs/benchmarks/gsm8k-qwen-dpo.md) for a reproducible end-to-end example.
+
+## DataSmith inside AgentClash
+
+DataSmith is the **local, training-oriented** layer. [AgentClash](https://agentclash.dev) is the **hosted eval and regression** layer.
+
+Inside AgentClash workspaces you can run the same weak-vs-strong loop as **Agentic Self-Instruct** generation on pinned datasets. Accepted synthetic rows become eval examples you can baseline, gate in CI, and promote into regression suites.
+
+| Capability | DataSmith (Python SDK) | AgentClash (hosted) |
+| --- | --- | --- |
+| Web-grounded seed construction | Yes | Seeds from existing examples |
+| Weak-vs-strong judge loop | Yes | Yes (`agentic_self_instruct`) |
+| OTLP trace ingestion | Yes | Trace import to candidates |
+| SFT / DPO / HF export | Yes | Eval and regression formats |
+| CI regression gates | Manual | Built-in dataset gates |
+
+Use DataSmith when you need offline dataset creation for fine-tunes. Use AgentClash when you need replay, scoring, and release gates on the same workloads.
+
+## What DataSmith is not
+
+DataSmith is the practical substrate, not Meta's full meta-optimization stack. It does not run outer-loop prompt evolution or RL training. It gives you the inner loop: ingestion, orchestration, acceptance policies, artifacts, CLI, and tests you can plug into whatever you are building.
+
+MIT licensed. Alpha (`0.1.0`). Feedback and contributions welcome on [GitHub](https://github.com/Atharva-Kanherkar/datasmith).
+
+## Get started
+
+1. **Local SDK:** `pip install datasmith` and follow the [README quickstart](https://github.com/Atharva-Kanherkar/datasmith).
+2. **Hosted generation:** Sign in at [agentclash.dev](https://agentclash.dev), open a dataset, and start **Agentic Self-Instruct** generation from the workspace UI.
+3. **Read the platform overview:** [/platform/datasmith](/platform/datasmith) for the full AgentClash + DataSmith story.
+
+Tell us what domain you want to generate data for first. That feedback shapes the next seed-constructor templates and export presets.

--- a/web/content/docs/guides/datasets-overview.mdx
+++ b/web/content/docs/guides/datasets-overview.mdx
@@ -63,6 +63,7 @@ Re-running sync is idempotent: cases that already exist for an example are skipp
 
 ## See also
 
+- [Synthetic dataset generation](/docs/guides/synthetic-dataset-generation) — Fast Self-Instruct and Agentic Self-Instruct in workspaces
 - [Dataset CI Gates](/docs/guides/dataset-ci-gates) — GitHub Actions recipe and API surface
 - [CI/CD workload recipes](/docs/guides/ci-cd-workload-recipes) — pick realistic agent workloads
 - [Interpret results](/docs/guides/interpret-results) — read scorecards and timelines

--- a/web/content/docs/guides/synthetic-dataset-generation.mdx
+++ b/web/content/docs/guides/synthetic-dataset-generation.mdx
@@ -1,0 +1,97 @@
+---
+title: Synthetic dataset generation
+description: Generate high-signal synthetic examples with Self-Instruct or Agentic Self-Instruct weak-vs-strong loops in AgentClash workspaces.
+dateModified: 2026-07-01
+---
+
+AgentClash can expand pinned datasets with synthetic examples generated from existing seeds. Two strategies are available:
+
+- **Fast Self-Instruct** — prompt-only generation for quick volume when you already trust your seeds.
+- **Agentic Self-Instruct** — weak-vs-strong solver rollouts with a judge that accepts only examples in the useful difficulty zone.
+
+The Agentic Self-Instruct loop follows the pattern described in [Meta FAIR Autodata](https://arxiv.org/abs/2606.25996). For offline training export (SFT, DPO, Hugging Face), use the open-source [DataSmith](https://github.com/Atharva-Kanherkar/datasmith) Python SDK.
+
+## When to use each strategy
+
+| Strategy | Best for | Tradeoff |
+| --- | --- | --- |
+| Fast Self-Instruct | Rapid expansion of well-curated seeds | Less quality filtering |
+| Agentic Self-Instruct | Targeted eval and regression datasets | Higher token cost per accepted row |
+
+Start with Agentic Self-Instruct when examples will gate releases or train downstream models. Use Fast Self-Instruct for exploratory coverage.
+
+## Prerequisites
+
+- A workspace dataset with at least one seed example (or import traces first).
+- Provider API keys or BYOK deployments configured in the workspace.
+- For Agentic Self-Instruct: weak and strong solver models (or deployments) selected in the generation dialog.
+
+## Start generation from the web UI
+
+1. Open **Workspaces → Datasets → [your dataset]**.
+2. Click **Synthetic generation**.
+3. Choose **Fast Self-Instruct** or **Agentic Self-Instruct**.
+4. Pin a target dataset version label for accepted rows.
+5. For Agentic Self-Instruct, configure acceptance thresholds (strong pass rate, weak fail rate, minimum score gap).
+6. Start the job and monitor progress. Rejected rows include reason codes for review.
+
+Accepted examples are written with `source=synthetic` and appear in the dataset version you specified.
+
+## Start generation from the CLI
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+export AGENTCLASH_TOKEN="<token>"
+export AGENTCLASH_WORKSPACE="<workspace-id>"
+
+agentclash dataset generate <datasetId> \
+  --strategy agentic_self_instruct \
+  --version-label "synthetic-v1" \
+  --max-examples 50
+```
+
+Poll job status:
+
+```bash
+agentclash dataset generate status <datasetId> <jobId>
+```
+
+See `agentclash dataset generate --help` for weak/strong deployment flags and acceptance tuning.
+
+## Agentic Self-Instruct acceptance policy
+
+The judge accepts a candidate when:
+
+- The strong solver meets your configured pass threshold.
+- The weak solver falls below its pass threshold (the example is learnable).
+- The score gap between strong and weak exceeds your minimum gap.
+
+The job summary includes `avg_gap` across accepted rows so you can compare runs over time.
+
+## After generation: eval and gates
+
+Synthetic rows are most valuable when they feed regression coverage:
+
+1. **Run a dataset eval** against a challenge pack — see [Datasets overview](/docs/guides/datasets-overview).
+2. **Record a baseline** from a green eval run.
+3. **Gate CI** with `agentclash dataset test` — see [Dataset CI gates](/docs/guides/dataset-ci-gates).
+4. **Sync into a regression suite** so escaped failures stay covered.
+
+## DataSmith for training export
+
+AgentClash optimizes for eval-ready datasets inside your workspace. When you need ShareGPT, DPO pairs, or Hugging Face Hub export for fine-tuning, use [DataSmith](https://github.com/Atharva-Kanherkar/datasmith):
+
+```bash
+pip install datasmith
+datasmith construct-seeds --brief "your domain" --output seeds.jsonl
+datasmith run --seeds seeds.jsonl --output-dir ./artifacts
+datasmith export --input ./artifacts/accepted.jsonl --format dpo --output pairs.jsonl
+```
+
+DataSmith also ingests OpenTelemetry traces locally. AgentClash trace import targets eval candidates in the hosted product.
+
+## See also
+
+- [Datasets overview](/docs/guides/datasets-overview) — baselines, eval runs, regression sync
+- [DataSmith platform page](/platform/datasmith) — SDK + hosted generation story
+- [Introducing DataSmith blog post](/blog/introducing-datasmith-synthetic-agent-data)

--- a/web/src/app/agentic-self-instruct/page.tsx
+++ b/web/src/app/agentic-self-instruct/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/agentic-self-instruct");
+
+export { metadata };
+export default Page;

--- a/web/src/app/platform/datasmith/page.tsx
+++ b/web/src/app/platform/datasmith/page.tsx
@@ -1,0 +1,499 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Database,
+  Download,
+  GitBranch,
+  Sparkles,
+  Terminal,
+  Workflow,
+} from "lucide-react";
+import { ClashMark } from "@/components/marketing/clash-mark";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  faqSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PAGE_PATH = "/platform/datasmith";
+const PAGE_TITLE =
+  "DataSmith Synthetic Data Generation for AI Agents - AgentClash";
+const PAGE_DESCRIPTION =
+  "Generate high-signal synthetic datasets with weak-vs-strong Agentic Self-Instruct. Open-source Python SDK for SFT and DPO export, plus hosted generation inside AgentClash for eval and regression.";
+const SOCIAL_IMAGE_ALT =
+  "AgentClash DataSmith synthetic data generation social preview.";
+
+const faqItems = [
+  {
+    question: "What is DataSmith?",
+    answer:
+      "DataSmith is an open-source Python SDK for synthetic dataset generation using a weak-vs-strong agentic loop. A challenger proposes examples, weak and strong solvers attempt them, and a judge accepts only high-signal rows ready for fine-tuning or evaluation.",
+  },
+  {
+    question: "How is DataSmith related to AgentClash?",
+    answer:
+      "DataSmith handles offline dataset creation and training export (SFT, DPO, Hugging Face). AgentClash runs the same Agentic Self-Instruct loop in hosted workspaces, then scores, replays, and gates regressions on the generated examples.",
+  },
+  {
+    question: "What models does DataSmith support?",
+    answer:
+      "Any provider that implements DataSmith's complete() protocol: OpenAI-compatible APIs, local inference, or your own wrapper. Weak and strong solvers can be different models, prompts, or compute budgets.",
+  },
+  {
+    question: "Can I turn production traces into training data?",
+    answer:
+      "Yes. DataSmith ingests OpenTelemetry JSON and span JSONL as seeds. AgentClash also supports trace import into workspace datasets for eval-oriented workflows.",
+  },
+];
+
+const workflow = [
+  {
+    icon: Sparkles,
+    title: "Construct seeds",
+    text: "Start from a domain brief, web-grounded search, production traces, or source documents.",
+  },
+  {
+    icon: Workflow,
+    title: "Run weak vs strong",
+    text: "Challenger proposes examples. Weak and strong solvers attempt them. Judge filters for the useful difficulty zone.",
+  },
+  {
+    icon: Download,
+    title: "Export for training",
+    text: "Ship ShareGPT, ChatML, DPO pairs, or push accepted rows to Hugging Face Hub.",
+  },
+  {
+    icon: GitBranch,
+    title: "Eval and gate in AgentClash",
+    text: "Run hosted Agentic Self-Instruct generation, baseline the dataset, and wire CI regression gates.",
+  },
+];
+
+const capabilities = [
+  "Web-grounded seed construction from domain briefs",
+  "Weak-vs-strong Agentic Self-Instruct judge loop",
+  "OpenTelemetry trace ingestion for seed material",
+  "Accepted and rejected JSONL with reason codes",
+  "ShareGPT, ChatML, DPO, and prompt-completion export",
+  "Provider-agnostic model interface (OpenAI-compatible or custom)",
+  "Hosted Agentic Self-Instruct inside AgentClash workspaces",
+  "Dataset baselines, eval runs, and CI regression gates",
+];
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: PAGE_PATH,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+};
+
+function StaticHeader() {
+  return (
+    <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+      <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2.5 text-white/90"
+        >
+          <ClashMark className="size-6" />
+          <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+            AgentClash
+          </span>
+        </Link>
+        <nav className="flex items-center gap-2 text-xs">
+          <Link
+            href="/docs"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            Docs
+          </Link>
+          <a
+            href="https://github.com/Atharva-Kanherkar/datasmith"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            DataSmith GitHub
+          </a>
+          <Link
+            href="/auth/login"
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+          >
+            Start
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function StaticFooter() {
+  return (
+    <footer className="border-t border-white/[0.06] bg-[#060606] px-6 py-10 sm:px-12">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-5 text-sm text-white/45 sm:flex-row sm:items-center sm:justify-between">
+        <Link href="/" className="font-medium text-white/65">
+          AgentClash
+        </Link>
+        <nav className="flex flex-wrap gap-5">
+          <Link
+            href="/platform/agent-evaluation"
+            className="transition-colors hover:text-white/75"
+          >
+            Agent evaluation
+          </Link>
+          <Link href="/blog" className="transition-colors hover:text-white/75">
+            Blog
+          </Link>
+          <a
+            href="https://github.com/Atharva-Kanherkar/datasmith"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-white/75"
+          >
+            DataSmith
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+function PipelineVisual() {
+  return (
+    <div className="overflow-hidden rounded-md border border-white/[0.08] bg-[#090909] shadow-2xl shadow-violet-950/20">
+      <div className="border-b border-white/[0.08] px-4 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <span className="size-2 rounded-full bg-violet-300" />
+            <span className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/45">
+              agentic self-instruct
+            </span>
+          </div>
+          <span className="rounded-md border border-violet-300/20 bg-violet-300/[0.06] px-2 py-1 font-[family-name:var(--font-mono)] text-2xs text-violet-100/75">
+            avg_gap 0.31
+          </span>
+        </div>
+      </div>
+      <div className="grid gap-px bg-white/[0.06] md:grid-cols-[0.92fr_1.08fr]">
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+            acceptance policy
+          </p>
+          <div className="mt-5 space-y-3">
+            {[
+              ["Strong solver", "0.92", "pass >= 0.85"],
+              ["Weak solver", "0.41", "pass <= 0.55"],
+              ["Score gap", "0.51", "gap >= 0.20"],
+              ["Judge verdict", "accepted", "grounded + rubric"],
+            ].map(([label, value, threshold]) => (
+              <div
+                key={label}
+                className="rounded-md border border-white/[0.08] bg-white/[0.025] p-4"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-sm font-medium text-white/78">
+                    {label}
+                  </span>
+                  <span className="font-[family-name:var(--font-mono)] text-sm text-white">
+                    {value}
+                  </span>
+                </div>
+                <p className="mt-2 font-[family-name:var(--font-mono)] text-2xs text-white/35">
+                  {threshold}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+            export targets
+          </p>
+          <div className="mt-5 space-y-4">
+            {[
+              "ShareGPT / ChatML for supervised fine-tuning",
+              "DPO pairs when weak and strong outputs diverge",
+              "AgentClash dataset eval and CI regression gates",
+            ].map((item, index) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-violet-300/25 bg-violet-300/10 font-[family-name:var(--font-mono)] text-2xs text-violet-100">
+                  {index + 1}
+                </span>
+                <span className="text-sm leading-6 text-white/62">{item}</span>
+              </div>
+            ))}
+          </div>
+          <pre className="mt-6 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-2xs leading-5 text-white/55">
+            pip install datasmith{"\n"}datasmith run --seeds seeds.jsonl
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DataSmithPage() {
+  return (
+    <>
+      <JsonLd
+        id="agentclash-platform-datasmith-schema"
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "DataSmith", url: PAGE_PATH },
+          ]),
+          faqSchema(faqItems),
+          productSchema({
+            name: PAGE_TITLE,
+            description: PAGE_DESCRIPTION,
+            url: PAGE_PATH,
+            applicationSubCategory: "Synthetic data generation software",
+            featureList: capabilities,
+          }),
+        ]}
+      />
+      <StaticHeader />
+      <main className="min-h-screen bg-[#060606] text-white">
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto grid max-w-[1440px] gap-14 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div>
+              <nav className="flex items-center gap-2 text-xs text-white/35">
+                <Link href="/" className="transition-colors hover:text-white/70">
+                  Home
+                </Link>
+                <span>/</span>
+                <span>DataSmith</span>
+              </nav>
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-violet-200/70">
+                Synthetic data for agents
+              </p>
+              <h1 className="mt-5 max-w-[14ch] font-sans text-5xl font-semibold leading-none tracking-tight text-white sm:text-7xl">
+                High-signal synthetic data, not noisy bulk
+              </h1>
+              <p className="mt-8 max-w-[58ch] text-base leading-8 text-white/62 sm:text-lg">
+                DataSmith generates training and eval datasets with a
+                weak-vs-strong agentic loop inspired by Meta FAIR Autodata. Use
+                the open-source Python SDK locally, or run Agentic Self-Instruct
+                inside AgentClash for replay, scoring, and CI gates.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href="https://github.com/Atharva-Kanherkar/datasmith"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+                >
+                  Star DataSmith on GitHub
+                  <ArrowRight className="size-4" />
+                </a>
+                <Link
+                  href="/auth/login"
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Try hosted generation
+                  <Database className="size-4" />
+                </Link>
+              </div>
+            </div>
+            <PipelineVisual />
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-3xl">
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+                Why weak vs strong
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Examples in the useful difficulty zone
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                Prompt-only self-instruct often produces tasks that are too easy
+                or too hard. The weak-vs-strong loop accepts rows only when a
+                strong solver succeeds and a weak solver struggles: the zone
+                where fine-tuning actually teaches something.
+              </p>
+            </div>
+            <div className="mt-12 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {capabilities.map((signal) => (
+                <div
+                  key={signal}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                >
+                  <CheckCircle2 className="size-5 text-violet-200" />
+                  <p className="mt-4 text-sm leading-6 text-white/78">
+                    {signal}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
+              <div>
+                <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+                  Workflow
+                </p>
+                <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                  From domain brief to trainer-ready export
+                </h2>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {workflow.map((item) => (
+                  <div
+                    key={item.title}
+                    className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                  >
+                    <item.icon className="size-5 text-violet-200" />
+                    <h3 className="mt-5 text-lg font-semibold tracking-normal text-white">
+                      {item.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-6 text-white/55">
+                      {item.text}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+            <div>
+              <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+                Start here
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Local SDK or hosted workspace generation
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                Pick DataSmith when you need offline SFT and DPO export. Pick
+                AgentClash when the same examples should baseline evals and
+                block regressions in CI.
+              </p>
+            </div>
+            <div className="grid gap-3">
+              {[
+                [
+                  "Introducing DataSmith",
+                  "Launch blog: weak-vs-strong loop, trace ingestion, and export formats.",
+                  "/blog/introducing-datasmith-synthetic-agent-data",
+                ],
+                [
+                  "Synthetic dataset generation guide",
+                  "Run Agentic Self-Instruct inside AgentClash workspaces.",
+                  "/docs/guides/synthetic-dataset-generation",
+                ],
+                [
+                  "Agentic Self-Instruct SEO hub",
+                  "Keyword landing for the Autodata-inspired generation pattern.",
+                  "/agentic-self-instruct",
+                ],
+                [
+                  "Datasets overview",
+                  "Baselines, eval runs, and regression suite sync after generation.",
+                  "/docs/guides/datasets-overview",
+                ],
+              ].map(([title, text, href]) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="group rounded-md border border-white/[0.08] bg-white/[0.03] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.05]"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold tracking-normal text-white">
+                        {title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-white/50">
+                        {text}
+                      </p>
+                    </div>
+                    <ArrowRight className="size-4 shrink-0 text-white/35 transition-colors group-hover:text-white/75" />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[960px]">
+            <p className="font-[family-name:var(--font-mono)] text-2xs uppercase tracking-normal text-white/35">
+              FAQ
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+              Questions teams ask about synthetic data generation
+            </h2>
+            <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {faqItems.map((item) => (
+                <section key={item.question} className="py-6">
+                  <h3 className="text-lg font-semibold tracking-normal text-white">
+                    {item.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-7 text-white/55">
+                    {item.answer}
+                  </p>
+                </section>
+              ))}
+            </div>
+            <div className="mt-12 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start hosted generation
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/docs/guides/synthetic-dataset-generation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+              >
+                Read the docs
+                <Terminal className="size-4" />
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <StaticFooter />
+    </>
+  );
+}

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -7,6 +7,9 @@ import AgentEvaluationPage, {
 import AgentRegressionTestingPage, {
   metadata as agentRegressionTestingMetadata,
 } from "./agent-regression-testing/page";
+import DataSmithPage, {
+  metadata as datasmithMetadata,
+} from "./datasmith/page";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -126,6 +129,27 @@ describe("platform pages structured data", () => {
       },
     });
   });
+
+  it("emits breadcrumb, FAQ, and SoftwareApplication data for DataSmith", () => {
+    render(<DataSmithPage />);
+
+    const jsonLd = getJsonLd("agentclash-platform-datasmith-schema");
+    const software = jsonLd.find(
+      (item) => item["@type"] === "SoftwareApplication",
+    );
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "FAQPage",
+      "SoftwareApplication",
+    ]);
+    expect(software).toMatchObject({
+      name: "DataSmith Synthetic Data Generation for AI Agents - AgentClash",
+      url: "https://www.agentclash.dev/platform/datasmith",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "Synthetic data generation software",
+    });
+  });
 });
 
 describe("platform page social metadata", () => {
@@ -218,5 +242,50 @@ describe("platform page social metadata", () => {
     expect(ogAlt).toContain("regression testing");
     expect(twitterAlt).toBe(ogAlt);
     expect(ogAlt).not.toBe(getSocialImageAlt(agentEvaluationMetadata).ogAlt);
+  });
+
+  it("adds explicit social image metadata for DataSmith", () => {
+    const title =
+      "DataSmith Synthetic Data Generation for AI Agents - AgentClash";
+    const description =
+      "Generate high-signal synthetic datasets with weak-vs-strong Agentic Self-Instruct. Open-source Python SDK for SFT and DPO export, plus hosted generation inside AgentClash for eval and regression.";
+
+    expect(datasmithMetadata).toMatchObject({
+      title,
+      description,
+      alternates: {
+        canonical: "/platform/datasmith",
+      },
+      openGraph: {
+        title,
+        description,
+        url: "/platform/datasmith",
+        type: "website",
+        locale: "en_US",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [
+          {
+            url: "/twitter-image.png",
+          },
+        ],
+      },
+    });
+
+    const { ogAlt, twitterAlt } = getSocialImageAlt(datasmithMetadata);
+    expect(ogAlt).toContain("DataSmith");
+    expect(ogAlt).toContain("synthetic data");
+    expect(twitterAlt).toBe(ogAlt);
   });
 });

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -13,6 +13,7 @@ import { metadata as tryoutsMetadata } from "./tryouts/page";
 import { metadata as agentOpportunityMetadata } from "./agent-opportunity/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
 import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
+import { metadata as datasmithMetadata } from "./platform/datasmith/page";
 import { metadata as sitemapMetadata } from "./sitemap/page";
 import { teamMetadata } from "./team/metadata";
 import { whyMetadata } from "./why/metadata";
@@ -74,6 +75,7 @@ describe("public canonical metadata", () => {
       agentRegressionTestingMetadata,
       "/platform/agent-regression-testing",
     );
+    expectCanonical(datasmithMetadata, "/platform/datasmith");
     expectCanonical(whyMetadata, "/why");
     expectCanonical(teamMetadata, "/team");
     expectCanonical(changelogMetadata, "/changelog");

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -119,6 +119,12 @@ describe("sitemap", () => {
       priority: 0.82,
     });
     expect(
+      byUrl.get("https://www.agentclash.dev/platform/datasmith"),
+    ).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.84,
+    });
+    expect(
       byUrl.get("https://www.agentclash.dev/agent-evals"),
     ).toMatchObject({
       changeFrequency: "monthly",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -248,6 +248,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ],
     },
     {
+      url: `${DOCS_ORIGIN}/platform/datasmith`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.84,
+      images: [
+        ogImage({
+          title: "DataSmith Synthetic Data Generation",
+          subtitle: "Weak-vs-strong Agentic Self-Instruct for AI agents",
+          kind: "Platform",
+        }),
+      ],
+    },
+    {
       url: `${DOCS_ORIGIN}/use-cases`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -59,6 +59,11 @@ const primaryPages = [
     description: "Catch AI agent regressions with baseline comparisons and CI gates.",
   },
   {
+    title: "DataSmith",
+    href: "/platform/datasmith",
+    description: "Weak-vs-strong synthetic data generation for agents and fine-tuning.",
+  },
+  {
     title: "Use cases",
     href: "/use-cases",
     description: "Coding, research, and support agent evaluation use cases.",

--- a/web/src/app/synthetic-data-generation-agents/page.tsx
+++ b/web/src/app/synthetic-data-generation-agents/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/synthetic-data-generation-agents");
+
+export { metadata };
+export default Page;

--- a/web/src/app/trace-to-dataset/page.tsx
+++ b/web/src/app/trace-to-dataset/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/trace-to-dataset");
+
+export { metadata };
+export default Page;

--- a/web/src/lib/blog-related-resources.ts
+++ b/web/src/lib/blog-related-resources.ts
@@ -70,6 +70,21 @@ const LINKS = {
     label: "Benchmarks",
     description: "Measured field reports with frozen challenge packs.",
   },
+  datasmith: {
+    href: "/platform/datasmith",
+    label: "DataSmith",
+    description: "Weak-vs-strong synthetic data generation for agents.",
+  },
+  syntheticDataGeneration: {
+    href: "/synthetic-data-generation-agents",
+    label: "Synthetic data generation",
+    description: "High-signal datasets with Agentic Self-Instruct.",
+  },
+  agenticSelfInstruct: {
+    href: "/agentic-self-instruct",
+    label: "Agentic Self-Instruct",
+    description: "Weak-vs-strong synthetic data loop inspired by Autodata.",
+  },
   passAtKPost: {
     href: "/blog/pass-at-k-vs-pass-power-k",
     label: "pass@k vs pass^k",
@@ -172,6 +187,11 @@ const BLOG_RELATED_RESOURCES: Record<string, BlogRelatedResourceLink[]> = {
     LINKS.openSourceEvaluation,
     LINKS.agentEvals,
     LINKS.compare,
+  ],
+  "introducing-datasmith-synthetic-agent-data": [
+    LINKS.datasmith,
+    LINKS.syntheticDataGeneration,
+    LINKS.agenticSelfInstruct,
   ],
 };
 

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -393,6 +393,53 @@ export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
       },
     ],
   },
+  {
+    id: "2026-06-22",
+    startDate: "2026-06-22",
+    endDate: "2026-07-01",
+    label: "Jun 22 – Jul 01, 2026",
+    headline: "DataSmith launch: weak-vs-strong synthetic data for agents",
+    summary:
+      "DataSmith ships as an open-source Python SDK for high-signal synthetic dataset generation with web-grounded seed construction, OTLP trace ingestion, and SFT/DPO export. AgentClash adds platform marketing, docs, and SEO surfaces for the hosted Agentic Self-Instruct loop.",
+    themes: [
+      "DataSmith SDK",
+      "Synthetic data generation",
+      "Agentic Self-Instruct",
+      "SEO and discoverability",
+    ],
+    entries: [
+      {
+        category: "added",
+        text: "DataSmith — open-source Python SDK for weak-vs-strong Agentic Self-Instruct synthetic data generation, inspired by Meta FAIR Autodata.",
+        href: "https://github.com/Atharva-Kanherkar/datasmith",
+      },
+      {
+        category: "added",
+        text: "/platform/datasmith landing page for the SDK + hosted generation story with FAQ and JSON-LD product schema.",
+        href: "/platform/datasmith",
+      },
+      {
+        category: "added",
+        text: "Synthetic dataset generation docs guide covering Fast Self-Instruct, Agentic Self-Instruct, CLI, and DataSmith export.",
+        href: "/docs/guides/synthetic-dataset-generation",
+      },
+      {
+        category: "added",
+        text: "Launch blog: Introducing DataSmith with pipeline overview, trace ingestion, and AgentClash integration table.",
+        href: "/blog/introducing-datasmith-synthetic-agent-data",
+      },
+      {
+        category: "added",
+        text: "SEO landing pages for synthetic data generation, Agentic Self-Instruct, trace-to-dataset workflows, and glossary definition.",
+        href: "/synthetic-data-generation-agents",
+      },
+      {
+        category: "improved",
+        text: "Datasets overview and sitemap updated with DataSmith and synthetic generation discovery links.",
+        href: "/docs/guides/datasets-overview",
+      },
+    ],
+  },
 ];
 
 export function getChangelogPeriods(): ChangelogPeriod[] {

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -381,6 +381,13 @@ export const DOCS_NAV: DocNavSection[] = [
         href: "/docs/guides/datasets-overview",
       },
       {
+        title: "Synthetic dataset generation",
+        description:
+          "Fast Self-Instruct and Agentic Self-Instruct weak-vs-strong generation in workspaces, plus DataSmith export.",
+        slug: ["guides", "synthetic-dataset-generation"],
+        href: "/docs/guides/synthetic-dataset-generation",
+      },
+      {
         title: "Dataset CI Gates",
         description:
           "Record dataset eval baselines, sync examples into regression suites, and gate CI with agentclash dataset test.",

--- a/web/src/lib/seo-pages/registry.ts
+++ b/web/src/lib/seo-pages/registry.ts
@@ -1347,6 +1347,356 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
       ...sharedDocsLinks.slice(0, 2),
     ],
   }),
+  page({
+    path: "/synthetic-data-generation-agents",
+    tier: "A",
+    keyword: "synthetic data generation AI agents",
+    intent: "High-intent training + eval",
+    pageTitle:
+      "Synthetic Data Generation for AI Agents - AgentClash & DataSmith",
+    metaDescription:
+      "Generate high-signal synthetic datasets for AI agents with weak-vs-strong Agentic Self-Instruct. Open-source DataSmith SDK for SFT and DPO export, plus hosted generation in AgentClash.",
+    socialImageAlt:
+      "AgentClash synthetic data generation for AI agents social preview.",
+    eyebrow: "Synthetic data",
+    h1: "Synthetic data generation for AI agents that teaches, not noise",
+    heroDescription:
+      "Bulk self-instruct produces volume without signal. AgentClash and DataSmith run a weak-vs-strong judge loop that accepts examples only when a strong solver succeeds and a weak solver struggles: the useful difficulty zone for fine-tuning and eval.",
+    proofSectionTitle: "Why weak-vs-strong beats prompt-only generation",
+    proofSectionDescription:
+      "Meta FAIR Autodata showed that agentic self-instruct with solver separation beats standard synthetic pipelines across CS, legal, and math settings. DataSmith implements the practical loop; AgentClash runs it hosted for regression-ready datasets.",
+    workflowSectionTitle: "From seeds to export or CI gates",
+    docsSectionTitle: "Start generating",
+    docsSectionDescription:
+      "Use DataSmith locally for training export, or AgentClash workspaces for eval baselines and CI gates on the same examples.",
+    faqSectionTitle: "Synthetic data generation FAQ",
+    applicationSubCategory: "Synthetic data generation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      {
+        name: "Synthetic data generation",
+        url: "/synthetic-data-generation-agents",
+      },
+    ],
+    schemaId: "agentclash-synthetic-data-generation-agents-schema",
+    searchKeywords:
+      "synthetic data generation AI agents agentic self instruct weak strong model judge SFT DPO fine tuning dataset generation",
+    sitemapTitle: "Synthetic data generation for agents",
+    sitemapDescription:
+      "Weak-vs-strong synthetic dataset generation for agent fine-tuning and eval.",
+    faqItems: [
+      {
+        question: "What is synthetic data generation for AI agents?",
+        answer:
+          "It is the process of creating labeled training or eval examples for agent workloads using LLM-driven pipelines instead of manual curation alone.",
+      },
+      {
+        question: "How does Agentic Self-Instruct improve data quality?",
+        answer:
+          "A challenger proposes examples, weak and strong solvers attempt them, and a judge accepts rows only when the score gap indicates the example is learnable but not trivial.",
+      },
+      {
+        question: "Should I use DataSmith or AgentClash for generation?",
+        answer:
+          "Use DataSmith for offline SFT, DPO, and Hugging Face export. Use AgentClash when generated examples should feed dataset evals, baselines, and CI regression gates.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "DataSmith platform page",
+        text: "SDK + hosted generation overview.",
+        href: "/platform/datasmith",
+      },
+      {
+        title: "Introducing DataSmith",
+        text: "Launch blog with pipeline details.",
+        href: "/blog/introducing-datasmith-synthetic-agent-data",
+      },
+      {
+        title: "Synthetic generation docs",
+        text: "Run Agentic Self-Instruct in AgentClash.",
+        href: "/docs/guides/synthetic-dataset-generation",
+      },
+      ...sharedDocsLinks.slice(0, 2),
+    ],
+  }),
+  page({
+    path: "/agentic-self-instruct",
+    tier: "A",
+    keyword: "agentic self instruct",
+    intent: "Autodata-inspired pattern",
+    pageTitle: "Agentic Self-Instruct for Synthetic Datasets - AgentClash",
+    metaDescription:
+      "Agentic Self-Instruct uses challenger, weak solver, strong solver, and judge roles to generate high-quality synthetic training data. Inspired by Meta FAIR Autodata.",
+    socialImageAlt: "AgentClash Agentic Self-Instruct social preview.",
+    eyebrow: "Agentic Self-Instruct",
+    h1: "Agentic Self-Instruct: weak-vs-strong synthetic data",
+    heroDescription:
+      "Agentic Self-Instruct is a four-role loop for synthetic dataset generation: challenger proposes, weak and strong solvers attempt, judge filters. DataSmith ships it as a Python SDK; AgentClash runs it hosted for eval-ready datasets.",
+    proofSectionTitle: "The four roles",
+    proofSectionDescription:
+      "Challenger generates candidates from seeds. Weak solver represents the model you want to improve. Strong solver represents a reference path. Judge scores quality and separation before acceptance.",
+    workflowSectionTitle: "Research to production",
+    docsSectionTitle: "Implement the loop",
+    docsSectionDescription:
+      "Read the synthetic generation guide, then try DataSmith locally or Agentic Self-Instruct in a workspace dataset.",
+    faqSectionTitle: "Agentic Self-Instruct FAQ",
+    applicationSubCategory: "Agentic Self-Instruct software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Agentic Self-Instruct", url: "/agentic-self-instruct" },
+    ],
+    schemaId: "agentclash-agentic-self-instruct-schema",
+    searchKeywords:
+      "agentic self instruct Autodata Meta FAIR weak strong solver judge synthetic training data challenger loop",
+    sitemapTitle: "Agentic Self-Instruct",
+    sitemapDescription:
+      "Weak-vs-strong synthetic data loop inspired by Meta FAIR Autodata.",
+    faqItems: [
+      {
+        question: "What is Agentic Self-Instruct?",
+        answer:
+          "An agentic loop where a challenger generates examples and weak/strong solvers plus a judge determine whether each row is in the useful difficulty zone for training.",
+      },
+      {
+        question: "How is it related to Meta FAIR Autodata?",
+        answer:
+          "Autodata formalized weak-vs-strong agentic self-instruct for synthetic data. DataSmith implements the practical inner loop; it is not an official Meta release.",
+      },
+      {
+        question: "Can I tune acceptance thresholds?",
+        answer:
+          "Yes. Both DataSmith and AgentClash expose strong pass rate, weak fail rate, and minimum score gap controls.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "DataSmith GitHub",
+        text: "Open-source Python SDK and CLI.",
+        href: "https://github.com/Atharva-Kanherkar/datasmith",
+      },
+      {
+        title: "Synthetic data generation",
+        text: "Broader SEO hub for agent dataset generation.",
+        href: "/synthetic-data-generation-agents",
+      },
+      {
+        title: "Glossary: Agentic Self-Instruct",
+        text: "Short definition and when to use it.",
+        href: "/glossary/agentic-self-instruct",
+      },
+      ...sharedDocsLinks.slice(0, 1),
+    ],
+  }),
+  page({
+    path: "/trace-to-dataset",
+    tier: "B",
+    keyword: "OpenTelemetry trace to dataset",
+    intent: "Trace ingestion workflow",
+    pageTitle: "Trace to Dataset: Turn Agent Traces into Training Data",
+    metaDescription:
+      "Convert OpenTelemetry agent traces into synthetic dataset seeds with DataSmith OTLP ingestion or AgentClash trace import for eval-ready regression coverage.",
+    socialImageAlt: "AgentClash trace to dataset social preview.",
+    eyebrow: "Trace to dataset",
+    h1: "Turn production agent traces into datasets",
+    heroDescription:
+      "The best seed material often comes from real agent runs. DataSmith ingests OTLP JSON and span JSONL locally for training export. AgentClash imports traces into workspace datasets for eval baselines and CI gates.",
+    proofSectionTitle: "Two paths from traces",
+    proofSectionDescription:
+      "Training teams use DataSmith ingest-otel for SFT and DPO pipelines. Platform teams use AgentClash trace import to promote production failures into regression coverage.",
+    workflowSectionTitle: "Trace ingestion workflow",
+    docsSectionTitle: "Ingest traces",
+    docsSectionDescription:
+      "Start with one exported trace bundle, convert to seeds or candidates, then expand with Agentic Self-Instruct generation.",
+    faqSectionTitle: "Trace to dataset FAQ",
+    applicationSubCategory: "Trace to dataset software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Trace to dataset", url: "/trace-to-dataset" },
+    ],
+    schemaId: "agentclash-trace-to-dataset-schema",
+    searchKeywords:
+      "trace to dataset OpenTelemetry training data agent traces synthetic dataset production traces OTLP ingestion LangSmith alternative",
+    sitemapTitle: "Trace to dataset",
+    sitemapDescription:
+      "Convert agent traces into synthetic dataset seeds and eval coverage.",
+    faqItems: [
+      {
+        question: "What trace formats does DataSmith support?",
+        answer:
+          "OTLP JSON exports and flattened span JSONL. See the DataSmith docs/otel.md guide for field expectations.",
+      },
+      {
+        question: "Does AgentClash import the same traces?",
+        answer:
+          "AgentClash supports OTel-compatible trace import into workspace datasets for eval and regression workflows, complementary to DataSmith training export.",
+      },
+      {
+        question: "Should traces become seeds or finished examples?",
+        answer:
+          "Usually seeds. Run Agentic Self-Instruct afterward to expand grounded, judge-filtered examples rather than training on raw spans alone.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "DataSmith OTLP docs",
+        text: "Local trace ingestion reference.",
+        href: "https://github.com/Atharva-Kanherkar/datasmith/blob/main/docs/otel.md",
+      },
+      {
+        title: "Synthetic data generation",
+        text: "Expand seeds with weak-vs-strong generation.",
+        href: "/synthetic-data-generation-agents",
+      },
+      {
+        title: "Agent regression testing",
+        text: "Gate releases on trace-derived coverage.",
+        href: "/platform/agent-regression-testing",
+      },
+      ...sharedDocsLinks.slice(0, 2),
+    ],
+  }),
+  page({
+    path: "/features/synthetic-dataset-generation",
+    tier: "B",
+    keyword: "synthetic dataset generation feature",
+    intent: "Feature keyword",
+    pageTitle: "Synthetic Dataset Generation in AgentClash - Feature",
+    metaDescription:
+      "Expand workspace datasets with Fast Self-Instruct or Agentic Self-Instruct generation. Accepted rows feed eval baselines, regression suites, and CI gates.",
+    socialImageAlt:
+      "AgentClash synthetic dataset generation feature social preview.",
+    eyebrow: "Feature",
+    h1: "Synthetic dataset generation inside AgentClash",
+    heroDescription:
+      "Generate eval-ready examples from pinned seeds without leaving your workspace. Choose fast prompt-only expansion or Agentic Self-Instruct with weak-vs-strong judge filtering.",
+    proofSectionTitle: "Generation strategies",
+    proofSectionDescription:
+      "Fast Self-Instruct adds volume quickly. Agentic Self-Instruct runs weak and strong solver rollouts with acceptance policies tuned to the useful difficulty zone.",
+    workflowSectionTitle: "From generation to gates",
+    docsSectionTitle: "Run your first job",
+    docsSectionDescription:
+      "Open a dataset, start synthetic generation, then baseline and gate the accepted rows.",
+    faqSectionTitle: "Synthetic generation FAQ",
+    applicationSubCategory: "Synthetic dataset generation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Features", url: "/features" },
+      {
+        name: "Synthetic dataset generation",
+        url: "/features/synthetic-dataset-generation",
+      },
+    ],
+    schemaId: "agentclash-synthetic-dataset-generation-feature-schema",
+    searchKeywords:
+      "synthetic dataset generation workspace datasets agentic self instruct eval baselines CI gates regression",
+    sitemapTitle: "Synthetic dataset generation",
+    sitemapDescription:
+      "Hosted weak-vs-strong generation for eval-ready datasets.",
+    faqItems: [
+      {
+        question: "Where do I start generation in AgentClash?",
+        answer:
+          "Open Workspaces, Datasets, your dataset, then Synthetic generation in the UI or use agentclash dataset generate from the CLI.",
+      },
+      {
+        question: "What happens to rejected examples?",
+        answer:
+          "Rejected rows are stored with reason codes and solver attempts so you can review why the judge declined them.",
+      },
+      {
+        question: "Can I export for fine-tuning from AgentClash?",
+        answer:
+          "AgentClash optimizes for eval formats. For SFT, DPO, and Hugging Face export, use the DataSmith Python SDK on the same seeds.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Synthetic generation guide",
+        text: "Docs for UI and CLI generation jobs.",
+        href: "/docs/guides/synthetic-dataset-generation",
+      },
+      {
+        title: "DataSmith platform page",
+        text: "Offline SDK for training export.",
+        href: "/platform/datasmith",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/glossary/agentic-self-instruct",
+    tier: "B",
+    keyword: "agentic self instruct definition",
+    intent: "Glossary",
+    pageTitle: "What Is Agentic Self-Instruct? - AgentClash Glossary",
+    metaDescription:
+      "Agentic Self-Instruct is a synthetic data loop where a challenger generates examples and weak/strong solvers plus a judge filter for the useful difficulty zone.",
+    socialImageAlt:
+      "AgentClash Agentic Self-Instruct glossary social preview.",
+    eyebrow: "Glossary",
+    h1: "What is Agentic Self-Instruct?",
+    heroDescription:
+      "Agentic Self-Instruct generates synthetic training examples by proposing tasks, running weak and strong solvers, and accepting rows only when the strong path succeeds and the weak path struggles.",
+    proofSectionTitle: "How it differs from self-instruct",
+    proofSectionDescription:
+      "Classic self-instruct prompts a model for more examples. Agentic Self-Instruct adds solver rollouts and a judge so difficulty is measured, not assumed.",
+    workflowSectionTitle: "Typical roles",
+    docsSectionTitle: "Go deeper",
+    docsSectionDescription:
+      "Read the Agentic Self-Instruct landing page and synthetic generation docs, or install DataSmith for local runs.",
+    faqSectionTitle: "Agentic Self-Instruct FAQ",
+    applicationSubCategory: "Agentic Self-Instruct glossary",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Glossary", url: "/glossary" },
+      {
+        name: "Agentic Self-Instruct",
+        url: "/glossary/agentic-self-instruct",
+      },
+    ],
+    schemaId: "agentclash-glossary-agentic-self-instruct-schema",
+    searchKeywords:
+      "agentic self instruct definition Autodata weak strong solver judge synthetic data glossary",
+    sitemapTitle: "Agentic Self-Instruct (glossary)",
+    sitemapDescription:
+      "Definition of the weak-vs-strong synthetic data loop.",
+    faqItems: [
+      {
+        question: "Who popularized Agentic Self-Instruct?",
+        answer:
+          "Meta FAIR's Autodata paper formalized weak-vs-strong agentic self-instruct for synthetic data generation and meta-optimization.",
+      },
+      {
+        question: "What is the useful difficulty zone?",
+        answer:
+          "Examples where a strong solver passes and a weak solver fails, indicating the row can teach the weak model something new.",
+      },
+      {
+        question: "Where can I run it?",
+        answer:
+          "DataSmith (pip install datasmith) for local export, or AgentClash workspaces for hosted generation tied to eval gates.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Agentic Self-Instruct hub",
+        text: "SEO landing with workflow and FAQ.",
+        href: "/agentic-self-instruct",
+      },
+      {
+        title: "DataSmith platform",
+        text: "Open-source SDK overview.",
+        href: "/platform/datasmith",
+      },
+      {
+        title: "Glossary index",
+        text: "More AgentClash terms.",
+        href: "/glossary",
+      },
+      ...sharedDocsLinks.slice(0, 1),
+    ],
+  }),
 ];
 
 const SEO_PAGE_BY_PATH = new Map(


### PR DESCRIPTION
## Summary
- Launch **DataSmith** discovery surfaces: `/platform/datasmith` platform page with FAQ + JSON-LD, launch blog post, and Jul 2026 changelog period
- Add **synthetic dataset generation docs** (`/docs/guides/synthetic-dataset-generation`) and cross-links from datasets overview
- Ship **SEO landing pages** targeting high-intent keywords: `/synthetic-data-generation-agents`, `/agentic-self-instruct`, `/trace-to-dataset`, `/features/synthetic-dataset-generation`, `/glossary/agentic-self-instruct`
- Update sitemap, HTML sitemap, blog related resources, and canonical metadata tests

## Keyword targets
| Page | Primary intent |
| --- | --- |
| `/synthetic-data-generation-agents` | synthetic data generation AI agents, SFT/DPO |
| `/agentic-self-instruct` | Autodata-inspired weak-vs-strong loop (trending) |
| `/trace-to-dataset` | OpenTelemetry trace → training/eval seeds |
| `/platform/datasmith` | Product hub linking SDK + hosted AgentClash generation |

## Test plan
- [x] `pnpm exec tsc --noEmit` in `web/`
- [x] `vitest run` for platform-pages, public-canonical-metadata, sitemap tests (DataSmith tests pass)
- [ ] Preview `/platform/datasmith`, `/blog/introducing-datasmith-synthetic-agent-data`, `/changelog/2026-06-22`
- [ ] Submit sitemap URLs to IndexNow after deploy (`/api/indexnow`)