### PR TITLE
[codex] Extract shared runtime execution harness

### DIFF
--- a/backend/internal/engine/multi_turn_executor.go
+++ b/backend/internal/engine/multi_turn_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agentclash/agentclash/runtime/challengepack"
 	"github.com/agentclash/agentclash/runtime/provider"
 	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/agentclash/agentclash/runtime/runner"
 	"github.com/google/uuid"
 )
 
@@ -111,18 +112,10 @@ func (e MultiTurnExecutor) WithHumanTurnGate(gate HumanTurnGate) MultiTurnExecut
 
 func (e MultiTurnExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
 	recorder := multiTurnRecorder(e.observer)
-	defer func() {
-		if err != nil {
-			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
-				err = errors.Join(err, NewFailure(StopReasonObserverError, "record multi_turn terminal failure event", observerErr))
-			}
-			return
-		}
-		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
-			result = Result{}
-			err = NewFailure(StopReasonObserverError, "record multi_turn terminal completion event", observerErr)
-		}
-	}()
+	defer runner.FinishWithObserver(ctx, e.observer, &result, &err, runner.TerminalObserverMessages{
+		Failure:    "record multi_turn terminal failure event",
+		Completion: "record multi_turn terminal completion event",
+	})
 
 	spec, err := userSimulatorForExecution(executionContext)
 	if err != nil {

--- a/backend/internal/engine/native_conversation.go
+++ b/backend/internal/engine/native_conversation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runner"
 	"github.com/agentclash/agentclash/runtime/sandbox"
 )
 
@@ -72,11 +73,9 @@ func (e NativeExecutor) BeginConversation(ctx context.Context, executionContext 
 		return nil, nil, err
 	}
 
-	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
-	cancel := func() {}
-	if timeout := runTimeout(executionContext); timeout > 0 {
-		runCtx, cancel = context.WithTimeout(runCtx, timeout)
-	}
+	runtimeCtx := runner.WithRuntimeTimeout(provider.WithWorkspaceSecrets(ctx, workspaceSecrets), runTimeout(executionContext))
+	runCtx := runtimeCtx.Context
+	cancel := runtimeCtx.Cancel
 
 	initialMessages, err := buildInitialMessages(executionContext)
 	if err != nil {

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agentclash/agentclash/runtime/challengepack"
 	"github.com/agentclash/agentclash/runtime/provider"
 	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/agentclash/agentclash/runtime/runner"
 	"github.com/agentclash/agentclash/runtime/sandbox"
 	"github.com/google/uuid"
 )
@@ -85,18 +86,10 @@ func (e NativeExecutor) WithAssetLoader(loader AssetLoader) NativeExecutor {
 }
 
 func (e NativeExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
-	defer func() {
-		if err != nil {
-			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
-				err = errors.Join(err, NewFailure(StopReasonObserverError, "record native terminal failure event", observerErr))
-			}
-			return
-		}
-		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
-			result = Result{}
-			err = NewFailure(StopReasonObserverError, "record native terminal completion event", observerErr)
-		}
-	}()
+	defer runner.FinishWithObserver(ctx, e.observer, &result, &err, runner.TerminalObserverMessages{
+		Failure:    "record native terminal failure event",
+		Completion: "record native terminal completion event",
+	})
 
 	if executionContext.Deployment.ProviderAccount == nil {
 		return Result{}, provider.NewFailure(
@@ -151,12 +144,9 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		}
 	}()
 
-	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
-	cancel := func() {}
-	if timeout := runTimeout(executionContext); timeout > 0 {
-		runCtx, cancel = context.WithTimeout(runCtx, timeout)
-	}
-	defer cancel()
+	runtimeCtx := runner.WithRuntimeTimeout(provider.WithWorkspaceSecrets(ctx, workspaceSecrets), runTimeout(executionContext))
+	runCtx := runtimeCtx.Context
+	defer runtimeCtx.Cancel()
 
 	initialMessages, err := buildInitialMessages(executionContext)
 	if err != nil {

--- a/backend/internal/engine/prompt_eval_executor.go
+++ b/backend/internal/engine/prompt_eval_executor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/runtime/challengepack"
 	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runner"
 	"github.com/google/uuid"
 )
 
@@ -55,18 +56,10 @@ func (e PromptEvalExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceI
 }
 
 func (e PromptEvalExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
-	defer func() {
-		if err != nil {
-			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
-				err = errors.Join(err, NewFailure(StopReasonObserverError, "record prompt_eval terminal failure event", observerErr))
-			}
-			return
-		}
-		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
-			result = Result{}
-			err = NewFailure(StopReasonObserverError, "record prompt_eval terminal completion event", observerErr)
-		}
-	}()
+	defer runner.FinishWithObserver(ctx, e.observer, &result, &err, runner.TerminalObserverMessages{
+		Failure:    "record prompt_eval terminal failure event",
+		Completion: "record prompt_eval terminal completion event",
+	})
 
 	if executionContext.Deployment.ProviderAccount == nil {
 		return Result{}, provider.NewFailure(
@@ -91,12 +84,9 @@ func (e PromptEvalExecutor) Execute(ctx context.Context, executionContext reposi
 	if err != nil {
 		return Result{}, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
 	}
-	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
-	cancel := func() {}
-	if timeout := runTimeout(executionContext); timeout > 0 {
-		runCtx, cancel = context.WithTimeout(runCtx, timeout)
-	}
-	defer cancel()
+	runtimeCtx := runner.WithRuntimeTimeout(provider.WithWorkspaceSecrets(ctx, workspaceSecrets), runTimeout(executionContext))
+	runCtx := runtimeCtx.Context
+	defer runtimeCtx.Cancel()
 
 	messages, err := buildPromptEvalMessages(executionContext)
 	if err != nil {

--- a/backend/internal/engine/responses_executor.go
+++ b/backend/internal/engine/responses_executor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runner"
 	"github.com/agentclash/agentclash/runtime/sandbox"
 	"github.com/google/uuid"
 )
@@ -64,18 +65,10 @@ func (e ResponsesExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceID
 }
 
 func (e ResponsesExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
-	defer func() {
-		if err != nil {
-			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
-				err = errors.Join(err, NewFailure(StopReasonObserverError, "record responses terminal failure event", observerErr))
-			}
-			return
-		}
-		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
-			result = Result{}
-			err = NewFailure(StopReasonObserverError, "record responses terminal completion event", observerErr)
-		}
-	}()
+	defer runner.FinishWithObserver(ctx, e.observer, &result, &err, runner.TerminalObserverMessages{
+		Failure:    "record responses terminal failure event",
+		Completion: "record responses terminal completion event",
+	})
 
 	if executionContext.Deployment.ProviderAccount == nil {
 		return Result{}, provider.NewFailure(
@@ -142,12 +135,9 @@ func (e ResponsesExecutor) Execute(ctx context.Context, executionContext reposit
 		}()
 	}
 
-	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
-	cancel := func() {}
-	if timeout := runTimeout(executionContext); timeout > 0 {
-		runCtx, cancel = context.WithTimeout(runCtx, timeout)
-	}
-	defer cancel()
+	runtimeCtx := runner.WithRuntimeTimeout(provider.WithWorkspaceSecrets(ctx, workspaceSecrets), runTimeout(executionContext))
+	runCtx := runtimeCtx.Context
+	defer runtimeCtx.Cancel()
 
 	messages, err := buildPromptEvalMessages(executionContext)
 	if err != nil {

--- a/runtime/runner/harness.go
+++ b/runtime/runner/harness.go
@@ -1,0 +1,49 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type TerminalObserverMessages struct {
+	Failure    string
+	Completion string
+}
+
+// FinishWithObserver records the terminal run event and preserves the executor
+// contract that observer failures become StopReasonObserverError failures.
+func FinishWithObserver(ctx context.Context, observer Observer, result *Result, err *error, messages TerminalObserverMessages) {
+	if observer == nil {
+		observer = NoopObserver{}
+	}
+	if *err != nil {
+		if observerErr := observer.OnRunFailure(ctx, *err); observerErr != nil {
+			*err = errors.Join(*err, NewFailure(StopReasonObserverError, messages.Failure, observerErr))
+		}
+		return
+	}
+	if observerErr := observer.OnRunComplete(ctx, *result); observerErr != nil {
+		*result = Result{}
+		*err = NewFailure(StopReasonObserverError, messages.Completion, observerErr)
+	}
+}
+
+type TimedContext struct {
+	Context context.Context
+	Cancel  context.CancelFunc
+}
+
+func WithRuntimeTimeout(ctx context.Context, timeout time.Duration) TimedContext {
+	if timeout <= 0 {
+		return TimedContext{
+			Context: ctx,
+			Cancel:  func() {},
+		}
+	}
+	child, cancel := context.WithTimeout(ctx, timeout)
+	return TimedContext{
+		Context: child,
+		Cancel:  cancel,
+	}
+}

--- a/runtime/runner/harness_test.go
+++ b/runtime/runner/harness_test.go
@@ -1,0 +1,149 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/runtime/provider"
+)
+
+type terminalObserver struct {
+	NoopObserver
+	completeResult Result
+	completeErr    error
+	failureErr     error
+	failureSeen    error
+}
+
+func (o *terminalObserver) OnRunComplete(_ context.Context, result Result) error {
+	o.completeResult = result
+	return o.completeErr
+}
+
+func (o *terminalObserver) OnRunFailure(_ context.Context, err error) error {
+	o.failureSeen = err
+	return o.failureErr
+}
+
+func TestFinishWithObserverRecordsCompletion(t *testing.T) {
+	observer := &terminalObserver{}
+	result := Result{
+		FinalOutput: "done",
+		StopReason:  StopReasonCompleted,
+		Usage:       provider.Usage{InputTokens: 12},
+	}
+	var err error
+
+	FinishWithObserver(context.Background(), observer, &result, &err, TerminalObserverMessages{
+		Failure:    "failure message",
+		Completion: "completion message",
+	})
+
+	if err != nil {
+		t.Fatalf("FinishWithObserver err = %v; want nil", err)
+	}
+	if observer.completeResult.FinalOutput != "done" {
+		t.Fatalf("OnRunComplete result = %+v; want final output done", observer.completeResult)
+	}
+	if result.FinalOutput != "done" {
+		t.Fatalf("result was mutated on success: %+v", result)
+	}
+}
+
+func TestFinishWithObserverConvertsCompletionObserverError(t *testing.T) {
+	observerErr := errors.New("observer failed")
+	observer := &terminalObserver{completeErr: observerErr}
+	result := Result{FinalOutput: "done", StopReason: StopReasonCompleted}
+	var err error
+
+	FinishWithObserver(context.Background(), observer, &result, &err, TerminalObserverMessages{
+		Failure:    "failure message",
+		Completion: "completion message",
+	})
+
+	if result != (Result{}) {
+		t.Fatalf("result = %+v; want zero result", result)
+	}
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("err = %T; want Failure", err)
+	}
+	if failure.StopReason != StopReasonObserverError {
+		t.Fatalf("StopReason = %q; want %q", failure.StopReason, StopReasonObserverError)
+	}
+	if failure.Message != "completion message" {
+		t.Fatalf("Message = %q; want completion message", failure.Message)
+	}
+	if !errors.Is(err, observerErr) {
+		t.Fatal("observer error must be preserved")
+	}
+}
+
+func TestFinishWithObserverJoinsFailureObserverError(t *testing.T) {
+	runErr := errors.New("run failed")
+	observerErr := errors.New("observer failed")
+	observer := &terminalObserver{failureErr: observerErr}
+	result := Result{FinalOutput: "ignored"}
+	err := runErr
+
+	FinishWithObserver(context.Background(), observer, &result, &err, TerminalObserverMessages{
+		Failure:    "failure message",
+		Completion: "completion message",
+	})
+
+	if !errors.Is(err, runErr) {
+		t.Fatal("run error must be preserved")
+	}
+	if !errors.Is(err, observerErr) {
+		t.Fatal("observer error must be joined")
+	}
+	if observer.failureSeen != runErr {
+		t.Fatalf("OnRunFailure saw %v; want run error", observer.failureSeen)
+	}
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("joined err = %T; want Failure present", err)
+	}
+	if failure.StopReason != StopReasonObserverError {
+		t.Fatalf("StopReason = %q; want %q", failure.StopReason, StopReasonObserverError)
+	}
+}
+
+func TestFinishWithObserverAllowsNilObserver(t *testing.T) {
+	result := Result{FinalOutput: "done", StopReason: StopReasonCompleted}
+	var err error
+
+	FinishWithObserver(context.Background(), nil, &result, &err, TerminalObserverMessages{})
+
+	if err != nil {
+		t.Fatalf("FinishWithObserver with nil observer err = %v; want nil", err)
+	}
+}
+
+func TestWithRuntimeTimeoutNoopsWhenUnset(t *testing.T) {
+	parent := context.Background()
+	timed := WithRuntimeTimeout(parent, 0)
+	defer timed.Cancel()
+
+	if timed.Context != parent {
+		t.Fatal("WithRuntimeTimeout should return parent context for non-positive timeout")
+	}
+	if _, ok := timed.Context.Deadline(); ok {
+		t.Fatal("non-positive timeout should not set a deadline")
+	}
+}
+
+func TestWithRuntimeTimeoutAppliesDeadline(t *testing.T) {
+	timed := WithRuntimeTimeout(context.Background(), time.Minute)
+	defer timed.Cancel()
+
+	deadline, ok := timed.Context.Deadline()
+	if !ok {
+		t.Fatal("positive timeout should set a deadline")
+	}
+	if time.Until(deadline) <= 0 {
+		t.Fatalf("deadline = %v; want future deadline", deadline)
+	}
+}

--- a/testing/codex-runtime-execution-harness.md
+++ b/testing/codex-runtime-execution-harness.md
@@ -1,0 +1,34 @@
+# codex/runtime-execution-harness — Test Contract
+
+## Functional Behavior
+
+- Add a shared executable runner harness in `runtime/runner` for terminal observer handling and runtime deadline context creation.
+- Rewire backend executors to use the shared harness without changing hosted execution behavior.
+- Preserve existing native, prompt-eval, and responses executor result/error semantics.
+- Keep repository-specific execution context, Temporal, storage, sandbox implementations, and provider orchestration in backend.
+- Do not add `agentclash local run`, Docker sandboxing, SQLite storage, or harness-builder behavior in this PR.
+
+## Unit Tests
+
+- `runtime/runner` tests cover terminal success/failure observer behavior and timeout context helpers.
+- Backend engine tests continue to pass.
+
+## Integration / Functional Tests
+
+- `go test ./...` from `runtime/` passes.
+- `go test ./...` from `backend/` passes.
+- `go test ./...` from `cli/` passes if CLI module wiring is touched.
+
+## Smoke Tests
+
+- `go list ./...` succeeds in `runtime/`.
+- `go list ./...` succeeds in `backend/`.
+- A temporary external module can import and use the new `runtime/runner` execution harness.
+
+## E2E Tests
+
+N/A — this PR is a runner harness extraction and does not add a user-facing run mode.
+
+## Manual / cURL Tests
+
+N/A — no HTTP API route behavior is intentionally changed.


### PR DESCRIPTION
## Summary
- add `runtime/runner` harness helpers for terminal observer finalization and runtime timeout contexts
- rewire native, prompt_eval, responses, multi_turn, and native conversation execution paths to use the shared helpers
- keep hosted-only execution concerns in backend: repository execution context, sandbox provisioning, provider orchestration, Temporal/storage, and HITL state handling

## Scope
This is the next M0 slice for #1147 after the shared runtime module and runner contract extraction. It does not add local run, Docker execution, SQLite, or harness-builder plumbing.

## Validation
- `cd runtime && go test ./...`
- `cd backend && go test ./internal/engine`
- `cd runtime && go build ./... && go vet ./... && go test -short -race -count=1 ./...`
- `cd backend && go test -short -race -count=1 ./...`
- external temp module import smoke for `github.com/agentclash/agentclash/runtime/runner`
