### PR TITLE
[codex] Extract shared runtime runner contracts

### DIFF
--- a/backend/internal/engine/contracts.go
+++ b/backend/internal/engine/contracts.go
@@ -1,0 +1,33 @@
+package engine
+
+import "github.com/agentclash/agentclash/runtime/runner"
+
+type StopReason = runner.StopReason
+
+const (
+	StopReasonCompleted     = runner.StopReasonCompleted
+	StopReasonTimeout       = runner.StopReasonTimeout
+	StopReasonStepLimit     = runner.StopReasonStepLimit
+	StopReasonToolLimit     = runner.StopReasonToolLimit
+	StopReasonProviderError = runner.StopReasonProviderError
+	StopReasonSandboxError  = runner.StopReasonSandboxError
+	StopReasonObserverError = runner.StopReasonObserverError
+)
+
+type Result = runner.Result
+type Failure = runner.Failure
+type PostExecutionVerificationResult = runner.PostExecutionVerificationResult
+type StandingsInjection = runner.StandingsInjection
+type Observer = runner.Observer
+type NoopObserver = runner.NoopObserver
+type SecretsLookup = runner.SecretsLookup
+type AssetContent = runner.AssetContent
+type AssetLoader = runner.AssetLoader
+
+func NewFailure(stopReason StopReason, message string, cause error) error {
+	return runner.NewFailure(stopReason, message, cause)
+}
+
+func AsFailure(err error) (Failure, bool) {
+	return runner.AsFailure(err)
+}

--- a/backend/internal/engine/human_turn_gate.go
+++ b/backend/internal/engine/human_turn_gate.go
@@ -1,94 +1,18 @@
 package engine
 
-import (
-	"context"
-	"errors"
-	"strings"
-	"time"
+import "github.com/agentclash/agentclash/runtime/runner"
 
-	"github.com/google/uuid"
-)
+var ErrHumanTurnTimeout = runner.ErrHumanTurnTimeout
 
-var ErrHumanTurnTimeout = errors.New("human turn timed out")
-
-// HumanTurnRequest identifies an in-run human actor pause.
-type HumanTurnRequest struct {
-	RunAgentID uuid.UUID
-	TurnIndex  int
-	PhaseID    string
-	PromptHint string
-	Timeout    time.Duration
-}
-
-// HumanTurnGate blocks until an operator submits the next user message.
-type HumanTurnGate interface {
-	WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (message string, err error)
-}
-
-type noopHumanTurnGate struct{}
-
-func (noopHumanTurnGate) WaitForHumanTurn(context.Context, HumanTurnRequest) (string, error) {
-	return "", errors.New("human turn gate is not configured")
-}
+type HumanTurnRequest = runner.HumanTurnRequest
+type HumanTurnGate = runner.HumanTurnGate
+type PollHumanTurnGate = runner.PollHumanTurnGate
+type HumanTurnStore = runner.HumanTurnStore
 
 func NoopHumanTurnGate() HumanTurnGate {
-	return noopHumanTurnGate{}
-}
-
-// PollHumanTurnGate polls a HumanTurnStore until a message arrives or timeout.
-type PollHumanTurnGate struct {
-	store HumanTurnStore
-}
-
-type HumanTurnStore interface {
-	MarkAwaitingHuman(ctx context.Context, req HumanTurnRequest) error
-	PollHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int) (message string, ready bool, err error)
-	MarkHumanTurnExpired(ctx context.Context, runAgentID uuid.UUID, turnIndex int) error
+	return runner.NoopHumanTurnGate()
 }
 
 func NewPollHumanTurnGate(store HumanTurnStore) PollHumanTurnGate {
-	return PollHumanTurnGate{store: store}
-}
-
-func (g PollHumanTurnGate) WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (string, error) {
-	if g.store == nil {
-		return "", errors.New("human turn store is not configured")
-	}
-	if err := g.store.MarkAwaitingHuman(ctx, req); err != nil {
-		return "", err
-	}
-
-	if req.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
-		defer cancel()
-	}
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		message, ready, err := g.store.PollHumanMessage(ctx, req.RunAgentID, req.TurnIndex)
-		if err != nil {
-			return "", err
-		}
-		if ready {
-			if strings.TrimSpace(message) == "" {
-				return "", errors.New("human turn message is empty")
-			}
-			return message, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			if req.Timeout > 0 {
-				cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				_ = g.store.MarkHumanTurnExpired(cleanupCtx, req.RunAgentID, req.TurnIndex)
-				cancel()
-				return "", ErrHumanTurnTimeout
-			}
-			return "", ctx.Err()
-		case <-ticker.C:
-		}
-	}
+	return runner.NewPollHumanTurnGate(store)
 }

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/racecontext"
@@ -33,130 +32,6 @@ const (
 	defaultRetryBackoff  = 250 * time.Millisecond
 	rateLimitMinBackoff  = 2 * time.Second
 )
-
-type StopReason string
-
-const (
-	StopReasonCompleted     StopReason = "completed"
-	StopReasonTimeout       StopReason = "timeout"
-	StopReasonStepLimit     StopReason = "step_limit"
-	StopReasonToolLimit     StopReason = "tool_limit"
-	StopReasonProviderError StopReason = "provider_error"
-	StopReasonSandboxError  StopReason = "sandbox_error"
-	StopReasonObserverError StopReason = "observer_error"
-)
-
-type Result struct {
-	FinalOutput   string
-	StopReason    StopReason
-	StepCount     int
-	ToolCallCount int
-	Usage         provider.Usage
-}
-
-type Failure struct {
-	StopReason StopReason
-	Message    string
-	Cause      error
-}
-
-func (f Failure) Error() string {
-	if strings.TrimSpace(f.Message) != "" {
-		return f.Message
-	}
-	return fmt.Sprintf("native engine stopped: %s", f.StopReason)
-}
-
-func (f Failure) Unwrap() error {
-	return f.Cause
-}
-
-func NewFailure(stopReason StopReason, message string, cause error) error {
-	return Failure{
-		StopReason: stopReason,
-		Message:    message,
-		Cause:      cause,
-	}
-}
-
-func AsFailure(err error) (Failure, bool) {
-	var failure Failure
-	if !errors.As(err, &failure) {
-		return Failure{}, false
-	}
-	return failure, true
-}
-
-// PostExecutionVerificationResult holds captured file or directory state from
-// the sandbox, emitted as a grader.verification.* event before sandbox teardown.
-type PostExecutionVerificationResult struct {
-	Key     string          `json:"key"`
-	Type    string          `json:"type"` // "file_capture", "directory_listing", or "code_execution"
-	Payload json.RawMessage `json:"payload"`
-}
-
-type Observer interface {
-	OnStepStart(ctx context.Context, step int) error
-	OnProviderCall(ctx context.Context, request provider.Request) error
-	OnProviderOutput(ctx context.Context, request provider.Request, delta provider.StreamDelta) error
-	OnProviderResponse(ctx context.Context, response provider.Response) error
-	OnToolExecution(ctx context.Context, record ToolExecutionRecord) error
-	OnStepEnd(ctx context.Context, step int) error
-	OnPostExecutionVerification(ctx context.Context, results []PostExecutionVerificationResult) error
-	OnStandingsInjected(ctx context.Context, injection StandingsInjection) error
-	OnRunComplete(ctx context.Context, result Result) error
-	OnRunFailure(ctx context.Context, err error) error
-}
-
-// StandingsInjection describes a race-context newswire message inserted
-// into the agent's context at a step boundary. Observers that persist
-// events should record this as `race.standings.injected` with the same
-// payload shape (see runevents.RaceStandingsInjectedPayload).
-type StandingsInjection struct {
-	StepIndex         int
-	TokensAdded       int
-	StandingsSnapshot string
-	TriggeredBy       runevents.RaceStandingsTrigger
-	MinStepGap        int
-}
-
-type NoopObserver struct{}
-
-func (NoopObserver) OnStepStart(context.Context, int) error                 { return nil }
-func (NoopObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
-func (NoopObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
-	return nil
-}
-func (NoopObserver) OnProviderResponse(context.Context, provider.Response) error { return nil }
-func (NoopObserver) OnToolExecution(context.Context, ToolExecutionRecord) error {
-	return nil
-}
-func (NoopObserver) OnStepEnd(context.Context, int) error { return nil }
-func (NoopObserver) OnPostExecutionVerification(context.Context, []PostExecutionVerificationResult) error {
-	return nil
-}
-func (NoopObserver) OnStandingsInjected(context.Context, StandingsInjection) error { return nil }
-func (NoopObserver) OnRunComplete(context.Context, Result) error                   { return nil }
-func (NoopObserver) OnRunFailure(context.Context, error) error                     { return nil }
-
-// SecretsLookup resolves ${secrets.X} references at run-start by returning
-// the plaintext secret map for a workspace. *repository.Repository satisfies
-// this interface; tests can substitute an in-memory fake.
-type SecretsLookup interface {
-	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
-}
-
-type AssetContent struct {
-	Content     []byte
-	ContentType string
-}
-
-// AssetLoader resolves artifact-backed challenge-pack assets before the
-// native sandbox starts executing. *worker.ArtifactAssetLoader is the
-// production implementation; tests can substitute an in-memory fake.
-type AssetLoader interface {
-	LoadAsset(ctx context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (AssetContent, error)
-}
 
 type NativeExecutor struct {
 	client              provider.Client

--- a/backend/internal/engine/tool_contracts.go
+++ b/backend/internal/engine/tool_contracts.go
@@ -1,0 +1,22 @@
+package engine
+
+import "github.com/agentclash/agentclash/runtime/runner"
+
+type ToolCategory = runner.ToolCategory
+type ToolFailureOrigin = runner.ToolFailureOrigin
+
+const (
+	ToolCategoryPrimitive = runner.ToolCategoryPrimitive
+	ToolCategoryComposed  = runner.ToolCategoryComposed
+	ToolCategoryMock      = runner.ToolCategoryMock
+
+	ToolFailureOriginPolicy     = runner.ToolFailureOriginPolicy
+	ToolFailureOriginResolution = runner.ToolFailureOriginResolution
+	ToolFailureOriginPrimitive  = runner.ToolFailureOriginPrimitive
+	ToolFailureOriginDelegation = runner.ToolFailureOriginDelegation
+	ToolFailureOriginCycle      = runner.ToolFailureOriginCycle
+	ToolFailureOriginDepth      = runner.ToolFailureOriginDepth
+)
+
+type ToolExecutionResult = runner.ToolExecutionResult
+type ToolExecutionRecord = runner.ToolExecutionRecord

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -13,22 +13,6 @@ import (
 	"github.com/agentclash/agentclash/runtime/templateutil"
 )
 
-type ToolCategory string
-type ToolFailureOrigin string
-
-const (
-	ToolCategoryPrimitive ToolCategory = "primitive"
-	ToolCategoryComposed  ToolCategory = "composed"
-	ToolCategoryMock      ToolCategory = "mock"
-
-	ToolFailureOriginPolicy     ToolFailureOrigin = "policy"
-	ToolFailureOriginResolution ToolFailureOrigin = "resolution"
-	ToolFailureOriginPrimitive  ToolFailureOrigin = "primitive"
-	ToolFailureOriginDelegation ToolFailureOrigin = "delegation"
-	ToolFailureOriginCycle      ToolFailureOrigin = "cycle"
-	ToolFailureOriginDepth      ToolFailureOrigin = "depth"
-)
-
 const MaxDelegationDepth = 8
 
 type Tool interface {
@@ -46,29 +30,6 @@ type ToolExecutionRequest struct {
 	NetworkAllowlist []string
 	Registry         *Registry
 	DelegationChain  []string
-}
-
-type ToolExecutionResult struct {
-	Content              string
-	IsError              bool
-	Completed            bool
-	FinalOutput          string
-	ResolvedToolName     string
-	ResolvedToolCategory ToolCategory
-	FailureOrigin        ToolFailureOrigin
-	ResolutionChain      []string
-	FailureDepth         int
-}
-
-type ToolExecutionRecord struct {
-	ToolCall             provider.ToolCall
-	Result               provider.ToolResult
-	ToolCategory         ToolCategory
-	ResolvedToolName     string
-	ResolvedToolCategory ToolCategory
-	FailureOrigin        ToolFailureOrigin
-	ResolutionChain      []string
-	FailureDepth         int
 }
 
 type Registry struct {

--- a/runtime/runner/contracts.go
+++ b/runtime/runner/contracts.go
@@ -1,0 +1,134 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+)
+
+type StopReason string
+
+const (
+	StopReasonCompleted     StopReason = "completed"
+	StopReasonTimeout       StopReason = "timeout"
+	StopReasonStepLimit     StopReason = "step_limit"
+	StopReasonToolLimit     StopReason = "tool_limit"
+	StopReasonProviderError StopReason = "provider_error"
+	StopReasonSandboxError  StopReason = "sandbox_error"
+	StopReasonObserverError StopReason = "observer_error"
+)
+
+type Result struct {
+	FinalOutput   string
+	StopReason    StopReason
+	StepCount     int
+	ToolCallCount int
+	Usage         provider.Usage
+}
+
+type Failure struct {
+	StopReason StopReason
+	Message    string
+	Cause      error
+}
+
+func (f Failure) Error() string {
+	if strings.TrimSpace(f.Message) != "" {
+		return f.Message
+	}
+	return fmt.Sprintf("runtime runner stopped: %s", f.StopReason)
+}
+
+func (f Failure) Unwrap() error {
+	return f.Cause
+}
+
+func NewFailure(stopReason StopReason, message string, cause error) error {
+	return Failure{
+		StopReason: stopReason,
+		Message:    message,
+		Cause:      cause,
+	}
+}
+
+func AsFailure(err error) (Failure, bool) {
+	var failure Failure
+	if !errors.As(err, &failure) {
+		return Failure{}, false
+	}
+	return failure, true
+}
+
+// PostExecutionVerificationResult holds captured file or directory state from
+// the sandbox, emitted as a grader.verification.* event before sandbox teardown.
+type PostExecutionVerificationResult struct {
+	Key     string          `json:"key"`
+	Type    string          `json:"type"` // "file_capture", "directory_listing", or "code_execution"
+	Payload json.RawMessage `json:"payload"`
+}
+
+// StandingsInjection describes a race-context newswire message inserted
+// into the agent's context at a step boundary. Observers that persist
+// events should record this as `race.standings.injected` with the same
+// payload shape (see runevents.RaceStandingsInjectedPayload).
+type StandingsInjection struct {
+	StepIndex         int
+	TokensAdded       int
+	StandingsSnapshot string
+	TriggeredBy       runevents.RaceStandingsTrigger
+	MinStepGap        int
+}
+
+type Observer interface {
+	OnStepStart(ctx context.Context, step int) error
+	OnProviderCall(ctx context.Context, request provider.Request) error
+	OnProviderOutput(ctx context.Context, request provider.Request, delta provider.StreamDelta) error
+	OnProviderResponse(ctx context.Context, response provider.Response) error
+	OnToolExecution(ctx context.Context, record ToolExecutionRecord) error
+	OnStepEnd(ctx context.Context, step int) error
+	OnPostExecutionVerification(ctx context.Context, results []PostExecutionVerificationResult) error
+	OnStandingsInjected(ctx context.Context, injection StandingsInjection) error
+	OnRunComplete(ctx context.Context, result Result) error
+	OnRunFailure(ctx context.Context, err error) error
+}
+
+type NoopObserver struct{}
+
+func (NoopObserver) OnStepStart(context.Context, int) error                 { return nil }
+func (NoopObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
+func (NoopObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+func (NoopObserver) OnProviderResponse(context.Context, provider.Response) error { return nil }
+func (NoopObserver) OnToolExecution(context.Context, ToolExecutionRecord) error  { return nil }
+func (NoopObserver) OnStepEnd(context.Context, int) error                        { return nil }
+func (NoopObserver) OnPostExecutionVerification(context.Context, []PostExecutionVerificationResult) error {
+	return nil
+}
+func (NoopObserver) OnStandingsInjected(context.Context, StandingsInjection) error { return nil }
+func (NoopObserver) OnRunComplete(context.Context, Result) error                   { return nil }
+func (NoopObserver) OnRunFailure(context.Context, error) error                     { return nil }
+
+// SecretsLookup resolves ${secrets.X} references at run-start by returning
+// the plaintext secret map for a workspace. Hosted and local runtimes can
+// provide different backing stores while sharing this contract.
+type SecretsLookup interface {
+	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
+}
+
+type AssetContent struct {
+	Content     []byte
+	ContentType string
+}
+
+// AssetLoader resolves artifact-backed challenge-pack assets before the
+// sandbox starts executing.
+type AssetLoader interface {
+	LoadAsset(ctx context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (AssetContent, error)
+}

--- a/runtime/runner/contracts.go
+++ b/runtime/runner/contracts.go
@@ -42,7 +42,7 @@ func (f Failure) Error() string {
 	if strings.TrimSpace(f.Message) != "" {
 		return f.Message
 	}
-	return fmt.Sprintf("runtime runner stopped: %s", f.StopReason)
+	return fmt.Sprintf("native engine stopped: %s", f.StopReason)
 }
 
 func (f Failure) Unwrap() error {

--- a/runtime/runner/contracts_test.go
+++ b/runtime/runner/contracts_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestFailureUnwrapAndAsFailure(t *testing.T) {
 
 func TestNoopObserverSatisfiesObserver(t *testing.T) {
 	var observer Observer = NoopObserver{}
-	if observer == nil {
-		t.Fatal("NoopObserver must satisfy Observer")
+	if err := observer.OnStepStart(context.Background(), 1); err != nil {
+		t.Fatalf("NoopObserver.OnStepStart: %v", err)
 	}
 }

--- a/runtime/runner/contracts_test.go
+++ b/runtime/runner/contracts_test.go
@@ -1,0 +1,29 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFailureUnwrapAndAsFailure(t *testing.T) {
+	cause := errors.New("boom")
+	err := NewFailure(StopReasonSandboxError, "sandbox failed", cause)
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("AsFailure returned ok=false for %T", err)
+	}
+	if failure.StopReason != StopReasonSandboxError {
+		t.Fatalf("StopReason = %q; want %q", failure.StopReason, StopReasonSandboxError)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("Failure must unwrap the original cause")
+	}
+}
+
+func TestNoopObserverSatisfiesObserver(t *testing.T) {
+	var observer Observer = NoopObserver{}
+	if observer == nil {
+		t.Fatal("NoopObserver must satisfy Observer")
+	}
+}

--- a/runtime/runner/human_turn.go
+++ b/runtime/runner/human_turn.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var ErrHumanTurnTimeout = errors.New("human turn timed out")
+
+// HumanTurnRequest identifies an in-run human actor pause.
+type HumanTurnRequest struct {
+	RunAgentID uuid.UUID
+	TurnIndex  int
+	PhaseID    string
+	PromptHint string
+	Timeout    time.Duration
+}
+
+// HumanTurnGate blocks until an operator submits the next user message.
+type HumanTurnGate interface {
+	WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (message string, err error)
+}
+
+type noopHumanTurnGate struct{}
+
+func (noopHumanTurnGate) WaitForHumanTurn(context.Context, HumanTurnRequest) (string, error) {
+	return "", errors.New("human turn gate is not configured")
+}
+
+func NoopHumanTurnGate() HumanTurnGate {
+	return noopHumanTurnGate{}
+}
+
+// PollHumanTurnGate polls a HumanTurnStore until a message arrives or timeout.
+type PollHumanTurnGate struct {
+	store HumanTurnStore
+}
+
+type HumanTurnStore interface {
+	MarkAwaitingHuman(ctx context.Context, req HumanTurnRequest) error
+	PollHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int) (message string, ready bool, err error)
+	MarkHumanTurnExpired(ctx context.Context, runAgentID uuid.UUID, turnIndex int) error
+}
+
+func NewPollHumanTurnGate(store HumanTurnStore) PollHumanTurnGate {
+	return PollHumanTurnGate{store: store}
+}
+
+func (g PollHumanTurnGate) WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (string, error) {
+	if g.store == nil {
+		return "", errors.New("human turn store is not configured")
+	}
+	if err := g.store.MarkAwaitingHuman(ctx, req); err != nil {
+		return "", err
+	}
+
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		message, ready, err := g.store.PollHumanMessage(ctx, req.RunAgentID, req.TurnIndex)
+		if err != nil {
+			return "", err
+		}
+		if ready {
+			if strings.TrimSpace(message) == "" {
+				return "", errors.New("human turn message is empty")
+			}
+			return message, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if req.Timeout > 0 {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				_ = g.store.MarkHumanTurnExpired(cleanupCtx, req.RunAgentID, req.TurnIndex)
+				cancel()
+				return "", ErrHumanTurnTimeout
+			}
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/runtime/runner/human_turn.go
+++ b/runtime/runner/human_turn.go
@@ -81,10 +81,10 @@ func (g PollHumanTurnGate) WaitForHumanTurn(ctx context.Context, req HumanTurnRe
 
 		select {
 		case <-ctx.Done():
-			if req.Timeout > 0 {
+			if req.Timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
 				_ = g.store.MarkHumanTurnExpired(cleanupCtx, req.RunAgentID, req.TurnIndex)
-				cancel()
 				return "", ErrHumanTurnTimeout
 			}
 			return "", ctx.Err()

--- a/runtime/runner/human_turn_test.go
+++ b/runtime/runner/human_turn_test.go
@@ -45,6 +45,25 @@ func TestPollHumanTurnGateExpiresOnTimeout(t *testing.T) {
 	}
 }
 
+func TestPollHumanTurnGateReturnsParentCancellation(t *testing.T) {
+	store := &fakeHumanTurnStore{}
+	gate := NewPollHumanTurnGate(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := gate.WaitForHumanTurn(ctx, HumanTurnRequest{
+		RunAgentID: uuid.New(),
+		TurnIndex:  1,
+		Timeout:    time.Hour,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v; want context.Canceled", err)
+	}
+	if store.markedExpired {
+		t.Fatal("parent cancellation must not mark human turn expired")
+	}
+}
+
 type fakeHumanTurnStore struct {
 	message        string
 	markedAwaiting bool

--- a/runtime/runner/human_turn_test.go
+++ b/runtime/runner/human_turn_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestPollHumanTurnGateReturnsReadyMessage(t *testing.T) {
+	store := &fakeHumanTurnStore{message: "continue"}
+	gate := NewPollHumanTurnGate(store)
+
+	got, err := gate.WaitForHumanTurn(context.Background(), HumanTurnRequest{
+		RunAgentID: uuid.New(),
+		TurnIndex:  2,
+	})
+	if err != nil {
+		t.Fatalf("WaitForHumanTurn: %v", err)
+	}
+	if got != "continue" {
+		t.Fatalf("message = %q; want continue", got)
+	}
+	if !store.markedAwaiting {
+		t.Fatal("expected MarkAwaitingHuman to be called")
+	}
+}
+
+func TestPollHumanTurnGateExpiresOnTimeout(t *testing.T) {
+	store := &fakeHumanTurnStore{}
+	gate := NewPollHumanTurnGate(store)
+
+	_, err := gate.WaitForHumanTurn(context.Background(), HumanTurnRequest{
+		RunAgentID: uuid.New(),
+		TurnIndex:  1,
+		Timeout:    time.Nanosecond,
+	})
+	if !errors.Is(err, ErrHumanTurnTimeout) {
+		t.Fatalf("error = %v; want ErrHumanTurnTimeout", err)
+	}
+	if !store.markedExpired {
+		t.Fatal("expected MarkHumanTurnExpired to be called")
+	}
+}
+
+type fakeHumanTurnStore struct {
+	message        string
+	markedAwaiting bool
+	markedExpired  bool
+}
+
+func (s *fakeHumanTurnStore) MarkAwaitingHuman(context.Context, HumanTurnRequest) error {
+	s.markedAwaiting = true
+	return nil
+}
+
+func (s *fakeHumanTurnStore) PollHumanMessage(context.Context, uuid.UUID, int) (string, bool, error) {
+	return s.message, s.message != "", nil
+}
+
+func (s *fakeHumanTurnStore) MarkHumanTurnExpired(context.Context, uuid.UUID, int) error {
+	s.markedExpired = true
+	return nil
+}

--- a/runtime/runner/tools.go
+++ b/runtime/runner/tools.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	"encoding/json"
+
+	"github.com/agentclash/agentclash/runtime/provider"
+)
+
+type ToolCategory string
+type ToolFailureOrigin string
+
+const (
+	ToolCategoryPrimitive ToolCategory = "primitive"
+	ToolCategoryComposed  ToolCategory = "composed"
+	ToolCategoryMock      ToolCategory = "mock"
+
+	ToolFailureOriginPolicy     ToolFailureOrigin = "policy"
+	ToolFailureOriginResolution ToolFailureOrigin = "resolution"
+	ToolFailureOriginPrimitive  ToolFailureOrigin = "primitive"
+	ToolFailureOriginDelegation ToolFailureOrigin = "delegation"
+	ToolFailureOriginCycle      ToolFailureOrigin = "cycle"
+	ToolFailureOriginDepth      ToolFailureOrigin = "depth"
+)
+
+type ToolExecutionResult struct {
+	Content              string
+	IsError              bool
+	Completed            bool
+	FinalOutput          string
+	ResolvedToolName     string
+	ResolvedToolCategory ToolCategory
+	FailureOrigin        ToolFailureOrigin
+	ResolutionChain      []string
+	FailureDepth         int
+}
+
+type ToolExecutionRecord struct {
+	ToolCall             provider.ToolCall
+	Result               provider.ToolResult
+	ToolCategory         ToolCategory
+	ResolvedToolName     string
+	ResolvedToolCategory ToolCategory
+	FailureOrigin        ToolFailureOrigin
+	ResolutionChain      []string
+	FailureDepth         int
+}
+
+type ToolDescriptor struct {
+	Name        string
+	Description string
+	Parameters  json.RawMessage
+	Category    ToolCategory
+}

--- a/testing/codex-runtime-runner-boundary.md
+++ b/testing/codex-runtime-runner-boundary.md
@@ -1,0 +1,35 @@
+# codex/runtime-runner-boundary — Test Contract
+
+## Functional Behavior
+
+- Add shared runtime runner boundary types that future CLI/local/desktop code can depend on without importing `backend/internal`.
+- Move backend-neutral execution contracts out of `backend/internal/engine` when they do not depend on repositories, Temporal, Postgres, API handlers, or hosted-only services.
+- Keep hosted execution behavior unchanged.
+- Keep backend-specific adapters and orchestration in `backend/internal`.
+- Do not add `agentclash local run`, Docker sandboxing, SQLite storage, or harness-builder behavior in this PR.
+
+## Unit Tests
+
+- New or moved runtime runner package tests pass.
+- Backend engine, worker, workflow, and API tests pass.
+- Runtime tests continue to pass.
+
+## Integration / Functional Tests
+
+- `go test ./...` from `runtime/` passes.
+- `go test ./...` from `backend/` passes.
+- `go test ./...` from `cli/` passes if CLI module wiring is touched.
+
+## Smoke Tests
+
+- `go list ./...` succeeds in `runtime/`.
+- `go list ./...` succeeds in `backend/`.
+- A temporary external module can import the new runner boundary package without importing backend internals.
+
+## E2E Tests
+
+N/A — this PR is a library boundary extraction and does not add a new user-facing run mode.
+
+## Manual / cURL Tests
+
+N/A — no HTTP API route behavior is intentionally changed.


### PR DESCRIPTION
## Summary

This is the second shared-runtime migration PR after #1148. It extracts the reusable runner boundary contracts into `runtime/runner` and keeps hosted executor/orchestration code in `backend/internal`.

What changed:

- adds `runtime/runner` with shared contracts for:
  - run `Result`, `StopReason`, `Failure`, and `AsFailure`
  - `Observer` / `NoopObserver`
  - post-execution verification and standings injection records
  - tool execution record/result category metadata
  - `SecretsLookup` and `AssetLoader`
  - human-turn gate/store contracts and polling gate
- rewires `backend/internal/engine` to alias those runtime contracts rather than owning private copies
- adds focused `runtime/runner` tests
- keeps actual hosted executors, repository adapters, Temporal, E2B implementation, and orchestration in backend

## Behavior note

This PR includes one intentional bug fix in `PollHumanTurnGate`: parent context cancellation with `Timeout > 0` now returns the parent context error, such as `context.Canceled`, instead of incorrectly returning `ErrHumanTurnTimeout` and marking the human turn expired.

Actual human-turn deadline expiry still returns `ErrHumanTurnTimeout` and calls `MarkHumanTurnExpired`. Both paths are covered by `runtime/runner` tests.

## Why

#1148 moved the reusable scoring/pack/provider/sandbox contracts. This PR exposes the next layer of runner contracts so future CLI/local/desktop runtime code can depend on stable public types without importing `backend/internal`.

This intentionally does not add `agentclash local run`, Docker sandboxing, SQLite storage, or harness-builder behavior.

## Validation

- `cd runtime && go build ./... && go vet ./... && go test -short -race -count=1 ./...`
- `cd backend && go test -short -race -count=1 ./...`
- `cd cli && go test ./...`
- temp external Go module importing `github.com/agentclash/agentclash/runtime/runner` and using `Observer`, `NoopObserver`, `NewFailure`, `AsFailure`, and stop reasons
