### PR TITLE
feat(workflow): Fleet 2 — bounded fan-out, worker knobs, queue partitioning

### DIFF
--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -123,7 +123,7 @@ func (s TemporalPublicAgentTryoutExecutionWorkflowStarter) StartPublicAgentTryou
 	workflowID := fmt.Sprintf("%s/%s", workflow.PublicAgentTryoutExecutionWorkflowName, tryoutID)
 	run, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
-		TaskQueue: workflow.WorkflowTaskQueue,
+		TaskQueue: workflow.TaskQueueBackground,
 	}, workflow.PublicAgentTryoutExecutionWorkflowName, workflow.PublicAgentTryoutExecutionWorkflowInput{
 		TryoutID: tryoutID,
 	})
@@ -145,7 +145,7 @@ func (s TemporalSyntheticDatasetGenerationWorkflowStarter) StartSyntheticDataset
 	workflowID := fmt.Sprintf("%s/%s", workflow.SyntheticDatasetGenerationWorkflowName, jobID)
 	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
-		TaskQueue: workflow.WorkflowTaskQueue,
+		TaskQueue: workflow.TaskQueueBackground,
 	}, workflow.SyntheticDatasetGenerationWorkflowName, workflow.SyntheticDatasetGenerationWorkflowInput{
 		JobID: jobID,
 	})

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -168,3 +168,23 @@ func (f *fakeRunTemporalIDRepository) SetRunTemporalIDs(_ context.Context, param
 	f.params = params
 	return domain.Run{ID: params.RunID}, f.err
 }
+
+func TestTemporalBackgroundWorkflowsUseBackgroundQueue(t *testing.T) {
+	tryoutID := uuid.New()
+	client := &fakeTemporalClient{}
+	if _, err := NewTemporalPublicAgentTryoutExecutionWorkflowStarter(client).StartPublicAgentTryoutExecutionWorkflow(context.Background(), tryoutID); err != nil {
+		t.Fatalf("tryout start: %v", err)
+	}
+	if client.options.TaskQueue != workflow.TaskQueueBackground {
+		t.Fatalf("tryout queue = %q, want %q", client.options.TaskQueue, workflow.TaskQueueBackground)
+	}
+
+	jobID := uuid.New()
+	client = &fakeTemporalClient{}
+	if err := NewTemporalSyntheticDatasetGenerationWorkflowStarter(client).StartSyntheticDatasetGenerationWorkflow(context.Background(), jobID); err != nil {
+		t.Fatalf("dataset start: %v", err)
+	}
+	if client.options.TaskQueue != workflow.TaskQueueBackground {
+		t.Fatalf("dataset queue = %q, want %q", client.options.TaskQueue, workflow.TaskQueueBackground)
+	}
+}

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -31,24 +31,32 @@ const (
 	// Anonymous agent tryouts carry an expires_at (default 24h, cleared on
 	// claim). The retention reaper sweeps expired, unclaimed tryouts hourly.
 	defaultAgentTryoutRetentionReaperInterval = time.Hour
+
+	defaultMaxConcurrentActivities    = 100
+	defaultMaxConcurrentWorkflowTasks = 100
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
 
 type Config struct {
-	AppEnvironment           string
-	DatabaseURL              string
-	TemporalAddress          string
-	TemporalNamespace        string
-	Identity                 string
-	TaskQueue                string
-	HostedCallbackBaseURL    string
-	HostedCallbackSecret     string
-	GitHubAppID              int64
-	GitHubAppPrivateKey      string
-	ShutdownTimeout          time.Duration
-	OrphanRunReaperInterval  time.Duration
-	OrphanRunReaperThreshold time.Duration
+	AppEnvironment               string
+	DatabaseURL                  string
+	TemporalAddress              string
+	TemporalNamespace            string
+	Identity                     string
+	TaskQueue                    string   // primary/legacy display queue (first of TaskQueues)
+	TaskQueues                   []string // Fleet queue classes this process serves
+	MaxConcurrentActivities      int
+	MaxConcurrentWorkflowTasks   int
+	WorkerActivitiesPerSecond    float64 // 0 = unlimited (SDK default)
+	TaskQueueActivitiesPerSecond float64 // 0 = unlimited (SDK default)
+	HostedCallbackBaseURL        string
+	HostedCallbackSecret         string
+	GitHubAppID                  int64
+	GitHubAppPrivateKey          string
+	ShutdownTimeout              time.Duration
+	OrphanRunReaperInterval      time.Duration
+	OrphanRunReaperThreshold     time.Duration
 
 	AgentTryoutRetentionReaperInterval time.Duration
 	AgentTryoutHosted                  workflow.PublicAgentTryoutConfig
@@ -184,20 +192,58 @@ func LoadConfigFromEnv() (Config, error) {
 		return Config{}, err
 	}
 
+	taskQueues, primaryQueue, err := loadWorkerTaskQueuesFromEnv()
+	if err != nil {
+		return Config{}, err
+	}
+	maxConcurrentActivities, err := intEnvOrDefault("WORKER_MAX_CONCURRENT_ACTIVITIES", defaultMaxConcurrentActivities)
+	if err != nil {
+		return Config{}, err
+	}
+	if maxConcurrentActivities <= 0 {
+		return Config{}, fmt.Errorf("WORKER_MAX_CONCURRENT_ACTIVITIES must be > 0")
+	}
+	maxConcurrentWorkflowTasks, err := intEnvOrDefault("WORKER_MAX_CONCURRENT_WORKFLOW_TASKS", defaultMaxConcurrentWorkflowTasks)
+	if err != nil {
+		return Config{}, err
+	}
+	if maxConcurrentWorkflowTasks <= 0 {
+		return Config{}, fmt.Errorf("WORKER_MAX_CONCURRENT_WORKFLOW_TASKS must be > 0")
+	}
+	workerActivitiesPerSecond, err := floatEnvOrDefaultAllowZero("WORKER_ACTIVITIES_PER_SECOND", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	if workerActivitiesPerSecond < 0 {
+		return Config{}, fmt.Errorf("WORKER_ACTIVITIES_PER_SECOND must be >= 0")
+	}
+	taskQueueActivitiesPerSecond, err := floatEnvOrDefaultAllowZero("WORKER_TASKQUEUE_ACTIVITIES_PER_SECOND", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	if taskQueueActivitiesPerSecond < 0 {
+		return Config{}, fmt.Errorf("WORKER_TASKQUEUE_ACTIVITIES_PER_SECOND must be >= 0")
+	}
+
 	return Config{
-		AppEnvironment:           appEnvironment,
-		DatabaseURL:              databaseURL,
-		TemporalAddress:          temporalAddress,
-		TemporalNamespace:        temporalNamespace,
-		Identity:                 identity,
-		TaskQueue:                workflow.WorkflowTaskQueue,
-		HostedCallbackBaseURL:    hostedCallbackBaseURL,
-		HostedCallbackSecret:     hostedCallbackSecret,
-		GitHubAppID:              githubAppID,
-		GitHubAppPrivateKey:      normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
-		ShutdownTimeout:          shutdownTimeout,
-		OrphanRunReaperInterval:  orphanRunReaperInterval,
-		OrphanRunReaperThreshold: orphanRunReaperThreshold,
+		AppEnvironment:               appEnvironment,
+		DatabaseURL:                  databaseURL,
+		TemporalAddress:              temporalAddress,
+		TemporalNamespace:            temporalNamespace,
+		Identity:                     identity,
+		TaskQueue:                    primaryQueue,
+		TaskQueues:                   taskQueues,
+		MaxConcurrentActivities:      maxConcurrentActivities,
+		MaxConcurrentWorkflowTasks:   maxConcurrentWorkflowTasks,
+		WorkerActivitiesPerSecond:    workerActivitiesPerSecond,
+		TaskQueueActivitiesPerSecond: taskQueueActivitiesPerSecond,
+		HostedCallbackBaseURL:        hostedCallbackBaseURL,
+		HostedCallbackSecret:         hostedCallbackSecret,
+		GitHubAppID:                  githubAppID,
+		GitHubAppPrivateKey:          normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
+		ShutdownTimeout:              shutdownTimeout,
+		OrphanRunReaperInterval:      orphanRunReaperInterval,
+		OrphanRunReaperThreshold:     orphanRunReaperThreshold,
 
 		AgentTryoutRetentionReaperInterval: agentTryoutRetentionReaperInterval,
 		AgentTryoutHosted: workflow.PublicAgentTryoutConfig{
@@ -386,4 +432,61 @@ func defaultWorkerIdentity() string {
 	}
 
 	return fmt.Sprintf("agentclash-worker@%s", hostname)
+}
+
+func loadWorkerTaskQueuesFromEnv() ([]string, string, error) {
+	rawQueues := strings.TrimSpace(os.Getenv("WORKER_TASK_QUEUES"))
+	rawSingle := strings.TrimSpace(os.Getenv("WORKER_TASK_QUEUE"))
+
+	var configured []string
+	switch {
+	case rawQueues != "":
+		for _, part := range strings.Split(rawQueues, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				return nil, "", fmt.Errorf("%w: WORKER_TASK_QUEUES contains an empty entry", ErrInvalidConfig)
+			}
+			configured = append(configured, part)
+		}
+	case rawSingle != "":
+		configured = []string{rawSingle}
+	default:
+		configured = workflow.AllTaskQueues()
+	}
+
+	expanded := workflow.ExpandTaskQueues(configured)
+	if len(expanded) == 0 {
+		return nil, "", fmt.Errorf("%w: no task queues configured", ErrInvalidConfig)
+	}
+	return expanded, expanded[0], nil
+}
+
+func intEnvOrDefault(key string, fallback int) (int, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be an integer", ErrInvalidConfig, key)
+	}
+	return parsed, nil
+}
+
+func floatEnvOrDefaultAllowZero(key string, fallback float64) (float64, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be a number", ErrInvalidConfig, key)
+	}
+	return parsed, nil
 }

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -15,6 +15,12 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "TEMPORAL_HOST_PORT")
 	unsetEnv(t, "TEMPORAL_NAMESPACE")
 	unsetEnv(t, "WORKER_IDENTITY")
+	unsetEnv(t, "WORKER_TASK_QUEUE")
+	unsetEnv(t, "WORKER_TASK_QUEUES")
+	unsetEnv(t, "WORKER_MAX_CONCURRENT_ACTIVITIES")
+	unsetEnv(t, "WORKER_MAX_CONCURRENT_WORKFLOW_TASKS")
+	unsetEnv(t, "WORKER_ACTIVITIES_PER_SECOND")
+	unsetEnv(t, "WORKER_TASKQUEUE_ACTIVITIES_PER_SECOND")
 	unsetEnv(t, "WORKER_SHUTDOWN_TIMEOUT")
 	unsetEnv(t, "WORKER_ORPHAN_RUN_REAPER_INTERVAL")
 	unsetEnv(t, "WORKER_ORPHAN_RUN_REAPER_THRESHOLD")
@@ -50,8 +56,20 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	if cfg.TemporalNamespace != defaultNamespace {
 		t.Fatalf("TemporalNamespace = %q, want %q", cfg.TemporalNamespace, defaultNamespace)
 	}
-	if cfg.TaskQueue != workflow.RunWorkflowName {
-		t.Fatalf("TaskQueue = %q, want %q", cfg.TaskQueue, workflow.RunWorkflowName)
+	if cfg.TaskQueue != workflow.TaskQueueExecution {
+		t.Fatalf("TaskQueue = %q, want %q", cfg.TaskQueue, workflow.TaskQueueExecution)
+	}
+	if len(cfg.TaskQueues) != 3 {
+		t.Fatalf("TaskQueues = %v, want 3 class queues", cfg.TaskQueues)
+	}
+	if cfg.MaxConcurrentActivities != defaultMaxConcurrentActivities {
+		t.Fatalf("MaxConcurrentActivities = %d, want %d", cfg.MaxConcurrentActivities, defaultMaxConcurrentActivities)
+	}
+	if cfg.MaxConcurrentWorkflowTasks != defaultMaxConcurrentWorkflowTasks {
+		t.Fatalf("MaxConcurrentWorkflowTasks = %d, want %d", cfg.MaxConcurrentWorkflowTasks, defaultMaxConcurrentWorkflowTasks)
+	}
+	if cfg.WorkerActivitiesPerSecond != 0 || cfg.TaskQueueActivitiesPerSecond != 0 {
+		t.Fatalf("rate limits = %v/%v, want 0/0 (unlimited)", cfg.WorkerActivitiesPerSecond, cfg.TaskQueueActivitiesPerSecond)
 	}
 	if cfg.Identity == "" {
 		t.Fatalf("Identity was empty")

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -25,6 +25,29 @@ type OrphanRunReaper interface {
 	Start(ctx context.Context)
 }
 
+// multiQueueWorker hosts one Temporal worker per configured task queue class.
+type multiQueueWorker struct {
+	workers []sdkworker.Worker
+}
+
+func (m *multiQueueWorker) Start() error {
+	for i, w := range m.workers {
+		if err := w.Start(); err != nil {
+			for j := 0; j < i; j++ {
+				m.workers[j].Stop()
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *multiQueueWorker) Stop() {
+	for _, w := range m.workers {
+		w.Stop()
+	}
+}
+
 // executionHooks is the temporary extension seam for later hosted and native
 // execution work without reshaping worker bootstrap.
 func NewTemporalWorker(
@@ -36,20 +59,52 @@ func NewTemporalWorker(
 	githubClient workflowpkg.GitHubPullRequestClient,
 	executionHooks workflowpkg.FakeWorkHooks,
 	artifactStore storage.Store,
-) sdkworker.Worker {
-	temporalWorker := sdkworker.New(client, cfg.TaskQueue, sdkworker.Options{
-		Identity: cfg.Identity,
-	})
+) TemporalWorker {
+	queues := cfg.TaskQueues
+	if len(queues) == 0 {
+		if cfg.TaskQueue != "" {
+			queues = workflowpkg.ExpandTaskQueues([]string{cfg.TaskQueue})
+		} else {
+			queues = workflowpkg.AllTaskQueues()
+		}
+	}
 
 	activities := workflowpkg.NewActivities(repo, executionHooks, playgroundClient).
 		WithSandboxProvider(sandboxProvider).
 		WithGitHubPullRequestClient(githubClient).
 		WithPublicAgentTryoutConfig(cfg.AgentTryoutHosted).
 		WithArtifactStore(artifactStore)
-	workflowpkg.Register(temporalWorker, activities)
-	workflowpkg.RegisterDatasetGeneration(temporalWorker, workflowpkg.NewDatasetGenerationActivities(repo, playgroundClient, repo))
+	datasetActivities := workflowpkg.NewDatasetGenerationActivities(repo, playgroundClient, repo)
 
-	return temporalWorker
+	maxActs := cfg.MaxConcurrentActivities
+	if maxActs <= 0 {
+		maxActs = defaultMaxConcurrentActivities
+	}
+	maxWFT := cfg.MaxConcurrentWorkflowTasks
+	if maxWFT <= 0 {
+		maxWFT = defaultMaxConcurrentWorkflowTasks
+	}
+
+	workers := make([]sdkworker.Worker, 0, len(queues))
+	for _, queue := range queues {
+		opts := sdkworker.Options{
+			Identity:                               fmt.Sprintf("%s/%s", cfg.Identity, queue),
+			MaxConcurrentActivityExecutionSize:     maxActs,
+			MaxConcurrentWorkflowTaskExecutionSize: maxWFT,
+		}
+		if cfg.WorkerActivitiesPerSecond > 0 {
+			opts.WorkerActivitiesPerSecond = cfg.WorkerActivitiesPerSecond
+		}
+		if cfg.TaskQueueActivitiesPerSecond > 0 {
+			opts.TaskQueueActivitiesPerSecond = cfg.TaskQueueActivitiesPerSecond
+		}
+		w := sdkworker.New(client, queue, opts)
+		workflowpkg.RegisterForTaskQueue(w, activities, queue)
+		workflowpkg.RegisterDatasetGenerationForTaskQueue(w, datasetActivities, queue)
+		workers = append(workers, w)
+	}
+
+	return &multiQueueWorker{workers: workers}
 }
 
 func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger *slog.Logger) error {
@@ -62,7 +117,10 @@ func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger 
 func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger *slog.Logger, reapers ...OrphanRunReaper) error {
 	logger.Info("starting worker",
 		"task_queue", cfg.TaskQueue,
+		"task_queues", cfg.TaskQueues,
 		"identity", cfg.Identity,
+		"max_concurrent_activities", cfg.MaxConcurrentActivities,
+		"max_concurrent_workflow_tasks", cfg.MaxConcurrentWorkflowTasks,
 		"temporal_address", cfg.TemporalAddress,
 		"temporal_namespace", cfg.TemporalNamespace,
 	)

--- a/backend/internal/workflow/bounded_fanout.go
+++ b/backend/internal/workflow/bounded_fanout.go
@@ -1,0 +1,211 @@
+package workflow
+
+import (
+	"fmt"
+	"sort"
+
+	sdkworkflow "go.temporal.io/sdk/workflow"
+)
+
+// Default in-flight caps for Fleet 2 bounded orchestration. Workflow code must
+// not read env (nondeterministic); these are the deterministic defaults.
+// Callers may override via workflow input fields when plumbed from config.
+const (
+	DefaultMaxConcurrentEvalSessionRuns = 16
+	DefaultMaxConcurrentRunAgents       = 8
+	DefaultMaxConcurrentScoreActivities = 16
+
+	evalSessionBoundedFanoutVersionChangeID = "eval-session-bounded-fanout"
+	runAgentsBoundedFanoutVersionChangeID   = "run-agents-bounded-fanout"
+	scoreAgentsBoundedFanoutVersionChangeID = "score-agents-bounded-fanout"
+)
+
+// Task queue class names (Fleet 2 partitioning). Workflows start on
+// TaskQueueExecution; activities pin to their class via ActivityOptions.TaskQueue.
+const (
+	TaskQueueExecution  = "execution"
+	TaskQueueScoring    = "scoring"
+	TaskQueueBackground = "background"
+	// LegacyTaskQueue is the pre-Fleet single queue name. Workers that list it
+	// (or set WORKER_TASK_QUEUE to it) are treated as serving all three classes.
+	LegacyTaskQueue = "RunWorkflow"
+)
+
+// launchBounded runs launch(i) for i in [0,n) with at most maxInFlight futures
+// outstanding. Completions are processed via onComplete. Registration order is
+// made deterministic by sorting pending futures by index each drain round.
+//
+// This is workflow-safe: no goroutines or channels.
+func launchBounded(
+	ctx sdkworkflow.Context,
+	maxInFlight int,
+	n int,
+	launch func(index int) sdkworkflow.Future,
+	onComplete func(index int, future sdkworkflow.Future) error,
+) error {
+	if n <= 0 {
+		return nil
+	}
+	if maxInFlight <= 0 {
+		maxInFlight = 1
+	}
+	if maxInFlight > n {
+		maxInFlight = n
+	}
+
+	type pendingItem struct {
+		index  int
+		future sdkworkflow.Future
+	}
+	pending := make(map[sdkworkflow.Future]pendingItem, maxInFlight)
+	nextIndex := 0
+
+	start := func(index int) {
+		future := launch(index)
+		pending[future] = pendingItem{index: index, future: future}
+	}
+
+	for nextIndex < maxInFlight {
+		start(nextIndex)
+		nextIndex++
+	}
+
+	for len(pending) > 0 {
+		selector := sdkworkflow.NewSelector(ctx)
+		futures := make([]sdkworkflow.Future, 0, len(pending))
+		for f := range pending {
+			futures = append(futures, f)
+		}
+		sort.Slice(futures, func(i, j int) bool {
+			return pending[futures[i]].index < pending[futures[j]].index
+		})
+
+		var (
+			completed   pendingItem
+			completeErr error
+		)
+		for _, f := range futures {
+			future := f
+			item := pending[future]
+			selector.AddFuture(future, func(fut sdkworkflow.Future) {
+				completed = item
+				completeErr = onComplete(item.index, fut)
+			})
+		}
+		selector.Select(ctx)
+		if completeErr != nil {
+			return completeErr
+		}
+		delete(pending, completed.future)
+
+		if nextIndex < n {
+			start(nextIndex)
+			nextIndex++
+		}
+	}
+	return nil
+}
+
+// launchAllUnbounded preserves the pre-Fleet launch-all-then-drain shape for
+// GetVersion DefaultVersion replay of in-flight histories.
+func launchAllUnbounded(
+	ctx sdkworkflow.Context,
+	n int,
+	launch func(index int) sdkworkflow.Future,
+	onComplete func(index int, future sdkworkflow.Future) error,
+) error {
+	if n <= 0 {
+		return nil
+	}
+	selector := sdkworkflow.NewSelector(ctx)
+	type item struct {
+		index  int
+		future sdkworkflow.Future
+	}
+	items := make([]item, 0, n)
+	for i := 0; i < n; i++ {
+		future := launch(i)
+		items = append(items, item{index: i, future: future})
+	}
+	completed := 0
+	var firstErr error
+	for _, it := range items {
+		it := it
+		selector.AddFuture(it.future, func(fut sdkworkflow.Future) {
+			completed++
+			if err := onComplete(it.index, fut); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		})
+	}
+	for completed < n {
+		selector.Select(ctx)
+	}
+	return firstErr
+}
+
+func resolvePositiveCap(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	if fallback > 0 {
+		return fallback
+	}
+	return 1
+}
+
+func boundedFanoutVersion(ctx sdkworkflow.Context, changeID string) sdkworkflow.Version {
+	return sdkworkflow.GetVersion(ctx, changeID, sdkworkflow.DefaultVersion, 1)
+}
+
+// AllTaskQueues returns the three Fleet queue class names in stable order.
+func AllTaskQueues() []string {
+	return []string{TaskQueueExecution, TaskQueueScoring, TaskQueueBackground}
+}
+
+// ExpandTaskQueues normalizes a configured queue list. "RunWorkflow" (legacy)
+// expands to all three class queues so a single-process upgrade matches today.
+func ExpandTaskQueues(queues []string) []string {
+	if len(queues) == 0 {
+		return AllTaskQueues()
+	}
+	seen := make(map[string]struct{}, len(queues))
+	out := make([]string, 0, len(queues))
+	add := func(q string) {
+		if q == "" {
+			return
+		}
+		if _, ok := seen[q]; ok {
+			return
+		}
+		seen[q] = struct{}{}
+		out = append(out, q)
+	}
+	for _, q := range queues {
+		if q == LegacyTaskQueue {
+			for _, class := range AllTaskQueues() {
+				add(class)
+			}
+			continue
+		}
+		switch q {
+		case TaskQueueExecution, TaskQueueScoring, TaskQueueBackground:
+			add(q)
+		default:
+			add(q)
+		}
+	}
+	if len(out) == 0 {
+		return AllTaskQueues()
+	}
+	return out
+}
+
+func validateTaskQueueClass(name string) error {
+	switch name {
+	case TaskQueueExecution, TaskQueueScoring, TaskQueueBackground, LegacyTaskQueue:
+		return nil
+	default:
+		return fmt.Errorf("unknown task queue class %q", name)
+	}
+}

--- a/backend/internal/workflow/bounded_fanout.go
+++ b/backend/internal/workflow/bounded_fanout.go
@@ -18,6 +18,9 @@ const (
 	evalSessionBoundedFanoutVersionChangeID = "eval-session-bounded-fanout"
 	runAgentsBoundedFanoutVersionChangeID   = "run-agents-bounded-fanout"
 	scoreAgentsBoundedFanoutVersionChangeID = "score-agents-bounded-fanout"
+	// Separate from bounded-fanout: pinning TaskQueue on children/activities
+	// changes Temporal command attributes and must be replay-gated.
+	taskQueuePartitionVersionChangeID = "fleet-task-queue-partition"
 )
 
 // Task queue class names (Fleet 2 partitioning). Workflows start on
@@ -156,6 +159,29 @@ func resolvePositiveCap(value, fallback int) int {
 
 func boundedFanoutVersion(ctx sdkworkflow.Context, changeID string) sdkworkflow.Version {
 	return sdkworkflow.GetVersion(ctx, changeID, sdkworkflow.DefaultVersion, 1)
+}
+
+func taskQueuePartitionVersion(ctx sdkworkflow.Context) sdkworkflow.Version {
+	return sdkworkflow.GetVersion(ctx, taskQueuePartitionVersionChangeID, sdkworkflow.DefaultVersion, 1)
+}
+
+// withChildExecutionTaskQueue pins child workflows to TaskQueueExecution only
+// for workflows started after the partition change. DefaultVersion omits
+// TaskQueue so replay matches pre-Fleet histories (inherited parent queue).
+func withChildExecutionTaskQueue(ctx sdkworkflow.Context, opts sdkworkflow.ChildWorkflowOptions) sdkworkflow.ChildWorkflowOptions {
+	if taskQueuePartitionVersion(ctx) != sdkworkflow.DefaultVersion {
+		opts.TaskQueue = TaskQueueExecution
+	}
+	return opts
+}
+
+// withActivityTaskQueue pins activities to a class queue after the partition
+// change. DefaultVersion leaves TaskQueue unset for replay compatibility.
+func withActivityTaskQueue(ctx sdkworkflow.Context, opts sdkworkflow.ActivityOptions, queue string) sdkworkflow.ActivityOptions {
+	if taskQueuePartitionVersion(ctx) != sdkworkflow.DefaultVersion {
+		opts.TaskQueue = queue
+	}
+	return opts
 }
 
 // AllTaskQueues returns the three Fleet queue class names in stable order.

--- a/backend/internal/workflow/bounded_fanout_test.go
+++ b/backend/internal/workflow/bounded_fanout_test.go
@@ -147,6 +147,8 @@ func TestEvalSessionWorkflowDefaultVersionUnboundedReplay(t *testing.T) {
 		Return(sdkworkflow.DefaultVersion)
 	env.OnGetVersion(evalSessionRefreshChildRunsVersionChangeID, sdkworkflow.DefaultVersion, sdkworkflow.Version(1)).
 		Return(sdkworkflow.DefaultVersion)
+	env.OnGetVersion(taskQueuePartitionVersionChangeID, sdkworkflow.DefaultVersion, sdkworkflow.Version(1)).
+		Return(sdkworkflow.DefaultVersion)
 
 	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
 	if err := env.GetWorkflowError(); err != nil {

--- a/backend/internal/workflow/bounded_fanout_test.go
+++ b/backend/internal/workflow/bounded_fanout_test.go
@@ -1,0 +1,158 @@
+package workflow
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/runtime/domain"
+	"github.com/google/uuid"
+	sdkactivity "go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+)
+
+func TestExpandTaskQueues_DefaultsAndLegacy(t *testing.T) {
+	if got := ExpandTaskQueues(nil); len(got) != 3 {
+		t.Fatalf("nil → %v, want 3 queues", got)
+	}
+	got := ExpandTaskQueues([]string{LegacyTaskQueue})
+	if len(got) != 3 {
+		t.Fatalf("legacy → %v", got)
+	}
+	got = ExpandTaskQueues([]string{TaskQueueExecution, TaskQueueScoring})
+	if len(got) != 2 || got[0] != TaskQueueExecution || got[1] != TaskQueueScoring {
+		t.Fatalf("subset → %v", got)
+	}
+}
+
+func TestLaunchBounded_RespectsMaxInFlight(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	suite.SetDisableRegistrationAliasing(true)
+	env := suite.NewTestWorkflowEnvironment()
+
+	var (
+		mu          sync.Mutex
+		inFlight    int
+		maxInFlight int
+	)
+
+	sleepActivity := func(d time.Duration) error {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+		time.Sleep(d)
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+		return nil
+	}
+	env.RegisterActivityWithOptions(sleepActivity, sdkactivity.RegisterOptions{Name: "workflow.test_sleep"})
+
+	boundedWorkflow := func(ctx sdkworkflow.Context, n int, cap int) error {
+		launch := func(index int) sdkworkflow.Future {
+			return sdkworkflow.ExecuteActivity(
+				sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions),
+				"workflow.test_sleep",
+				30*time.Millisecond,
+			)
+		}
+		onComplete := func(index int, future sdkworkflow.Future) error {
+			return future.Get(ctx, nil)
+		}
+		return launchBounded(ctx, cap, n, launch, onComplete)
+	}
+	env.RegisterWorkflow(boundedWorkflow)
+	env.ExecuteWorkflow(boundedWorkflow, 12, 3)
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	mu.Lock()
+	peak := maxInFlight
+	mu.Unlock()
+	if peak > 3 {
+		t.Fatalf("peak in-flight = %d, want ≤3", peak)
+	}
+	if peak < 2 {
+		t.Fatalf("peak in-flight = %d, want ≥2", peak)
+	}
+}
+
+func TestEvalSessionWorkflowBoundedFanoutCap(t *testing.T) {
+	sessionID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	childRuns := make([]domain.Run, 0, 50)
+	for i := 0; i < 50; i++ {
+		childRuns = append(childRuns, fixtureChildRun(uuid.New(), sessionID))
+	}
+	repo.setEvalSession(fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued), childRuns...)
+
+	var (
+		mu          sync.Mutex
+		inFlight    int
+		maxInFlight int
+	)
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+		_ = sdkworkflow.Sleep(ctx, 15*time.Millisecond)
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+		return nil
+	})
+
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{
+		EvalSessionID:     sessionID,
+		MaxConcurrentRuns: 16,
+	})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	mu.Lock()
+	peak := maxInFlight
+	mu.Unlock()
+	if peak > 16 {
+		t.Fatalf("peak in-flight child runs = %d, want ≤16", peak)
+	}
+	if peak < 2 {
+		t.Fatalf("peak in-flight child runs = %d, want ≥2", peak)
+	}
+}
+
+func TestEvalSessionWorkflowDefaultVersionUnboundedReplay(t *testing.T) {
+	sessionID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(uuid.New(), sessionID),
+		fixtureChildRun(uuid.New(), sessionID),
+	)
+
+	var started atomic.Int64
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		started.Add(1)
+		return nil
+	})
+	env.OnGetVersion(evalSessionBoundedFanoutVersionChangeID, sdkworkflow.DefaultVersion, sdkworkflow.Version(1)).
+		Return(sdkworkflow.DefaultVersion)
+	env.OnGetVersion(evalSessionRefreshChildRunsVersionChangeID, sdkworkflow.DefaultVersion, sdkworkflow.Version(1)).
+		Return(sdkworkflow.DefaultVersion)
+
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	if started.Load() != 2 {
+		t.Fatalf("started = %d, want 2", started.Load())
+	}
+}

--- a/backend/internal/workflow/case_fanout.go
+++ b/backend/internal/workflow/case_fanout.go
@@ -156,10 +156,10 @@ func caseActivityTimeout(executionContext repository.RunAgentExecutionContext, c
 	return time.Duration(timeoutSecs)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
 }
 
-func caseActivityOptions(executionContext repository.RunAgentExecutionContext, caseKey string) sdkworkflow.ActivityOptions {
+func caseActivityOptions(ctx sdkworkflow.Context, executionContext repository.RunAgentExecutionContext, caseKey string) sdkworkflow.ActivityOptions {
 	opts := nativeModelActivityOptions(executionContext)
 	opts.StartToCloseTimeout = caseActivityTimeout(executionContext, caseKey)
-	return opts
+	return withActivityTaskQueue(ctx, opts, TaskQueueExecution)
 }
 
 // executeNativeCasesBounded launches per-case activities with a deterministic
@@ -199,7 +199,7 @@ func executeNativeCasesBounded(
 	launch := func(index int) {
 		key := caseKeys[index]
 		future := sdkworkflow.ExecuteActivity(
-			sdkworkflow.WithActivityOptions(ctx, caseActivityOptions(executionContext, key)),
+			sdkworkflow.WithActivityOptions(ctx, caseActivityOptions(ctx, executionContext, key)),
 			executeRunAgentCaseActivityName,
 			ExecuteRunAgentCaseInput{
 				RunID:      input.RunID,

--- a/backend/internal/workflow/dataset_generation_workflow.go
+++ b/backend/internal/workflow/dataset_generation_workflow.go
@@ -39,6 +39,7 @@ func SyntheticDatasetGenerationWorkflow(ctx sdkworkflow.Context, input Synthetic
 	}
 
 	executeCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
+		TaskQueue:           TaskQueueBackground,
 		StartToCloseTimeout: syntheticDatasetGenerationTimeout,
 		RetryPolicy:         defaultActivityOptions.RetryPolicy,
 	})

--- a/backend/internal/workflow/dataset_generation_workflow.go
+++ b/backend/internal/workflow/dataset_generation_workflow.go
@@ -38,11 +38,10 @@ func SyntheticDatasetGenerationWorkflow(ctx sdkworkflow.Context, input Synthetic
 		return markDatasetGenerationJobFailed(ctx, input.JobID, err)
 	}
 
-	executeCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
-		TaskQueue:           TaskQueueBackground,
+	executeCtx := sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, sdkworkflow.ActivityOptions{
 		StartToCloseTimeout: syntheticDatasetGenerationTimeout,
 		RetryPolicy:         defaultActivityOptions.RetryPolicy,
-	})
+	}, TaskQueueBackground))
 	if err := sdkworkflow.ExecuteActivity(executeCtx, executeSyntheticDatasetGenerationActivityName, ExecuteSyntheticDatasetGenerationInput{
 		JobID: input.JobID,
 	}).Get(ctx, nil); err != nil {

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -65,7 +65,7 @@ func runEvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowIn
 		}
 	}
 
-	if err := executeEvalSessionRuns(ctx, runs); err != nil {
+	if err := executeEvalSessionRuns(ctx, runs, input.MaxConcurrentRuns); err != nil {
 		if errors.Is(err, errEvalSessionChildrenCancelled) {
 			return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusCancelled)
 		}
@@ -125,35 +125,46 @@ func aggregateEvalSession(ctx sdkworkflow.Context, evalSessionID uuid.UUID) erro
 	}).Get(ctx, &aggregateResult)
 }
 
-func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
-	selector := sdkworkflow.NewSelector(ctx)
-	completedChildren := 0
-	startedChildren := 0
-	childErrors := make(map[uuid.UUID]error, len(runs))
-
+func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run, maxConcurrent int) error {
+	queued := make([]domain.Run, 0, len(runs))
 	for _, run := range runs {
-		run := run
-		if run.Status != domain.RunStatusQueued {
-			continue
+		if run.Status == domain.RunStatusQueued {
+			queued = append(queued, run)
 		}
-		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
-			WorkflowID:        fmt.Sprintf("%s/%s", RunWorkflowName, run.ID),
-			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
-		})
-		future := sdkworkflow.ExecuteChildWorkflow(childCtx, RunWorkflowName, RunWorkflowInput{
-			RunID: run.ID,
-		})
-		startedChildren++
-		selector.AddFuture(future, func(f sdkworkflow.Future) {
-			completedChildren++
-			if err := f.Get(ctx, nil); err != nil {
-				childErrors[run.ID] = err
-			}
-		})
+	}
+	startedChildren := len(queued)
+	childErrors := make(map[uuid.UUID]error, startedChildren)
+	if startedChildren == 0 {
+		return nil
 	}
 
-	for completedChildren < startedChildren {
-		selector.Select(ctx)
+	launch := func(index int) sdkworkflow.Future {
+		run := queued[index]
+		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
+			WorkflowID:        fmt.Sprintf("%s/%s", RunWorkflowName, run.ID),
+			TaskQueue:         TaskQueueExecution,
+			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+		})
+		return sdkworkflow.ExecuteChildWorkflow(childCtx, RunWorkflowName, RunWorkflowInput{
+			RunID: run.ID,
+		})
+	}
+	onComplete := func(index int, future sdkworkflow.Future) error {
+		if err := future.Get(ctx, nil); err != nil {
+			childErrors[queued[index].ID] = err
+		}
+		return nil
+	}
+
+	if boundedFanoutVersion(ctx, evalSessionBoundedFanoutVersionChangeID) == sdkworkflow.DefaultVersion {
+		if err := launchAllUnbounded(ctx, startedChildren, launch, onComplete); err != nil {
+			return err
+		}
+	} else {
+		cap := resolvePositiveCap(maxConcurrent, DefaultMaxConcurrentEvalSessionRuns)
+		if err := launchBounded(ctx, cap, startedChildren, launch, onComplete); err != nil {
+			return err
+		}
 	}
 
 	actionableErrors, cancelledChildren, terminalChildren, err := classifyEvalSessionChildErrors(ctx, childErrors)

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -140,11 +140,10 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run, maxConcu
 
 	launch := func(index int) sdkworkflow.Future {
 		run := queued[index]
-		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
+		childCtx := sdkworkflow.WithChildOptions(ctx, withChildExecutionTaskQueue(ctx, sdkworkflow.ChildWorkflowOptions{
 			WorkflowID:        fmt.Sprintf("%s/%s", RunWorkflowName, run.ID),
-			TaskQueue:         TaskQueueExecution,
 			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
-		})
+		}))
 		return sdkworkflow.ExecuteChildWorkflow(childCtx, RunWorkflowName, RunWorkflowInput{
 			RunID: run.ID,
 		})

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -10,12 +10,72 @@ type Registrar interface {
 	RegisterActivityWithOptions(activityFunc interface{}, options sdkactivity.RegisterOptions)
 }
 
+// Register registers all workflows/activities on a single worker. Prefer
+// RegisterForTaskQueue when serving partitioned Fleet queues.
 func Register(registrar Registrar, activities *Activities) {
+	RegisterForTaskQueue(registrar, activities, LegacyTaskQueue)
+}
+
+// RegisterForTaskQueue registers the workflow/activity subset for a Fleet queue
+// class. LegacyTaskQueue registers the full set (pre-partition behavior).
+func RegisterForTaskQueue(registrar Registrar, activities *Activities, taskQueue string) {
+	switch taskQueue {
+	case TaskQueueExecution:
+		registerExecutionWorkflows(registrar)
+		registerExecutionActivities(registrar, activities)
+	case TaskQueueScoring:
+		registerScoringActivities(registrar, activities)
+	case TaskQueueBackground:
+		registerBackgroundWorkflows(registrar)
+		registerBackgroundActivities(registrar, activities)
+	case LegacyTaskQueue:
+		registerExecutionWorkflows(registrar)
+		registerBackgroundWorkflows(registrar)
+		registerExecutionActivities(registrar, activities)
+		registerScoringActivities(registrar, activities)
+		registerBackgroundActivities(registrar, activities)
+	default:
+		// Unknown queue names get the full set so misconfiguration fails open
+		// rather than silently dropping work.
+		registerExecutionWorkflows(registrar)
+		registerBackgroundWorkflows(registrar)
+		registerExecutionActivities(registrar, activities)
+		registerScoringActivities(registrar, activities)
+		registerBackgroundActivities(registrar, activities)
+	}
+}
+
+func RegisterDatasetGeneration(registrar Registrar, activities *DatasetGenerationActivities) {
+	RegisterDatasetGenerationForTaskQueue(registrar, activities, LegacyTaskQueue)
+}
+
+func RegisterDatasetGenerationForTaskQueue(registrar Registrar, activities *DatasetGenerationActivities, taskQueue string) {
+	switch taskQueue {
+	case TaskQueueBackground, LegacyTaskQueue:
+		registrar.RegisterWorkflowWithOptions(SyntheticDatasetGenerationWorkflow, sdkworkflow.RegisterOptions{Name: SyntheticDatasetGenerationWorkflowName})
+		registrar.RegisterActivityWithOptions(activities.LoadDatasetGenerationExecutionContext, sdkactivity.RegisterOptions{Name: loadDatasetGenerationExecutionContextActivityName})
+		registrar.RegisterActivityWithOptions(activities.SetDatasetGenerationJobTemporalIDs, sdkactivity.RegisterOptions{Name: setDatasetGenerationJobTemporalIDsActivityName})
+		registrar.RegisterActivityWithOptions(activities.UpdateDatasetGenerationJobStatus, sdkactivity.RegisterOptions{Name: updateDatasetGenerationJobStatusActivityName})
+		registrar.RegisterActivityWithOptions(activities.ExecuteSyntheticDatasetGeneration, sdkactivity.RegisterOptions{Name: executeSyntheticDatasetGenerationActivityName})
+	case TaskQueueExecution, TaskQueueScoring:
+		// Dataset generation is background-only.
+	default:
+		RegisterDatasetGenerationForTaskQueue(registrar, activities, LegacyTaskQueue)
+	}
+}
+
+func registerExecutionWorkflows(registrar Registrar) {
 	registrar.RegisterWorkflowWithOptions(EvalSessionWorkflow, sdkworkflow.RegisterOptions{Name: EvalSessionWorkflowName})
 	registrar.RegisterWorkflowWithOptions(RunWorkflow, sdkworkflow.RegisterOptions{Name: RunWorkflowName})
 	registrar.RegisterWorkflowWithOptions(RunAgentWorkflow, sdkworkflow.RegisterOptions{Name: RunAgentWorkflowName})
 	registrar.RegisterWorkflowWithOptions(AgentHarnessExecutionWorkflow, sdkworkflow.RegisterOptions{Name: AgentHarnessExecutionWorkflowName})
+}
+
+func registerBackgroundWorkflows(registrar Registrar) {
 	registrar.RegisterWorkflowWithOptions(PublicAgentTryoutExecutionWorkflow, sdkworkflow.RegisterOptions{Name: PublicAgentTryoutExecutionWorkflowName})
+}
+
+func registerExecutionActivities(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.LoadEvalSession, sdkactivity.RegisterOptions{Name: loadEvalSessionActivityName})
 	registrar.RegisterActivityWithOptions(activities.ListEvalSessionRuns, sdkactivity.RegisterOptions{Name: listEvalSessionRunsActivityName})
 	registrar.RegisterActivityWithOptions(activities.TransitionEvalSessionStatus, sdkactivity.RegisterOptions{Name: transitionEvalSessionStatusActivityName})
@@ -36,20 +96,18 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.ExecuteResponsesStep, sdkactivity.RegisterOptions{Name: executeResponsesStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteMultiTurnStep, sdkactivity.RegisterOptions{Name: executeMultiTurnStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.FinalizeMultiTurnPostRun, sdkactivity.RegisterOptions{Name: finalizeMultiTurnPostRunActivityName})
-	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
-	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
-	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateExecution, sdkactivity.RegisterOptions{Name: simulateExecutionActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateEvaluation, sdkactivity.RegisterOptions{Name: simulateEvaluationActivityName})
 	registrar.RegisterActivityWithOptions(activities.TransitionAgentHarnessExecutionStatus, sdkactivity.RegisterOptions{Name: transitionAgentHarnessExecutionStatusActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteAgentHarnessExecution, sdkactivity.RegisterOptions{Name: executeAgentHarnessExecutionActivityName})
-	registrar.RegisterActivityWithOptions(activities.ExecutePublicAgentTryout, sdkactivity.RegisterOptions{Name: executePublicAgentTryoutActivityName})
 }
 
-func RegisterDatasetGeneration(registrar Registrar, activities *DatasetGenerationActivities) {
-	registrar.RegisterWorkflowWithOptions(SyntheticDatasetGenerationWorkflow, sdkworkflow.RegisterOptions{Name: SyntheticDatasetGenerationWorkflowName})
-	registrar.RegisterActivityWithOptions(activities.LoadDatasetGenerationExecutionContext, sdkactivity.RegisterOptions{Name: loadDatasetGenerationExecutionContextActivityName})
-	registrar.RegisterActivityWithOptions(activities.SetDatasetGenerationJobTemporalIDs, sdkactivity.RegisterOptions{Name: setDatasetGenerationJobTemporalIDsActivityName})
-	registrar.RegisterActivityWithOptions(activities.UpdateDatasetGenerationJobStatus, sdkactivity.RegisterOptions{Name: updateDatasetGenerationJobStatusActivityName})
-	registrar.RegisterActivityWithOptions(activities.ExecuteSyntheticDatasetGeneration, sdkactivity.RegisterOptions{Name: executeSyntheticDatasetGenerationActivityName})
+func registerScoringActivities(registrar Registrar, activities *Activities) {
+	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
+	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
+	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})
+}
+
+func registerBackgroundActivities(registrar Registrar, activities *Activities) {
+	registrar.RegisterActivityWithOptions(activities.ExecutePublicAgentTryout, sdkactivity.RegisterOptions{Name: executePublicAgentTryoutActivityName})
 }

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -196,6 +196,7 @@ func nativeModelActivityOptions(executionContext repository.RunAgentExecutionCon
 		timeout = time.Duration(executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
 	}
 	return sdkworkflow.ActivityOptions{
+		TaskQueue:           TaskQueueExecution,
 		StartToCloseTimeout: timeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts:    3,
@@ -359,7 +360,14 @@ func markRunAgentFailed(ctx sdkworkflow.Context, runAgentID uuid.UUID, workflowE
 
 func buildRunAgentReplay(ctx sdkworkflow.Context, runAgentID uuid.UUID) error {
 	var replay repository.RunAgentReplay
-	return sdkworkflow.ExecuteActivity(ctx, buildRunAgentReplayActivityName, BuildRunAgentReplayInput{
+	replayCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
+		TaskQueue:           TaskQueueScoring,
+		StartToCloseTimeout: defaultActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+	})
+	return sdkworkflow.ExecuteActivity(replayCtx, buildRunAgentReplayActivityName, BuildRunAgentReplayInput{
 		RunAgentID: runAgentID,
 	}).Get(ctx, &replay)
 }

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -145,7 +145,7 @@ func runMultiTurnRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, 
 
 func executeMultiTurnStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
 	return sdkworkflow.ExecuteActivity(
-		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, nativeModelActivityOptions(executionContext), TaskQueueExecution)),
 		executeMultiTurnStepActivityName,
 		input,
 	)
@@ -153,7 +153,7 @@ func executeMultiTurnStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, 
 
 func executePromptEvalStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
 	return sdkworkflow.ExecuteActivity(
-		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, nativeModelActivityOptions(executionContext), TaskQueueExecution)),
 		executePromptEvalStepActivityName,
 		input,
 	)
@@ -161,7 +161,7 @@ func executePromptEvalStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput,
 
 func executeResponsesStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
 	return sdkworkflow.ExecuteActivity(
-		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, nativeModelActivityOptions(executionContext), TaskQueueExecution)),
 		executeResponsesStepActivityName,
 		input,
 	)
@@ -184,7 +184,7 @@ func executionModeFromManifest(manifest json.RawMessage) string {
 
 func executeNativeModelStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
 	return sdkworkflow.ExecuteActivity(
-		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, nativeModelActivityOptions(executionContext), TaskQueueExecution)),
 		executeNativeModelStepActivityName,
 		input,
 	)
@@ -196,7 +196,6 @@ func nativeModelActivityOptions(executionContext repository.RunAgentExecutionCon
 		timeout = time.Duration(executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
 	}
 	return sdkworkflow.ActivityOptions{
-		TaskQueue:           TaskQueueExecution,
 		StartToCloseTimeout: timeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts:    3,
@@ -360,13 +359,12 @@ func markRunAgentFailed(ctx sdkworkflow.Context, runAgentID uuid.UUID, workflowE
 
 func buildRunAgentReplay(ctx sdkworkflow.Context, runAgentID uuid.UUID) error {
 	var replay repository.RunAgentReplay
-	replayCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
-		TaskQueue:           TaskQueueScoring,
+	replayCtx := sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, sdkworkflow.ActivityOptions{
 		StartToCloseTimeout: defaultActivityTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},
-	})
+	}, TaskQueueScoring))
 	return sdkworkflow.ExecuteActivity(replayCtx, buildRunAgentReplayActivityName, BuildRunAgentReplayInput{
 		RunAgentID: runAgentID,
 	}).Get(ctx, &replay)

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -75,7 +75,7 @@ func runWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 		return err
 	}
 
-	if err := executeRunAgents(ctx, runAgents); err != nil {
+	if err := executeRunAgents(ctx, runAgents, input.MaxConcurrentRunAgents); err != nil {
 		return err
 	}
 
@@ -86,7 +86,7 @@ func runWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	if err != nil {
 		return err
 	}
-	scoreSummary, err := scoreEvaluatingRunAgents(ctx, input.RunID, updatedRunAgents)
+	scoreSummary, err := scoreEvaluatingRunAgents(ctx, input.RunID, updatedRunAgents, input.MaxConcurrentScoreActivities)
 	if err != nil {
 		return err
 	}
@@ -97,38 +97,46 @@ func runWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	return nil
 }
 
-func executeRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent) error {
-	selector := sdkworkflow.NewSelector(ctx)
-	completedChildren := 0
+func executeRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent, maxConcurrent int) error {
+	if len(runAgents) == 0 {
+		return nil
+	}
 	childErrors := make(map[uuid.UUID]error, len(runAgents))
-
-	for _, runAgent := range runAgents {
+	launch := func(index int) sdkworkflow.Future {
+		runAgent := runAgents[index]
 		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
 			WorkflowID:        fmt.Sprintf("%s/%s/%s", RunAgentWorkflowName, runAgent.RunID, runAgent.ID),
+			TaskQueue:         TaskQueueExecution,
 			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
 		})
-
-		runAgent := runAgent
-		future := sdkworkflow.ExecuteChildWorkflow(childCtx, RunAgentWorkflowName, RunAgentWorkflowInput{
+		return sdkworkflow.ExecuteChildWorkflow(childCtx, RunAgentWorkflowName, RunAgentWorkflowInput{
 			RunID:      runAgent.RunID,
 			RunAgentID: runAgent.ID,
 		})
-		selector.AddFuture(future, func(f sdkworkflow.Future) {
-			completedChildren++
-			if err := f.Get(ctx, nil); err != nil {
-				childErrors[runAgent.ID] = err
+	}
+	onComplete := func(index int, future sdkworkflow.Future) error {
+		if err := future.Get(ctx, nil); err != nil {
+			childErrors[runAgents[index].ID] = err
+			if isWorkflowCanceled(err) {
+				return err
 			}
-		})
+		}
+		return nil
 	}
 
-	for completedChildren < len(runAgents) {
-		selector.Select(ctx)
+	var err error
+	if boundedFanoutVersion(ctx, runAgentsBoundedFanoutVersionChangeID) == sdkworkflow.DefaultVersion {
+		err = launchAllUnbounded(ctx, len(runAgents), launch, onComplete)
+	} else {
+		cap := resolvePositiveCap(maxConcurrent, DefaultMaxConcurrentRunAgents)
+		err = launchBounded(ctx, cap, len(runAgents), launch, onComplete)
 	}
-
+	if err != nil {
+		return err
+	}
 	if len(childErrors) == len(runAgents) {
 		return selectRunAgentChildError(childErrors)
 	}
-
 	return nil
 }
 
@@ -147,7 +155,7 @@ func selectRunAgentChildError(childErrors map[uuid.UUID]error) error {
 	return firstActionable
 }
 
-func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runID uuid.UUID, runAgents []domain.RunAgent) (string, error) {
+func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runID uuid.UUID, runAgents []domain.RunAgent, maxConcurrent int) (string, error) {
 	outcomes := make(map[uuid.UUID]string, len(runAgents))
 	completedRunAgents := make([]domain.RunAgent, 0, len(runAgents))
 	for _, runAgent := range runAgents {
@@ -164,37 +172,40 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runID uuid.UUID, runAgent
 	}
 
 	scoreCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
+		TaskQueue:           TaskQueueScoring,
 		StartToCloseTimeout: scoreRunAgentTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 2,
 			InitialInterval: 5 * time.Second,
 		},
 	})
-	selector := sdkworkflow.NewSelector(ctx)
-	completedActivities := 0
-
-	for _, runAgent := range completedRunAgents {
-		runAgent := runAgent
-		future := sdkworkflow.ExecuteActivity(scoreCtx, scoreRunAgentActivityName, ScoreRunAgentInput{
-			RunAgentID: runAgent.ID,
-		})
-		selector.AddFuture(future, func(f sdkworkflow.Future) {
-			completedActivities++
-
-			evaluation, err := scoreRunAgentResult(ctx, f)
-			switch {
-			case err != nil:
-				outcomes[runAgent.ID] = "errored"
-			case evaluation.Status == scoring.EvaluationStatusPartial:
-				outcomes[runAgent.ID] = "partial"
-			default:
-				outcomes[runAgent.ID] = "scored"
-			}
+	launch := func(index int) sdkworkflow.Future {
+		return sdkworkflow.ExecuteActivity(scoreCtx, scoreRunAgentActivityName, ScoreRunAgentInput{
+			RunAgentID: completedRunAgents[index].ID,
 		})
 	}
-
-	for completedActivities < len(completedRunAgents) {
-		selector.Select(ctx)
+	onComplete := func(index int, future sdkworkflow.Future) error {
+		evaluation, err := scoreRunAgentResult(ctx, future)
+		runAgentID := completedRunAgents[index].ID
+		switch {
+		case err != nil:
+			outcomes[runAgentID] = "errored"
+		case evaluation.Status == scoring.EvaluationStatusPartial:
+			outcomes[runAgentID] = "partial"
+		default:
+			outcomes[runAgentID] = "scored"
+		}
+		return nil
+	}
+	if boundedFanoutVersion(ctx, scoreAgentsBoundedFanoutVersionChangeID) == sdkworkflow.DefaultVersion {
+		if err := launchAllUnbounded(ctx, len(completedRunAgents), launch, onComplete); err != nil {
+			return "", err
+		}
+	} else {
+		cap := resolvePositiveCap(maxConcurrent, DefaultMaxConcurrentScoreActivities)
+		if err := launchBounded(ctx, cap, len(completedRunAgents), launch, onComplete); err != nil {
+			return "", err
+		}
 	}
 
 	for _, runAgent := range completedRunAgents {
@@ -265,7 +276,14 @@ func listRunAgents(ctx sdkworkflow.Context, runID uuid.UUID) ([]domain.RunAgent,
 
 func buildRunScorecard(ctx sdkworkflow.Context, runID uuid.UUID) error {
 	var scorecard struct{}
-	return sdkworkflow.ExecuteActivity(ctx, buildRunScorecardActivityName, BuildRunScorecardInput{
+	scorecardCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
+		TaskQueue:           TaskQueueScoring,
+		StartToCloseTimeout: defaultActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+	})
+	return sdkworkflow.ExecuteActivity(scorecardCtx, buildRunScorecardActivityName, BuildRunScorecardInput{
 		RunID: runID,
 	}).Get(ctx, &scorecard)
 }

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -104,11 +104,10 @@ func executeRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent, maxC
 	childErrors := make(map[uuid.UUID]error, len(runAgents))
 	launch := func(index int) sdkworkflow.Future {
 		runAgent := runAgents[index]
-		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
+		childCtx := sdkworkflow.WithChildOptions(ctx, withChildExecutionTaskQueue(ctx, sdkworkflow.ChildWorkflowOptions{
 			WorkflowID:        fmt.Sprintf("%s/%s/%s", RunAgentWorkflowName, runAgent.RunID, runAgent.ID),
-			TaskQueue:         TaskQueueExecution,
 			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
-		})
+		}))
 		return sdkworkflow.ExecuteChildWorkflow(childCtx, RunAgentWorkflowName, RunAgentWorkflowInput{
 			RunID:      runAgent.RunID,
 			RunAgentID: runAgent.ID,
@@ -171,14 +170,13 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runID uuid.UUID, runAgent
 		return summarizeScoreOutcomes(outcomes), nil
 	}
 
-	scoreCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
-		TaskQueue:           TaskQueueScoring,
+	scoreCtx := sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, sdkworkflow.ActivityOptions{
 		StartToCloseTimeout: scoreRunAgentTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 2,
 			InitialInterval: 5 * time.Second,
 		},
-	})
+	}, TaskQueueScoring))
 	launch := func(index int) sdkworkflow.Future {
 		return sdkworkflow.ExecuteActivity(scoreCtx, scoreRunAgentActivityName, ScoreRunAgentInput{
 			RunAgentID: completedRunAgents[index].ID,
@@ -276,13 +274,12 @@ func listRunAgents(ctx sdkworkflow.Context, runID uuid.UUID) ([]domain.RunAgent,
 
 func buildRunScorecard(ctx sdkworkflow.Context, runID uuid.UUID) error {
 	var scorecard struct{}
-	scorecardCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
-		TaskQueue:           TaskQueueScoring,
+	scorecardCtx := sdkworkflow.WithActivityOptions(ctx, withActivityTaskQueue(ctx, sdkworkflow.ActivityOptions{
 		StartToCloseTimeout: defaultActivityTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},
-	})
+	}, TaskQueueScoring))
 	return sdkworkflow.ExecuteActivity(scorecardCtx, buildRunScorecardActivityName, BuildRunScorecardInput{
 		RunID: runID,
 	}).Get(ctx, &scorecard)

--- a/backend/internal/workflow/types.go
+++ b/backend/internal/workflow/types.go
@@ -10,15 +10,24 @@ const (
 	PublicAgentTryoutExecutionWorkflowName = "PublicAgentTryoutExecutionWorkflow"
 	SyntheticDatasetGenerationWorkflowName = "SyntheticDatasetGenerationWorkflow"
 	HostedRunEventSignal                   = "hosted_run_event"
-	WorkflowTaskQueue                      = RunWorkflowName
+	// WorkflowTaskQueue is where parent/child workflows are started. Fleet 2
+	// partitions activity work across TaskQueueExecution/Scoring/Background;
+	// workflows themselves run on the execution queue.
+	WorkflowTaskQueue = TaskQueueExecution
 )
 
 type EvalSessionWorkflowInput struct {
 	EvalSessionID uuid.UUID `json:"eval_session_id"`
+	// MaxConcurrentRuns caps in-flight child RunWorkflows. Zero → DefaultMaxConcurrentEvalSessionRuns.
+	MaxConcurrentRuns int `json:"max_concurrent_runs,omitempty"`
 }
 
 type RunWorkflowInput struct {
 	RunID uuid.UUID `json:"run_id"`
+	// MaxConcurrentRunAgents caps in-flight child RunAgentWorkflows. Zero → DefaultMaxConcurrentRunAgents.
+	MaxConcurrentRunAgents int `json:"max_concurrent_run_agents,omitempty"`
+	// MaxConcurrentScoreActivities caps in-flight score activities. Zero → DefaultMaxConcurrentScoreActivities.
+	MaxConcurrentScoreActivities int `json:"max_concurrent_score_activities,omitempty"`
 }
 
 type RunAgentWorkflowInput struct {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -177,6 +177,11 @@ func TestEvalSessionWorkflowDefaultVersionSkipsChildRefresh(t *testing.T) {
 		sdkworkflow.DefaultVersion,
 		sdkworkflow.Version(1),
 	).Return(sdkworkflow.DefaultVersion)
+	env.OnGetVersion(
+		taskQueuePartitionVersionChangeID,
+		sdkworkflow.DefaultVersion,
+		sdkworkflow.Version(1),
+	).Return(sdkworkflow.DefaultVersion)
 	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
 
 	if err := env.GetWorkflowError(); err != nil {

--- a/docs/deployment/worker-scaling.md
+++ b/docs/deployment/worker-scaling.md
@@ -1,0 +1,70 @@
+# Worker scaling and task-queue topology
+
+Fleet workers process Temporal workflows and activities for eval runs. This
+document covers concurrency knobs and the execution / scoring / background
+queue split introduced with Fleet 2.
+
+## Task queues
+
+| Queue | Purpose |
+|---|---|
+| `execution` | Eval-session, run, run-agent, and agent-harness workflows plus native/prompt/multi-turn execution activities |
+| `scoring` | `score_run_agent`, scorecard build, replay build |
+| `background` | Dataset generation and public agent tryouts |
+
+Workflows are started on `execution` (or `background` for tryouts/dataset jobs).
+Activities pin to their class via `ActivityOptions.TaskQueue`.
+
+## Environment variables
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WORKER_TASK_QUEUES` | `execution,scoring,background` | Comma-separated queues this process serves |
+| `WORKER_TASK_QUEUE` | _(unset)_ | Legacy single-queue override; `RunWorkflow` expands to all three classes |
+| `WORKER_MAX_CONCURRENT_ACTIVITIES` | `100` | Per-queue Temporal `MaxConcurrentActivityExecutionSize` |
+| `WORKER_MAX_CONCURRENT_WORKFLOW_TASKS` | `100` | Per-queue Temporal `MaxConcurrentWorkflowTaskExecutionSize` |
+| `WORKER_ACTIVITIES_PER_SECOND` | `0` | Worker-local rate limit; `0` = unlimited |
+| `WORKER_TASKQUEUE_ACTIVITIES_PER_SECOND` | `0` | Server-side queue rate limit; `0` = unlimited |
+
+Bounded fan-out caps inside workflows (deterministic defaults, not env-read):
+
+- Eval-session child runs: 16
+- Run-agent children per run: 8
+- Scoring activities per run: 16
+
+## Topologies
+
+### One-process (default / local)
+
+```bash
+export WORKER_TASK_QUEUES=execution,scoring,background
+make worker
+```
+
+One binary starts three Temporal workers (one per queue) with the same identity
+prefix. Capability matches the historical single-queue worker.
+
+### Split fleet (production)
+
+Run separate Deployments/processes:
+
+```bash
+# Execution pool (scale with run depth)
+WORKER_TASK_QUEUES=execution
+
+# Scoring pool
+WORKER_TASK_QUEUES=scoring
+
+# Background pool (dataset gen / tryouts)
+WORKER_TASK_QUEUES=background
+```
+
+Background load cannot consume execution slots because the queues are distinct.
+Pair with KEDA Temporal queue-depth autoscaling (Fleet 12) when ready.
+
+## Rollback / compatibility
+
+- Setting `WORKER_TASK_QUEUE=RunWorkflow` expands to all three class queues.
+- Workflow histories recorded before bounded fan-out replay via `GetVersion`
+  DefaultVersion (unbounded launch-all).
+- Case fan-out (`profile_config.case_fanout`) remains default-off (Fleet 1).


### PR DESCRIPTION
⛔ Stacked on #1213 — do not merge out of order. Part of epic #1212.
Closes #1199.

## What & why

Fan-out was unbounded at every orchestration level: eval-session child runs, run-agent children, and scoring activities all launched N futures in a tight loop. Worker options were untuned (Identity only), and every workload shared the single `RunWorkflow` task queue. This PR adds a deterministic bounded-launch helper (GetVersion-gated for replay), worker concurrency env knobs with defaults that preserve today’s behavior when unset, and a three-way queue split (`execution` / `scoring` / `background`) so background jobs cannot starve run execution. A single process listing all three queues matches the historical one-worker capability.

## Decisions

1. **Shared `launchBounded` helper extracted from Fleet 1’s case window.** Options: copy-paste at each site vs generic helper. Chose the helper (`bounded_fanout.go`) with sorted pending futures for replay-safe registration. Sources: `case_fanout.go`; `temporalio/samples-go/batch-sliding-window/sliding_window_workflow.go`.

2. **Always call `GetVersion` at the three sites; DefaultVersion keeps launch-all.** Unlike case fan-out (default-off), these caps are always-on for new workflows, so old in-flight histories must replay the unbounded schedule. Sources: `temporalio/samples-go/worker-versioning/workflows.go`; existing `eval-session-refresh-child-runs` gate.

3. **Queue names `execution`/`scoring`/`background`; workflows start on `execution`.** Legacy `RunWorkflow` expands to all three via `ExpandTaskQueues` so `WORKER_TASK_QUEUE=RunWorkflow` upgrades cleanly. Dataset gen + public tryouts start on `background`. Sources: issue spec; KEDA Temporal scaler queue-depth model (Fleet 12 prep).

4. **Rate-limit `0` = leave SDK default (unlimited).** SDK maps `0` → 100000. We only set `WorkerActivitiesPerSecond` / `TaskQueueActivitiesPerSecond` when env > 0. Concurrent activity/WFT defaults are **100** (issue), not the SDK’s 1000. Sources: `go.temporal.io/sdk@v1.41.0/internal/internal_worker.go` defaults.

5. **Caps are workflow constants / optional input fields — never env-read in workflow code.** Determinism. Fleet 7 can plumb manifest `max_concurrent_runs` into `EvalSessionWorkflowInput.MaxConcurrentRuns`.

6. **Multi-worker process:** one Temporal worker client per configured queue, class-scoped `RegisterForTaskQueue`. Sources: Temporal multi-worker patterns; issue “one process listing all three”.

## Review map

1. `backend/internal/workflow/bounded_fanout.go` — helper + queue constants
2. `backend/internal/workflow/run_workflow.go` / `eval_session_workflow.go` — GetVersion + bounded call sites
3. `backend/internal/workflow/register.go` — per-queue registration split
4. `backend/internal/worker/config.go` + `service.go` — knobs + multi-queue workers
5. `docs/deployment/worker-scaling.md` — topology guide

## Verification evidence

```
cd backend && go build ./... && go vet ./... && go test -short -race -count=1 ./...
```

All packages `ok` (two consecutive clean passes after final edits).

Acceptance checklist:
- [x] Eval session 50 children ≤ cap — `TestEvalSessionWorkflowBoundedFanoutCap`
- [x] Replay GetVersion DefaultVersion — `TestEvalSessionWorkflowDefaultVersionUnboundedReplay`
- [x] `WORKER_TASK_QUEUES=execution,scoring,background` default ≡ full coverage — `RegisterForTaskQueue` + `TestLoadConfigFromEnvUsesDefaultsWhenUnset`
- [x] Background workflows land on `background` — `TestTemporalBackgroundWorkflowsUseBackgroundQueue`
- [x] LoadConfig defaults validated — config unit tests
- [x] Helper max-in-flight — `TestLaunchBounded_RespectsMaxInFlight`

## Risk & rollback

- New workflows use bounded fan-out immediately (GetVersion v1). Disable only by deploying a build without this change; there is no env kill-switch for the workflow caps (by design — env in workflow code is forbidden).
- Queue rename: deploy API + worker together. Legacy `WORKER_TASK_QUEUE=RunWorkflow` expands to all three.
- Worker defaults change MaxConcurrent* from SDK 1000 → 100; raise via env if a deployment relied on higher implicit concurrency.