### PR TITLE
fix(deploy): build backend images from repo root so ../runtime resolves

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,3 +49,22 @@ jobs:
 
       - name: Run tests (short mode)
         run: go test -short -race -count=1 ./...
+
+  docker:
+    # The production images build from the REPO ROOT context because backend/
+    # replaces the shared runtime module with ../runtime. Building them here
+    # catches context breakage that `go build` cannot see (it broke silently
+    # between 2026-07-02 and 2026-08-08).
+    name: Docker Images
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build api-server image
+        run: docker build -f backend/Dockerfile --build-arg TARGET=api-server .
+
+      - name: Build worker image
+        run: docker build -f backend/Dockerfile.worker .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,26 @@
+# Build context is the REPO ROOT (not backend/): the backend module depends on
+# the sibling runtime module via `replace ../runtime` in backend/go.mod, so both
+# module directories must be inside the build context.
+#
+#   docker build -f backend/Dockerfile --build-arg TARGET=api-server .
+#
+# On Railway, leave the service Root Directory unset and point Dockerfile Path
+# at backend/Dockerfile.
+
 # ---- Build stage ----
 FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY backend/go.mod backend/go.sum backend/
+COPY runtime/go.mod runtime/go.sum runtime/
+
+WORKDIR /src/backend
 RUN go mod download
-COPY . .
+
+COPY backend /src/backend
+COPY runtime /src/runtime
 
 # TARGET selects which binary to build: api-server or worker
 ARG TARGET=api-server
@@ -20,8 +34,8 @@ RUN apk add --no-cache ca-certificates tzdata postgresql17-client bash
 COPY --from=builder /app /app
 
 # Include migrations so Railway deploy commands can run them
-COPY --from=builder /src/db/migrations /migrations
-COPY --from=builder /src/scripts/migrate.sh /migrate.sh
+COPY --from=builder /src/backend/db/migrations /migrations
+COPY --from=builder /src/backend/scripts/migrate.sh /migrate.sh
 RUN chmod +x /migrate.sh
 
 EXPOSE 8080

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,12 +1,26 @@
+# Build context is the REPO ROOT (not backend/): the backend module depends on
+# the sibling runtime module via `replace ../runtime` in backend/go.mod, so both
+# module directories must be inside the build context.
+#
+#   docker build -f backend/Dockerfile.worker .
+#
+# On Railway, leave the service Root Directory unset and point Dockerfile Path
+# at backend/Dockerfile.worker.
+
 # ---- Build stage ----
 FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY backend/go.mod backend/go.sum backend/
+COPY runtime/go.mod runtime/go.sum runtime/
+
+WORKDIR /src/backend
 RUN go mod download
-COPY . .
+
+COPY backend /src/backend
+COPY runtime /src/runtime
 
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /app ./cmd/worker
 


### PR DESCRIPTION
## Problem

Prod backend (api.agentclash.dev + Temporal worker) is down. Railway builds for both Go services fail in seconds:

```
go: github.com/agentclash/agentclash/runtime@v0.0.0 (replaced by ../runtime):
    reading /runtime/go.mod: open /runtime/go.mod: no such file or directory
```

`backend/go.mod` gained `replace github.com/agentclash/agentclash/runtime => ../runtime` in 3d379148 (2026-07-02), but the Railway services build with **`backend/` as the Docker context**, so `../runtime` doesn't exist inside the build. Nothing caught this: CI runs `go build ./...` from a full checkout and never builds the production images.

## Fix

- `backend/Dockerfile` + `backend/Dockerfile.worker`: expect the **repo root** as build context; copy `backend/` and `runtime/` in, module manifests first so the `go mod download` layer stays cached.
- Backend CI: new **Docker Images** job builds both images on every backend/runtime PR, so context breakage fails fast instead of surfacing at deploy time.

## Railway (dashboard change, paired with this PR)

Clear **Root Directory** (`backend` → unset) on the `agentclash` services in `agentclash-prod` and `agentclash-worker-prod`. Dockerfile Path already points at `backend/Dockerfile` / `backend/Dockerfile.worker`. The `try-cli` service already builds from repo root the same way.

## Verification

- Both images build locally from repo root (api + worker).
- Image smoke check: `/app` binary present and executes to the expected startup phase; 68 migrations + `/migrate.sh` present in the api image.
- Post-merge: Railway redeploy both services → `GET https://api.agentclash.dev/healthz` 200, worker connects to Temporal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g1vtEvgfPP2VhMJfTNJz