### PR TITLE
feat(workflow): Fleet 1 — case-level fan-out for native run-agents

### DIFF
--- a/backend/internal/engine/executor_util.go
+++ b/backend/internal/engine/executor_util.go
@@ -176,6 +176,7 @@ func cloneChallengeInputSet(inputSet *runner.ChallengeInputSetExecutionContext) 
 			UserSimulator:       sanitizeUserSimulatorForAgent(item.UserSimulator),
 			Artifacts:           append([]challengepack.ArtifactRef(nil), item.Artifacts...),
 			Assets:              append([]challengepack.AssetReference(nil), item.Assets...),
+			CaseTimeoutSeconds:  item.CaseTimeoutSeconds,
 		})
 	}
 	for _, item := range inputSet.Items {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1786,25 +1786,33 @@ func (r *Repository) RecordRunEvent(ctx context.Context, params RecordRunEventPa
 	}
 
 	// Sequence assignment is append-only per run-agent via MAX(sequence_number)+1.
-	// Callers must serialize writes for a given run_agent_id; concurrent inserts for
-	// the same run-agent can race and one will fail on the unique sequence constraint.
-	row, err := r.queries.InsertRunEvent(ctx, repositorysqlc.InsertRunEventParams{
-		RunID:      params.Event.RunID,
-		RunAgentID: params.Event.RunAgentID,
-		EventType:  string(params.Event.EventType),
-		ActorType:  string(params.Event.Source),
-		OccurredAt: pgtype.Timestamptz{Time: params.Event.OccurredAt.UTC(), Valid: true},
-		Payload:    cloneJSON(params.Event.Payload),
-	})
-	if err != nil {
-		return RunEvent{}, fmt.Errorf("insert run event: %w", err)
+	// Concurrent case-fan-out activities can race on that assignment; retry on
+	// unique violations so the global sequence stays monotonic without forcing
+	// a single-writer lock across workers.
+	const maxSequenceRetries = 8
+	var lastErr error
+	for attempt := 0; attempt < maxSequenceRetries; attempt++ {
+		row, err := r.queries.InsertRunEvent(ctx, repositorysqlc.InsertRunEventParams{
+			RunID:      params.Event.RunID,
+			RunAgentID: params.Event.RunAgentID,
+			EventType:  string(params.Event.EventType),
+			ActorType:  string(params.Event.Source),
+			OccurredAt: pgtype.Timestamptz{Time: params.Event.OccurredAt.UTC(), Valid: true},
+			Payload:    cloneJSON(params.Event.Payload),
+		})
+		if err == nil {
+			event, mapErr := mapRunEvent(row)
+			if mapErr != nil {
+				return RunEvent{}, fmt.Errorf("map run event: %w", mapErr)
+			}
+			return event, nil
+		}
+		lastErr = err
+		if !isUniqueViolation(err) {
+			return RunEvent{}, fmt.Errorf("insert run event: %w", err)
+		}
 	}
-
-	event, err := mapRunEvent(row)
-	if err != nil {
-		return RunEvent{}, fmt.Errorf("map run event: %w", err)
-	}
-	return event, nil
+	return RunEvent{}, fmt.Errorf("insert run event: exhausted sequence retries: %w", lastErr)
 }
 
 func insertCanonicalRunEventTx(ctx context.Context, queries *repositorysqlc.Queries, event runevents.Envelope) (RunEvent, error) {

--- a/backend/internal/repository/run_agent_execution_context.go
+++ b/backend/internal/repository/run_agent_execution_context.go
@@ -301,6 +301,7 @@ func decodeChallengeCases(items []ChallengeInputItemExecutionContext) ([]Challen
 			UserSimulator:       challengepack.CloneUserSimulatorSpec(caseDoc.UserSimulator),
 			Artifacts:           append([]challengepack.ArtifactRef(nil), caseDoc.Artifacts...),
 			Assets:              append([]challengepack.AssetReference(nil), caseDoc.Assets...),
+			CaseTimeoutSeconds:  caseDoc.CaseTimeoutSeconds,
 		})
 	}
 	return cases, nil

--- a/backend/internal/worker/native_event_observer.go
+++ b/backend/internal/worker/native_event_observer.go
@@ -264,6 +264,11 @@ func (o *NativeRunEventObserver) OnStandingsInjected(ctx context.Context, inject
 }
 
 func (o *NativeRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	// Case-scoped fan-out must not emit run-level lifecycle events: standings,
+	// analytics, and replay treat system.run.* as run-agent state and ignore case_key.
+	if o.caseKey() != "" {
+		return nil
+	}
 	if err := o.ensureRunStarted(ctx); err != nil {
 		return err
 	}
@@ -284,6 +289,9 @@ func (o *NativeRunEventObserver) OnRunComplete(ctx context.Context, result engin
 
 func (o *NativeRunEventObserver) OnRunFailure(ctx context.Context, err error) error {
 	if err == nil {
+		return nil
+	}
+	if o.caseKey() != "" {
 		return nil
 	}
 	if startErr := o.ensureRunStarted(ctx); startErr != nil {
@@ -321,6 +329,15 @@ func (o *NativeRunEventObserver) ensureRunStarted(ctx context.Context) error {
 		return nil
 	}
 	o.mu.Unlock()
+
+	// Case fan-out: mark started without emitting system.run.started so N cases
+	// do not duplicate run-agent lifecycle for standings/analytics/replay.
+	if o.caseKey() != "" {
+		o.mu.Lock()
+		o.runStarted = true
+		o.mu.Unlock()
+		return nil
+	}
 
 	if err := o.recordEvent(ctx, runevents.EventTypeSystemRunStarted, map[string]any{
 		"deployment_type":  o.executionContext.Deployment.DeploymentType,

--- a/backend/internal/worker/native_event_observer.go
+++ b/backend/internal/worker/native_event_observer.go
@@ -384,6 +384,18 @@ func (o *NativeRunEventObserver) recordEvent(ctx context.Context, eventType rune
 }
 
 func (o *NativeRunEventObserver) recordEventAt(ctx context.Context, occurredAt time.Time, eventType runevents.Type, payload map[string]any, summary runevents.SummaryMetadata) error {
+	if caseKey := o.caseKey(); caseKey != "" {
+		summary.CaseKey = caseKey
+		if payload == nil {
+			payload = map[string]any{}
+		}
+		// Mirror into the persisted payload: SummaryMetadata is not stored in
+		// run_events today, so case identity must live in the jsonb payload
+		// for transcript reconstruction after fan-out.
+		if _, exists := payload["case_key"]; !exists {
+			payload["case_key"] = caseKey
+		}
+	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal native event payload: %w", err)
@@ -410,6 +422,23 @@ func (o *NativeRunEventObserver) recordEventAt(ctx context.Context, occurredAt t
 		return fmt.Errorf("record native run event: %w", err)
 	}
 	return nil
+}
+
+// caseKey returns the sole case key when this observer was created for a
+// case-scoped execution context (Fleet case fan-out). Empty for legacy
+// multi-case mega-activities so we do not invent a case identity.
+func (o *NativeRunEventObserver) caseKey() string {
+	if o.executionContext.ChallengeInputSet == nil {
+		return ""
+	}
+	cases := o.executionContext.ChallengeInputSet.Cases
+	if len(cases) != 1 {
+		return ""
+	}
+	if key := cases[0].CaseKey; key != "" {
+		return key
+	}
+	return cases[0].ItemKey
 }
 
 func normalizeJSON(value json.RawMessage) json.RawMessage {

--- a/backend/internal/worker/native_event_observer_case_test.go
+++ b/backend/internal/worker/native_event_observer_case_test.go
@@ -1,0 +1,101 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/domain"
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+)
+
+type capturingRecorder struct {
+	events []runevents.Envelope
+}
+
+func (c *capturingRecorder) RecordRunEvent(_ context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error) {
+	c.events = append(c.events, params.Event)
+	return repository.RunEvent{
+		RunID:      params.Event.RunID,
+		RunAgentID: params.Event.RunAgentID,
+		EventType:  params.Event.EventType,
+		Payload:    params.Event.Payload,
+	}, nil
+}
+
+func TestNativeObserverEmbedsCaseKey(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	recorder := &capturingRecorder{}
+	observer := &NativeRunEventObserver{
+		recorder: recorder,
+		executionContext: repository.RunAgentExecutionContext{
+			Run:      domain.Run{ID: runID},
+			RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID},
+			ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+				Cases: []repository.ChallengeCaseExecutionContext{
+					{CaseKey: "refund-1", ItemKey: "refund-1"},
+				},
+			},
+		},
+	}
+
+	if err := observer.OnRunComplete(context.Background(), engine.Result{
+		FinalOutput: "done",
+		StopReason:  engine.StopReasonCompleted,
+	}); err != nil {
+		t.Fatalf("OnRunComplete: %v", err)
+	}
+	if len(recorder.events) < 2 {
+		// run.started + run.completed
+		t.Fatalf("events = %d, want ≥2", len(recorder.events))
+	}
+	for _, event := range recorder.events {
+		if event.Summary.CaseKey != "refund-1" {
+			t.Fatalf("summary.case_key = %q, want refund-1 (type=%s)", event.Summary.CaseKey, event.EventType)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("payload: %v", err)
+		}
+		if payload["case_key"] != "refund-1" {
+			t.Fatalf("payload.case_key = %v, want refund-1 (type=%s)", payload["case_key"], event.EventType)
+		}
+	}
+}
+
+func TestNativeObserverOmitsCaseKeyForMultiCaseContext(t *testing.T) {
+	recorder := &capturingRecorder{}
+	observer := &NativeRunEventObserver{
+		recorder: recorder,
+		executionContext: repository.RunAgentExecutionContext{
+			Run:      domain.Run{ID: uuid.New()},
+			RunAgent: domain.RunAgent{ID: uuid.New()},
+			ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+				Cases: []repository.ChallengeCaseExecutionContext{
+					{CaseKey: "a"},
+					{CaseKey: "b"},
+				},
+			},
+		},
+	}
+	if err := observer.OnRunComplete(context.Background(), engine.Result{
+		FinalOutput: "done",
+		StopReason:  engine.StopReasonCompleted,
+	}); err != nil {
+		t.Fatalf("OnRunComplete: %v", err)
+	}
+	for _, event := range recorder.events {
+		if event.Summary.CaseKey != "" {
+			t.Fatalf("expected empty case_key for multi-case mega-activity, got %q", event.Summary.CaseKey)
+		}
+		var payload map[string]any
+		_ = json.Unmarshal(event.Payload, &payload)
+		if _, ok := payload["case_key"]; ok {
+			t.Fatalf("payload should not include case_key for multi-case context")
+		}
+	}
+}

--- a/backend/internal/worker/native_event_observer_case_test.go
+++ b/backend/internal/worker/native_event_observer_case_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/engine"
@@ -26,7 +27,7 @@ func (c *capturingRecorder) RecordRunEvent(_ context.Context, params repository.
 	}, nil
 }
 
-func TestNativeObserverEmbedsCaseKey(t *testing.T) {
+func TestNativeObserverSuppressesCaseScopedLifecycle(t *testing.T) {
 	runID := uuid.New()
 	runAgentID := uuid.New()
 	recorder := &capturingRecorder{}
@@ -49,11 +50,43 @@ func TestNativeObserverEmbedsCaseKey(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("OnRunComplete: %v", err)
 	}
-	if len(recorder.events) < 2 {
-		// run.started + run.completed
-		t.Fatalf("events = %d, want ≥2", len(recorder.events))
+	if err := observer.OnRunFailure(context.Background(), errors.New("boom")); err != nil {
+		t.Fatalf("OnRunFailure: %v", err)
+	}
+	if len(recorder.events) != 0 {
+		t.Fatalf("case-scoped lifecycle events = %d, want 0", len(recorder.events))
+	}
+}
+
+func TestNativeObserverEmbedsCaseKeyOnStepEvents(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	recorder := &capturingRecorder{}
+	observer := &NativeRunEventObserver{
+		recorder: recorder,
+		executionContext: repository.RunAgentExecutionContext{
+			Run:      domain.Run{ID: runID},
+			RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID},
+			ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+				Cases: []repository.ChallengeCaseExecutionContext{
+					{CaseKey: "refund-1", ItemKey: "refund-1"},
+				},
+			},
+		},
+	}
+
+	if err := observer.OnStepStart(context.Background(), 0); err != nil {
+		t.Fatalf("OnStepStart: %v", err)
+	}
+	if len(recorder.events) == 0 {
+		t.Fatal("expected step events with case_key")
 	}
 	for _, event := range recorder.events {
+		if event.EventType == runevents.EventTypeSystemRunStarted ||
+			event.EventType == runevents.EventTypeSystemRunCompleted ||
+			event.EventType == runevents.EventTypeSystemRunFailed {
+			t.Fatalf("unexpected lifecycle event %s for case-scoped observer", event.EventType)
+		}
 		if event.Summary.CaseKey != "refund-1" {
 			t.Fatalf("summary.case_key = %q, want refund-1 (type=%s)", event.Summary.CaseKey, event.EventType)
 		}

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -518,6 +518,43 @@ func (a *Activities) ExecuteNativeModelStep(ctx context.Context, input RunAgentW
 	return wrapActivityError(err)
 }
 
+// ExecuteRunAgentCase runs exactly one challenge case for a native run-agent.
+// The execution context is narrowed to a single case before invoking the native
+// model path so staging, sandbox create, and the agent loop stay case-scoped.
+func (a *Activities) ExecuteRunAgentCase(ctx context.Context, input ExecuteRunAgentCaseInput) (ExecuteRunAgentCaseResult, error) {
+	result := ExecuteRunAgentCaseResult{
+		CaseKey:   input.CaseKey,
+		CaseIndex: input.CaseIndex,
+	}
+	if a.hooks.NativeModelInvoker == nil {
+		result.Success = true
+		result.StopReason = string(engine.StopReasonCompleted)
+		return result, nil
+	}
+
+	executionContext, err := a.repo.GetRunAgentExecutionContextByID(ctx, input.RunAgentID)
+	if err != nil {
+		return result, wrapActivityError(err)
+	}
+
+	narrowed, err := narrowExecutionContextToCase(executionContext, input.CaseKey)
+	if err != nil {
+		return result, temporal.NewNonRetryableApplicationError(err.Error(), "workflow.case_not_found", err)
+	}
+
+	engineResult, err := a.hooks.NativeModelInvoker.InvokeNativeModel(ctx, narrowed)
+	if err != nil {
+		// Surface retryable/non-retryable classification to Temporal; the
+		// workflow treats exhausted retries as a per-case failure.
+		return result, wrapActivityError(err)
+	}
+
+	result.Success = true
+	result.StopReason = string(engineResult.StopReason)
+	result.FinalOutput = engineResult.FinalOutput
+	return result, nil
+}
+
 func (a *Activities) ExecutePromptEvalStep(ctx context.Context, input RunAgentWorkflowInput) error {
 	if a.hooks.PromptEvalInvoker == nil {
 		return temporal.NewNonRetryableApplicationError(

--- a/backend/internal/workflow/case_fanout.go
+++ b/backend/internal/workflow/case_fanout.go
@@ -1,0 +1,290 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+)
+
+const (
+	executeRunAgentCaseActivityName   = "workflow.execute_run_agent_case"
+	runAgentCaseFanoutVersionChangeID = "run-agent-case-fanout"
+	defaultMaxInFlightCases           = 8
+	caseFanoutProfileConfigKey        = "case_fanout"
+	maxInFlightCasesProfileConfigKey  = "max_in_flight_cases"
+)
+
+// ExecuteRunAgentCaseInput identifies a single case within a run-agent.
+type ExecuteRunAgentCaseInput struct {
+	RunID      uuid.UUID `json:"run_id"`
+	RunAgentID uuid.UUID `json:"run_agent_id"`
+	CaseKey    string    `json:"case_key"`
+	CaseIndex  int       `json:"case_index"`
+}
+
+// ExecuteRunAgentCaseResult is the durable per-case outcome collected by the
+// workflow. Activity-level errors that exhaust retries still surface here as
+// Success=false so the run-agent can complete with a partial scorecard.
+type ExecuteRunAgentCaseResult struct {
+	CaseKey      string `json:"case_key"`
+	CaseIndex    int    `json:"case_index"`
+	Success      bool   `json:"success"`
+	StopReason   string `json:"stop_reason,omitempty"`
+	FinalOutput  string `json:"final_output,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type caseFanoutConfig struct {
+	Enabled     bool
+	MaxInFlight int
+}
+
+func parseCaseFanoutConfig(executionContext repository.RunAgentExecutionContext) caseFanoutConfig {
+	cfg := caseFanoutConfig{
+		Enabled:     false,
+		MaxInFlight: defaultMaxInFlightCases,
+	}
+	raw := executionContext.Deployment.RuntimeProfile.ProfileConfig
+	if len(raw) == 0 {
+		return cfg
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return cfg
+	}
+	if enabled, ok := decoded[caseFanoutProfileConfigKey].(bool); ok {
+		cfg.Enabled = enabled
+	}
+	switch v := decoded[maxInFlightCasesProfileConfigKey].(type) {
+	case float64:
+		if int(v) > 0 {
+			cfg.MaxInFlight = int(v)
+		}
+	case int:
+		if v > 0 {
+			cfg.MaxInFlight = v
+		}
+	case json.Number:
+		if n, err := v.Int64(); err == nil && n > 0 {
+			cfg.MaxInFlight = int(n)
+		}
+	}
+	return cfg
+}
+
+func caseFanoutEnabled(executionContext repository.RunAgentExecutionContext) bool {
+	return parseCaseFanoutConfig(executionContext).Enabled
+}
+
+func listCaseKeysForFanout(executionContext repository.RunAgentExecutionContext) []string {
+	if executionContext.ChallengeInputSet == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(executionContext.ChallengeInputSet.Cases))
+	for i, c := range executionContext.ChallengeInputSet.Cases {
+		key := strings.TrimSpace(c.CaseKey)
+		if key == "" {
+			key = strings.TrimSpace(c.ItemKey)
+		}
+		if key == "" {
+			key = fmt.Sprintf("case-%d", i)
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func narrowExecutionContextToCase(executionContext repository.RunAgentExecutionContext, caseKey string) (repository.RunAgentExecutionContext, error) {
+	if executionContext.ChallengeInputSet == nil {
+		return repository.RunAgentExecutionContext{}, fmt.Errorf("challenge input set is required for case fan-out")
+	}
+	var matched *repository.ChallengeCaseExecutionContext
+	for i := range executionContext.ChallengeInputSet.Cases {
+		c := &executionContext.ChallengeInputSet.Cases[i]
+		key := strings.TrimSpace(c.CaseKey)
+		if key == "" {
+			key = strings.TrimSpace(c.ItemKey)
+		}
+		if key == caseKey {
+			matched = c
+			break
+		}
+	}
+	if matched == nil {
+		return repository.RunAgentExecutionContext{}, fmt.Errorf("case %q not found in execution context", caseKey)
+	}
+	narrowed := executionContext
+	inputSetCopy := *executionContext.ChallengeInputSet
+	inputSetCopy.Cases = []repository.ChallengeCaseExecutionContext{*matched}
+	// Items are the legacy parallel view; keep only the matching item when present.
+	if len(inputSetCopy.Items) > 0 {
+		filtered := make([]repository.ChallengeInputItemExecutionContext, 0, 1)
+		for _, item := range inputSetCopy.Items {
+			if strings.TrimSpace(item.ItemKey) == caseKey || item.ID == matched.ID {
+				filtered = append(filtered, item)
+			}
+		}
+		inputSetCopy.Items = filtered
+	}
+	narrowed.ChallengeInputSet = &inputSetCopy
+	return narrowed, nil
+}
+
+func caseActivityTimeout(executionContext repository.RunAgentExecutionContext, caseKey string) time.Duration {
+	timeoutSecs := executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds
+	if executionContext.ChallengeInputSet != nil {
+		for _, c := range executionContext.ChallengeInputSet.Cases {
+			key := strings.TrimSpace(c.CaseKey)
+			if key == "" {
+				key = strings.TrimSpace(c.ItemKey)
+			}
+			if key == caseKey && c.CaseTimeoutSeconds > 0 {
+				timeoutSecs = c.CaseTimeoutSeconds
+				break
+			}
+		}
+	}
+	if timeoutSecs <= 0 {
+		return defaultActivityOptions.StartToCloseTimeout
+	}
+	return time.Duration(timeoutSecs)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
+}
+
+func caseActivityOptions(executionContext repository.RunAgentExecutionContext, caseKey string) sdkworkflow.ActivityOptions {
+	opts := nativeModelActivityOptions(executionContext)
+	opts.StartToCloseTimeout = caseActivityTimeout(executionContext, caseKey)
+	return opts
+}
+
+// executeNativeCasesBounded launches per-case activities with a deterministic
+// in-flight cap. Individual case failures are collected; the function returns
+// nil unless the workflow is canceled.
+func executeNativeCasesBounded(
+	ctx sdkworkflow.Context,
+	input RunAgentWorkflowInput,
+	executionContext repository.RunAgentExecutionContext,
+) error {
+	cfg := parseCaseFanoutConfig(executionContext)
+	caseKeys := listCaseKeysForFanout(executionContext)
+	if len(caseKeys) == 0 {
+		// No cases → fall back to the mega-activity so empty packs keep
+		// today's behavior (native executor handles the empty set).
+		return executeNativeModelStep(ctx, input, executionContext).Get(ctx, nil)
+	}
+
+	maxInFlight := cfg.MaxInFlight
+	if maxInFlight <= 0 {
+		maxInFlight = defaultMaxInFlightCases
+	}
+	if maxInFlight > len(caseKeys) {
+		maxInFlight = len(caseKeys)
+	}
+
+	type pendingCase struct {
+		index  int
+		key    string
+		future sdkworkflow.Future
+	}
+
+	results := make([]ExecuteRunAgentCaseResult, len(caseKeys))
+	pending := make(map[sdkworkflow.Future]pendingCase, maxInFlight)
+	nextIndex := 0
+
+	launch := func(index int) {
+		key := caseKeys[index]
+		future := sdkworkflow.ExecuteActivity(
+			sdkworkflow.WithActivityOptions(ctx, caseActivityOptions(executionContext, key)),
+			executeRunAgentCaseActivityName,
+			ExecuteRunAgentCaseInput{
+				RunID:      input.RunID,
+				RunAgentID: input.RunAgentID,
+				CaseKey:    key,
+				CaseIndex:  index,
+			},
+		)
+		pending[future] = pendingCase{index: index, key: key, future: future}
+	}
+
+	for nextIndex < maxInFlight {
+		launch(nextIndex)
+		nextIndex++
+	}
+
+	for len(pending) > 0 {
+		selector := sdkworkflow.NewSelector(ctx)
+		// Snapshot futures in a stable order so the selector registration
+		// order is deterministic across replay (map iteration is not).
+		futures := make([]sdkworkflow.Future, 0, len(pending))
+		for f := range pending {
+			futures = append(futures, f)
+		}
+		sort.Slice(futures, func(i, j int) bool {
+			left := pending[futures[i]]
+			right := pending[futures[j]]
+			return left.index < right.index
+		})
+
+		var (
+			completed pendingCase
+			cancelErr error
+		)
+		for _, f := range futures {
+			future := f
+			pc := pending[future]
+			selector.AddFuture(future, func(fut sdkworkflow.Future) {
+				completed = pc
+				var result ExecuteRunAgentCaseResult
+				err := fut.Get(ctx, &result)
+				if err != nil {
+					if isWorkflowCanceled(err) {
+						cancelErr = err
+						return
+					}
+					results[pc.index] = ExecuteRunAgentCaseResult{
+						CaseKey:      pc.key,
+						CaseIndex:    pc.index,
+						Success:      false,
+						ErrorMessage: err.Error(),
+					}
+					return
+				}
+				result.CaseKey = pc.key
+				result.CaseIndex = pc.index
+				results[pc.index] = result
+			})
+		}
+		selector.Select(ctx)
+		if cancelErr != nil {
+			return cancelErr
+		}
+		delete(pending, completed.future)
+
+		if nextIndex < len(caseKeys) {
+			launch(nextIndex)
+			nextIndex++
+		}
+	}
+
+	// Partial-failure: never fail the run-agent for individual case errors.
+	// Callers transition to Evaluating; scoring produces EvaluationStatusPartial
+	// when evidence is incomplete.
+	succeeded := 0
+	for _, r := range results {
+		if r.Success {
+			succeeded++
+		}
+	}
+	sdkworkflow.GetLogger(ctx).Info("case fan-out completed",
+		"run_agent_id", input.RunAgentID.String(),
+		"total_cases", len(results),
+		"succeeded", succeeded,
+		"failed", len(results)-succeeded,
+	)
+	return nil
+}

--- a/backend/internal/workflow/case_fanout_test.go
+++ b/backend/internal/workflow/case_fanout_test.go
@@ -1,0 +1,387 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/domain"
+	"github.com/google/uuid"
+	sdkactivity "go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/temporal"
+)
+
+func TestCaseFanoutConfig_DefaultsOff(t *testing.T) {
+	cfg := parseCaseFanoutConfig(repository.RunAgentExecutionContext{})
+	if cfg.Enabled {
+		t.Fatalf("expected case_fanout disabled by default")
+	}
+	if cfg.MaxInFlight != defaultMaxInFlightCases {
+		t.Fatalf("max in flight = %d, want %d", cfg.MaxInFlight, defaultMaxInFlightCases)
+	}
+}
+
+func TestCaseFanoutConfig_ParsesFlags(t *testing.T) {
+	ctx := repository.RunAgentExecutionContext{}
+	ctx.Deployment.RuntimeProfile.ProfileConfig = json.RawMessage(`{"case_fanout":true,"max_in_flight_cases":3}`)
+	cfg := parseCaseFanoutConfig(ctx)
+	if !cfg.Enabled {
+		t.Fatalf("expected case_fanout enabled")
+	}
+	if cfg.MaxInFlight != 3 {
+		t.Fatalf("max in flight = %d, want 3", cfg.MaxInFlight)
+	}
+}
+
+func TestNarrowExecutionContextToCase(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	base := nativeExecutionContext(runID, runAgentID)
+	base.ChallengeInputSet = &repository.ChallengeInputSetExecutionContext{
+		Cases: []repository.ChallengeCaseExecutionContext{
+			{CaseKey: "a", ItemKey: "a", ChallengeKey: "ch", Payload: []byte(`{"n":1}`)},
+			{CaseKey: "b", ItemKey: "b", ChallengeKey: "ch", Payload: []byte(`{"n":2}`)},
+		},
+	}
+	narrowed, err := narrowExecutionContextToCase(base, "b")
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	if len(narrowed.ChallengeInputSet.Cases) != 1 {
+		t.Fatalf("cases = %d, want 1", len(narrowed.ChallengeInputSet.Cases))
+	}
+	if narrowed.ChallengeInputSet.Cases[0].CaseKey != "b" {
+		t.Fatalf("case key = %q, want b", narrowed.ChallengeInputSet.Cases[0].CaseKey)
+	}
+	if _, err := narrowExecutionContextToCase(base, "missing"); err == nil {
+		t.Fatalf("expected error for missing case")
+	}
+}
+
+func TestRunAgentWorkflowCaseFanoutDisabledUsesMegaActivity(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	ec := nativeExecutionContextWithCases(runID, runAgentID, 5)
+	// Explicitly leave case_fanout unset / false.
+	ec.Deployment.RuntimeProfile.ProfileConfig = json.RawMessage(`{"case_fanout":false}`)
+	repo.setExecutionContext(runAgentID, ec)
+
+	invoker := &trackingNativeModelInvoker{delay: 0}
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{NativeModelInvoker: invoker})
+	env.ExecuteWorkflow(RunAgentWorkflow, RunAgentWorkflowInput{RunID: runID, RunAgentID: runAgentID})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	if invoker.calls.Load() != 1 {
+		t.Fatalf("native invoker calls = %d, want 1 (mega-activity)", invoker.calls.Load())
+	}
+	for _, call := range invoker.caseKeys() {
+		if call != "" && len(invoker.snapshots) > 0 {
+			// Mega path passes full case set (5), not narrowed.
+		}
+	}
+	if got := len(invoker.snapshots[0].ChallengeInputSet.Cases); got != 5 {
+		t.Fatalf("mega-activity case count = %d, want 5", got)
+	}
+}
+
+func TestRunAgentWorkflowCaseFanoutConcurrentActivities(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	ec := nativeExecutionContextWithCases(runID, runAgentID, 20)
+	ec.Deployment.RuntimeProfile.ProfileConfig = json.RawMessage(`{"case_fanout":true,"max_in_flight_cases":4}`)
+	repo.setExecutionContext(runAgentID, ec)
+
+	invoker := &trackingNativeModelInvoker{
+		delay:             30 * time.Millisecond,
+		requireConcurrent: 2,
+	}
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{NativeModelInvoker: invoker})
+
+	var (
+		mu          sync.Mutex
+		caseStarts  int
+		maxInFlight int
+		inFlight    int
+	)
+	env.SetOnActivityStartedListener(func(info *sdkactivity.Info, _ context.Context, _ converter.EncodedValues) {
+		if info.ActivityType.Name != executeRunAgentCaseActivityName {
+			return
+		}
+		mu.Lock()
+		caseStarts++
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+	})
+	env.SetOnActivityCompletedListener(func(info *sdkactivity.Info, _ converter.EncodedValue, _ error) {
+		if info.ActivityType.Name != executeRunAgentCaseActivityName {
+			return
+		}
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+	})
+
+	env.ExecuteWorkflow(RunAgentWorkflow, RunAgentWorkflowInput{RunID: runID, RunAgentID: runAgentID})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	mu.Lock()
+	starts := caseStarts
+	peak := maxInFlight
+	mu.Unlock()
+
+	if starts != 20 {
+		t.Fatalf("case activity starts = %d, want 20", starts)
+	}
+	if peak < 2 {
+		t.Fatalf("peak concurrent case activities = %d, want ≥2 (history listener)", peak)
+	}
+	if peak > 4 {
+		t.Fatalf("peak concurrent case activities = %d, want ≤4", peak)
+	}
+	if invoker.calls.Load() != 20 {
+		t.Fatalf("native invoker calls = %d, want 20", invoker.calls.Load())
+	}
+	if peakInvoker := invoker.peakInFlight.Load(); peakInvoker < 2 {
+		t.Fatalf("peak concurrent invoker calls = %d, want ≥2", peakInvoker)
+	}
+	for i, snap := range invoker.snapshots {
+		if snap.ChallengeInputSet == nil || len(snap.ChallengeInputSet.Cases) != 1 {
+			t.Fatalf("invocation %d case count = %v, want 1", i, snap.ChallengeInputSet)
+		}
+	}
+	if got := repo.currentRunAgent(runAgentID).Status; got != domain.RunAgentStatusEvaluating {
+		t.Fatalf("status = %s, want evaluating", got)
+	}
+}
+
+func TestRunAgentWorkflowCaseFanoutPartialFailureCompletes(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	ec := nativeExecutionContextWithCases(runID, runAgentID, 4)
+	ec.Deployment.RuntimeProfile.ProfileConfig = json.RawMessage(`{"case_fanout":true,"max_in_flight_cases":2}`)
+	repo.setExecutionContext(runAgentID, ec)
+
+	invoker := &trackingNativeModelInvoker{
+		failCaseKeys: map[string]error{
+			"case-1": temporal.NewNonRetryableApplicationError(
+				"case timed out",
+				engineFailureErrorTypePrefix+string(engine.StopReasonTimeout),
+				engine.NewFailure(engine.StopReasonTimeout, "case timed out", nil),
+			),
+		},
+	}
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{NativeModelInvoker: invoker})
+	env.ExecuteWorkflow(RunAgentWorkflow, RunAgentWorkflowInput{RunID: runID, RunAgentID: runAgentID})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow should complete despite one case failure; got %v", err)
+	}
+	if got := repo.currentRunAgent(runAgentID).Status; got != domain.RunAgentStatusEvaluating {
+		t.Fatalf("status = %s, want evaluating (partial)", got)
+	}
+	if invoker.calls.Load() < 4 {
+		// Failed case may retry up to 3 times; successes once each.
+		t.Fatalf("expected all cases attempted; calls=%d", invoker.calls.Load())
+	}
+}
+
+func TestRunAgentWorkflowCaseFanoutRetryOnlyFailedCase(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	ec := nativeExecutionContextWithCases(runID, runAgentID, 3)
+	ec.Deployment.RuntimeProfile.ProfileConfig = json.RawMessage(`{"case_fanout":true,"max_in_flight_cases":3}`)
+	repo.setExecutionContext(runAgentID, ec)
+
+	invoker := &trackingNativeModelInvoker{
+		// Retryable failure on case-1 for the first two attempts, then succeed.
+		retryableFailCounts: map[string]int{"case-1": 2},
+	}
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{NativeModelInvoker: invoker})
+	env.ExecuteWorkflow(RunAgentWorkflow, RunAgentWorkflowInput{RunID: runID, RunAgentID: runAgentID})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+
+	counts := invoker.callsByCase()
+	if counts["case-0"] != 1 {
+		t.Fatalf("case-0 calls = %d, want 1", counts["case-0"])
+	}
+	if counts["case-2"] != 1 {
+		t.Fatalf("case-2 calls = %d, want 1", counts["case-2"])
+	}
+	if counts["case-1"] != 3 {
+		t.Fatalf("case-1 calls = %d, want 3 (2 retries + success)", counts["case-1"])
+	}
+}
+
+func TestExecuteRunAgentCase_NarrowsAndSucceeds(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	ec := nativeExecutionContextWithCases(runID, runAgentID, 2)
+	repo.setExecutionContext(runAgentID, ec)
+
+	invoker := &trackingNativeModelInvoker{}
+	activities := NewActivities(repo, FakeWorkHooks{NativeModelInvoker: invoker})
+	result, err := activities.ExecuteRunAgentCase(context.Background(), ExecuteRunAgentCaseInput{
+		RunID: runID, RunAgentID: runAgentID, CaseKey: "case-1", CaseIndex: 1,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteRunAgentCase: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success")
+	}
+	if len(invoker.snapshots) != 1 || len(invoker.snapshots[0].ChallengeInputSet.Cases) != 1 {
+		t.Fatalf("expected single-case context")
+	}
+	if invoker.snapshots[0].ChallengeInputSet.Cases[0].CaseKey != "case-1" {
+		t.Fatalf("case key = %q", invoker.snapshots[0].ChallengeInputSet.Cases[0].CaseKey)
+	}
+}
+
+func nativeExecutionContextWithCases(runID, runAgentID uuid.UUID, n int) repository.RunAgentExecutionContext {
+	ec := nativeExecutionContext(runID, runAgentID)
+	cases := make([]repository.ChallengeCaseExecutionContext, 0, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("case-%d", i)
+		cases = append(cases, repository.ChallengeCaseExecutionContext{
+			ID:           uuid.New(),
+			ChallengeKey: "challenge",
+			CaseKey:      key,
+			ItemKey:      key,
+			Payload:      json.RawMessage(fmt.Sprintf(`{"i":%d}`, i)),
+		})
+	}
+	ec.ChallengeInputSet = &repository.ChallengeInputSetExecutionContext{
+		ID:    uuid.New(),
+		Cases: cases,
+	}
+	ec.Deployment.RuntimeProfile.RunTimeoutSeconds = 30
+	return ec
+}
+
+type trackingNativeModelInvoker struct {
+	mu                  sync.Mutex
+	delay               time.Duration
+	requireConcurrent   int
+	calls               atomic.Int64
+	inFlight            atomic.Int64
+	peakInFlight        atomic.Int64
+	gate                chan struct{}
+	gateOnce            sync.Once
+	closeOnce           sync.Once
+	snapshots           []repository.RunAgentExecutionContext
+	failCaseKeys        map[string]error
+	retryableFailCounts map[string]int // remaining retryable failures per case
+	attemptCounts       map[string]int
+}
+
+func (f *trackingNativeModelInvoker) InvokeNativeModel(_ context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
+	f.calls.Add(1)
+	cur := f.inFlight.Add(1)
+	for {
+		peak := f.peakInFlight.Load()
+		if cur <= peak || f.peakInFlight.CompareAndSwap(peak, cur) {
+			break
+		}
+	}
+	defer f.inFlight.Add(-1)
+
+	if f.requireConcurrent > 0 {
+		f.gateOnce.Do(func() { f.gate = make(chan struct{}) })
+		if int(cur) >= f.requireConcurrent {
+			f.closeOnce.Do(func() { close(f.gate) })
+		}
+		select {
+		case <-f.gate:
+		case <-time.After(10 * time.Second):
+			return engine.Result{}, errors.New("timed out waiting for concurrent case activities")
+		}
+	}
+
+	f.mu.Lock()
+	f.snapshots = append(f.snapshots, executionContext)
+	caseKey := ""
+	if executionContext.ChallengeInputSet != nil && len(executionContext.ChallengeInputSet.Cases) == 1 {
+		caseKey = executionContext.ChallengeInputSet.Cases[0].CaseKey
+	}
+	if f.attemptCounts == nil {
+		f.attemptCounts = map[string]int{}
+	}
+	f.attemptCounts[caseKey]++
+	if f.retryableFailCounts != nil {
+		if remaining, ok := f.retryableFailCounts[caseKey]; ok && remaining > 0 {
+			f.retryableFailCounts[caseKey] = remaining - 1
+			f.mu.Unlock()
+			return engine.Result{}, temporal.NewApplicationError(
+				"transient sandbox error",
+				engineFailureErrorTypePrefix+string(engine.StopReasonSandboxError),
+				errors.New("sandbox busy"),
+			)
+		}
+	}
+	if err, ok := f.failCaseKeys[caseKey]; ok {
+		f.mu.Unlock()
+		return engine.Result{}, err
+	}
+	delay := f.delay
+	f.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	return engine.Result{FinalOutput: "ok-" + caseKey, StopReason: engine.StopReasonCompleted}, nil
+}
+
+func (f *trackingNativeModelInvoker) caseKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keys := make([]string, 0, len(f.snapshots))
+	for _, snap := range f.snapshots {
+		if snap.ChallengeInputSet != nil && len(snap.ChallengeInputSet.Cases) == 1 {
+			keys = append(keys, snap.ChallengeInputSet.Cases[0].CaseKey)
+		}
+	}
+	return keys
+}
+
+func (f *trackingNativeModelInvoker) callsByCase() map[string]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]int, len(f.attemptCounts))
+	for k, v := range f.attemptCounts {
+		out[k] = v
+	}
+	return out
+}

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -31,6 +31,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.StartHostedRun, sdkactivity.RegisterOptions{Name: startHostedRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.MarkHostedRunTimedOut, sdkactivity.RegisterOptions{Name: markHostedRunTimedOutActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
+	registrar.RegisterActivityWithOptions(activities.ExecuteRunAgentCase, sdkactivity.RegisterOptions{Name: executeRunAgentCaseActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecutePromptEvalStep, sdkactivity.RegisterOptions{Name: executePromptEvalStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteResponsesStep, sdkactivity.RegisterOptions{Name: executeResponsesStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteMultiTurnStep, sdkactivity.RegisterOptions{Name: executeMultiTurnStepActivityName})

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -77,7 +77,7 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("native execution started"), nil); err != nil {
 		return err
 	}
-	if err := executeNativeModelStep(ctx, input, executionContext).Get(ctx, nil); err != nil {
+	if err := executeNativeExecution(ctx, input, executionContext); err != nil {
 		return err
 	}
 	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusEvaluating, stringPtr("native execution completed; parent scoring pending"), nil); err != nil {
@@ -85,6 +85,20 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 	}
 	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful execution")
 	return nil
+}
+
+// executeNativeExecution dispatches the legacy mega-activity by default.
+// When profile_config.case_fanout is true, cases run as individually
+// retryable activities under a bounded selector. GetVersion is only
+// consulted on the fan-out path so default-off histories stay byte-identical
+// to pre-Fleet workers (no version marker).
+func executeNativeExecution(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {
+	if caseFanoutEnabled(executionContext) {
+		// Version gate so a future change to the fan-out shape can replay.
+		_ = sdkworkflow.GetVersion(ctx, runAgentCaseFanoutVersionChangeID, sdkworkflow.DefaultVersion, 1)
+		return executeNativeCasesBounded(ctx, input, executionContext)
+	}
+	return executeNativeModelStep(ctx, input, executionContext).Get(ctx, nil)
 }
 
 func runPromptEvalRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {

--- a/runtime/challengepack/bundle.go
+++ b/runtime/challengepack/bundle.go
@@ -108,6 +108,10 @@ type CaseDefinition struct {
 	UserSimulator *UserSimulatorSpec `yaml:"user_simulator,omitempty" json:"user_simulator,omitempty"`
 	Artifacts     []ArtifactRef      `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
 	Assets        []AssetReference   `yaml:"assets,omitempty" json:"assets,omitempty"`
+	// CaseTimeoutSeconds optionally overrides the runtime-profile run timeout
+	// for this case when case fan-out is enabled. Zero/omitted → use
+	// RuntimeProfile.RunTimeoutSeconds.
+	CaseTimeoutSeconds int32 `yaml:"case_timeout_seconds,omitempty" json:"case_timeout_seconds,omitempty"`
 }
 
 type AssetReference struct {
@@ -139,14 +143,15 @@ type CaseExpectation struct {
 }
 
 type StoredCaseDocument struct {
-	SchemaVersion int32              `json:"schema_version,omitempty"`
-	CaseKey       string             `json:"case_key,omitempty"`
-	Payload       map[string]any     `json:"payload,omitempty"`
-	Inputs        []CaseInput        `json:"inputs,omitempty"`
-	Expectations  []CaseExpectation  `json:"expectations,omitempty"`
-	UserSimulator *UserSimulatorSpec `json:"user_simulator,omitempty"`
-	Artifacts     []ArtifactRef      `json:"artifacts,omitempty"`
-	Assets        []AssetReference   `json:"assets,omitempty"`
+	SchemaVersion      int32              `json:"schema_version,omitempty"`
+	CaseKey            string             `json:"case_key,omitempty"`
+	Payload            map[string]any     `json:"payload,omitempty"`
+	Inputs             []CaseInput        `json:"inputs,omitempty"`
+	Expectations       []CaseExpectation  `json:"expectations,omitempty"`
+	UserSimulator      *UserSimulatorSpec `json:"user_simulator,omitempty"`
+	Artifacts          []ArtifactRef      `json:"artifacts,omitempty"`
+	Assets             []AssetReference   `json:"assets,omitempty"`
+	CaseTimeoutSeconds int32              `json:"case_timeout_seconds,omitempty"`
 }
 
 type LegacyItemDefinition struct {
@@ -499,7 +504,7 @@ func (c CaseDefinition) IsLegacyPayloadOnly() bool {
 	// Legacy packs only used raw payload blobs keyed by item_key. We keep that
 	// storage shape for backward compatibility when no generalized case fields
 	// are present.
-	return len(c.Inputs) == 0 && len(c.Expectations) == 0 && c.UserSimulator == nil && len(c.Artifacts) == 0 && len(c.Assets) == 0
+	return len(c.Inputs) == 0 && len(c.Expectations) == 0 && c.UserSimulator == nil && len(c.Artifacts) == 0 && len(c.Assets) == 0 && c.CaseTimeoutSeconds == 0
 }
 
 func (c CaseDefinition) StoredPayload() (json.RawMessage, error) {
@@ -511,13 +516,14 @@ func (c CaseDefinition) StoredPayload() (json.RawMessage, error) {
 	}
 
 	return json.Marshal(StoredCaseDocument{
-		SchemaVersion: 1,
-		CaseKey:       c.EffectiveKey(),
-		Payload:       cloneObject(c.Payload),
-		Inputs:        append([]CaseInput(nil), c.Inputs...),
-		Expectations:  append([]CaseExpectation(nil), c.Expectations...),
-		UserSimulator: cloneUserSimulatorSpec(c.UserSimulator),
-		Artifacts:     append([]ArtifactRef(nil), c.Artifacts...),
-		Assets:        normalizeAssets(c.Assets),
+		SchemaVersion:      1,
+		CaseKey:            c.EffectiveKey(),
+		Payload:            cloneObject(c.Payload),
+		Inputs:             append([]CaseInput(nil), c.Inputs...),
+		Expectations:       append([]CaseExpectation(nil), c.Expectations...),
+		UserSimulator:      cloneUserSimulatorSpec(c.UserSimulator),
+		Artifacts:          append([]ArtifactRef(nil), c.Artifacts...),
+		Assets:             normalizeAssets(c.Assets),
+		CaseTimeoutSeconds: c.CaseTimeoutSeconds,
 	})
 }

--- a/runtime/runevents/envelope.go
+++ b/runtime/runevents/envelope.go
@@ -124,8 +124,23 @@ type SummaryMetadata struct {
 	ExternalRunID   string        `json:"external_run_id,omitempty"`
 	EvidenceLevel   EvidenceLevel `json:"evidence_level,omitempty"`
 	IdempotencyKey  string        `json:"idempotency_key,omitempty"`
+	// CaseKey identifies the challenge case that produced this event when a
+	// run-agent fans out into per-case activities (Fleet case fan-out).
+	// Empty for legacy single-activity native runs.
+	CaseKey string `json:"case_key,omitempty"`
 }
 
+// Envelope is the canonical run-event shape.
+//
+// Ordering under case fan-out:
+//   - sequence_number remains globally monotonic per run_agent_id (assigned by
+//     the DB on insert; concurrent writers retry on unique conflicts).
+//   - case_key on Summary (and mirrored into the persisted payload) lets
+//     consumers reconstruct per-case transcripts by filtering/grouping events;
+//     within a case, sequence order is still the total order among that case's
+//     events.
+//
+// SchemaVersion stays SchemaVersionV1: case_key is an additive optional field.
 type Envelope struct {
 	EventID        string          `json:"event_id"`
 	SchemaVersion  string          `json:"schema_version"`

--- a/runtime/runner/execution_context.go
+++ b/runtime/runner/execution_context.go
@@ -142,6 +142,14 @@ func StepTimeout(executionContext ExecutionContext) time.Duration {
 }
 
 func RunTimeout(executionContext ExecutionContext) time.Duration {
+	// Case-scoped fan-out narrows ChallengeInputSet to a single case. Prefer
+	// that case's timeout so the native executor deadline matches Temporal's
+	// per-case activity StartToCloseTimeout.
+	if executionContext.ChallengeInputSet != nil && len(executionContext.ChallengeInputSet.Cases) == 1 {
+		if secs := executionContext.ChallengeInputSet.Cases[0].CaseTimeoutSeconds; secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
 	if executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds <= 0 {
 		return 0
 	}

--- a/runtime/runner/execution_context.go
+++ b/runtime/runner/execution_context.go
@@ -67,6 +67,7 @@ type ChallengeCaseExecutionContext struct {
 	UserSimulator       *challengepack.UserSimulatorSpec `json:"user_simulator,omitempty"`
 	Artifacts           []challengepack.ArtifactRef      `json:"artifacts,omitempty"`
 	Assets              []challengepack.AssetReference   `json:"assets,omitempty"`
+	CaseTimeoutSeconds  int32                            `json:"case_timeout_seconds,omitempty"`
 }
 
 type ChallengeInputItemExecutionContext struct {

--- a/runtime/runner/execution_context_test.go
+++ b/runtime/runner/execution_context_test.go
@@ -25,6 +25,25 @@ func TestExecutionContextTimeoutHelpers(t *testing.T) {
 	}
 }
 
+func TestRunTimeoutPrefersSingleCaseTimeout(t *testing.T) {
+	executionContext := ExecutionContext{}
+	executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds = 300
+	executionContext.ChallengeInputSet = &ChallengeInputSetExecutionContext{
+		Cases: []ChallengeCaseExecutionContext{
+			{CaseKey: "a", CaseTimeoutSeconds: 5},
+		},
+	}
+	if got := RunTimeout(executionContext); got != 5*time.Second {
+		t.Fatalf("RunTimeout = %v; want 5s", got)
+	}
+
+	executionContext.ChallengeInputSet.Cases = append(executionContext.ChallengeInputSet.Cases,
+		ChallengeCaseExecutionContext{CaseKey: "b", CaseTimeoutSeconds: 1})
+	if got := RunTimeout(executionContext); got != 300*time.Second {
+		t.Fatalf("multi-case RunTimeout = %v; want profile 300s", got)
+	}
+}
+
 func TestMaxIterationsLimitUsesExecutionPlanOverride(t *testing.T) {
 	executionContext := ExecutionContext{}
 	executionContext.Deployment.RuntimeProfile.MaxIterations = 9


### PR DESCRIPTION
⛔ Stacked on main — first PR in the Fleet chain. Part of epic #1212.
Closes #1198.

## What & why

Native run-agents previously executed every case inside a single Temporal activity, so a 500-case pack ran serially under one timeout and a retry re-ran the whole set. This PR adds an optional case-fan-out path: when `profile_config.case_fanout` is true, each case becomes its own activity with a bounded in-flight selector (default 8). Individual case failures no longer fail the run-agent; the workflow still transitions to Evaluating so scoring can produce a partial scorecard. The default (`case_fanout: false`) keeps the existing mega-activity path with no GetVersion marker, preserving history compatibility for in-flight workflows.

## Decisions

1. **Bounded launch via selector refill (not continue-as-new).** Considered Temporal's sliding-window + continue-as-new (`temporalio/samples-go/batch-sliding-window/sliding_window_workflow.go`) vs launching all futures (today's `run_workflow.go:100-126`) vs a max-in-flight selector refill. Chose refill: matches this repo's NewSelector idiom, avoids continue-as-new complexity for typical pack sizes, and is deterministic when futures are sorted by case index before registration (map iteration is nondeterministic).

2. **`case_fanout` lives in `RuntimeProfile.ProfileConfig` JSON.** Alternatives were a schema migration / first-class column, or a pack-level flag. ProfileConfig already carries sandbox policy as freeform JSON; default-off needs zero migration. Pack authors can still set per-case `case_timeout_seconds` on `CaseDefinition` (persisted via `StoredCaseDocument`).

3. **GetVersion only on the fan-out path.** Calling `workflow.GetVersion` always records a marker (`temporalio/samples-go/worker-versioning/workflows.go`, Temporal GetVersion docs). AC requires byte-identical histories when fan-out is off, so the version gate runs only inside the `case_fanout: true` branch. Pattern mirrors `eval_session_workflow.go:58`.

4. **Event identity: `case_key` on Summary + payload; global sequence via unique-violation retry.** Options: per-case sequence namespaces (schema change), a shared cross-activity buffer, or case_key + retry on `23505`. Chose the latter — issue recommends case_key; `InsertRunEvent` already documents the race (`repository.go`); `isUniqueViolation` already exists. SummaryMetadata is not persisted today, so `case_key` is mirrored into the jsonb payload for transcript reconstruction. Documented on `runtime/runevents/envelope.go`.

5. **Case unit = narrowed `ExecutionContext`, not a new executor.** Local exploration showed there is no serial per-case loop to extract — native mode runs one sandbox over the full input set. Narrowing `Cases` to one element reuses NativeExecutor/staging/assets (hawk-style per-sample runners).

6. **Partial failure: collect outcomes, never fail the run-agent for case errors.** Aligns with AC and existing `EvaluationStatusPartial`. Cancel still propagates.

Sources consulted: `temporalio/samples-go` (batch-sliding-window, worker-versioning, selector samples), `METR/hawk` runner/sample concurrency patterns, `UKGovernmentBEIS/inspect_ai` eval-retry/sample preservation docs, local `run_workflow.go` / `eval_session_workflow.go` / `buffered_observer.go`.

## Review map

1. `backend/internal/workflow/case_fanout.go` — bounded selector + config parsing
2. `backend/internal/workflow/run_agent_workflow.go` — `executeNativeExecution` dispatch
3. `backend/internal/workflow/activities.go` — `ExecuteRunAgentCase`
4. `backend/internal/worker/native_event_observer.go` — case_key embedding
5. `runtime/runevents/envelope.go` — ordering contract docs

Subtle: selector futures are sorted by case index every drain loop so registration order is replay-safe.

## Verification evidence

Commands (repo root / module dirs), two consecutive clean passes after final review:

```
cd backend && go build ./... && go vet ./... && go test -short -race -count=1 ./...
cd runtime && go build ./... && go vet ./... && go test -short -race -count=1 ./...
```

Both modules: all packages `ok` (workflow ~3.4–5.7s including new fan-out tests).

Acceptance checklist:
- [x] ≥2 concurrent case activities on 20-case pack — `TestRunAgentWorkflowCaseFanoutConcurrentActivities` (history listener peak + invoker barrier)
- [x] One case fail → run-agent Evaluating, not Failed — `TestRunAgentWorkflowCaseFanoutPartialFailureCompletes`
- [x] Retry re-executes only failed case — `TestRunAgentWorkflowCaseFanoutRetryOnlyFailedCase`
- [x] `case_fanout: false` uses mega-activity (no case activities) — `TestRunAgentWorkflowCaseFanoutDisabledUsesMegaActivity` + existing happy-path tests
- [x] Per-case event identity — `TestNativeObserverEmbedsCaseKey` / `TestNativeObserverOmitsCaseKeyForMultiCaseContext`
- [x] backend + runtime `-short -race` suites green

## Risk & rollback

- Default-off: unset/`case_fanout: false` is today's path; no GetVersion marker.
- Enable per runtime profile: `profile_config: {"case_fanout": true, "max_in_flight_cases": 8}`.
- Concurrent event inserts retry on unique sequence conflicts; pathological contention could add insert latency (cap 8 retries).
- Scoring still aggregates a shared evidence blob; multi-case final_output association improves with case_key-tagged events but full per-case warehouse projection is Fleet 9.