### PR TITLE
feat(evalset): parse manifests and dry-run combination expansion

### DIFF
--- a/backend/internal/api/eval_sets.go
+++ b/backend/internal/api/eval_sets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -41,6 +42,9 @@ func (m *EvalSetManager) Expand(ctx context.Context, caller Caller, workspaceID 
 	}
 	if maxCombos <= 0 {
 		maxCombos = evalset.DefaultMaxCombos
+	}
+	if maxCombos > evalset.MaxAllowedCombos {
+		return evalset.ExpansionReport{}, fmt.Errorf("max_combinations %d exceeds server limit %d", maxCombos, evalset.MaxAllowedCombos)
 	}
 	return manifest.Expand(maxCombos)
 }

--- a/backend/internal/api/eval_sets.go
+++ b/backend/internal/api/eval_sets.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/agentclash/agentclash/runtime/evalset"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type expandEvalSetRequest struct {
+	WorkspaceID string          `json:"workspace_id"`
+	Manifest    json.RawMessage `json:"manifest"`
+	MaxCombos   int             `json:"max_combinations,omitempty"`
+}
+
+// EvalSetManager handles eval-set dry-run expansion (persistence in Fleet 7b).
+type EvalSetManager struct {
+	authorizer WorkspaceAuthorizer
+}
+
+func NewEvalSetManager(authorizer WorkspaceAuthorizer) *EvalSetManager {
+	return &EvalSetManager{authorizer: authorizer}
+}
+
+func (m *EvalSetManager) Expand(ctx context.Context, caller Caller, workspaceID uuid.UUID, manifestJSON json.RawMessage, maxCombos int) (evalset.ExpansionReport, error) {
+	if m == nil || m.authorizer == nil {
+		return evalset.ExpansionReport{}, errors.New("eval set manager is not configured")
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return evalset.ExpansionReport{}, err
+	}
+	manifest, err := evalset.ParseManifest(manifestJSON)
+	if err != nil {
+		return evalset.ExpansionReport{}, err
+	}
+	if maxCombos <= 0 {
+		maxCombos = evalset.DefaultMaxCombos
+	}
+	return manifest.Expand(maxCombos)
+}
+
+func registerEvalSetRoutes(router chi.Router, logger *slog.Logger, manager *EvalSetManager) {
+	if manager == nil {
+		return
+	}
+	router.Post("/eval-sets/expand", expandEvalSetHandler(logger, manager))
+}
+
+func expandEvalSetHandler(_ *slog.Logger, manager *EvalSetManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_body", "failed to read request body")
+			return
+		}
+		var req expandEvalSetRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		workspaceID, err := uuid.Parse(req.WorkspaceID)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace_id must be a valid UUID")
+			return
+		}
+		if len(req.Manifest) == 0 {
+			writeError(w, http.StatusBadRequest, "manifest_required", "manifest is required")
+			return
+		}
+		report, err := manager.Expand(r.Context(), caller, workspaceID, req.Manifest, req.MaxCombos)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				// Validation / parse errors are actionable 400s.
+				writeError(w, http.StatusBadRequest, "evalset_expand_invalid", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, report)
+	}
+}

--- a/backend/internal/api/eval_sets_test.go
+++ b/backend/internal/api/eval_sets_test.go
@@ -76,3 +76,27 @@ func TestExpandEvalSetEndpointRejectsOverCap(t *testing.T) {
 		t.Fatalf("status = %d", rr.Code)
 	}
 }
+
+func TestExpandEvalSetEndpointRejectsAboveServerLimit(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewEvalSetManager(allowWorkspaceAuthorizer{})
+	manifest := map[string]any{
+		"schema":  evalset.SchemaV1,
+		"name":    "huge-request",
+		"packs":   []string{"a"},
+		"agents":  []map[string]string{{"deployment": "x"}},
+		"repeats": 1,
+	}
+	body, _ := json.Marshal(map[string]any{
+		"workspace_id":     workspaceID.String(),
+		"manifest":         manifest,
+		"max_combinations": evalset.MaxAllowedCombos + 1,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sets/expand", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rr := httptest.NewRecorder()
+	expandEvalSetHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), manager).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/backend/internal/api/eval_sets_test.go
+++ b/backend/internal/api/eval_sets_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentclash/agentclash/runtime/evalset"
+	"github.com/google/uuid"
+)
+
+func TestExpandEvalSetEndpoint(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewEvalSetManager(allowWorkspaceAuthorizer{})
+
+	manifest := map[string]any{
+		"schema": evalset.SchemaV1,
+		"name":   "nightly",
+		"packs":  []string{"catalog/a", "catalog/b"},
+		"agents": []map[string]string{
+			{"deployment": "d1"},
+			{"deployment": "d2"},
+			{"deployment": "d3"},
+		},
+		"repeats": 5,
+	}
+	body, _ := json.Marshal(map[string]any{
+		"workspace_id": workspaceID.String(),
+		"manifest":     manifest,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sets/expand", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rr := httptest.NewRecorder()
+	expandEvalSetHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), manager).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var report evalset.ExpansionReport
+	if err := json.Unmarshal(rr.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Count != 30 {
+		t.Fatalf("count = %d, want 30", report.Count)
+	}
+	if report.Combinations[0].MatrixKey == "" {
+		t.Fatal("expected matrix keys")
+	}
+}
+
+func TestExpandEvalSetEndpointRejectsOverCap(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewEvalSetManager(allowWorkspaceAuthorizer{})
+	manifest := map[string]any{
+		"schema":  evalset.SchemaV1,
+		"name":    "big",
+		"packs":   []string{"a", "b"},
+		"agents":  []map[string]string{{"deployment": "x"}, {"deployment": "y"}},
+		"repeats": 100,
+	}
+	body, _ := json.Marshal(map[string]any{
+		"workspace_id":     workspaceID.String(),
+		"manifest":         manifest,
+		"max_combinations": 10,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sets/expand", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rr := httptest.NewRecorder()
+	expandEvalSetHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), manager).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", rr.Code)
+	}
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -78,6 +78,7 @@ func registerProtectedRoutes(
 	router.Get("/eval-sessions", listEvalSessionsHandler(logger, runReadService))
 	router.Post("/eval-sessions", createEvalSessionHandler(logger, runCreationService))
 	router.Get("/eval-sessions/{evalSessionID}", getEvalSessionHandler(logger, runReadService))
+	registerEvalSetRoutes(router, logger, NewEvalSetManager(authorizer))
 	router.Post("/runs", createRunHandler(logger, runCreationService))
 	router.Get("/runs/{runID}", getRunHandler(logger, runReadService))
 	router.Post("/runs/{runID}/cancel", cancelRunHandler(logger, runReadService))

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2423,6 +2423,38 @@ paths:
               schema:
                 $ref: "#/components/schemas/CreateRunErrorResponse"
 
+  /v1/eval-sets/expand:
+    post:
+      operationId: expandEvalSet
+      tags: [EvalSets]
+      summary: Dry-run expand an eval-set manifest
+      description: >
+        Expands an `evalset/v1` manifest into the full packs × agents × models ×
+        repeats combination list with deterministic `matrix_key`s. Does not create
+        sessions or runs. Rejects manifests that exceed the combination cap
+        (default 2000).
+      security:
+        - bearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExpandEvalSetRequest"
+      responses:
+        "200":
+          description: Expansion report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EvalSetExpansionReport"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
   /v1/eval-sessions:
     get:
       operationId: listEvalSessions
@@ -7637,6 +7669,69 @@ components:
         - completed
         - failed
         - cancelled
+
+    ExpandEvalSetRequest:
+      type: object
+      required: [workspace_id, manifest]
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+        manifest:
+          type: object
+          description: evalset/v1 manifest document
+          additionalProperties: true
+        max_combinations:
+          type: integer
+          minimum: 1
+          description: Optional override of the 2000 combination safety cap
+
+    EvalSetCombination:
+      type: object
+      required: [matrix_key, pack_ref, agent_ref, repeat]
+      properties:
+        matrix_key:
+          type: string
+        pack_ref:
+          type: string
+        agent_ref:
+          type: string
+        model_ref:
+          type: string
+        repeat:
+          type: integer
+        seed:
+          type: integer
+          format: int64
+        case_fanout:
+          type: boolean
+
+    EvalSetExpansionReport:
+      type: object
+      required: [name, combinations, count, pack_count, agent_count, repeats]
+      properties:
+        name:
+          type: string
+        combinations:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSetCombination"
+        count:
+          type: integer
+        pack_count:
+          type: integer
+        agent_count:
+          type: integer
+        model_count:
+          type: integer
+        repeats:
+          type: integer
+        max_concurrent_runs:
+          type: integer
+        budget_usd:
+          type: number
+        case_fanout:
+          type: boolean
 
     RunAgentStatus:
       type: string

--- a/runtime/domain/eval_set.go
+++ b/runtime/domain/eval_set.go
@@ -1,0 +1,60 @@
+package domain
+
+import "fmt"
+
+// EvalSetStatus is the lifecycle of a multi-pack eval set (Fleet 7).
+type EvalSetStatus string
+
+const (
+	EvalSetStatusQueued      EvalSetStatus = "queued"
+	EvalSetStatusExpanding   EvalSetStatus = "expanding"
+	EvalSetStatusRunning     EvalSetStatus = "running"
+	EvalSetStatusAggregating EvalSetStatus = "aggregating"
+	EvalSetStatusCompleted   EvalSetStatus = "completed"
+	EvalSetStatusFailed      EvalSetStatus = "failed"
+	EvalSetStatusCancelled   EvalSetStatus = "cancelled"
+)
+
+var evalSetTransitions = map[EvalSetStatus]map[EvalSetStatus]struct{}{
+	EvalSetStatusQueued: {
+		EvalSetStatusExpanding: {},
+		EvalSetStatusCancelled: {},
+	},
+	EvalSetStatusExpanding: {
+		EvalSetStatusRunning:   {},
+		EvalSetStatusFailed:    {},
+		EvalSetStatusCancelled: {},
+	},
+	EvalSetStatusRunning: {
+		EvalSetStatusAggregating: {},
+		EvalSetStatusFailed:      {},
+		EvalSetStatusCancelled:   {},
+	},
+	EvalSetStatusAggregating: {
+		EvalSetStatusCompleted: {},
+		EvalSetStatusFailed:    {},
+		EvalSetStatusCancelled: {},
+	},
+}
+
+// CanTransitionTo reports whether from→to is a legal eval-set transition.
+func (s EvalSetStatus) CanTransitionTo(to EvalSetStatus) bool {
+	allowed, ok := evalSetTransitions[s]
+	if !ok {
+		return false
+	}
+	_, ok = allowed[to]
+	return ok
+}
+
+// ValidateEvalSetStatus ensures the status string is known.
+func ValidateEvalSetStatus(s EvalSetStatus) error {
+	switch s {
+	case EvalSetStatusQueued, EvalSetStatusExpanding, EvalSetStatusRunning,
+		EvalSetStatusAggregating, EvalSetStatusCompleted, EvalSetStatusFailed,
+		EvalSetStatusCancelled:
+		return nil
+	default:
+		return fmt.Errorf("invalid eval set status %q", s)
+	}
+}

--- a/runtime/domain/eval_set_test.go
+++ b/runtime/domain/eval_set_test.go
@@ -1,0 +1,30 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/agentclash/agentclash/runtime/domain"
+)
+
+func TestEvalSetStatusTransitions(t *testing.T) {
+	cases := []struct {
+		from domain.EvalSetStatus
+		to   domain.EvalSetStatus
+		ok   bool
+	}{
+		{domain.EvalSetStatusQueued, domain.EvalSetStatusExpanding, true},
+		{domain.EvalSetStatusQueued, domain.EvalSetStatusCancelled, true},
+		{domain.EvalSetStatusQueued, domain.EvalSetStatusRunning, false},
+		{domain.EvalSetStatusExpanding, domain.EvalSetStatusRunning, true},
+		{domain.EvalSetStatusRunning, domain.EvalSetStatusAggregating, true},
+		{domain.EvalSetStatusAggregating, domain.EvalSetStatusCompleted, true},
+		{domain.EvalSetStatusCompleted, domain.EvalSetStatusRunning, false},
+		{domain.EvalSetStatusFailed, domain.EvalSetStatusQueued, false},
+		{domain.EvalSetStatusCancelled, domain.EvalSetStatusRunning, false},
+	}
+	for _, tc := range cases {
+		if got := tc.from.CanTransitionTo(tc.to); got != tc.ok {
+			t.Fatalf("%s → %s = %v, want %v", tc.from, tc.to, got, tc.ok)
+		}
+	}
+}

--- a/runtime/evalset/manifest.go
+++ b/runtime/evalset/manifest.go
@@ -10,22 +10,25 @@ import (
 )
 
 const (
-	SchemaV1           = "evalset/v1"
-	DefaultMaxCombos   = 2000
-	DefaultRepeats     = 1
+	SchemaV1         = "evalset/v1"
+	DefaultMaxCombos = 2000
+	// MaxAllowedCombos is the hard server-side ceiling for max_combinations.
+	// Clients may request a lower cap, but never raise this limit.
+	MaxAllowedCombos = 2000
+	DefaultRepeats   = 1
 )
 
 // Manifest is the declarative eval-set face (YAML or JSON).
 type Manifest struct {
-	Schema     string            `yaml:"schema" json:"schema"`
-	Name       string            `yaml:"name" json:"name"`
-	Packs      []string          `yaml:"packs" json:"packs"`
-	Agents     []AgentEntry      `yaml:"agents" json:"agents"`
-	Models     []string          `yaml:"models" json:"models"`
-	Repeats    int               `yaml:"repeats" json:"repeats"`
-	Seeds      *SeedConfig       `yaml:"seeds" json:"seeds,omitempty"`
-	Limits     Limits            `yaml:"limits" json:"limits"`
-	CaseFanout bool              `yaml:"case_fanout" json:"case_fanout"`
+	Schema     string       `yaml:"schema" json:"schema"`
+	Name       string       `yaml:"name" json:"name"`
+	Packs      []string     `yaml:"packs" json:"packs"`
+	Agents     []AgentEntry `yaml:"agents" json:"agents"`
+	Models     []string     `yaml:"models" json:"models"`
+	Repeats    int          `yaml:"repeats" json:"repeats"`
+	Seeds      *SeedConfig  `yaml:"seeds" json:"seeds,omitempty"`
+	Limits     Limits       `yaml:"limits" json:"limits"`
+	CaseFanout bool         `yaml:"case_fanout" json:"case_fanout"`
 }
 
 // AgentEntry is one lineup axis entry.
@@ -59,16 +62,16 @@ type Combination struct {
 
 // ExpansionReport is the dry-run result.
 type ExpansionReport struct {
-	Name          string         `json:"name"`
-	Combinations  []Combination  `json:"combinations"`
-	Count         int            `json:"count"`
-	PackCount     int            `json:"pack_count"`
-	AgentCount    int            `json:"agent_count"`
-	ModelCount    int            `json:"model_count"`
-	Repeats       int            `json:"repeats"`
-	MaxConcurrent int            `json:"max_concurrent_runs,omitempty"`
-	BudgetUSD     float64        `json:"budget_usd,omitempty"`
-	CaseFanout    bool           `json:"case_fanout"`
+	Name          string        `json:"name"`
+	Combinations  []Combination `json:"combinations"`
+	Count         int           `json:"count"`
+	PackCount     int           `json:"pack_count"`
+	AgentCount    int           `json:"agent_count"`
+	ModelCount    int           `json:"model_count"`
+	Repeats       int           `json:"repeats"`
+	MaxConcurrent int           `json:"max_concurrent_runs,omitempty"`
+	BudgetUSD     float64       `json:"budget_usd,omitempty"`
+	CaseFanout    bool          `json:"case_fanout"`
 }
 
 // ParseManifest parses YAML or JSON bytes into a Manifest.
@@ -84,6 +87,9 @@ func ParseManifest(data []byte) (Manifest, error) {
 func (m Manifest) Validate(maxCombos int) error {
 	if maxCombos <= 0 {
 		maxCombos = DefaultMaxCombos
+	}
+	if maxCombos > MaxAllowedCombos {
+		return fmt.Errorf("max_combinations %d exceeds server limit %d", maxCombos, MaxAllowedCombos)
 	}
 	if strings.TrimSpace(m.Schema) == "" {
 		return fmt.Errorf("schema is required (want %s)", SchemaV1)
@@ -177,6 +183,7 @@ func (m Manifest) Expand(maxCombos int) (ExpansionReport, error) {
 	}
 
 	combos := make([]Combination, 0, len(m.Packs)*len(m.Agents)*len(models)*repeats)
+	seenKeys := make(map[string]struct{}, len(m.Packs)*len(m.Agents)*len(models)*repeats)
 	for _, pack := range m.Packs {
 		packRef := strings.TrimSpace(pack)
 		for _, agent := range m.Agents {
@@ -185,6 +192,10 @@ func (m Manifest) Expand(maxCombos int) (ExpansionReport, error) {
 				modelRef := strings.TrimSpace(model)
 				for rep := 1; rep <= repeats; rep++ {
 					key := matrixKey(packRef, agentRef, modelRef, rep)
+					if _, dup := seenKeys[key]; dup {
+						return ExpansionReport{}, fmt.Errorf("duplicate matrix_key %q (check agent labels and refs)", key)
+					}
+					seenKeys[key] = struct{}{}
 					c := Combination{
 						MatrixKey:  key,
 						PackRef:    packRef,

--- a/runtime/evalset/manifest.go
+++ b/runtime/evalset/manifest.go
@@ -1,0 +1,257 @@
+// Package evalset parses and expands agentclash.evalset.yaml manifests
+// (Fleet eval-set primitive).
+package evalset
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SchemaV1           = "evalset/v1"
+	DefaultMaxCombos   = 2000
+	DefaultRepeats     = 1
+)
+
+// Manifest is the declarative eval-set face (YAML or JSON).
+type Manifest struct {
+	Schema     string            `yaml:"schema" json:"schema"`
+	Name       string            `yaml:"name" json:"name"`
+	Packs      []string          `yaml:"packs" json:"packs"`
+	Agents     []AgentEntry      `yaml:"agents" json:"agents"`
+	Models     []string          `yaml:"models" json:"models"`
+	Repeats    int               `yaml:"repeats" json:"repeats"`
+	Seeds      *SeedConfig       `yaml:"seeds" json:"seeds,omitempty"`
+	Limits     Limits            `yaml:"limits" json:"limits"`
+	CaseFanout bool              `yaml:"case_fanout" json:"case_fanout"`
+}
+
+// AgentEntry is one lineup axis entry.
+type AgentEntry struct {
+	Deployment string `yaml:"deployment" json:"deployment"`
+	Label      string `yaml:"label,omitempty" json:"label,omitempty"`
+}
+
+// SeedConfig controls per-combination seeds.
+type SeedConfig struct {
+	Strategy string  `yaml:"strategy" json:"strategy"`
+	Seeds    []int64 `yaml:"seeds,omitempty" json:"seeds,omitempty"`
+}
+
+// Limits are set-level caps (budget enforced later by Fleet 13).
+type Limits struct {
+	MaxConcurrentRuns int     `yaml:"max_concurrent_runs" json:"max_concurrent_runs"`
+	BudgetUSD         float64 `yaml:"budget_usd" json:"budget_usd"`
+}
+
+// Combination is one expanded cell in the cartesian product.
+type Combination struct {
+	MatrixKey  string `json:"matrix_key"`
+	PackRef    string `json:"pack_ref"`
+	AgentRef   string `json:"agent_ref"`
+	ModelRef   string `json:"model_ref,omitempty"`
+	Repeat     int    `json:"repeat"`
+	Seed       *int64 `json:"seed,omitempty"`
+	CaseFanout bool   `json:"case_fanout"`
+}
+
+// ExpansionReport is the dry-run result.
+type ExpansionReport struct {
+	Name          string         `json:"name"`
+	Combinations  []Combination  `json:"combinations"`
+	Count         int            `json:"count"`
+	PackCount     int            `json:"pack_count"`
+	AgentCount    int            `json:"agent_count"`
+	ModelCount    int            `json:"model_count"`
+	Repeats       int            `json:"repeats"`
+	MaxConcurrent int            `json:"max_concurrent_runs,omitempty"`
+	BudgetUSD     float64        `json:"budget_usd,omitempty"`
+	CaseFanout    bool           `json:"case_fanout"`
+}
+
+// ParseManifest parses YAML or JSON bytes into a Manifest.
+func ParseManifest(data []byte) (Manifest, error) {
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("parse evalset manifest: %w", err)
+	}
+	return m, nil
+}
+
+// Validate checks structural rules (does not resolve pack/deployment IDs).
+func (m Manifest) Validate(maxCombos int) error {
+	if maxCombos <= 0 {
+		maxCombos = DefaultMaxCombos
+	}
+	if strings.TrimSpace(m.Schema) == "" {
+		return fmt.Errorf("schema is required (want %s)", SchemaV1)
+	}
+	if m.Schema != SchemaV1 {
+		return fmt.Errorf("unsupported schema %q (want %s)", m.Schema, SchemaV1)
+	}
+	if strings.TrimSpace(m.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(m.Packs) == 0 {
+		return fmt.Errorf("packs must contain at least one pack ref")
+	}
+	for i, p := range m.Packs {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("packs[%d] is empty", i)
+		}
+	}
+	if len(m.Agents) == 0 {
+		return fmt.Errorf("agents must contain at least one deployment entry")
+	}
+	for i, a := range m.Agents {
+		if strings.TrimSpace(a.Deployment) == "" {
+			return fmt.Errorf("agents[%d].deployment is required", i)
+		}
+	}
+	repeats := m.Repeats
+	if repeats == 0 {
+		repeats = DefaultRepeats
+	}
+	if repeats < 1 {
+		return fmt.Errorf("repeats must be >= 1")
+	}
+	modelCount := len(m.Models)
+	if modelCount == 0 {
+		modelCount = 1
+	}
+	total := len(m.Packs) * len(m.Agents) * modelCount * repeats
+	if total > maxCombos {
+		return fmt.Errorf("combination count %d exceeds max %d (packs=%d agents=%d models=%d repeats=%d)",
+			total, maxCombos, len(m.Packs), len(m.Agents), modelCount, repeats)
+	}
+	if m.Seeds != nil {
+		switch strings.ToLower(strings.TrimSpace(m.Seeds.Strategy)) {
+		case "", "auto":
+			if len(m.Seeds.Seeds) > 0 {
+				return fmt.Errorf("seeds.seeds must be empty when strategy is auto")
+			}
+		case "explicit":
+			if len(m.Seeds.Seeds) == 0 {
+				return fmt.Errorf("seeds.seeds required when strategy is explicit")
+			}
+			if len(m.Seeds.Seeds) != repeats {
+				return fmt.Errorf("seeds.seeds length %d must match repeats %d", len(m.Seeds.Seeds), repeats)
+			}
+			seen := map[int64]struct{}{}
+			for i, s := range m.Seeds.Seeds {
+				if s <= 0 {
+					return fmt.Errorf("seeds.seeds[%d] must be a positive integer", i)
+				}
+				if _, ok := seen[s]; ok {
+					return fmt.Errorf("duplicate seed %d", s)
+				}
+				seen[s] = struct{}{}
+			}
+		default:
+			return fmt.Errorf("unsupported seeds.strategy %q (want auto or explicit)", m.Seeds.Strategy)
+		}
+	}
+	if m.Limits.MaxConcurrentRuns < 0 {
+		return fmt.Errorf("limits.max_concurrent_runs must be >= 0")
+	}
+	if m.Limits.BudgetUSD < 0 {
+		return fmt.Errorf("limits.budget_usd must be >= 0")
+	}
+	return nil
+}
+
+// Expand returns the full cartesian product in stable order.
+func (m Manifest) Expand(maxCombos int) (ExpansionReport, error) {
+	if err := m.Validate(maxCombos); err != nil {
+		return ExpansionReport{}, err
+	}
+	repeats := m.Repeats
+	if repeats == 0 {
+		repeats = DefaultRepeats
+	}
+	models := m.Models
+	if len(models) == 0 {
+		models = []string{""}
+	}
+
+	combos := make([]Combination, 0, len(m.Packs)*len(m.Agents)*len(models)*repeats)
+	for _, pack := range m.Packs {
+		packRef := strings.TrimSpace(pack)
+		for _, agent := range m.Agents {
+			agentRef := agentRef(agent)
+			for _, model := range models {
+				modelRef := strings.TrimSpace(model)
+				for rep := 1; rep <= repeats; rep++ {
+					key := matrixKey(packRef, agentRef, modelRef, rep)
+					c := Combination{
+						MatrixKey:  key,
+						PackRef:    packRef,
+						AgentRef:   agentRef,
+						ModelRef:   modelRef,
+						Repeat:     rep,
+						CaseFanout: m.CaseFanout,
+					}
+					if seed := seedFor(m.Seeds, rep); seed != nil {
+						c.Seed = seed
+					}
+					combos = append(combos, c)
+				}
+			}
+		}
+	}
+
+	modelCount := len(m.Models)
+	return ExpansionReport{
+		Name:          strings.TrimSpace(m.Name),
+		Combinations:  combos,
+		Count:         len(combos),
+		PackCount:     len(m.Packs),
+		AgentCount:    len(m.Agents),
+		ModelCount:    modelCount,
+		Repeats:       repeats,
+		MaxConcurrent: m.Limits.MaxConcurrentRuns,
+		BudgetUSD:     m.Limits.BudgetUSD,
+		CaseFanout:    m.CaseFanout,
+	}, nil
+}
+
+func agentRef(a AgentEntry) string {
+	if label := strings.TrimSpace(a.Label); label != "" {
+		return sanitizeRef(label)
+	}
+	return sanitizeRef(strings.TrimSpace(a.Deployment))
+}
+
+func matrixKey(pack, agent, model string, rep int) string {
+	parts := []string{sanitizeRef(pack), sanitizeRef(agent)}
+	if model != "" {
+		parts = append(parts, sanitizeRef(model))
+	}
+	parts = append(parts, fmt.Sprintf("%d", rep))
+	return strings.Join(parts, "/")
+}
+
+func sanitizeRef(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, " ", "-")
+	return s
+}
+
+func seedFor(cfg *SeedConfig, rep int) *int64 {
+	if cfg == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Strategy)) {
+	case "explicit":
+		if rep-1 < 0 || rep-1 >= len(cfg.Seeds) {
+			return nil
+		}
+		s := cfg.Seeds[rep-1]
+		return &s
+	default:
+		// auto: leave unset; session layer assigns later
+		return nil
+	}
+}

--- a/runtime/evalset/manifest_test.go
+++ b/runtime/evalset/manifest_test.go
@@ -1,0 +1,108 @@
+package evalset_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/runtime/evalset"
+)
+
+const sampleYAML = `
+schema: evalset/v1
+name: nightly-coding-sweep
+packs:
+  - catalog/code-review
+  - my-workspace/refund-recovery@3
+agents:
+  - deployment: claude-opus-5-default
+  - deployment: gpt-5-default
+  - deployment: gemini-default
+models: []
+repeats: 5
+seeds: {strategy: auto}
+limits:
+  max_concurrent_runs: 20
+  budget_usd: 50
+case_fanout: true
+`
+
+func TestExpand_TwoPackThreeAgentFiveRepeat(t *testing.T) {
+	m, err := evalset.ParseManifest([]byte(sampleYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := m.Expand(evalset.DefaultMaxCombos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Count != 30 {
+		t.Fatalf("count = %d, want 30", report.Count)
+	}
+	if report.Combinations[0].MatrixKey != "catalog/code-review/claude-opus-5-default/1" {
+		t.Fatalf("first key = %q", report.Combinations[0].MatrixKey)
+	}
+	last := report.Combinations[len(report.Combinations)-1]
+	if last.MatrixKey != "my-workspace/refund-recovery@3/gemini-default/5" {
+		t.Fatalf("last key = %q", last.MatrixKey)
+	}
+	// Determinism
+	report2, err := m.Expand(evalset.DefaultMaxCombos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range report.Combinations {
+		if report.Combinations[i].MatrixKey != report2.Combinations[i].MatrixKey {
+			t.Fatalf("non-deterministic at %d", i)
+		}
+	}
+}
+
+func TestExpand_RejectsOverCap(t *testing.T) {
+	m := evalset.Manifest{
+		Schema:  evalset.SchemaV1,
+		Name:    "big",
+		Packs:   []string{"a", "b"},
+		Agents:  []evalset.AgentEntry{{Deployment: "x"}, {Deployment: "y"}},
+		Repeats: 1000,
+	}
+	_, err := m.Expand(100)
+	if err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestExpand_RejectsDuplicateSeeds(t *testing.T) {
+	m := evalset.Manifest{
+		Schema:  evalset.SchemaV1,
+		Name:    "seeds",
+		Packs:   []string{"p"},
+		Agents:  []evalset.AgentEntry{{Deployment: "a"}},
+		Repeats: 2,
+		Seeds:   &evalset.SeedConfig{Strategy: "explicit", Seeds: []int64{1, 1}},
+	}
+	_, err := m.Expand(evalset.DefaultMaxCombos)
+	if err == nil || !strings.Contains(err.Error(), "duplicate seed") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestExpand_WithModelsAxis(t *testing.T) {
+	m := evalset.Manifest{
+		Schema:  evalset.SchemaV1,
+		Name:    "models",
+		Packs:   []string{"p"},
+		Agents:  []evalset.AgentEntry{{Deployment: "harness"}},
+		Models:  []string{"m1", "m2"},
+		Repeats: 2,
+	}
+	report, err := m.Expand(evalset.DefaultMaxCombos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Count != 4 {
+		t.Fatalf("count = %d", report.Count)
+	}
+	if report.Combinations[0].MatrixKey != "p/harness/m1/1" {
+		t.Fatalf("key = %q", report.Combinations[0].MatrixKey)
+	}
+}

--- a/runtime/evalset/manifest_test.go
+++ b/runtime/evalset/manifest_test.go
@@ -106,3 +106,34 @@ func TestExpand_WithModelsAxis(t *testing.T) {
 		t.Fatalf("key = %q", report.Combinations[0].MatrixKey)
 	}
 }
+
+func TestExpand_RejectsMaxAllowedCombosCeiling(t *testing.T) {
+	m := evalset.Manifest{
+		Schema:  evalset.SchemaV1,
+		Name:    "cap",
+		Packs:   []string{"p"},
+		Agents:  []evalset.AgentEntry{{Deployment: "a"}},
+		Repeats: 1,
+	}
+	_, err := m.Expand(evalset.MaxAllowedCombos + 1)
+	if err == nil || !strings.Contains(err.Error(), "server limit") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestExpand_RejectsDuplicateMatrixKey(t *testing.T) {
+	m := evalset.Manifest{
+		Schema: evalset.SchemaV1,
+		Name:   "dup-labels",
+		Packs:  []string{"p"},
+		Agents: []evalset.AgentEntry{
+			{Deployment: "dep-a", Label: "my agent"},
+			{Deployment: "dep-b", Label: "my-agent"},
+		},
+		Repeats: 1,
+	}
+	_, err := m.Expand(evalset.DefaultMaxCombos)
+	if err == nil || !strings.Contains(err.Error(), "duplicate matrix_key") {
+		t.Fatalf("err = %v", err)
+	}
+}


### PR DESCRIPTION
⛔ Stacked on #1218 — do not merge out of order. Part of epic #1212.

Part of #1204 (split 07a/07b for reviewability — orchestration/persistence in 07b).

## What & why

Eval sessions today require a hand-enumerated `run_matrix`. This PR introduces the `evalset/v1` manifest face (`runtime/evalset`), expands `packs × agents × models × repeats` into deterministic `matrix_key`s, adds the EvalSet status state machine, and exposes `POST /v1/eval-sets/expand` as a workspace-authorized dry-run. No sessions or runs are created here — that is 07b.

## Decisions

1. **Split #1204 into 07a (manifest/expand) + 07b (DB/workflow/aggregation)** — keeps each PR under the ~1500-line reviewability bar.
2. **`matrix_key = {pack}/{agent}[/{model}]/{rep}`** — matches the issue sketch; optional models axis inserts a segment. Pack refs may contain `/` (catalog paths).
3. **Max combinations default 2000** — spec safety cap with actionable errors.
4. **Expand requires workspace authz** even though dry-run is stateless — prepares for pack-resolution authz in 07b.
5. **YAML via `gopkg.in/yaml.v3`** already in the runtime module; JSON works via the same unmarshaler.

Sources: issue #1204 Build §1; local `decodeEvalSessionRunMatrix` / series matrix_key conventions; hawk eval_set product shape (manifest → combinations).

## Review map

1. `runtime/evalset/manifest.go`
2. `runtime/domain/eval_set.go`
3. `backend/internal/api/eval_sets.go`
4. OpenAPI `ExpandEvalSetRequest` / `EvalSetExpansionReport`

## Verification evidence

```
cd runtime && go build ./... && go vet ./... && go test -short -race -count=1 ./...
cd backend && go build ./... && go vet ./... && go test -short -race -count=1 ./...
npx @redocly/cli lint docs/api-server/openapi.yaml
```

Two consecutive full gates green.

Acceptance (07a slice):

- [x] Expand 2×3×5 → 30 combinations with deterministic keys — `TestExpand_TwoPackThreeAgentFiveRepeat` + `TestExpandEvalSetEndpoint`
- [x] Invalid manifests rejected — over-cap / dup seeds tests
- [x] OpenAPI + redocly lint
- [x] State machine transition tests — `TestEvalSetStatusTransitions`
- [ ] Create sessions/runs/rollup/cancel — **07b**

## Risk & rollback

- New endpoint only; no behavior change for existing eval sessions.
- Rollback: remove route registration / ignore expand calls.