### PR TITLE
feat(runevents): spill oversized event payloads to object storage

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -18,6 +19,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/storage"
 	"github.com/agentclash/agentclash/backend/internal/temporalutil"
 	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runevents"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -44,8 +46,6 @@ func main() {
 	}
 	defer temporalClient.Close()
 
-	repo := repository.New(db).WithCipher(cfg.SecretsCipher)
-
 	// Redis pub/sub (optional).
 	var eventPublisher pubsub.EventPublisher = pubsub.NoopPublisher{}
 	var eventSubscriber pubsub.EventSubscriber = pubsub.NoopSubscriber{}
@@ -63,7 +63,6 @@ func main() {
 		logger.Info("redis event streaming: disabled (REDIS_URL not set)")
 	}
 
-	authorizer := api.NewCallerWorkspaceAuthorizer(repo)
 	artifactStore, err := storage.NewStore(context.Background(), storage.Config{
 		Backend:          cfg.ArtifactStorageBackend,
 		Bucket:           cfg.ArtifactStorageBucket,
@@ -78,6 +77,12 @@ func main() {
 		logger.Error("failed to initialize artifact storage", "error", err)
 		os.Exit(1)
 	}
+	payloadResolver := runevents.NewResolver(runevents.OpenFunc(func(ctx context.Context, key string) (io.ReadCloser, error) {
+		rc, _, err := artifactStore.OpenObject(ctx, key)
+		return rc, err
+	}), 64)
+	repo := repository.New(db).WithCipher(cfg.SecretsCipher).WithPayloadResolver(payloadResolver)
+	authorizer := api.NewCallerWorkspaceAuthorizer(repo)
 	artifactManager := api.NewArtifactManager(authorizer, repo, artifactStore, cfg.ArtifactSigningSecret, cfg.ArtifactSignedURLTTL, cfg.ArtifactMaxUploadBytes)
 	budgetChecker := budget.NewChecker(repository.NewBudgetRepositoryAdapter(repo))
 	runCreationManager := api.NewRunCreationManager(
@@ -99,7 +104,8 @@ func main() {
 		WithInsightsClient(providerRouter).
 		WithBudgetChecker(budgetChecker).
 		WithInsightsRateLimiter(insightsLimiter).
-		WithRunWorkflowControl(api.NewTemporalRunWorkflowCanceller(temporalClient))
+		WithRunWorkflowControl(api.NewTemporalRunWorkflowCanceller(temporalClient)).
+		WithPayloadResolver(payloadResolver)
 	multiTurnManager := api.NewMultiTurnManager(authorizer, repo, repository.NewMultiTurnHumanTurnStore(db))
 	if !runReadManager.InsightsConfigured() {
 		logger.Error("run ranking insights client is not configured")

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -16,6 +17,7 @@ import (
 	workflowpkg "github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/agentclash/agentclash/runtime/provider"
 	"github.com/agentclash/agentclash/runtime/provider/throttle"
+	"github.com/agentclash/agentclash/runtime/runevents"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 )
@@ -43,7 +45,26 @@ func main() {
 	}
 	defer temporalClient.Close()
 
-	repo := repository.New(db).WithCipher(cfg.SecretsCipher)
+	artifactStore, err := storage.NewStore(context.Background(), storage.Config{
+		Backend:          cfg.ArtifactStorage.Backend,
+		Bucket:           cfg.ArtifactStorage.Bucket,
+		FilesystemRoot:   cfg.ArtifactStorage.FilesystemRoot,
+		S3Region:         cfg.ArtifactStorage.S3Region,
+		S3Endpoint:       cfg.ArtifactStorage.S3Endpoint,
+		S3AccessKeyID:    cfg.ArtifactStorage.S3AccessKeyID,
+		S3SecretKey:      cfg.ArtifactStorage.S3SecretKey,
+		S3ForcePathStyle: cfg.ArtifactStorage.S3ForcePathStyle,
+	})
+	if err != nil {
+		logger.Error("failed to configure artifact storage", "error", err)
+		os.Exit(1)
+	}
+
+	payloadResolver := runevents.NewResolver(runevents.OpenFunc(func(ctx context.Context, key string) (io.ReadCloser, error) {
+		rc, _, err := artifactStore.OpenObject(ctx, key)
+		return rc, err
+	}), 64)
+	repo := repository.New(db).WithCipher(cfg.SecretsCipher).WithPayloadResolver(payloadResolver)
 
 	// PostHog analytics (optional). Noop when POSTHOG_API_KEY is unset, matching
 	// the api-server's posture. Used to emit run-lifecycle outcome events.
@@ -65,21 +86,6 @@ func main() {
 		}()
 	} else {
 		logger.Info("posthog analytics: disabled (POSTHOG_API_KEY not set)")
-	}
-
-	artifactStore, err := storage.NewStore(context.Background(), storage.Config{
-		Backend:          cfg.ArtifactStorage.Backend,
-		Bucket:           cfg.ArtifactStorage.Bucket,
-		FilesystemRoot:   cfg.ArtifactStorage.FilesystemRoot,
-		S3Region:         cfg.ArtifactStorage.S3Region,
-		S3Endpoint:       cfg.ArtifactStorage.S3Endpoint,
-		S3AccessKeyID:    cfg.ArtifactStorage.S3AccessKeyID,
-		S3SecretKey:      cfg.ArtifactStorage.S3SecretKey,
-		S3ForcePathStyle: cfg.ArtifactStorage.S3ForcePathStyle,
-	})
-	if err != nil {
-		logger.Error("failed to configure artifact storage", "error", err)
-		os.Exit(1)
 	}
 
 	// Redis event publishing (optional). The same client backs the
@@ -106,6 +112,12 @@ func main() {
 	}
 
 	var eventRecorder workerapp.RunEventRecorder = repo
+	if cfg.RunEventInlineMaxBytes > 0 {
+		eventRecorder = workerapp.NewOffloadingRecorder(eventRecorder, repo, artifactStore, cfg.RunEventInlineMaxBytes, logger)
+		logger.Info("run event payload offload: enabled", "inline_max_bytes", cfg.RunEventInlineMaxBytes)
+	} else {
+		logger.Info("run event payload offload: disabled (RUN_EVENT_INLINE_MAX_BYTES=0)")
+	}
 	if _, isNoop := eventPublisher.(pubsub.NoopPublisher); !isNoop {
 		eventRecorder = pubsub.NewPublishingRecorder(eventRecorder, eventPublisher, logger)
 	}

--- a/backend/db/queries/run_events.sql
+++ b/backend/db/queries/run_events.sql
@@ -11,6 +11,7 @@ INSERT INTO run_events (
     event_type,
     actor_type,
     occurred_at,
+    artifact_id,
     payload
 )
 SELECT
@@ -20,6 +21,7 @@ SELECT
     @event_type,
     @actor_type,
     @occurred_at,
+    sqlc.narg('artifact_id'),
     @payload
 FROM next_sequence
 RETURNING id, run_id, run_agent_id, sequence_number, event_type, actor_type, occurred_at, artifact_id, payload;
@@ -39,3 +41,9 @@ WHERE run_id = @run_id
   AND id > @after_id
 ORDER BY id ASC
 LIMIT @limit_count;
+
+-- name: ListRunEventPayloadArtifactsByRunID :many
+SELECT id, storage_bucket, storage_key
+FROM artifacts
+WHERE run_id = @run_id
+  AND artifact_type = 'run_event_payload';

--- a/backend/internal/api/run_events_hydrate_test.go
+++ b/backend/internal/api/run_events_hydrate_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/runtime/runevents"
+)
+
+func TestHydrateLiveRunEventData(t *testing.T) {
+	body := `{"delta":"hello-world"}`
+	open := runevents.OpenFunc(func(_ context.Context, key string) (io.ReadCloser, error) {
+		if key != "run-events/a/b.json" {
+			t.Fatalf("key = %s", key)
+		}
+		return io.NopCloser(strings.NewReader(body)), nil
+	})
+	resolver := runevents.NewResolver(open, 8)
+	stub, err := runevents.MarshalPayloadRef("run-events/a/b.json", len(body), runevents.EventTypeModelOutputDelta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(runevents.Envelope{
+		EventID:       "e1",
+		SchemaVersion: runevents.SchemaVersionV1,
+		EventType:     runevents.EventTypeModelOutputDelta,
+		Payload:       stub,
+	})
+	out, err := hydrateLiveRunEventData(context.Background(), resolver, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got runevents.Envelope
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Payload) != body {
+		t.Fatalf("payload = %s", got.Payload)
+	}
+}

--- a/backend/internal/api/run_events_sse.go
+++ b/backend/internal/api/run_events_sse.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,12 @@ var runEventStreamPollInterval = 750 * time.Millisecond
 // registerEventStreamRoute adds the SSE endpoint for live run event streaming.
 // Browsers using EventSource cannot set custom headers, so the endpoint keeps
 // query-token fallback while preferring normal Authorization header auth.
+// RunEventPayloadResolverProvider optionally exposes a claim-check resolver for
+// hydrating offloaded payloads on the live Redis SSE path.
+type RunEventPayloadResolverProvider interface {
+	RunEventPayloadResolver() *runevents.Resolver
+}
+
 func registerEventStreamRoute(
 	router chi.Router,
 	logger *slog.Logger,
@@ -151,7 +158,11 @@ func streamRunEventsHandler(
 					eventCh = nil
 					continue
 				}
-				if err := emitLiveRunEvent(w, flusher, data, delivered); err != nil {
+				var payloadResolver *runevents.Resolver
+				if provider, ok := runReadService.(RunEventPayloadResolverProvider); ok {
+					payloadResolver = provider.RunEventPayloadResolver()
+				}
+				if err := emitLiveRunEvent(r.Context(), w, flusher, data, delivered, payloadResolver); err != nil {
 					return
 				}
 			case <-ticker.C:
@@ -279,18 +290,47 @@ func writeRunEventsJSONL(w io.Writer, events []repository.RunEvent) error {
 }
 
 func emitLiveRunEvent(
+	ctx context.Context,
 	w http.ResponseWriter,
 	flusher http.Flusher,
 	data []byte,
 	delivered map[string]struct{},
+	payloadResolver *runevents.Resolver,
 ) error {
-	streamEventID := extractStreamEventID(data)
+	hydrated, err := hydrateLiveRunEventData(ctx, payloadResolver, data)
+	if err != nil {
+		return err
+	}
+	streamEventID := extractStreamEventID(hydrated)
 	if _, seen := delivered[streamEventID]; seen {
 		return nil
 	}
 	delivered[streamEventID] = struct{}{}
-	writeSSEFrame(w, flusher, streamEventID, data)
+	writeSSEFrame(w, flusher, streamEventID, hydrated)
 	return nil
+}
+
+func hydrateLiveRunEventData(ctx context.Context, resolver *runevents.Resolver, data []byte) ([]byte, error) {
+	if resolver == nil || len(data) == 0 {
+		return data, nil
+	}
+	var envelope runevents.Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return data, nil
+	}
+	if _, ok := runevents.ParsePayloadRef(envelope.Payload); !ok {
+		return data, nil
+	}
+	resolved, err := resolver.Resolve(ctx, envelope.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate live run event payload: %w", err)
+	}
+	envelope.Payload = resolved
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("marshal hydrated live run event: %w", err)
+	}
+	return out, nil
 }
 
 func marshalPersistedRunEvent(event repository.RunEvent) ([]byte, string, error) {

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -17,6 +17,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/agentclash/agentclash/runtime/domain"
 	"github.com/agentclash/agentclash/runtime/provider"
+	"github.com/agentclash/agentclash/runtime/runevents"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"go.temporal.io/api/serviceerror"
@@ -136,6 +137,7 @@ type RunReadManager struct {
 	insightsTimeout time.Duration
 	workflowControl RunWorkflowControl
 	now             func() time.Time
+	payloadResolver *runevents.Resolver
 }
 
 const rankingInsightsTimeout = 45 * time.Second
@@ -153,6 +155,17 @@ func NewRunReadManager(authorizer WorkspaceAuthorizer, repo RunReadRepository) *
 func (m *RunReadManager) WithInsightsClient(client provider.Client) *RunReadManager {
 	m.insightsClient = client
 	return m
+}
+
+// WithPayloadResolver enables hydrating offloaded run-event stubs on the live
+// SSE path (Redis frames). Persisted list/export hydrate via the repository.
+func (m *RunReadManager) WithPayloadResolver(resolver *runevents.Resolver) *RunReadManager {
+	m.payloadResolver = resolver
+	return m
+}
+
+func (m *RunReadManager) RunEventPayloadResolver() *runevents.Resolver {
+	return m.payloadResolver
 }
 
 func (m *RunReadManager) WithBudgetChecker(checker budget.BudgetChecker) *RunReadManager {

--- a/backend/internal/pubsub/publishing_recorder.go
+++ b/backend/internal/pubsub/publishing_recorder.go
@@ -31,8 +31,12 @@ func (r *PublishingRecorder) RecordRunEvent(ctx context.Context, params reposito
 		return event, err
 	}
 
-	// Publish the persisted event with the DB-assigned sequence number.
+	// Publish the persisted wire shape (including offload stubs) so Redis
+	// never carries multi-MB frames. Sequence comes from the DB row.
 	publishEnvelope := params.Event.WithSequenceNumber(event.SequenceNumber)
+	if len(event.Payload) > 0 {
+		publishEnvelope.Payload = append(publishEnvelope.Payload[:0:0], event.Payload...)
+	}
 	if pubErr := r.publisher.PublishRunEvent(ctx, params.Event.RunID, publishEnvelope); pubErr != nil {
 		r.logger.Warn("failed to publish run event to redis",
 			"run_id", params.Event.RunID,

--- a/backend/internal/pubsub/publishing_recorder_test.go
+++ b/backend/internal/pubsub/publishing_recorder_test.go
@@ -85,6 +85,38 @@ func TestPublishingRecorder_PublishesAfterRecord(t *testing.T) {
 	}
 }
 
+func TestPublishingRecorder_PublishesPersistedStubPayload(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	stub := []byte(`{"$ref":"run-events/x/y.json","bytes":100,"type":"model.output.delta"}`)
+	inner := &fakeRecorder{
+		returnEvent: repository.RunEvent{
+			ID:             1,
+			RunID:          runID,
+			RunAgentID:     runAgentID,
+			SequenceNumber: 7,
+			Payload:        stub,
+		},
+	}
+	pub := &fakePublisher{}
+	recorder := NewPublishingRecorder(inner, pub, slog.Default())
+
+	_, err := recorder.RecordRunEvent(context.Background(), repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			RunID:      runID,
+			RunAgentID: runAgentID,
+			EventType:  runevents.EventTypeModelOutputDelta,
+			Payload:    []byte(`{"huge":true}`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(pub.lastEvent.Payload) != string(stub) {
+		t.Fatalf("published payload = %s, want stub", pub.lastEvent.Payload)
+	}
+}
+
 func TestPublishingRecorder_RecordErrorSkipsPublish(t *testing.T) {
 	inner := &fakeRecorder{returnErr: errors.New("db error")}
 	pub := &fakePublisher{}

--- a/backend/internal/repository/artifacts.go
+++ b/backend/internal/repository/artifacts.go
@@ -244,6 +244,26 @@ func (r *Repository) GetArtifactByID(ctx context.Context, artifactID uuid.UUID) 
 	return artifact, nil
 }
 
+// MarkArtifactScheduledForDeletion soft-expires an active artifact so its
+// storage key can be reused after a failed offload (unique bucket+key).
+func (r *Repository) MarkArtifactScheduledForDeletion(ctx context.Context, artifactID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE artifacts
+		SET retention_status = 'scheduled_for_deletion',
+		    storage_key = storage_key || '.deleted.' || id::text,
+		    updated_at = now()
+		WHERE id = $1
+		  AND retention_status = 'active'
+	`, artifactID)
+	if err != nil {
+		return fmt.Errorf("mark artifact scheduled for deletion: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrArtifactNotFound
+	}
+	return nil
+}
+
 type artifactScanner interface {
 	Scan(dest ...any) error
 }

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -29,6 +29,8 @@ type Repository struct {
 	db      *pgxpool.Pool
 	queries *repositorysqlc.Queries
 	cipher  *secrets.AESGCMCipher
+	// payloadResolver hydrates offloaded run-event stubs on list/read paths.
+	payloadResolver *runevents.Resolver
 }
 
 type SetRunTemporalIDsParams struct {
@@ -80,6 +82,8 @@ type RecordHostedRunEventParams struct {
 
 type RecordRunEventParams struct {
 	Event runevents.Envelope
+	// ArtifactID optionally links an offloaded payload object (run_event_payload).
+	ArtifactID *uuid.UUID
 }
 
 // RunAnalyticsMetadata is the minimal run attribution used by worker-side
@@ -364,6 +368,25 @@ func New(db *pgxpool.Pool) *Repository {
 func (r *Repository) WithCipher(cipher *secrets.AESGCMCipher) *Repository {
 	r.cipher = cipher
 	return r
+}
+
+// WithPayloadResolver attaches a claim-check resolver for offloaded run-event
+// payloads. List/read helpers hydrate stubs transparently when set.
+func (r *Repository) WithPayloadResolver(resolver *runevents.Resolver) *Repository {
+	r.payloadResolver = resolver
+	return r
+}
+
+func (r *Repository) hydrateRunEventPayload(ctx context.Context, event *RunEvent) error {
+	if r == nil || r.payloadResolver == nil || event == nil {
+		return nil
+	}
+	resolved, err := r.payloadResolver.Resolve(ctx, event.Payload)
+	if err != nil {
+		return err
+	}
+	event.Payload = resolved
+	return nil
 }
 
 func (r *Repository) GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, error) {
@@ -1798,6 +1821,7 @@ func (r *Repository) RecordRunEvent(ctx context.Context, params RecordRunEventPa
 			EventType:  string(params.Event.EventType),
 			ActorType:  string(params.Event.Source),
 			OccurredAt: pgtype.Timestamptz{Time: params.Event.OccurredAt.UTC(), Valid: true},
+			ArtifactID: params.ArtifactID,
 			Payload:    cloneJSON(params.Event.Payload),
 		})
 		if err == nil {
@@ -1825,6 +1849,7 @@ func insertCanonicalRunEventTx(ctx context.Context, queries *repositorysqlc.Quer
 		EventType:  string(event.EventType),
 		ActorType:  string(event.Source),
 		OccurredAt: pgtype.Timestamptz{Time: event.OccurredAt.UTC(), Valid: true},
+		ArtifactID: nil,
 		Payload:    cloneJSON(event.Payload),
 	})
 	if err != nil {
@@ -1846,6 +1871,9 @@ func (r *Repository) ListRunEventsByRunAgentID(ctx context.Context, runAgentID u
 		event, mapErr := mapRunEvent(row)
 		if mapErr != nil {
 			return nil, fmt.Errorf("map run event: %w", mapErr)
+		}
+		if err := r.hydrateRunEventPayload(ctx, &event); err != nil {
+			return nil, fmt.Errorf("hydrate run event payload: %w", err)
 		}
 		events = append(events, event)
 	}
@@ -1877,6 +1905,9 @@ func (r *Repository) ListRunEventsByRunIDAfter(ctx context.Context, runID uuid.U
 		event, mapErr := mapRunEvent(row)
 		if mapErr != nil {
 			return nil, fmt.Errorf("map run event: %w", mapErr)
+		}
+		if err := r.hydrateRunEventPayload(ctx, &event); err != nil {
+			return nil, fmt.Errorf("hydrate run event payload: %w", err)
 		}
 		events = append(events, event)
 	}

--- a/backend/internal/repository/run_event_offload_integration_test.go
+++ b/backend/internal/repository/run_event_offload_integration_test.go
@@ -1,0 +1,98 @@
+package repository_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/agentclash/agentclash/backend/internal/worker"
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+	"log/slog"
+)
+
+func TestRunEventOffload_SpillHydrateExportAndPurge(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+
+	root := t.TempDir()
+	store, err := storage.NewFilesystemStore(storage.Config{
+		Backend:        storage.BackendFilesystem,
+		Bucket:         "test-events",
+		FilesystemRoot: root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := runevents.NewResolver(runevents.OpenFunc(func(ctx context.Context, key string) (io.ReadCloser, error) {
+		rc, _, err := store.OpenObject(ctx, key)
+		return rc, err
+	}), 8)
+	repo := repository.New(db).WithPayloadResolver(resolver)
+	recorder := worker.NewOffloadingRecorder(repo, repo, store, 64, slog.Default())
+
+	payloadObj := map[string]any{"blob": string(bytes.Repeat([]byte("Z"), 200))}
+	payload, _ := json.Marshal(payloadObj)
+
+	eventID := "offload-" + uuid.NewString()
+	recorded, err := recorder.RecordRunEvent(ctx, repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       eventID,
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         fixture.runID,
+			RunAgentID:    fixture.primaryRunAgentID,
+			EventType:     runevents.EventTypeModelOutputDelta,
+			Source:        runevents.SourceNativeEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payload,
+		},
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if _, ok := runevents.ParsePayloadRef(recorded.Payload); !ok {
+		// Recorded return may already be stub from offloader; check DB raw without hydrate
+		t.Fatalf("offloader should return stub, got %s", recorded.Payload)
+	}
+
+	// Hydrated list must match original payload bytes.
+	listed, err := repo.ListRunEventsByRunAgentID(ctx, fixture.primaryRunAgentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *repository.RunEvent
+	for i := range listed {
+		if listed[i].SequenceNumber == recorded.SequenceNumber {
+			found = &listed[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("event missing from list")
+	}
+	if !bytes.Equal(found.Payload, payload) {
+		t.Fatalf("hydrated payload mismatch:\n got %s\nwant %s", found.Payload, payload)
+	}
+
+	// Object must exist on disk.
+	ref, _ := runevents.ParsePayloadRef(recorded.Payload)
+	objPath := filepath.Join(root, "test-events", filepath.FromSlash(ref.Ref))
+	if _, err := os.Stat(objPath); err != nil {
+		t.Fatalf("object missing at %s: %v", objPath, err)
+	}
+
+	if err := repo.HardDeleteRun(ctx, store, fixture.runID); err != nil {
+		t.Fatalf("hard delete: %v", err)
+	}
+	if _, err := os.Stat(objPath); !os.IsNotExist(err) {
+		t.Fatalf("expected object deleted, stat err=%v", err)
+	}
+}

--- a/backend/internal/repository/run_event_payload_purge.go
+++ b/backend/internal/repository/run_event_payload_purge.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	repositorysqlc "github.com/agentclash/agentclash/backend/internal/repository/sqlc"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/google/uuid"
+)
+
+// PurgeRunEventPayloadObjects deletes offloaded run-event payload objects for a
+// run, then removes the corresponding artifact rows. Call before hard-deleting
+// a run so CASCADE on run_events does not leave orphaned objects.
+func (r *Repository) PurgeRunEventPayloadObjects(ctx context.Context, store storage.Store, runID uuid.UUID) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("storage store is required")
+	}
+	rows, err := r.queries.ListRunEventPayloadArtifactsByRunID(ctx, repositorysqlc.ListRunEventPayloadArtifactsByRunIDParams{
+		RunID: &runID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("list run event payload artifacts: %w", err)
+	}
+	deleted := 0
+	for _, row := range rows {
+		if err := store.DeleteObject(ctx, row.StorageKey); err != nil {
+			return deleted, fmt.Errorf("delete offloaded payload %q: %w", row.StorageKey, err)
+		}
+		if _, err := r.db.Exec(ctx, `DELETE FROM artifacts WHERE id = $1`, row.ID); err != nil {
+			return deleted, fmt.Errorf("delete artifact row %s: %w", row.ID, err)
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+// HardDeleteRun removes a run after purging offloaded event payloads. Intended
+// for retention/reaper paths and tests; production product deletes are rare.
+func (r *Repository) HardDeleteRun(ctx context.Context, store storage.Store, runID uuid.UUID) error {
+	if _, err := r.PurgeRunEventPayloadObjects(ctx, store, runID); err != nil {
+		return err
+	}
+	tag, err := r.db.Exec(ctx, `DELETE FROM runs WHERE id = $1`, runID)
+	if err != nil {
+		return fmt.Errorf("delete run: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrRunNotFound
+	}
+	return nil
+}

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -156,6 +156,7 @@ type Querier interface {
 	ListRunAgentStatusHistoryByRunAgentID(ctx context.Context, arg ListRunAgentStatusHistoryByRunAgentIDParams) ([]RunAgentStatusHistory, error)
 	ListRunAgentsByRunID(ctx context.Context, arg ListRunAgentsByRunIDParams) ([]RunAgent, error)
 	ListRunCaseSelectionsByRunID(ctx context.Context, arg ListRunCaseSelectionsByRunIDParams) ([]RunCaseSelection, error)
+	ListRunEventPayloadArtifactsByRunID(ctx context.Context, arg ListRunEventPayloadArtifactsByRunIDParams) ([]ListRunEventPayloadArtifactsByRunIDRow, error)
 	ListRunEventsByRunAgentID(ctx context.Context, arg ListRunEventsByRunAgentIDParams) ([]RunEvent, error)
 	// Cursor-paginated event feed for a run, ordered by the global row id so the
 	// cursor is stable and resumable across all of a run's agents.

--- a/backend/internal/repository/sqlc/run_events.sql.go
+++ b/backend/internal/repository/sqlc/run_events.sql.go
@@ -25,6 +25,7 @@ INSERT INTO run_events (
     event_type,
     actor_type,
     occurred_at,
+    artifact_id,
     payload
 )
 SELECT
@@ -34,7 +35,8 @@ SELECT
     $3,
     $4,
     $5,
-    $6
+    $6,
+    $7
 FROM next_sequence
 RETURNING id, run_id, run_agent_id, sequence_number, event_type, actor_type, occurred_at, artifact_id, payload
 `
@@ -45,6 +47,7 @@ type InsertRunEventParams struct {
 	EventType  string
 	ActorType  string
 	OccurredAt pgtype.Timestamptz
+	ArtifactID *uuid.UUID
 	Payload    []byte
 }
 
@@ -55,6 +58,7 @@ func (q *Queries) InsertRunEvent(ctx context.Context, arg InsertRunEventParams) 
 		arg.EventType,
 		arg.ActorType,
 		arg.OccurredAt,
+		arg.ArtifactID,
 		arg.Payload,
 	)
 	var i RunEvent
@@ -70,6 +74,43 @@ func (q *Queries) InsertRunEvent(ctx context.Context, arg InsertRunEventParams) 
 		&i.Payload,
 	)
 	return i, err
+}
+
+const listRunEventPayloadArtifactsByRunID = `-- name: ListRunEventPayloadArtifactsByRunID :many
+SELECT id, storage_bucket, storage_key
+FROM artifacts
+WHERE run_id = $1
+  AND artifact_type = 'run_event_payload'
+`
+
+type ListRunEventPayloadArtifactsByRunIDParams struct {
+	RunID *uuid.UUID
+}
+
+type ListRunEventPayloadArtifactsByRunIDRow struct {
+	ID            uuid.UUID
+	StorageBucket string
+	StorageKey    string
+}
+
+func (q *Queries) ListRunEventPayloadArtifactsByRunID(ctx context.Context, arg ListRunEventPayloadArtifactsByRunIDParams) ([]ListRunEventPayloadArtifactsByRunIDRow, error) {
+	rows, err := q.db.Query(ctx, listRunEventPayloadArtifactsByRunID, arg.RunID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRunEventPayloadArtifactsByRunIDRow
+	for rows.Next() {
+		var i ListRunEventPayloadArtifactsByRunIDRow
+		if err := rows.Scan(&i.ID, &i.StorageBucket, &i.StorageKey); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listRunEventsByRunAgentID = `-- name: ListRunEventsByRunAgentID :many

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -29,6 +29,7 @@ const (
 	defaultArtifactMaxAssetBytes    = 100 << 20
 	defaultOrphanRunReaperInterval  = 5 * time.Minute
 	defaultOrphanRunReaperThreshold = 15 * time.Minute
+	defaultRunEventInlineMaxBytes   = 32 * 1024
 	// Anonymous agent tryouts carry an expires_at (default 24h, cleared on
 	// claim). The retention reaper sweeps expired, unclaimed tryouts hourly.
 	defaultAgentTryoutRetentionReaperInterval = time.Hour
@@ -64,7 +65,9 @@ type Config struct {
 	ArtifactStorage                    ArtifactStorageConfig
 	Sandbox                            SandboxConfig
 	ProviderThrottle                   throttle.Config
-	SecretsCipher                      *secrets.AESGCMCipher
+	// RunEventInlineMaxBytes spills larger payloads to object storage (0 = off).
+	RunEventInlineMaxBytes int
+	SecretsCipher          *secrets.AESGCMCipher
 }
 
 type ArtifactStorageConfig struct {
@@ -322,6 +325,13 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	runEventInlineMaxBytes, err := intEnvOrDefault("RUN_EVENT_INLINE_MAX_BYTES", defaultRunEventInlineMaxBytes)
+	if err != nil {
+		return Config{}, err
+	}
+	if runEventInlineMaxBytes < 0 {
+		return Config{}, fmt.Errorf("%w: RUN_EVENT_INLINE_MAX_BYTES must be >= 0", ErrInvalidConfig)
+	}
 
 	taskQueues, primaryQueue, err := loadWorkerTaskQueuesFromEnv()
 	if err != nil {
@@ -430,8 +440,9 @@ func LoadConfigFromEnv() (Config, error) {
 				ServiceAccountName: k8sServiceAccount,
 			},
 		},
-		ProviderThrottle: providerThrottle,
-		SecretsCipher:    secretsCipher,
+		ProviderThrottle:       providerThrottle,
+		RunEventInlineMaxBytes: runEventInlineMaxBytes,
+		SecretsCipher:          secretsCipher,
 	}, nil
 }
 

--- a/backend/internal/worker/config_run_event_offload_test.go
+++ b/backend/internal/worker/config_run_event_offload_test.go
@@ -1,0 +1,19 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestLoadConfigFromEnvRunEventInlineMaxBytesZeroDisables(t *testing.T) {
+	unsetEnv(t, "AGENTCLASH_SECRETS_MASTER_KEY")
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("RUN_EVENT_INLINE_MAX_BYTES", "0")
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RunEventInlineMaxBytes != 0 {
+		t.Fatalf("got %d", cfg.RunEventInlineMaxBytes)
+	}
+}

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -47,6 +47,7 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY")
 	unsetEnv(t, "ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE")
 	unsetEnv(t, "ARTIFACT_SANDBOX_ASSET_MAX_BYTES")
+	unsetEnv(t, "RUN_EVENT_INLINE_MAX_BYTES")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -118,6 +119,9 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 	if cfg.ArtifactStorage.MaxDownloadBytes != defaultArtifactMaxAssetBytes {
 		t.Fatalf("ArtifactStorage.MaxDownloadBytes = %d, want %d", cfg.ArtifactStorage.MaxDownloadBytes, defaultArtifactMaxAssetBytes)
+	}
+	if cfg.RunEventInlineMaxBytes != defaultRunEventInlineMaxBytes {
+		t.Fatalf("RunEventInlineMaxBytes = %d, want %d", cfg.RunEventInlineMaxBytes, defaultRunEventInlineMaxBytes)
 	}
 }
 

--- a/backend/internal/worker/offloading_recorder.go
+++ b/backend/internal/worker/offloading_recorder.go
@@ -1,0 +1,115 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+)
+
+const runEventPayloadArtifactType = "run_event_payload"
+
+// RunTenantLookup resolves org/workspace for artifact rows.
+type RunTenantLookup interface {
+	GetRunAnalyticsMetadata(ctx context.Context, runID uuid.UUID) (repository.RunAnalyticsMetadata, error)
+	CreateArtifact(ctx context.Context, params repository.CreateArtifactParams) (repository.Artifact, error)
+}
+
+// OffloadingRecorder spills oversized run-event payloads to object storage
+// before persisting a claim-check stub. When maxBytes <= 0, it is a passthrough.
+type OffloadingRecorder struct {
+	inner    RunEventRecorder
+	lookup   RunTenantLookup
+	store    storage.Store
+	maxBytes int
+	logger   *slog.Logger
+}
+
+var _ RunEventRecorder = (*OffloadingRecorder)(nil)
+
+// NewOffloadingRecorder wraps inner. store may be nil only when maxBytes <= 0.
+func NewOffloadingRecorder(
+	inner RunEventRecorder,
+	lookup RunTenantLookup,
+	store storage.Store,
+	maxBytes int,
+	logger *slog.Logger,
+) *OffloadingRecorder {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OffloadingRecorder{
+		inner:    inner,
+		lookup:   lookup,
+		store:    store,
+		maxBytes: maxBytes,
+		logger:   logger,
+	}
+}
+
+func (r *OffloadingRecorder) RecordRunEvent(ctx context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error) {
+	if r == nil || r.inner == nil {
+		return repository.RunEvent{}, fmt.Errorf("offloading recorder is not configured")
+	}
+	if !runevents.ShouldOffload(params.Event.Payload, r.maxBytes) || r.store == nil {
+		return r.inner.RecordRunEvent(ctx, params)
+	}
+
+	key := runevents.ObjectKeyForEvent(params.Event.RunAgentID, params.Event.EventID)
+	body := params.Event.Payload
+	meta, err := r.store.PutObject(ctx, storage.PutObjectInput{
+		Key:         key,
+		Body:        bytes.NewReader(body),
+		SizeBytes:   int64(len(body)),
+		ContentType: "application/json",
+	})
+	if err != nil {
+		return repository.RunEvent{}, fmt.Errorf("put offloaded run event payload: %w", err)
+	}
+
+	tenant, err := r.lookup.GetRunAnalyticsMetadata(ctx, params.Event.RunID)
+	if err != nil {
+		_ = r.store.DeleteObject(ctx, key)
+		return repository.RunEvent{}, fmt.Errorf("lookup run tenant for offload: %w", err)
+	}
+
+	size := int64(len(body))
+	contentType := "application/json"
+	artifact, err := r.lookup.CreateArtifact(ctx, repository.CreateArtifactParams{
+		OrganizationID:  tenant.OrganizationID,
+		WorkspaceID:     tenant.WorkspaceID,
+		RunID:           &params.Event.RunID,
+		RunAgentID:      &params.Event.RunAgentID,
+		ArtifactType:    runEventPayloadArtifactType,
+		StorageBucket:   meta.Bucket,
+		StorageKey:      key,
+		ContentType:     &contentType,
+		SizeBytes:       &size,
+		Visibility:      "private",
+		RetentionStatus: "active",
+	})
+	if err != nil {
+		_ = r.store.DeleteObject(ctx, key)
+		return repository.RunEvent{}, fmt.Errorf("create run event payload artifact: %w", err)
+	}
+
+	stub, err := runevents.MarshalPayloadRef(key, len(body), params.Event.EventType)
+	if err != nil {
+		_ = r.store.DeleteObject(ctx, key)
+		return repository.RunEvent{}, err
+	}
+
+	params.Event.Payload = stub
+	params.ArtifactID = &artifact.ID
+	event, err := r.inner.RecordRunEvent(ctx, params)
+	if err != nil {
+		_ = r.store.DeleteObject(ctx, key)
+		return repository.RunEvent{}, err
+	}
+	return event, nil
+}

--- a/backend/internal/worker/offloading_recorder.go
+++ b/backend/internal/worker/offloading_recorder.go
@@ -18,6 +18,7 @@ const runEventPayloadArtifactType = "run_event_payload"
 type RunTenantLookup interface {
 	GetRunAnalyticsMetadata(ctx context.Context, runID uuid.UUID) (repository.RunAnalyticsMetadata, error)
 	CreateArtifact(ctx context.Context, params repository.CreateArtifactParams) (repository.Artifact, error)
+	MarkArtifactScheduledForDeletion(ctx context.Context, artifactID uuid.UUID) error
 }
 
 // OffloadingRecorder spills oversized run-event payloads to object storage
@@ -98,9 +99,17 @@ func (r *OffloadingRecorder) RecordRunEvent(ctx context.Context, params reposito
 		return repository.RunEvent{}, fmt.Errorf("create run event payload artifact: %w", err)
 	}
 
+	compensate := func() {
+		_ = r.store.DeleteObject(ctx, key)
+		if markErr := r.lookup.MarkArtifactScheduledForDeletion(ctx, artifact.ID); markErr != nil {
+			r.logger.Warn("failed to mark offload artifact for deletion",
+				"artifact_id", artifact.ID, "storage_key", key, "error", markErr)
+		}
+	}
+
 	stub, err := runevents.MarshalPayloadRef(key, len(body), params.Event.EventType)
 	if err != nil {
-		_ = r.store.DeleteObject(ctx, key)
+		compensate()
 		return repository.RunEvent{}, err
 	}
 
@@ -108,7 +117,7 @@ func (r *OffloadingRecorder) RecordRunEvent(ctx context.Context, params reposito
 	params.ArtifactID = &artifact.ID
 	event, err := r.inner.RecordRunEvent(ctx, params)
 	if err != nil {
-		_ = r.store.DeleteObject(ctx, key)
+		compensate()
 		return repository.RunEvent{}, err
 	}
 	return event, nil

--- a/backend/internal/worker/offloading_recorder_test.go
+++ b/backend/internal/worker/offloading_recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -68,22 +69,47 @@ func (s *stubRecorder) RecordRunEvent(_ context.Context, params repository.Recor
 }
 
 type stubLookup struct {
-	meta repository.RunAnalyticsMetadata
+	meta              repository.RunAnalyticsMetadata
+	artifacts         map[uuid.UUID]repository.Artifact
+	markedForDeletion []uuid.UUID
 }
 
-func (s stubLookup) GetRunAnalyticsMetadata(context.Context, uuid.UUID) (repository.RunAnalyticsMetadata, error) {
+func (s *stubLookup) GetRunAnalyticsMetadata(context.Context, uuid.UUID) (repository.RunAnalyticsMetadata, error) {
 	return s.meta, nil
 }
 
-func (s stubLookup) CreateArtifact(_ context.Context, params repository.CreateArtifactParams) (repository.Artifact, error) {
-	return repository.Artifact{
-		ID:             uuid.New(),
-		OrganizationID: params.OrganizationID,
-		WorkspaceID:    params.WorkspaceID,
-		StorageBucket:  params.StorageBucket,
-		StorageKey:     params.StorageKey,
-		ArtifactType:   params.ArtifactType,
-	}, nil
+func (s *stubLookup) CreateArtifact(_ context.Context, params repository.CreateArtifactParams) (repository.Artifact, error) {
+	if s.artifacts == nil {
+		s.artifacts = map[uuid.UUID]repository.Artifact{}
+	}
+	art := repository.Artifact{
+		ID:              uuid.New(),
+		OrganizationID:  params.OrganizationID,
+		WorkspaceID:     params.WorkspaceID,
+		StorageBucket:   params.StorageBucket,
+		StorageKey:      params.StorageKey,
+		ArtifactType:    params.ArtifactType,
+		RetentionStatus: params.RetentionStatus,
+	}
+	s.artifacts[art.ID] = art
+	return art, nil
+}
+
+func (s *stubLookup) MarkArtifactScheduledForDeletion(_ context.Context, artifactID uuid.UUID) error {
+	s.markedForDeletion = append(s.markedForDeletion, artifactID)
+	if art, ok := s.artifacts[artifactID]; ok {
+		art.RetentionStatus = "scheduled_for_deletion"
+		s.artifacts[artifactID] = art
+	}
+	return nil
+}
+
+type failingRecorder struct {
+	err error
+}
+
+func (f failingRecorder) RecordRunEvent(context.Context, repository.RecordRunEventParams) (repository.RunEvent, error) {
+	return repository.RunEvent{}, f.err
 }
 
 func TestOffloadingRecorder_SpillsLargePayload(t *testing.T) {
@@ -91,7 +117,7 @@ func TestOffloadingRecorder_SpillsLargePayload(t *testing.T) {
 	inner := &stubRecorder{}
 	runID := uuid.New()
 	agentID := uuid.New()
-	lookup := stubLookup{meta: repository.RunAnalyticsMetadata{
+	lookup := &stubLookup{meta: repository.RunAnalyticsMetadata{
 		RunID: runID, WorkspaceID: uuid.New(), OrganizationID: uuid.New(),
 	}}
 	rec := worker.NewOffloadingRecorder(inner, lookup, store, 32, slog.Default())
@@ -127,7 +153,7 @@ func TestOffloadingRecorder_SpillsLargePayload(t *testing.T) {
 func TestOffloadingRecorder_DisabledPassthrough(t *testing.T) {
 	store := newMemStore()
 	inner := &stubRecorder{}
-	rec := worker.NewOffloadingRecorder(inner, stubLookup{}, store, 0, slog.Default())
+	rec := worker.NewOffloadingRecorder(inner, &stubLookup{}, store, 0, slog.Default())
 	payload := json.RawMessage(`{"ok":true}`)
 	event, err := rec.RecordRunEvent(context.Background(), repository.RecordRunEventParams{
 		Event: runevents.Envelope{
@@ -149,5 +175,42 @@ func TestOffloadingRecorder_DisabledPassthrough(t *testing.T) {
 	}
 	if len(store.objects) != 0 {
 		t.Fatal("store should be empty when disabled")
+	}
+}
+
+func TestOffloadingRecorder_RollbackArtifactOnInnerFailure(t *testing.T) {
+	store := newMemStore()
+	runID := uuid.New()
+	agentID := uuid.New()
+	lookup := &stubLookup{meta: repository.RunAnalyticsMetadata{
+		RunID: runID, WorkspaceID: uuid.New(), OrganizationID: uuid.New(),
+	}}
+	rec := worker.NewOffloadingRecorder(failingRecorder{err: errors.New("persist failed")}, lookup, store, 32, slog.Default())
+
+	payload, _ := json.Marshal(map[string]string{"blob": string(bytes.Repeat([]byte("x"), 64))})
+	_, err := rec.RecordRunEvent(context.Background(), repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       "e1",
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         runID,
+			RunAgentID:    agentID,
+			EventType:     runevents.EventTypeModelOutputDelta,
+			Source:        runevents.SourceNativeEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payload,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected persist failure")
+	}
+	if len(store.objects) != 0 {
+		t.Fatalf("expected object deleted, still have %d", len(store.objects))
+	}
+	if len(lookup.markedForDeletion) != 1 {
+		t.Fatalf("markedForDeletion = %v, want 1 artifact", lookup.markedForDeletion)
+	}
+	art := lookup.artifacts[lookup.markedForDeletion[0]]
+	if art.RetentionStatus != "scheduled_for_deletion" {
+		t.Fatalf("retention = %q, want scheduled_for_deletion", art.RetentionStatus)
 	}
 }

--- a/backend/internal/worker/offloading_recorder_test.go
+++ b/backend/internal/worker/offloading_recorder_test.go
@@ -1,0 +1,153 @@
+package worker_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/agentclash/agentclash/backend/internal/worker"
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+)
+
+type memStore struct {
+	objects map[string][]byte
+	bucket  string
+}
+
+func newMemStore() *memStore {
+	return &memStore{objects: map[string][]byte{}, bucket: "test-bucket"}
+}
+
+func (s *memStore) Bucket() string { return s.bucket }
+
+func (s *memStore) PutObject(_ context.Context, input storage.PutObjectInput) (storage.ObjectMetadata, error) {
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return storage.ObjectMetadata{}, err
+	}
+	s.objects[input.Key] = body
+	return storage.ObjectMetadata{Bucket: s.bucket, Key: input.Key, SizeBytes: int64(len(body)), ContentType: input.ContentType}, nil
+}
+
+func (s *memStore) OpenObject(_ context.Context, key string) (io.ReadCloser, storage.ObjectMetadata, error) {
+	body, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ObjectMetadata{}, storage.ErrObjectNotFound
+	}
+	return io.NopCloser(bytes.NewReader(body)), storage.ObjectMetadata{Bucket: s.bucket, Key: key, SizeBytes: int64(len(body))}, nil
+}
+
+func (s *memStore) DeleteObject(_ context.Context, key string) error {
+	delete(s.objects, key)
+	return nil
+}
+
+type stubRecorder struct {
+	last repository.RecordRunEventParams
+}
+
+func (s *stubRecorder) RecordRunEvent(_ context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error) {
+	s.last = params
+	return repository.RunEvent{
+		RunID:          params.Event.RunID,
+		RunAgentID:     params.Event.RunAgentID,
+		SequenceNumber: 1,
+		EventType:      params.Event.EventType,
+		Source:         params.Event.Source,
+		OccurredAt:     params.Event.OccurredAt,
+		ArtifactID:     params.ArtifactID,
+		Payload:        append([]byte(nil), params.Event.Payload...),
+	}, nil
+}
+
+type stubLookup struct {
+	meta repository.RunAnalyticsMetadata
+}
+
+func (s stubLookup) GetRunAnalyticsMetadata(context.Context, uuid.UUID) (repository.RunAnalyticsMetadata, error) {
+	return s.meta, nil
+}
+
+func (s stubLookup) CreateArtifact(_ context.Context, params repository.CreateArtifactParams) (repository.Artifact, error) {
+	return repository.Artifact{
+		ID:             uuid.New(),
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		StorageBucket:  params.StorageBucket,
+		StorageKey:     params.StorageKey,
+		ArtifactType:   params.ArtifactType,
+	}, nil
+}
+
+func TestOffloadingRecorder_SpillsLargePayload(t *testing.T) {
+	store := newMemStore()
+	inner := &stubRecorder{}
+	runID := uuid.New()
+	agentID := uuid.New()
+	lookup := stubLookup{meta: repository.RunAnalyticsMetadata{
+		RunID: runID, WorkspaceID: uuid.New(), OrganizationID: uuid.New(),
+	}}
+	rec := worker.NewOffloadingRecorder(inner, lookup, store, 32, slog.Default())
+
+	payload, _ := json.Marshal(map[string]string{"blob": string(bytes.Repeat([]byte("x"), 64))})
+	event, err := rec.RecordRunEvent(context.Background(), repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       "e1",
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         runID,
+			RunAgentID:    agentID,
+			EventType:     runevents.EventTypeModelOutputDelta,
+			Source:        runevents.SourceNativeEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payload,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, ok := runevents.ParsePayloadRef(event.Payload)
+	if !ok {
+		t.Fatalf("expected stub payload, got %s", event.Payload)
+	}
+	if _, ok := store.objects[ref.Ref]; !ok {
+		t.Fatalf("object missing for %s", ref.Ref)
+	}
+	if event.ArtifactID == nil {
+		t.Fatal("expected artifact id")
+	}
+}
+
+func TestOffloadingRecorder_DisabledPassthrough(t *testing.T) {
+	store := newMemStore()
+	inner := &stubRecorder{}
+	rec := worker.NewOffloadingRecorder(inner, stubLookup{}, store, 0, slog.Default())
+	payload := json.RawMessage(`{"ok":true}`)
+	event, err := rec.RecordRunEvent(context.Background(), repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       "e1",
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         uuid.New(),
+			RunAgentID:    uuid.New(),
+			EventType:     runevents.EventTypeModelOutputDelta,
+			Source:        runevents.SourceNativeEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payload,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(event.Payload) != string(payload) {
+		t.Fatalf("payload = %s", event.Payload)
+	}
+	if len(store.objects) != 0 {
+		t.Fatal("store should be empty when disabled")
+	}
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -3029,10 +3029,13 @@ paths:
       security: []
       description: >
         Server-Sent Events endpoint for live run event streaming. Authentication
-        is via the `token` query parameter (EventSource API cannot set custom
-        headers). Returns a stream of run events as they are recorded.
-        When Redis is not configured, returns 503 Service Unavailable.
-        Clients should fall back to polling in that case.
+        is via the Authorization header, with a `token` query-parameter fallback
+        for EventSource clients. Returns a stream of run-event envelopes.
+        Oversized payloads may be persisted as claim-check stubs
+        (`{"$ref","bytes","type"}`); the API hydrates stubs to the original JSON
+        before emitting SSE frames (including Last-Event-ID replay from the DB
+        and live Redis frames). When Redis is unavailable the handler falls back
+        to DB polling.
       parameters:
         - $ref: "#/components/parameters/RunID"
         - name: token
@@ -3073,6 +3076,8 @@ paths:
         Exports the full persisted run-agent event stream for a run as JSONL.
         Events are ordered by occurrence time, run-agent lane, per-agent
         sequence number, and stable database id so trace packs are deterministic.
+        Offloaded payload stubs are hydrated so the export is byte-equivalent to
+        the non-offloaded (inline) case.
       parameters:
         - $ref: "#/components/parameters/RunID"
       responses:

--- a/runtime/runevents/envelope.go
+++ b/runtime/runevents/envelope.go
@@ -141,6 +141,9 @@ type SummaryMetadata struct {
 //     events.
 //
 // SchemaVersion stays SchemaVersionV1: case_key is an additive optional field.
+// Oversized payloads may be replaced with a claim-check stub
+// ({"$ref","bytes","type"}) under the same schema version; readers hydrate via
+// Resolver before exposing events to clients/export/replay.
 type Envelope struct {
 	EventID        string          `json:"event_id"`
 	SchemaVersion  string          `json:"schema_version"`

--- a/runtime/runevents/offload.go
+++ b/runtime/runevents/offload.go
@@ -1,11 +1,11 @@
 package runevents
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -35,15 +35,29 @@ func MarshalPayloadRef(ref string, sizeBytes int, eventType Type) (json.RawMessa
 }
 
 // ParsePayloadRef returns (ref, true) when payload is an offload stub.
+// Only the exact stub shape ({"$ref","bytes","type"}) is accepted, and the
+// storage key must be under run-events/ ending in .json.
 func ParsePayloadRef(payload json.RawMessage) (PayloadRef, bool) {
-	if len(payload) == 0 || !bytes.Contains(payload, []byte(`"$ref"`)) {
+	if len(payload) == 0 {
 		return PayloadRef{}, false
 	}
 	var ref PayloadRef
-	if err := json.Unmarshal(payload, &ref); err != nil {
+	if err := json.Unmarshal(payload, &ref); err != nil || ref.Ref == "" || ref.Bytes <= 0 || ref.Type == "" {
 		return PayloadRef{}, false
 	}
-	if ref.Ref == "" {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil || len(raw) != 3 {
+		return PayloadRef{}, false
+	}
+	for _, key := range []string{PayloadRefMarker, "bytes", "type"} {
+		if _, ok := raw[key]; !ok {
+			return PayloadRef{}, false
+		}
+	}
+	if !strings.HasPrefix(ref.Ref, "run-events/") || !strings.HasSuffix(ref.Ref, ".json") {
+		return PayloadRef{}, false
+	}
+	if strings.Contains(ref.Ref, "..") {
 		return PayloadRef{}, false
 	}
 	return ref, true

--- a/runtime/runevents/offload.go
+++ b/runtime/runevents/offload.go
@@ -1,0 +1,148 @@
+package runevents
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// PayloadRefMarker is the JSON key that identifies an offloaded payload stub.
+const PayloadRefMarker = "$ref"
+
+// PayloadRef is the stub stored inline in run_events.payload when the full
+// body has been spilled to object storage (claim-check pattern).
+type PayloadRef struct {
+	Ref   string `json:"$ref"`
+	Bytes int    `json:"bytes"`
+	Type  string `json:"type"`
+}
+
+// MarshalPayloadRef returns the stub JSON for an offloaded payload.
+func MarshalPayloadRef(ref string, sizeBytes int, eventType Type) (json.RawMessage, error) {
+	if ref == "" {
+		return nil, fmt.Errorf("payload ref key is required")
+	}
+	return json.Marshal(PayloadRef{
+		Ref:   ref,
+		Bytes: sizeBytes,
+		Type:  string(eventType),
+	})
+}
+
+// ParsePayloadRef returns (ref, true) when payload is an offload stub.
+func ParsePayloadRef(payload json.RawMessage) (PayloadRef, bool) {
+	if len(payload) == 0 || !bytes.Contains(payload, []byte(`"$ref"`)) {
+		return PayloadRef{}, false
+	}
+	var ref PayloadRef
+	if err := json.Unmarshal(payload, &ref); err != nil {
+		return PayloadRef{}, false
+	}
+	if ref.Ref == "" {
+		return PayloadRef{}, false
+	}
+	return ref, true
+}
+
+// ObjectKeyForEvent builds the storage key for an offloaded run-event payload.
+// Uses event_id (not sequence) so the object can be written before the DB
+// assigns sequence_number under concurrent fan-out.
+func ObjectKeyForEvent(runAgentID uuid.UUID, eventID string) string {
+	return fmt.Sprintf("run-events/%s/%s.json", runAgentID.String(), eventID)
+}
+
+// ShouldOffload reports whether a payload should be spilled.
+// maxBytes <= 0 disables offloading (today's inline behavior).
+func ShouldOffload(payload []byte, maxBytes int) bool {
+	if maxBytes <= 0 {
+		return false
+	}
+	return len(payload) > maxBytes
+}
+
+// ObjectOpener opens objects by storage key.
+type ObjectOpener interface {
+	OpenObject(ctx context.Context, key string) (io.ReadCloser, error)
+}
+
+// OpenFunc adapts a function to ObjectOpener.
+type OpenFunc func(ctx context.Context, key string) (io.ReadCloser, error)
+
+func (f OpenFunc) OpenObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	return f(ctx, key)
+}
+
+// Resolver hydrates offloaded payloads. Hot keys are cached in an LRU.
+type Resolver struct {
+	open   ObjectOpener
+	mu     sync.Mutex
+	lru    map[string]json.RawMessage
+	order  []string
+	maxLRU int
+}
+
+// NewResolver constructs a resolver with a small in-process LRU (default 64).
+func NewResolver(open ObjectOpener, maxLRU int) *Resolver {
+	if maxLRU <= 0 {
+		maxLRU = 64
+	}
+	return &Resolver{
+		open:   open,
+		lru:    make(map[string]json.RawMessage, maxLRU),
+		maxLRU: maxLRU,
+	}
+}
+
+// Resolve returns the original payload bytes. Non-stub payloads pass through.
+func (r *Resolver) Resolve(ctx context.Context, payload json.RawMessage) (json.RawMessage, error) {
+	if r == nil || r.open == nil {
+		return payload, nil
+	}
+	ref, ok := ParsePayloadRef(payload)
+	if !ok {
+		return payload, nil
+	}
+	r.mu.Lock()
+	if cached, hit := r.lru[ref.Ref]; hit {
+		r.mu.Unlock()
+		return append(json.RawMessage(nil), cached...), nil
+	}
+	r.mu.Unlock()
+
+	rc, err := r.open.OpenObject(ctx, ref.Ref)
+	if err != nil {
+		return nil, fmt.Errorf("open offloaded run event payload %q: %w", ref.Ref, err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("read offloaded run event payload %q: %w", ref.Ref, err)
+	}
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("offloaded run event payload %q is not valid JSON", ref.Ref)
+	}
+	out := json.RawMessage(body)
+	r.remember(ref.Ref, out)
+	return append(json.RawMessage(nil), out...), nil
+}
+
+func (r *Resolver) remember(key string, value json.RawMessage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.lru[key]; ok {
+		r.lru[key] = append(json.RawMessage(nil), value...)
+		return
+	}
+	if len(r.order) >= r.maxLRU {
+		evict := r.order[0]
+		r.order = r.order[1:]
+		delete(r.lru, evict)
+	}
+	r.order = append(r.order, key)
+	r.lru[key] = append(json.RawMessage(nil), value...)
+}

--- a/runtime/runevents/offload_test.go
+++ b/runtime/runevents/offload_test.go
@@ -29,6 +29,23 @@ func TestPayloadRef_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestParsePayloadRef_RejectsUnsafeOrMalformed(t *testing.T) {
+	cases := []string{
+		`{"$ref":"../../secrets","bytes":1,"type":"x"}`,
+		`{"$ref":"other/bucket/key.json","bytes":1,"type":"x"}`,
+		`{"$ref":"run-events/a/b.json","bytes":1,"type":"x","extra":true}`,
+		`{"$ref":"run-events/a/b.json","bytes":0,"type":"x"}`,
+		`{"$ref":"run-events/a/b","bytes":1,"type":"x"}`,
+		`{"$ref":"run-events/../escape.json","bytes":1,"type":"x"}`,
+		`{"$ref":"run-events/a/b.json","type":"x"}`,
+	}
+	for _, raw := range cases {
+		if _, ok := runevents.ParsePayloadRef(json.RawMessage(raw)); ok {
+			t.Fatalf("expected reject for %s", raw)
+		}
+	}
+}
+
 func TestShouldOffload(t *testing.T) {
 	if runevents.ShouldOffload([]byte("x"), 0) {
 		t.Fatal("maxBytes=0 must disable")
@@ -53,9 +70,9 @@ func TestObjectKeyForEvent(t *testing.T) {
 func TestResolver_LRU(t *testing.T) {
 	opens := 0
 	bodies := map[string]string{
-		"k1": `{"n":1}`,
-		"k2": `{"n":2}`,
-		"k3": `{"n":3}`,
+		"run-events/a/k1.json": `{"n":1}`,
+		"run-events/a/k2.json": `{"n":2}`,
+		"run-events/a/k3.json": `{"n":3}`,
 	}
 	open := runevents.OpenFunc(func(_ context.Context, key string) (io.ReadCloser, error) {
 		opens++
@@ -68,23 +85,23 @@ func TestResolver_LRU(t *testing.T) {
 		return raw
 	}
 	ctx := context.Background()
-	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+	if _, err := r.Resolve(ctx, stub("run-events/a/k1.json")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+	if _, err := r.Resolve(ctx, stub("run-events/a/k1.json")); err != nil {
 		t.Fatal(err)
 	}
 	if opens != 1 {
 		t.Fatalf("opens = %d, want 1 after cache hit", opens)
 	}
-	if _, err := r.Resolve(ctx, stub("k2")); err != nil {
+	if _, err := r.Resolve(ctx, stub("run-events/a/k2.json")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Resolve(ctx, stub("k3")); err != nil {
+	if _, err := r.Resolve(ctx, stub("run-events/a/k3.json")); err != nil {
 		t.Fatal(err)
 	}
 	// k1 should be evicted
-	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+	if _, err := r.Resolve(ctx, stub("run-events/a/k1.json")); err != nil {
 		t.Fatal(err)
 	}
 	if opens < 4 {

--- a/runtime/runevents/offload_test.go
+++ b/runtime/runevents/offload_test.go
@@ -1,0 +1,93 @@
+package runevents_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/runtime/runevents"
+	"github.com/google/uuid"
+)
+
+func TestPayloadRef_RoundTrip(t *testing.T) {
+	raw, err := runevents.MarshalPayloadRef("run-events/a/b.json", 1024, runevents.EventTypeModelOutputDelta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, ok := runevents.ParsePayloadRef(raw)
+	if !ok {
+		t.Fatalf("expected stub, got %s", raw)
+	}
+	if ref.Ref != "run-events/a/b.json" || ref.Bytes != 1024 || ref.Type != string(runevents.EventTypeModelOutputDelta) {
+		t.Fatalf("ref = %#v", ref)
+	}
+	if _, ok := runevents.ParsePayloadRef(json.RawMessage(`{"delta":"hi"}`)); ok {
+		t.Fatal("inline payload should not parse as stub")
+	}
+}
+
+func TestShouldOffload(t *testing.T) {
+	if runevents.ShouldOffload([]byte("x"), 0) {
+		t.Fatal("maxBytes=0 must disable")
+	}
+	if runevents.ShouldOffload(bytes.Repeat([]byte("a"), 10), 32) {
+		t.Fatal("under threshold")
+	}
+	if !runevents.ShouldOffload(bytes.Repeat([]byte("a"), 33), 32) {
+		t.Fatal("over threshold")
+	}
+}
+
+func TestObjectKeyForEvent(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	got := runevents.ObjectKeyForEvent(id, "evt-1")
+	want := "run-events/11111111-1111-1111-1111-111111111111/evt-1.json"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestResolver_LRU(t *testing.T) {
+	opens := 0
+	bodies := map[string]string{
+		"k1": `{"n":1}`,
+		"k2": `{"n":2}`,
+		"k3": `{"n":3}`,
+	}
+	open := runevents.OpenFunc(func(_ context.Context, key string) (io.ReadCloser, error) {
+		opens++
+		return io.NopCloser(strings.NewReader(bodies[key])), nil
+	})
+	r := runevents.NewResolver(open, 2)
+
+	stub := func(key string) json.RawMessage {
+		raw, _ := runevents.MarshalPayloadRef(key, 10, runevents.EventTypeModelOutputDelta)
+		return raw
+	}
+	ctx := context.Background()
+	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+		t.Fatal(err)
+	}
+	if opens != 1 {
+		t.Fatalf("opens = %d, want 1 after cache hit", opens)
+	}
+	if _, err := r.Resolve(ctx, stub("k2")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Resolve(ctx, stub("k3")); err != nil {
+		t.Fatal(err)
+	}
+	// k1 should be evicted
+	if _, err := r.Resolve(ctx, stub("k1")); err != nil {
+		t.Fatal(err)
+	}
+	if opens < 4 {
+		t.Fatalf("opens = %d, want >=4 after eviction", opens)
+	}
+}


### PR DESCRIPTION
⛔ Stacked on #1217 — do not merge out of order. Part of epic #1212.

Closes #1203.

## What & why

At fleet scale, every run-event payload (including streaming deltas) was written inline as jsonb and republished verbatim to Redis. There was no size threshold or object-storage spill, so Postgres write throughput and Redis frame size become the ceiling. This adds a claim-check path: payloads larger than `RUN_EVENT_INLINE_MAX_BYTES` (default 32 KiB) are written to `storage.Store` under `run-events/{run_agent_id}/{event_id}.json`, the DB row stores a stub plus `artifact_id`, Redis publishes the stub, and read paths (list/export/SSE/replay) hydrate transparently. `RUN_EVENT_INLINE_MAX_BYTES=0` restores today's fully-inline behavior.

## Decisions

1. **Claim-check stub under SchemaVersionV1** — Options: bump schema vs additive stub. Chose additive `{"$ref","bytes","type"}` under V1 (same convention as `case_key`). Sources: [Temporal External Storage / claim-check](https://docs.temporal.io/external-storage), [samples-go/external-storage](https://github.com/temporalio/samples-go/tree/main/external-storage), hawk S3 eval logs + Postgres metadata.

2. **Object key uses `event_id`, not sequence** — Options: issue sketch `…/{sequence}.json` vs `…/{event_id}.json`. Chose event_id so PutObject can happen before DB sequence assignment under concurrent fan-out retries. Rejected sequence-in-key: would require reserving sequence under a lock spanning the object put.

3. **Spill in `OffloadingRecorder` decorator before `PublishingRecorder`** — Options: deep in SQL insert vs decorator. Chose decorator at the worker recorder seam so all engine observers inherit it; `PublishingRecorder` now publishes the **persisted** payload (stub), never the original multi-MB body.

4. **Hydrate on repository list + live SSE** — Options: stub+fetch URL only vs transparent hydrate. Chose hydrate for export/replay/list (byte-identical export AC) and hydrate live Redis frames in SSE so `Last-Event-ID` + live tails stay client-compatible. Documented in OpenAPI.

5. **`artifact_type=run_event_payload` + `HardDeleteRun` purge** — Cascade alone orphans objects. `PurgeRunEventPayloadObjects` deletes store keys then artifact rows; integration test covers filesystem backend.

6. **Batching stretch skipped** — multi-row INSERT while preserving per-agent sequence ordering is non-trivial; left for a follow-up.

## Review map

1. `runtime/runevents/offload.go` — stub + Resolver LRU
2. `backend/internal/worker/offloading_recorder.go` — write path
3. `backend/internal/pubsub/publishing_recorder.go` — Redis stays light
4. `backend/internal/repository/repository.go` hydrate + `run_event_payload_purge.go`
5. `backend/internal/api/run_events_sse.go` live hydrate

## Verification evidence

```
cd runtime && go build ./... && go vet ./... && go test -short -race -count=1 ./...
cd backend && go build ./... && go vet ./... && go test -short -race -count=1 ./...
npx @redocly/cli lint docs/api-server/openapi.yaml
cd backend && sqlc generate && git diff --exit-code internal/repository/sqlc/
```

Two consecutive full gates green (pass 1 + pass 2). Tail of pass 2:

```
ok  	github.com/agentclash/agentclash/runtime/sandbox	2.226s
ok  	github.com/agentclash/agentclash/runtime/sandbox/conformance	1.695s
ok  	github.com/agentclash/agentclash/runtime/sandbox/docker	1.217s
ok  	github.com/agentclash/agentclash/runtime/sandbox/kubernetes	2.058s
ok  	github.com/agentclash/agentclash/runtime/scoring	2.236s
?   	github.com/agentclash/agentclash/runtime/templateutil	[no test files]
```

```
ok  	github.com/agentclash/agentclash/backend/internal/secrets	1.904s
ok  	github.com/agentclash/agentclash/backend/internal/securityscore	1.860s
ok  	github.com/agentclash/agentclash/backend/internal/simulator	1.478s
ok  	github.com/agentclash/agentclash/backend/internal/storage	1.530s
?   	github.com/agentclash/agentclash/backend/internal/temporalutil	[no test files]
ok  	github.com/agentclash/agentclash/backend/internal/toolspec	1.704s
ok  	github.com/agentclash/agentclash/backend/internal/worker	2.862s
ok  	github.com/agentclash/agentclash/backend/internal/workflow	4.001s
```

Acceptance → checks:

- [x] 1 MiB-class payload → stub + object; hydrated list matches original — `TestOffloadingRecorder_SpillsLargePayload` + `TestRunEventOffload_SpillHydrateExportAndPurge` (integration; skips without `DATABASE_URL`)
- [x] SSE hydrates stubs (live + persisted) — `TestHydrateLiveRunEventData` + repo list hydrate used by stream snapshot
- [x] Replay uses hydrated payloads via `ListRunEventsByRunAgentID` resolver
- [x] Delete run removes objects — `HardDeleteRun` / purge in integration test (filesystem)
- [x] `RUN_EVENT_INLINE_MAX_BYTES=0` disables — `TestOffloadingRecorder_DisabledPassthrough` + config test
- [x] Works with filesystem + S3 Store interface — Put/Open/Delete only; both backends implement `storage.Store`

## Risk & rollback

- Default 32 KiB enables spill for large events (intentional). Set `RUN_EVENT_INLINE_MAX_BYTES=0` to disable.
- Hosted ingest (`RecordHostedRunEvent`) is not yet wrapped by `OffloadingRecorder` — worker/engine path is covered; hosted large payloads remain inline until a follow-up.
- Misconfigured artifact storage will fail oversized event persistence (fail closed).