### PR TITLE
chore(web): remove Playgrounds and Knowledge Sources from workspace nav

### DIFF
--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -3,7 +3,6 @@ import {
   Rocket,
   PackageOpen,
   Play,
-  FlaskConical,
   ClipboardCheck,
   GitCompare,
   ShieldCheck,
@@ -70,11 +69,6 @@ export const navSections: NavSection[] = [
         icon: Play,
       },
       {
-        label: "Playgrounds",
-        href: (id) => `/workspaces/${id}/playgrounds`,
-        icon: FlaskConical,
-      },
-      {
         label: "Regression Suites",
         href: (id) => `/workspaces/${id}/regression-suites`,
         icon: ClipboardCheck,
@@ -118,11 +112,6 @@ export const navSections: NavSection[] = [
         label: "Tools",
         href: (id) => `/workspaces/${id}/tools`,
         icon: Wrench,
-      },
-      {
-        label: "Knowledge Sources",
-        href: (id) => `/workspaces/${id}/knowledge-sources`,
-        icon: Database,
       },
       {
         label: "Artifacts",


### PR DESCRIPTION
## Summary
- Remove **Playgrounds** and **Knowledge Sources** from the workspace sidebar (`nav-items.ts`).
- These items add IA noise: Playgrounds still mark LLM-as-judge as coming soon, and Knowledge Sources are CRUD without engine consumption.
- Underlying routes/pages are left in place so deep links and CLI-adjacent flows keep working; this is a nav demotion only.

## Test plan
- [ ] Open any workspace and confirm sidebar no longer lists Playgrounds or Knowledge Sources
- [ ] Confirm Benchmarks still shows Challenge Packs, Pack Library, Datasets, Runs, Regression Suites
- [ ] Confirm Infrastructure still shows Runtime Profiles, Provider Accounts, Tools, Artifacts, Secrets
- [ ] Optional: hit `/workspaces/{id}/playgrounds` and `/workspaces/{id}/knowledge-sources` directly and confirm pages still load


Made with [Cursor](https://cursor.com)