### PR TITLE
feat(web): live eval-set matrix dashboard (#1207)

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/case-explorer.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/case-explorer.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import useSWR from "swr";
+
+import { createApiClient } from "@/lib/api/client";
+import {
+  downloadEvalSetExport,
+  listEvalSetCases,
+  searchEvalSetCases,
+} from "@/lib/api/eval-sets";
+import type { EvalSetCaseResult } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export function CaseExplorer({ evalSetId }: { evalSetId: string }) {
+  const { accessToken, getAccessToken } = useAccessToken();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const q = searchParams.get("q") ?? "";
+  const verdict = searchParams.get("verdict") ?? "";
+  const minScore = searchParams.get("min_score") ?? "";
+  const [draftQ, setDraftQ] = useState(q);
+  const [exporting, setExporting] = useState<"csv" | "jsonl" | null>(null);
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (value) next.set(key, value);
+      else next.delete(key);
+      next.set("tab", "cases");
+      router.replace(`${pathname}?${next.toString()}`);
+    },
+    [pathname, router, searchParams],
+  );
+
+  const { data, error, isLoading } = useSWR(
+    accessToken
+      ? (["eval-set-cases", evalSetId, q, verdict, minScore] as const)
+      : null,
+    async () => {
+      const token = (await getAccessToken()) ?? accessToken;
+      if (!token) return [] as EvalSetCaseResult[];
+      const api = createApiClient(token);
+      const params: Record<string, string | number | undefined> = {
+        verdict: verdict || undefined,
+        min_score: minScore || undefined,
+        limit: 50,
+      };
+      const res = q
+        ? await searchEvalSetCases(api, evalSetId, { ...params, q })
+        : await listEvalSetCases(api, evalSetId, params);
+      return res.cases ?? [];
+    },
+  );
+  const cases = data ?? [];
+
+  async function onExport(format: "csv" | "jsonl") {
+    setExporting(format);
+    try {
+      const token = (await getAccessToken()) ?? accessToken;
+      if (!token) return;
+      await downloadEvalSetExport(token, evalSetId, format);
+    } finally {
+      setExporting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <form
+        className="flex flex-wrap items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setParam("q", draftQ.trim());
+        }}
+      >
+        <div className="min-w-[12rem] flex-1">
+          <label className="text-xs text-muted-foreground">
+            Transcript search
+          </label>
+          <Input
+            value={draftQ}
+            onChange={(e) => setDraftQ(e.target.value)}
+            placeholder="e.g. refund"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground">Verdict</label>
+          <Input
+            value={verdict}
+            onChange={(e) => setParam("verdict", e.target.value)}
+            placeholder="pass / fail"
+            className="w-28"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground">Min score</label>
+          <Input
+            value={minScore}
+            onChange={(e) => setParam("min_score", e.target.value)}
+            placeholder="0.5"
+            className="w-24"
+          />
+        </div>
+        <Button type="submit" variant="secondary">
+          Apply
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={exporting !== null}
+          onClick={() => void onExport("csv")}
+        >
+          {exporting === "csv" ? "Exporting…" : "Export CSV"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={exporting !== null}
+          onClick={() => void onExport("jsonl")}
+        >
+          {exporting === "jsonl" ? "Exporting…" : "Export JSONL"}
+        </Button>
+      </form>
+      {error ? (
+        <p className="text-sm text-destructive">
+          {error instanceof Error ? error.message : "Failed to load cases"}
+        </p>
+      ) : null}
+      {isLoading && !data ? (
+        <p className="text-sm text-muted-foreground">Loading cases…</p>
+      ) : null}
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Matrix</TableHead>
+              <TableHead>Verdict</TableHead>
+              <TableHead>Score</TableHead>
+              <TableHead>Snippet</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {cases.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell className="font-mono text-xs">{c.matrix_key}</TableCell>
+                <TableCell>{c.verdict || "—"}</TableCell>
+                <TableCell>{c.score ?? "—"}</TableCell>
+                <TableCell className="max-w-md text-xs text-muted-foreground">
+                  {highlightSnippet(
+                    c.snippet || c.transcript_text?.slice(0, 160) || "—",
+                    q,
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {cases.length === 0 && !error && !isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          No cases match these filters.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function highlightSnippet(text: string, q: string) {
+  if (!q.trim()) return text;
+  const idx = text.toLowerCase().indexOf(q.toLowerCase());
+  if (idx < 0) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-amber-200/80 text-foreground dark:bg-amber-500/30">
+        {text.slice(idx, idx + q.length)}
+      </mark>
+      {text.slice(idx + q.length)}
+    </>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
@@ -84,7 +84,7 @@ function EvalSetDetailInner({
     !!detail && EVAL_SET_ACTIVE.includes(detail.eval_set.status);
   const liveKey =
     active && sessionIds.length > 0
-      ? (["eval-set-live", evalSetId, ...sessionIds.slice(0, 24)] as const)
+      ? (["eval-set-live", evalSetId, ...sessionIds] as const)
       : null;
 
   const { data: live = {} } = useSWR<LiveStatusMap>(
@@ -95,7 +95,7 @@ function EvalSetDetailInner({
       const api = createApiClient(token);
       const nextLive: LiveStatusMap = {};
       await Promise.all(
-        sessionIds.slice(0, 24).map(async (sessionId) => {
+        sessionIds.map(async (sessionId) => {
           try {
             const session = await getEvalSession(api, sessionId);
             for (const run of session.runs ?? []) {
@@ -122,6 +122,12 @@ function EvalSetDetailInner({
     () => (detail ? buildMatrixGrid(detail, live) : null),
     [detail, live],
   );
+
+  const selectedLive = useMemo(() => {
+    if (!selected || !grid) return selected;
+    const key = `${selected.agentRef}\0${selected.packRef}`;
+    return grid.cells[key] ?? selected;
+  }, [selected, grid]);
 
   const setTab = (value: string) => {
     const next = new URLSearchParams(searchParams.toString());
@@ -150,8 +156,8 @@ function EvalSetDetailInner({
   const runs = detail.result?.run_count ?? detail.result?.aggregate?.runs ?? 0;
   const sessions =
     detail.eval_session_ids?.length ?? detail.result?.session_count ?? 0;
-  const selectedKey = selected
-    ? `${selected.agentRef}\0${selected.packRef}`
+  const selectedKey = selectedLive
+    ? `${selectedLive.agentRef}\0${selectedLive.packRef}`
     : null;
 
   return (
@@ -203,17 +209,17 @@ function EvalSetDetailInner({
             selectedKey={selectedKey}
             onSelect={setSelected}
           />
-          {selected ? (
+          {selectedLive ? (
             <div className="rounded-lg border border-border bg-card/40 p-4">
               <h2 className="text-sm font-semibold">
-                {shortRef(selected.agentRef)} × {shortRef(selected.packRef)}
+                {shortRef(selectedLive.agentRef)} × {shortRef(selectedLive.packRef)}
               </h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                {selected.passCount}/{selected.totalCount} completed · state{" "}
-                {selected.state}
+                {selectedLive.passCount}/{selectedLive.totalCount} completed · state{" "}
+                {selectedLive.state}
               </p>
               <ul className="mt-3 space-y-2">
-                {selected.combos.map((c) => (
+                {selectedLive.combos.map((c) => (
                   <li
                     key={c.matrixKey}
                     className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs"

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { Suspense, useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Grid3x3 } from "lucide-react";
+import useSWR from "swr";
+
+import { createApiClient } from "@/lib/api/client";
+import { compareEvalSets, getEvalSession } from "@/lib/api/eval-sets";
+import type { CompareEvalSetsResponse, GetEvalSetResponse } from "@/lib/api/types";
+import { useApiQuery } from "@/lib/api/swr";
+import {
+  EVAL_SET_ACTIVE,
+  buildMatrixGrid,
+  completionPercent,
+  inFlightCount,
+  type LiveStatusMap,
+  type MatrixCell,
+} from "@/lib/eval-sets";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CaseExplorer } from "./case-explorer";
+import { MatrixGridView } from "./matrix-grid";
+
+const POLL_MS = 5000;
+
+export function EvalSetDetailClient({
+  workspaceId,
+  evalSetId,
+}: {
+  workspaceId: string;
+  evalSetId: string;
+}) {
+  return (
+    <Suspense fallback={<p className="text-sm text-muted-foreground">Loading…</p>}>
+      <EvalSetDetailInner workspaceId={workspaceId} evalSetId={evalSetId} />
+    </Suspense>
+  );
+}
+
+function EvalSetDetailInner({
+  workspaceId,
+  evalSetId,
+}: {
+  workspaceId: string;
+  evalSetId: string;
+}) {
+  const { accessToken, getAccessToken } = useAccessToken();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tab = searchParams.get("tab") ?? "matrix";
+  const [selected, setSelected] = useState<MatrixCell | null>(null);
+  const [compareId, setCompareId] = useState("");
+  const [compare, setCompare] = useState<CompareEvalSetsResponse | null>(null);
+  const [compareError, setCompareError] = useState<string | null>(null);
+
+  const { data: detail, error, isLoading } = useApiQuery<GetEvalSetResponse>(
+    `/v1/eval-sets/${evalSetId}`,
+    undefined,
+    {
+      refreshInterval: (response) =>
+        response && EVAL_SET_ACTIVE.includes(response.eval_set.status)
+          ? POLL_MS
+          : 0,
+    },
+  );
+
+  const sessionIds = detail?.eval_session_ids ?? [];
+  const active =
+    !!detail && EVAL_SET_ACTIVE.includes(detail.eval_set.status);
+  const liveKey =
+    active && sessionIds.length > 0
+      ? (["eval-set-live", evalSetId, ...sessionIds.slice(0, 24)] as const)
+      : null;
+
+  const { data: live = {} } = useSWR<LiveStatusMap>(
+    liveKey,
+    async () => {
+      const token = (await getAccessToken()) ?? accessToken;
+      if (!token) return {};
+      const api = createApiClient(token);
+      const nextLive: LiveStatusMap = {};
+      await Promise.all(
+        sessionIds.slice(0, 24).map(async (sessionId) => {
+          try {
+            const session = await getEvalSession(api, sessionId);
+            for (const run of session.runs ?? []) {
+              if (!run.matrix_key) continue;
+              nextLive[run.matrix_key] = {
+                status: run.status,
+                runId: run.id,
+              };
+            }
+          } catch {
+            // best-effort
+          }
+        }),
+      );
+      return nextLive;
+    },
+    {
+      refreshInterval: active ? POLL_MS : 0,
+      revalidateOnFocus: true,
+    },
+  );
+
+  const grid = useMemo(
+    () => (detail ? buildMatrixGrid(detail, live) : null),
+    [detail, live],
+  );
+
+  const setTab = (value: string) => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.set("tab", value);
+    router.replace(`${pathname}?${next.toString()}`);
+  };
+
+  if (error && !detail) {
+    return (
+      <EmptyState
+        icon={<Grid3x3 className="h-8 w-8" />}
+        title="Eval set unavailable"
+        description={
+          error instanceof Error ? error.message : "Failed to load eval set"
+        }
+      />
+    );
+  }
+  if ((isLoading && !detail) || !detail || !grid) {
+    return <p className="text-sm text-muted-foreground">Loading eval set…</p>;
+  }
+
+  const set = detail.eval_set;
+  const pct = completionPercent(detail, live);
+  const flight = inFlightCount(live);
+  const runs = detail.result?.run_count ?? detail.result?.aggregate?.runs ?? 0;
+  const sessions =
+    detail.eval_session_ids?.length ?? detail.result?.session_count ?? 0;
+  const selectedKey = selected
+    ? `${selected.agentRef}\0${selected.packRef}`
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <Link
+            href={`/workspaces/${workspaceId}/eval-sets`}
+            className="text-xs text-muted-foreground hover:underline"
+          >
+            ← Eval sets
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight">{set.name}</h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{set.status}</Badge>
+            <span className="text-sm text-muted-foreground">
+              {set.combination_count} combinations · {sessions} sessions · {runs}{" "}
+              runs
+            </span>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Complete" value={`${pct}%`} />
+          <Stat label="In flight" value={String(flight)} />
+          <Stat
+            label="Elapsed"
+            value={
+              set.started_at
+                ? formatElapsed(set.started_at, set.finished_at)
+                : "—"
+            }
+          />
+          <Stat
+            label="Budget"
+            value={set.budget_usd != null ? `$${set.budget_usd}` : "—"}
+          />
+        </div>
+      </div>
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="matrix">Matrix</TabsTrigger>
+          <TabsTrigger value="cases">Case explorer</TabsTrigger>
+          <TabsTrigger value="compare">Compare</TabsTrigger>
+        </TabsList>
+        <TabsContent value="matrix" className="space-y-4">
+          <MatrixGridView
+            grid={grid}
+            selectedKey={selectedKey}
+            onSelect={setSelected}
+          />
+          {selected ? (
+            <div className="rounded-lg border border-border bg-card/40 p-4">
+              <h2 className="text-sm font-semibold">
+                {shortRef(selected.agentRef)} × {shortRef(selected.packRef)}
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {selected.passCount}/{selected.totalCount} completed · state{" "}
+                {selected.state}
+              </p>
+              <ul className="mt-3 space-y-2">
+                {selected.combos.map((c) => (
+                  <li
+                    key={c.matrixKey}
+                    className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs"
+                  >
+                    <span className="text-muted-foreground">{c.matrixKey}</span>
+                    <span className="flex items-center gap-2">
+                      <Badge variant="outline">{c.status || "queued"}</Badge>
+                      {c.runId ? (
+                        <Link
+                          href={`/workspaces/${workspaceId}/runs/${c.runId}`}
+                          className="underline-offset-4 hover:underline"
+                        >
+                          Open run
+                        </Link>
+                      ) : null}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </TabsContent>
+        <TabsContent value="cases">
+          <CaseExplorer evalSetId={evalSetId} />
+        </TabsContent>
+        <TabsContent value="compare" className="space-y-4">
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="min-w-[16rem] flex-1">
+              <label className="text-xs text-muted-foreground">
+                Compare with eval set ID
+              </label>
+              <Input
+                value={compareId}
+                onChange={(e) => setCompareId(e.target.value)}
+                placeholder="previous eval set uuid"
+              />
+            </div>
+            <Button
+              type="button"
+              onClick={async () => {
+                if (!accessToken || !compareId.trim()) return;
+                try {
+                  const api = createApiClient(accessToken);
+                  const res = await compareEvalSets(
+                    api,
+                    evalSetId,
+                    compareId.trim(),
+                  );
+                  setCompare(res);
+                  setCompareError(null);
+                } catch (err) {
+                  setCompareError(
+                    err instanceof Error ? err.message : "Compare failed",
+                  );
+                }
+              }}
+            >
+              Compare
+            </Button>
+          </div>
+          {compareError ? (
+            <p className="text-sm text-destructive">{compareError}</p>
+          ) : null}
+          {compare ? (
+            <div className="space-y-3 overflow-x-auto">
+              <p className="text-sm text-muted-foreground">
+                {compare.shared_keys} shared keys · {compare.regressions.length}{" "}
+                regressions
+              </p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Matrix</TableHead>
+                    <TableHead>A</TableHead>
+                    <TableHead>B</TableHead>
+                    <TableHead>Delta</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {compare.regressions.map((r) => (
+                    <TableRow key={`${r.matrix_key}:${r.case_key}`}>
+                      <TableCell className="font-mono text-xs">
+                        {r.matrix_key}
+                      </TableCell>
+                      <TableCell>{r.a_score}</TableCell>
+                      <TableCell className="text-red-600 dark:text-red-400">
+                        {r.b_score}
+                      </TableCell>
+                      <TableCell className="text-red-600 dark:text-red-400">
+                        {r.delta.toFixed(3)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {compare.regressions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No score regressions.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-background/70 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function formatElapsed(startedAt: string, finishedAt?: string | null): string {
+  const start = new Date(startedAt).getTime();
+  const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
+  const sec = Math.max(0, Math.round((end - start) / 1000));
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  return `${min}m ${sec % 60}s`;
+}
+
+function shortRef(ref: string): string {
+  if (ref.length <= 24) return ref;
+  return `${ref.slice(0, 10)}…${ref.slice(-8)}`;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/matrix-grid.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/matrix-grid.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { MatrixCell, MatrixGrid as Grid } from "@/lib/eval-sets";
+import { cn } from "@/lib/utils";
+
+export function MatrixGridView({
+  grid,
+  onSelect,
+  selectedKey,
+}: {
+  grid: Grid;
+  onSelect?: (cell: MatrixCell) => void;
+  selectedKey?: string | null;
+}) {
+  if (grid.rowLabels.length === 0 || grid.colLabels.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Matrix will appear once combinations are expanded.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full min-w-[32rem] border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-10 bg-background px-3 py-2 text-left text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              {grid.rowAxis === "agent" ? "Agent \\ Pack" : "Pack \\ Agent"}
+            </th>
+            {grid.colLabels.map((col) => (
+              <th
+                key={col}
+                className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
+              >
+                <span className="line-clamp-2 max-w-[8rem] font-mono text-[11px]">
+                  {shortRef(col)}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {grid.rowLabels.map((row) => (
+            <tr key={row} className="border-t border-border">
+              <th className="sticky left-0 z-10 bg-background px-3 py-2 text-left font-mono text-[11px] font-medium">
+                {shortRef(row)}
+              </th>
+              {grid.colLabels.map((col) => {
+                const cell = grid.cells[`${row}\0${col}`];
+                const state = cell?.state ?? "queued";
+                const cellKey = cell
+                  ? `${cell.agentRef}\0${cell.packRef}`
+                  : null;
+                const active = cellKey != null && cellKey === selectedKey;
+                const passRate =
+                  cell && cell.totalCount > 0
+                    ? `${cell.passCount}/${cell.totalCount}`
+                    : "—";
+                return (
+                  <td key={col} className="px-2 py-2">
+                    <button
+                      type="button"
+                      disabled={!cell}
+                      onClick={() => cell && onSelect?.(cell)}
+                      className={cn(
+                        "flex h-14 w-full min-w-[5.5rem] flex-col items-start justify-center rounded-md border px-2 text-left transition",
+                        state === "queued" &&
+                          "border-border/60 bg-muted/20 text-muted-foreground",
+                        state === "running" &&
+                          "border-amber-600/50 bg-amber-500/10 text-amber-950 dark:text-amber-100 animate-pulse",
+                        state === "scored" &&
+                          "border-emerald-600/40 bg-emerald-500/10",
+                        state === "failed" && "border-red-600/40 bg-red-500/10",
+                        active && "ring-2 ring-foreground/30",
+                      )}
+                    >
+                      <span className="text-[10px] uppercase tracking-[0.14em] opacity-70">
+                        {state}
+                      </span>
+                      <span className="mt-0.5 font-mono text-[11px]">
+                        {passRate}
+                      </span>
+                    </button>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function shortRef(ref: string): string {
+  if (ref.length <= 18) return ref;
+  return `${ref.slice(0, 8)}…${ref.slice(-6)}`;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/page.tsx
@@ -1,0 +1,12 @@
+import { EvalSetDetailClient } from "./eval-set-detail-client";
+
+export default async function EvalSetDetailPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; evalSetId: string }>;
+}) {
+  const { workspaceId, evalSetId } = await params;
+  return (
+    <EvalSetDetailClient workspaceId={workspaceId} evalSetId={evalSetId} />
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/eval-sets-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/eval-sets-client.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { Grid3x3 } from "lucide-react";
+
+import type { ListEvalSetsResponse } from "@/lib/api/types";
+import { useApiQuery } from "@/lib/api/swr";
+import { EVAL_SET_ACTIVE } from "@/lib/eval-sets";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const POLL_MS = 5000;
+
+export function EvalSetsClient({ workspaceId }: { workspaceId: string }) {
+  const { data, error, isLoading } = useApiQuery<ListEvalSetsResponse>(
+    "/v1/eval-sets",
+    { workspace_id: workspaceId },
+    {
+      refreshInterval: (response) =>
+        response?.eval_sets?.some((s) => EVAL_SET_ACTIVE.includes(s.status))
+          ? POLL_MS
+          : 0,
+    },
+  );
+  const sets = data?.eval_sets ?? [];
+
+  if (isLoading && !data) {
+    return <p className="text-sm text-muted-foreground">Loading eval sets…</p>;
+  }
+  if (error) {
+    return (
+      <EmptyState
+        icon={<Grid3x3 className="h-8 w-8" />}
+        title="Could not load eval sets"
+        description={
+          error instanceof Error ? error.message : "Failed to load eval sets"
+        }
+      />
+    );
+  }
+  if (sets.length === 0) {
+    return (
+      <EmptyState
+        icon={<Grid3x3 className="h-8 w-8" />}
+        title="No eval sets yet"
+        description="Submit a manifest with agentclash evalset submit sweep.yaml to create one."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Eval Sets</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Multi-pack matrices filling in live as combinations complete.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Combinations</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sets.map((set) => (
+              <TableRow key={set.id}>
+                <TableCell>
+                  <Link
+                    href={`/workspaces/${workspaceId}/eval-sets/${set.id}`}
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
+                  >
+                    {set.name}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{set.status}</Badge>
+                </TableCell>
+                <TableCell>{set.combination_count}</TableCell>
+                <TableCell className="text-muted-foreground">
+                  {new Date(set.created_at).toLocaleString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/page.tsx
@@ -1,0 +1,10 @@
+import { EvalSetsClient } from "./eval-sets-client";
+
+export default async function EvalSetsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = await params;
+  return <EvalSetsClient workspaceId={workspaceId} />;
+}

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -15,6 +15,7 @@ import {
   Lock,
   Cog,
   LibraryBig,
+  Grid3x3,
   type LucideIcon,
 } from "lucide-react";
 
@@ -67,6 +68,11 @@ export const navSections: NavSection[] = [
         label: "Runs",
         href: (id) => `/workspaces/${id}/runs`,
         icon: Play,
+      },
+      {
+        label: "Eval Sets",
+        href: (id) => `/workspaces/${id}/eval-sets`,
+        icon: Grid3x3,
       },
       {
         label: "Regression Suites",

--- a/web/src/lib/__tests__/eval-sets.test.ts
+++ b/web/src/lib/__tests__/eval-sets.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import type { GetEvalSetResponse } from "@/lib/api/types";
+import {
+  agentRefFromMatrixKey,
+  buildMatrixGrid,
+  completionPercent,
+  inFlightCount,
+} from "../eval-sets";
+
+function detailFixture(): GetEvalSetResponse {
+  const packs = ["pack-a", "pack-b", "pack-c"];
+  const agents = ["agent-1", "agent-2", "agent-3", "agent-4"];
+  const combinations = [];
+  for (const pack of packs) {
+    for (const agent of agents) {
+      for (let r = 1; r <= 5; r++) {
+        combinations.push({
+          matrix_key: `${pack}/${agent}/${r}`,
+          pack_ref: pack,
+          agent_ref: agent,
+          repeat: r,
+        });
+      }
+    }
+  }
+  return {
+    eval_set: {
+      id: "es-1",
+      workspace_id: "ws-1",
+      organization_id: "org-1",
+      name: "sweep",
+      status: "running",
+      combination_count: 60,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      expansion: { combinations, count: 60 },
+    },
+  };
+}
+
+describe("agentRefFromMatrixKey", () => {
+  it("strips multi-segment pack refs", () => {
+    expect(
+      agentRefFromMatrixKey(
+        "catalog/code-review/claude-opus-5-default/1",
+        "catalog/code-review",
+      ),
+    ).toBe("claude-opus-5-default");
+  });
+});
+
+describe("buildMatrixGrid", () => {
+  it("builds a 4×3 agent×pack grid for 3 packs × 4 agents × 5 repeats", () => {
+    const grid = buildMatrixGrid(detailFixture());
+    expect(grid.rowAxis).toBe("agent");
+    expect(grid.rowLabels).toHaveLength(4);
+    expect(grid.colLabels).toHaveLength(3);
+    const cell = grid.cells[`agent-1\0pack-a`];
+    expect(cell?.totalCount).toBe(5);
+    expect(cell?.state).toBe("queued");
+  });
+
+  it("updates cell state from live run statuses without full page rebuild", () => {
+    const detail = detailFixture();
+    const live = {
+      "pack-a/agent-1/1": { status: "running", runId: "run-1" },
+      "pack-a/agent-1/2": { status: "completed", runId: "run-2" },
+      "pack-a/agent-1/3": { status: "queued", runId: "run-3" },
+      "pack-a/agent-1/4": { status: "queued" },
+      "pack-a/agent-1/5": { status: "queued" },
+    };
+    const grid = buildMatrixGrid(detail, live);
+    expect(grid.cells[`agent-1\0pack-a`]?.state).toBe("running");
+    expect(grid.cells[`agent-2\0pack-a`]?.state).toBe("queued");
+
+    const scoredLive = Object.fromEntries(
+      [1, 2, 3, 4, 5].map((r) => [
+        `pack-a/agent-1/${r}`,
+        { status: "completed", runId: `run-${r}` },
+      ]),
+    );
+    const scored = buildMatrixGrid(detail, scoredLive);
+    expect(scored.cells[`agent-1\0pack-a`]?.state).toBe("scored");
+    expect(scored.cells[`agent-1\0pack-a`]?.passCount).toBe(5);
+  });
+
+  it("flips axes when packs outnumber agents", () => {
+    const detail = detailFixture();
+    detail.eval_set.expansion = {
+      combinations: [
+        {
+          matrix_key: "p1/a1/1",
+          pack_ref: "p1",
+          agent_ref: "a1",
+          repeat: 1,
+        },
+        {
+          matrix_key: "p2/a1/1",
+          pack_ref: "p2",
+          agent_ref: "a1",
+          repeat: 1,
+        },
+        {
+          matrix_key: "p3/a1/1",
+          pack_ref: "p3",
+          agent_ref: "a1",
+          repeat: 1,
+        },
+      ],
+      count: 3,
+    };
+    detail.eval_set.combination_count = 3;
+    const grid = buildMatrixGrid(detail);
+    expect(grid.rowAxis).toBe("pack");
+    expect(grid.rowLabels).toEqual(["p1", "p2", "p3"]);
+    expect(grid.colLabels).toEqual(["a1"]);
+  });
+});
+
+describe("completionPercent / inFlightCount", () => {
+  it("computes completion from live map", () => {
+    const detail = detailFixture();
+    const live: Record<string, { status: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      live[`k-${i}`] = { status: "completed" };
+    }
+    for (let i = 30; i < 60; i++) {
+      live[`k-${i}`] = { status: i === 30 ? "running" : "queued" };
+    }
+    expect(completionPercent(detail, live)).toBe(50);
+    expect(inFlightCount(live)).toBe(1);
+  });
+});

--- a/web/src/lib/api/eval-sets.ts
+++ b/web/src/lib/api/eval-sets.ts
@@ -1,0 +1,100 @@
+import type { ApiClient } from "./client";
+import type {
+  CompareEvalSetsResponse,
+  EvalSessionDetail,
+  EvalSetCaseResult,
+  EvalSetReportResponse,
+  GetEvalSetResponse,
+  ListEvalSetsResponse,
+} from "./types";
+
+export function listEvalSets(
+  api: ApiClient,
+  workspaceId: string,
+): Promise<ListEvalSetsResponse> {
+  return api.get<ListEvalSetsResponse>("/v1/eval-sets", {
+    params: { workspace_id: workspaceId },
+  });
+}
+
+export function getEvalSet(
+  api: ApiClient,
+  evalSetId: string,
+): Promise<GetEvalSetResponse> {
+  return api.get<GetEvalSetResponse>(`/v1/eval-sets/${evalSetId}`);
+}
+
+export function getEvalSetReport(
+  api: ApiClient,
+  evalSetId: string,
+): Promise<EvalSetReportResponse> {
+  return api.get<EvalSetReportResponse>(`/v1/eval-sets/${evalSetId}/report`);
+}
+
+export function searchEvalSetCases(
+  api: ApiClient,
+  evalSetId: string,
+  params: Record<string, string | number | undefined>,
+): Promise<{ cases: EvalSetCaseResult[]; query: string }> {
+  return api.get(`/v1/eval-sets/${evalSetId}/search`, { params });
+}
+
+export function listEvalSetCases(
+  api: ApiClient,
+  evalSetId: string,
+  params: Record<string, string | number | undefined>,
+): Promise<{ cases: EvalSetCaseResult[]; next_cursor?: string }> {
+  return api.get(`/v1/eval-sets/${evalSetId}/cases`, { params });
+}
+
+export function compareEvalSets(
+  api: ApiClient,
+  a: string,
+  b: string,
+): Promise<CompareEvalSetsResponse> {
+  return api.get<CompareEvalSetsResponse>("/v1/compare/eval-sets", {
+    params: { a, b },
+  });
+}
+
+export function getEvalSession(
+  api: ApiClient,
+  evalSessionId: string,
+): Promise<EvalSessionDetail> {
+  return api.get<EvalSessionDetail>(`/v1/eval-sessions/${evalSessionId}`);
+}
+
+export function evalSetExportUrl(
+  evalSetId: string,
+  format: "csv" | "jsonl",
+): string {
+  const base =
+    typeof window === "undefined"
+      ? process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL
+      : process.env.NEXT_PUBLIC_API_URL;
+  return `${(base ?? "").replace(/\/+$/, "")}/v1/eval-sets/${evalSetId}/export?format=${format}`;
+}
+
+/** Authenticated download for warehouse export (Bearer required). */
+export async function downloadEvalSetExport(
+  token: string,
+  evalSetId: string,
+  format: "csv" | "jsonl",
+): Promise<void> {
+  const url = evalSetExportUrl(evalSetId, format);
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Export failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = `eval-set-${evalSetId}.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -104,6 +104,17 @@ export {
   type PromotionOverridesInput,
 } from "./regression";
 export {
+  listEvalSets,
+  getEvalSet,
+  getEvalSetReport,
+  searchEvalSetCases,
+  listEvalSetCases,
+  compareEvalSets,
+  getEvalSession,
+  evalSetExportUrl,
+  downloadEvalSetExport,
+} from "./eval-sets";
+export {
   addDatasetExample,
   createDataset,
   createDatasetBaseline,

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -887,6 +887,9 @@ export interface EvalSessionChildRun {
   name: string;
   status: RunStatus;
   execution_mode: string;
+  seed?: number;
+  matrix_key?: string;
+  deployment_lineup?: string;
   queued_at?: string;
   started_at?: string;
   finished_at?: string;
@@ -2802,6 +2805,125 @@ export interface AgentTryoutArtifact {
 
 export interface ListAgentTryoutArtifactsResponse {
   items: AgentTryoutArtifact[];
+}
+
+// --- Eval sets (Fleet) ---
+
+export type EvalSetStatus =
+  | "queued"
+  | "expanding"
+  | "running"
+  | "aggregating"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface EvalSet {
+  id: string;
+  workspace_id: string;
+  organization_id: string;
+  name: string;
+  status: EvalSetStatus;
+  combination_count: number;
+  max_concurrent_runs?: number;
+  budget_usd?: number | null;
+  case_fanout?: boolean;
+  failure_reason?: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+  expansion?: {
+    combinations?: Array<{
+      matrix_key: string;
+      pack_ref: string;
+      agent_ref: string;
+      model_ref?: string;
+      repeat: number;
+      status?: string;
+    }>;
+    count?: number;
+  };
+}
+
+export interface EvalSetResult {
+  eval_set_id: string;
+  aggregate?: {
+    sessions?: number;
+    runs?: number;
+    combinations?: Array<{
+      matrix_key?: string;
+      pack_ref?: string;
+      status?: string;
+    }>;
+    per_pack?: Record<string, number>;
+  };
+  evidence?: Record<string, unknown>;
+  session_count: number;
+  run_count: number;
+}
+
+export interface GetEvalSetResponse {
+  eval_set: EvalSet;
+  eval_session_ids?: string[];
+  result?: EvalSetResult;
+}
+
+export interface ListEvalSetsResponse {
+  eval_sets: EvalSet[];
+  total: number;
+}
+
+export interface EvalSetCaseResult {
+  id: string;
+  matrix_key: string;
+  pack_ref: string;
+  case_key: string;
+  agent_deployment_id?: string;
+  model?: string;
+  score?: number | null;
+  verdict?: string;
+  transcript_text?: string;
+  snippet?: string;
+  run_id: string;
+  run_agent_id: string;
+}
+
+export interface EvalSetReportResponse {
+  eval_set_id: string;
+  marginals: Array<{
+    pack_ref: string;
+    agent_deployment_id: string;
+    model: string;
+    n: number;
+    mean_score: number;
+    p50_score: number;
+    p95_score: number;
+    wins: number;
+    losses: number;
+  }>;
+  win_matrix: Array<Record<string, unknown>>;
+  totals: { n: number; wins: number };
+}
+
+export interface CompareEvalSetsResponse {
+  a_eval_set_id: string;
+  b_eval_set_id: string;
+  deltas: Array<{
+    matrix_key: string;
+    case_key: string;
+    a_score?: number | null;
+    b_score?: number | null;
+    delta?: number | null;
+  }>;
+  regressions: Array<{
+    matrix_key: string;
+    case_key: string;
+    a_score: number;
+    b_score: number;
+    delta: number;
+  }>;
+  shared_keys: number;
 }
 
 // --- Errors ---

--- a/web/src/lib/eval-sets.ts
+++ b/web/src/lib/eval-sets.ts
@@ -1,0 +1,237 @@
+import type { GetEvalSetResponse } from "@/lib/api/types";
+
+export type EvalSetStatus =
+  | "queued"
+  | "expanding"
+  | "running"
+  | "aggregating"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export const EVAL_SET_ACTIVE: EvalSetStatus[] = [
+  "queued",
+  "expanding",
+  "running",
+  "aggregating",
+];
+
+export type MatrixCellState = "queued" | "running" | "scored" | "failed";
+
+export interface MatrixComboRef {
+  matrixKey: string;
+  status: string;
+  runId?: string;
+}
+
+export interface MatrixCell {
+  packRef: string;
+  agentRef: string;
+  state: MatrixCellState;
+  /** Fraction of repeats/models that reached a terminal status. */
+  doneCount: number;
+  totalCount: number;
+  passCount: number;
+  combos: MatrixComboRef[];
+}
+
+export interface MatrixGrid {
+  rowAxis: "agent" | "pack";
+  rowLabels: string[];
+  colLabels: string[];
+  cells: Record<string, MatrixCell>; // key = `${row}\0${col}`
+}
+
+export type LiveStatusMap = Record<string, { status: string; runId?: string }>;
+
+function terminal(status: string): boolean {
+  return ["completed", "failed", "cancelled", "canceled"].includes(
+    status.toLowerCase(),
+  );
+}
+
+function runningish(status: string): boolean {
+  return [
+    "running",
+    "provisioning",
+    "scoring",
+    "queued",
+    "draft",
+    "aggregating",
+    "expanding",
+  ].includes(status.toLowerCase());
+}
+
+function cellState(combos: MatrixComboRef[]): MatrixCellState {
+  if (combos.length === 0) return "queued";
+  if (combos.some((c) => runningish(c.status) && !terminal(c.status))) {
+    // "queued" run status still means the set has work in flight for this cell
+    // when the parent set is active; treat non-terminal as running except pure empty.
+    const anyActive = combos.some((c) => {
+      const s = c.status.toLowerCase();
+      return s === "running" || s === "provisioning" || s === "scoring";
+    });
+    if (anyActive) return "running";
+  }
+  if (combos.every((c) => c.status.toLowerCase() === "completed")) return "scored";
+  if (combos.some((c) => ["failed", "cancelled", "canceled"].includes(c.status.toLowerCase()))) {
+    if (combos.every((c) => terminal(c.status))) return "failed";
+    return "running";
+  }
+  if (combos.every((c) => terminal(c.status))) return "scored";
+  if (combos.some((c) => c.status && c.status.toLowerCase() !== "queued")) {
+    return "running";
+  }
+  return "queued";
+}
+
+/** Strip pack_ref prefix from matrix_key to recover agent_ref (and optional model). */
+export function agentRefFromMatrixKey(matrixKey: string, packRef: string): string {
+  const prefix = `${packRef}/`;
+  let rest = matrixKey.startsWith(prefix)
+    ? matrixKey.slice(prefix.length)
+    : matrixKey;
+  // drop trailing /repeat
+  const last = rest.lastIndexOf("/");
+  if (last > 0 && /^\d+$/.test(rest.slice(last + 1))) {
+    rest = rest.slice(0, last);
+  }
+  // if model segment present, keep agent as first segment for grid axis
+  const slash = rest.indexOf("/");
+  if (slash > 0) return rest.slice(0, slash);
+  return rest || "agent";
+}
+
+export function buildMatrixGrid(
+  detail: GetEvalSetResponse,
+  live?: LiveStatusMap,
+): MatrixGrid {
+  const expansionCombos = detail.eval_set.expansion?.combinations ?? [];
+  const resultCombos = detail.result?.aggregate?.combinations ?? [];
+  const statusByKey = new Map<string, { status: string; runId?: string }>();
+
+  for (const c of resultCombos) {
+    if (!c.matrix_key) continue;
+    statusByKey.set(c.matrix_key, { status: c.status ?? "queued" });
+  }
+  if (live) {
+    for (const [key, value] of Object.entries(live)) {
+      statusByKey.set(key, value);
+    }
+  }
+
+  type Seed = { matrix_key: string; pack_ref: string; agent_ref: string };
+  const seeds: Seed[] = [];
+
+  if (expansionCombos.length > 0) {
+    for (const c of expansionCombos) {
+      seeds.push({
+        matrix_key: c.matrix_key,
+        pack_ref: c.pack_ref,
+        agent_ref: c.agent_ref,
+      });
+    }
+  } else {
+    for (const c of resultCombos) {
+      if (!c.matrix_key) continue;
+      const pack = c.pack_ref || "pack";
+      seeds.push({
+        matrix_key: c.matrix_key,
+        pack_ref: pack,
+        agent_ref: agentRefFromMatrixKey(c.matrix_key, pack),
+      });
+    }
+  }
+
+  const packs = new Set<string>();
+  const agents = new Set<string>();
+  const byCell = new Map<string, MatrixComboRef[]>();
+
+  for (const c of seeds) {
+    packs.add(c.pack_ref);
+    agents.add(c.agent_ref);
+    const liveStatus = statusByKey.get(c.matrix_key);
+    const status = liveStatus?.status ?? "queued";
+    const key = `${c.agent_ref}\0${c.pack_ref}`;
+    const list = byCell.get(key) ?? [];
+    list.push({
+      matrixKey: c.matrix_key,
+      status,
+      runId: liveStatus?.runId,
+    });
+    byCell.set(key, list);
+  }
+
+  const packLabels = [...packs].sort();
+  const agentLabels = [...agents].sort();
+  const flip = packLabels.length > agentLabels.length;
+
+  const cells: Record<string, MatrixCell> = {};
+  for (const [key, combos] of byCell) {
+    const [agentRef, packRef] = key.split("\0");
+    const doneCount = combos.filter((c) => terminal(c.status)).length;
+    const passCount = combos.filter(
+      (c) => c.status.toLowerCase() === "completed",
+    ).length;
+    const cell: MatrixCell = {
+      packRef,
+      agentRef,
+      state: cellState(combos),
+      doneCount,
+      totalCount: combos.length,
+      passCount,
+      combos,
+    };
+    if (flip) {
+      cells[`${packRef}\0${agentRef}`] = cell;
+    } else {
+      cells[`${agentRef}\0${packRef}`] = cell;
+    }
+  }
+
+  if (flip) {
+    return {
+      rowAxis: "pack",
+      rowLabels: packLabels,
+      colLabels: agentLabels,
+      cells,
+    };
+  }
+  return {
+    rowAxis: "agent",
+    rowLabels: agentLabels,
+    colLabels: packLabels,
+    cells,
+  };
+}
+
+export function completionPercent(
+  detail: GetEvalSetResponse,
+  live?: LiveStatusMap,
+): number {
+  const total = detail.eval_set.combination_count || 0;
+  if (total <= 0) return 0;
+
+  if (live && Object.keys(live).length > 0) {
+    const done = Object.values(live).filter((v) => terminal(v.status)).length;
+    return Math.min(100, Math.round((done / total) * 100));
+  }
+
+  const combos = detail.result?.aggregate?.combinations ?? [];
+  const withKeys = combos.filter((c) => c.matrix_key);
+  const done = withKeys.filter((c) => terminal(c.status ?? "")).length;
+  if (withKeys.length === 0) {
+    // Fall back to set-level status for header until live map exists.
+    if (detail.eval_set.status === "completed") return 100;
+    return 0;
+  }
+  return Math.min(100, Math.round((done / total) * 100));
+}
+
+export function inFlightCount(live?: LiveStatusMap): number {
+  if (!live) return 0;
+  return Object.values(live).filter((v) => {
+    const s = v.status.toLowerCase();
+    return s === "running" || s === "provisioning" || s === "scoring";
+  }).length;
+}

--- a/web/src/lib/workspace-resource.ts
+++ b/web/src/lib/workspace-resource.ts
@@ -23,6 +23,12 @@ export const workspaceResourceKeys = {
       limit: RUN_PAGE_SIZE,
       offset,
     }),
+  evalSets: (workspaceId: string): ApiQueryKey =>
+    apiQueryKey("/v1/eval-sets", {
+      workspace_id: workspaceId,
+    }),
+  evalSet: (evalSetId: string): ApiQueryKey =>
+    apiQueryKey(`/v1/eval-sets/${evalSetId}`),
   regressionSuites: (workspaceId: string, offset = 0): ApiQueryKey =>
     apiQueryKey(`/v1/workspaces/${workspaceId}/regression-suites`, {
       limit: SUITE_PAGE_SIZE,


### PR DESCRIPTION
⛔ Stacked on #1222 — do not merge out of order. Part of epic #1212.

Closes #1207.

## What & why

Fleet 10 adds the workspace eval-set surface: an index that polls set status, and a detail page whose agent×pack matrix fills in live as child runs move queued→running→scored/failed. Case explorer wires Fleet 9 search/filters/export through shareable URL params; compare tab surfaces score regressions between two sets. Progress header shows completion %, in-flight count, elapsed, and budget when present.

## Decisions

1. **Workspace-scoped routes** `/workspaces/[id]/eval-sets` (not bare `/eval-sets`). Matches app-shell tenancy URLs used by runs/regression. Rejected top-level `/eval-sets`.

2. **SWR poll of `GET /v1/eval-sets/{id}` + child `GET /v1/eval-sessions/{id}` for live cells** (5s while active). Aggregate JSON only lands after `AggregateEvalSet`, so mid-run status comes from session child runs (`matrix_key` + `status`). Sources: issue #1207 (“SSE not needed at index”); local `eval-session-list.tsx` refreshInterval pattern; hawk React viewer poll model. Rejected inventing matrix SSE; rejected waiting only on aggregate (cells would freeze until completion).

3. **Grid axes = agent × pack with repeat roll-up**; flip when `|packs| > |agents|`. One cell per (agent, pack) aggregating repeats/models; drill-down lists per-`matrix_key` runs. Sources: issue Build §2; hawk sample-grid readability. Rejected one cell per matrix_key (too wide for 5-repeat sweeps).

4. **Authenticated export via `fetch` + blob download**. Warehouse export requires Bearer; mirrors `download-artifact-button.tsx`. Rejected `window.open` of naked export URL (401).

5. **Pure helpers + vitest** for `buildMatrixGrid` / completion math (`web/src/lib/__tests__/eval-sets.test.ts`). Pattern from `eval-sessions.test.ts`. Full browser Temporal e2e deferred (needs live hosted set); covered by live-map unit tests + poll wiring.

6. **No new npm deps**; reuse Badge/Table/Tabs + builder/quiet-utilitarian tokens. Scanner tab OOS (#1208).

## Review map

1. `web/src/lib/eval-sets.ts` — grid aggregation + live merge
2. `web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx` — poll + tabs
3. `.../matrix-grid.tsx` — cell states / pulse
4. `.../case-explorer.tsx` — URL params + auth export
5. `web/src/components/app-shell/nav-items.ts` — Benchmarks → Eval Sets

## Verification evidence

```
cd web && pnpm exec vitest run src/lib/__tests__/eval-sets.test.ts  # 5 passed (×2)
cd web && pnpm lint   # 0 errors (pre-existing warnings only)
cd web && pnpm exec tsc --noEmit  # clean
cd web && pnpm build  # success; routes /eval-sets and /eval-sets/[evalSetId] present
```

Two consecutive full gate passes with zero code changes after the second.

Acceptance:

- [x] 3×4×5 matrix + queued→scored without refresh — `buildMatrixGrid` unit tests + SWR 5s refresh while active
- [x] Search/filters URL params — `q`, `verdict`, `min_score`, `tab` via `router.replace`
- [x] Compare flags regressions — Compare tab → `/v1/compare/eval-sets`
- [x] `pnpm build` / `lint` / `tsc` clean; no lockfile changes (no new deps)
- [x] Empty/error states + mobile-readable overflow-x tables
- [ ] Index score sparkline — deferred (no per-set score series API yet); status + combination_count shown instead (noted in review contract)

## Risk & rollback

- Read-only UI over existing Fleet 7/9 APIs; no backend/schema change.
- Disable path: remove nav item / routes; APIs remain unused by web.
- Live session fan-out capped at 24 sessions per poll to bound client load.