### PR TITLE
feat(deploy): Helm chart, KEDA Temporal scaling, GHCR images (#1209)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,35 @@
+name: Helm chart
+
+on:
+  pull_request:
+    paths:
+      - "deploy/helm/**"
+      - "deploy/kind/**"
+      - ".github/workflows/helm.yml"
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/**"
+      - "deploy/kind/**"
+      - ".github/workflows/helm.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+      - name: helm lint
+        run: helm lint deploy/helm/agentclash
+      - name: helm template (smoke)
+        run: |
+          helm template smoke deploy/helm/agentclash \
+            --set secrets.create=true \
+            --set secrets.data.DATABASE_URL=postgres://x \
+            --set keda.enabled=true \
+            --set workers.mode=split \
+            > /tmp/agentclash-rendered.yaml
+          grep -q 'kind: Deployment' /tmp/agentclash-rendered.yaml
+          grep -q 'kind: ScaledObject' /tmp/agentclash-rendered.yaml

--- a/.github/workflows/release-backend-images.yml
+++ b/.github/workflows/release-backend-images.yml
@@ -36,21 +36,35 @@ jobs:
             file: backend/Dockerfile.worker
             build_args: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Resolve tag
         id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Validate via env var — never expand raw dispatch input into bash source.
+            if [[ ! "$DISPATCH_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+              echo "Invalid image tag: must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}" >&2
+              exit 1
+            fi
+            echo "tag=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            if [[ ! "$REF_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+              echo "Invalid ref name for image tag: ${REF_NAME}" >&2
+              exit 1
+            fi
+            echo "tag=${REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -58,7 +72,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.file }}
@@ -72,7 +86,7 @@ jobs:
           sbom: true
 
       - name: Attest
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}-${{ matrix.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -81,8 +95,8 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.16.2
       - name: helm lint

--- a/.github/workflows/release-backend-images.yml
+++ b/.github/workflows/release-backend-images.yml
@@ -1,0 +1,89 @@
+name: Release backend images
+
+# Publishes multi-arch api-server + worker images to GHCR on version tags
+# (Fleet 12 / #1209). Provenance attestation mirrors the CLI npm release path.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to publish
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/agentclash/agentclash
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: api-server
+            file: backend/Dockerfile
+            build_args: TARGET=api-server
+          - name: worker
+            file: backend/Dockerfile.worker
+            build_args: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          build-args: ${{ matrix.build_args }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.name }}:${{ steps.meta.outputs.tag }}
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.name }}:latest
+          provenance: true
+          sbom: true
+
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}-${{ matrix.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+      - name: helm lint
+        run: helm lint deploy/helm/agentclash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Authorization is data-aware — it happens in the manager after loading the reso
 
 ### Sandbox Abstraction
 
-`backend/internal/sandbox/sandbox.go` defines a `Provider` interface. E2B is the current implementation, but it's replaceable. When `SANDBOX_PROVIDER=unconfigured`, a noop provider is used (runs queue but don't execute).
+`runtime/sandbox/sandbox.go` defines a `Provider` interface. Implementations include E2B, Docker, and Kubernetes (`runtime/sandbox/…`); the worker wires them from `SANDBOX_PROVIDER`. When `SANDBOX_PROVIDER=unconfigured`, `UnconfiguredProvider` returns errors on Create (runs do not silently queue). Self-host install: `docs/deployment/self-host-kubernetes.md` and `deploy/helm/agentclash/`.
 
 ### SQLC Code Generation
 

--- a/deploy/helm/agentclash/Chart.yaml
+++ b/deploy/helm/agentclash/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: agentclash
+description: AgentClash control + execution plane (api-server, workers, optional KEDA)
+type: application
+version: 0.1.0
+appVersion: "0.0.0"
+keywords:
+  - agentclash
+  - temporal
+  - evaluations
+home: https://github.com/agentclash/agentclash
+sources:
+  - https://github.com/agentclash/agentclash
+maintainers:
+  - name: agentclash

--- a/deploy/helm/agentclash/templates/NOTES.txt
+++ b/deploy/helm/agentclash/templates/NOTES.txt
@@ -1,0 +1,16 @@
+AgentClash {{ .Chart.Version }} installed as release {{ .Release.Name }}.
+
+Components:
+  - api-server: {{ include "agentclash.fullname" . }}-api-server
+  - workers: mode={{ .Values.workers.mode }}
+  - KEDA: {{ .Values.keda.enabled }}
+  - sandbox.provider: {{ .Values.sandbox.provider }}
+
+Next:
+  1. Ensure Secret {{ include "agentclash.secretName" . }} has DATABASE_URL (+ REDIS_URL).
+  2. Point TEMPORAL_ADDRESS at a reachable Temporal frontend ({{ .Values.external.temporalAddress }}).
+  3. Port-forward: kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agentclash.fullname" . }}-api-server 8080:8080
+  4. Docs: docs/deployment/self-host-kubernetes.md
+
+Workers scale on Temporal queue depth when keda.enabled=true. Sandbox concurrency
+is still capped by SANDBOX_MAX_CONCURRENT (Fleet 3) regardless of replica count.

--- a/deploy/helm/agentclash/templates/NOTES.txt
+++ b/deploy/helm/agentclash/templates/NOTES.txt
@@ -8,7 +8,7 @@ Components:
 
 Next:
   1. Ensure Secret {{ include "agentclash.secretName" . }} has DATABASE_URL (+ REDIS_URL).
-  2. Point TEMPORAL_ADDRESS at a reachable Temporal frontend ({{ .Values.external.temporalAddress }}).
+  2. Point TEMPORAL_HOST_PORT (values.external.temporalAddress) at a reachable Temporal frontend ({{ .Values.external.temporalAddress }}).
   3. Port-forward: kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agentclash.fullname" . }}-api-server 8080:8080
   4. Docs: docs/deployment/self-host-kubernetes.md
 

--- a/deploy/helm/agentclash/templates/_helpers.tpl
+++ b/deploy/helm/agentclash/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{- define "agentclash.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agentclash.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "agentclash.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentclash.labels" -}}
+app.kubernetes.io/name: {{ include "agentclash.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "agentclash.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentclash.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "agentclash.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "agentclash.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentclash.apiImage" -}}
+{{- $repo := .Values.apiServer.image.repository | default (printf "%s/%s-api-server" .Values.image.registry .Values.image.repository) -}}
+{{- printf "%s:%s" $repo .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentclash.workerImage" -}}
+{{- $repo := .Values.workers.image.repository | default (printf "%s/%s-worker" .Values.image.registry .Values.image.repository) -}}
+{{- printf "%s:%s" $repo .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentclash.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "agentclash.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentclash.temporalEndpoint" -}}
+{{- if .Values.keda.temporalEndpoint -}}
+{{- .Values.keda.temporalEndpoint -}}
+{{- else -}}
+{{- .Values.external.temporalAddress -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/agentclash/templates/api-server.yaml
+++ b/deploy/helm/agentclash/templates/api-server.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.apiServer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentclash.fullname" . }}-api-server
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api-server
+spec:
+  replicas: {{ .Values.apiServer.replicas }}
+  selector:
+    matchLabels:
+      {{- include "agentclash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api-server
+  template:
+    metadata:
+      labels:
+        {{- include "agentclash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api-server
+    spec:
+      serviceAccountName: {{ include "agentclash.serviceAccountName" . }}
+      containers:
+        - name: api-server
+          image: {{ include "agentclash.apiImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.apiServer.service.port }}
+            {{- if .Values.apiServer.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.apiServer.metrics.port }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "agentclash.secretName" . }}
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.external.temporalAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.external.temporalNamespace | quote }}
+            {{- if .Values.apiServer.metrics.enabled }}
+            - name: METRICS_ENABLED
+              value: "true"
+            - name: METRICS_ADDR
+              value: {{ printf ":%v" .Values.apiServer.metrics.port | quote }}
+            {{- end }}
+          readinessProbe:
+            {{- toYaml .Values.apiServer.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.apiServer.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentclash.fullname" . }}-api-server
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api-server
+spec:
+  type: {{ .Values.apiServer.service.type }}
+  selector:
+    {{- include "agentclash.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api-server
+  ports:
+    - name: http
+      port: {{ .Values.apiServer.service.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/agentclash/templates/api-server.yaml
+++ b/deploy/helm/agentclash/templates/api-server.yaml
@@ -34,7 +34,7 @@ spec:
             - secretRef:
                 name: {{ include "agentclash.secretName" . }}
           env:
-            - name: TEMPORAL_ADDRESS
+            - name: TEMPORAL_HOST_PORT
               value: {{ .Values.external.temporalAddress | quote }}
             - name: TEMPORAL_NAMESPACE
               value: {{ .Values.external.temporalNamespace | quote }}

--- a/deploy/helm/agentclash/templates/keda-scaledobjects.yaml
+++ b/deploy/helm/agentclash/templates/keda-scaledobjects.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.keda.enabled }}
+{{- if eq .Values.workers.mode "combined" }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "agentclash.fullname" . }}-worker
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "agentclash.fullname" . }}-worker
+  pollingInterval: {{ .Values.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.workers.combined.minReplicas }}
+  maxReplicaCount: {{ .Values.workers.combined.maxReplicas }}
+  triggers:
+    # Combined workers poll all queues; scale on execution backlog as primary signal.
+    - type: temporal
+      metadata:
+        namespace: {{ .Values.keda.temporalNamespace | default .Values.external.temporalNamespace | quote }}
+        taskQueue: "execution"
+        targetQueueSize: {{ .Values.workers.combined.targetQueueSize | quote }}
+        activationTargetQueueSize: "0"
+        endpoint: {{ include "agentclash.temporalEndpoint" . | quote }}
+        queueTypes: "workflow,activity"
+{{- else }}
+{{- range $name, $class := .Values.workers.classes }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "agentclash.fullname" $ }}-worker-{{ $name }}
+  labels:
+    {{- include "agentclash.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "agentclash.fullname" $ }}-worker-{{ $name }}
+  pollingInterval: {{ $.Values.keda.pollingInterval }}
+  cooldownPeriod: {{ $.Values.keda.cooldownPeriod }}
+  minReplicaCount: {{ $class.minReplicas }}
+  maxReplicaCount: {{ $class.maxReplicas }}
+  triggers:
+    - type: temporal
+      metadata:
+        namespace: {{ $.Values.keda.temporalNamespace | default $.Values.external.temporalNamespace | quote }}
+        taskQueue: {{ $class.taskQueue | quote }}
+        targetQueueSize: {{ $class.targetQueueSize | quote }}
+        activationTargetQueueSize: "0"
+        endpoint: {{ include "agentclash.temporalEndpoint" $ | quote }}
+        queueTypes: "workflow,activity"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agentclash/templates/rbac-sandbox.yaml
+++ b/deploy/helm/agentclash/templates/rbac-sandbox.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.sandbox.provider "kubernetes") .Values.serviceAccount.create }}
+# Minimal RBAC so the kubernetes sandbox provider can create Job/Pod/exec in-cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentclash.fullname" . }}-sandbox
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentclash.fullname" . }}-sandbox
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentclash.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agentclash.fullname" . }}-sandbox
+{{- end }}

--- a/deploy/helm/agentclash/templates/secret.yaml
+++ b/deploy/helm/agentclash/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentclash.secretName" . }}
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $k, $v := .Values.secrets.data }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agentclash/templates/serviceaccount.yaml
+++ b/deploy/helm/agentclash/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentclash.serviceAccountName" . }}
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agentclash/templates/servicemonitor.yaml
+++ b/deploy/helm/agentclash/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.serviceMonitor.enabled .Values.apiServer.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "agentclash.fullname" . }}-api-server
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "agentclash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api-server
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      path: /metrics
+{{- end }}

--- a/deploy/helm/agentclash/templates/workers.yaml
+++ b/deploy/helm/agentclash/templates/workers.yaml
@@ -1,0 +1,113 @@
+{{- if eq .Values.workers.mode "combined" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentclash.fullname" . }}-worker
+  labels:
+    {{- include "agentclash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.workers.combined.minReplicas }}
+  selector:
+    matchLabels:
+      {{- include "agentclash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "agentclash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      serviceAccountName: {{ include "agentclash.serviceAccountName" . }}
+      containers:
+        - name: worker
+          image: {{ include "agentclash.workerImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "agentclash.secretName" . }}
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.external.temporalAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.external.temporalNamespace | quote }}
+            - name: WORKER_TASK_QUEUES
+              value: {{ .Values.workers.combined.taskQueues | quote }}
+            - name: SANDBOX_PROVIDER
+              value: {{ .Values.sandbox.provider | quote }}
+            - name: SANDBOX_MAX_CONCURRENT
+              value: {{ .Values.sandbox.maxConcurrent | quote }}
+            {{- if .Values.workers.metrics.enabled }}
+            - name: METRICS_ENABLED
+              value: "true"
+            - name: METRICS_ADDR
+              value: {{ printf ":%v" .Values.workers.metrics.port | quote }}
+            {{- end }}
+            {{- range $k, $v := .Values.workers.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.workers.resources | nindent 12 }}
+{{- else }}
+{{- range $name, $class := .Values.workers.classes }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentclash.fullname" $ }}-worker-{{ $name }}
+  labels:
+    {{- include "agentclash.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker-{{ $name }}
+spec:
+  # KEDA owns replica count when enabled; seed with minReplicas for install.
+  replicas: {{ $class.minReplicas }}
+  selector:
+    matchLabels:
+      {{- include "agentclash.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: worker-{{ $name }}
+  template:
+    metadata:
+      labels:
+        {{- include "agentclash.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: worker-{{ $name }}
+    spec:
+      serviceAccountName: {{ include "agentclash.serviceAccountName" $ }}
+      containers:
+        - name: worker
+          image: {{ include "agentclash.workerImage" $ }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "agentclash.secretName" $ }}
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: {{ $.Values.external.temporalAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ $.Values.external.temporalNamespace | quote }}
+            - name: WORKER_TASK_QUEUES
+              value: {{ $class.taskQueue | quote }}
+            - name: SANDBOX_PROVIDER
+              value: {{ $.Values.sandbox.provider | quote }}
+            - name: SANDBOX_MAX_CONCURRENT
+              value: {{ $.Values.sandbox.maxConcurrent | quote }}
+            {{- if eq $.Values.sandbox.provider "kubernetes" }}
+            - name: SANDBOX_KUBERNETES_NAMESPACE
+              value: {{ default $.Release.Namespace $.Values.sandbox.kubernetes.namespace | quote }}
+            - name: SANDBOX_KUBERNETES_DEFAULT_IMAGE
+              value: {{ $.Values.sandbox.kubernetes.defaultImage | quote }}
+            {{- end }}
+            {{- if $.Values.workers.metrics.enabled }}
+            - name: METRICS_ENABLED
+              value: "true"
+            - name: METRICS_ADDR
+              value: {{ printf ":%v" $.Values.workers.metrics.port | quote }}
+            {{- end }}
+            {{- range $k, $v := $.Values.workers.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml $.Values.workers.resources | nindent 12 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agentclash/templates/workers.yaml
+++ b/deploy/helm/agentclash/templates/workers.yaml
@@ -27,7 +27,7 @@ spec:
             - secretRef:
                 name: {{ include "agentclash.secretName" . }}
           env:
-            - name: TEMPORAL_ADDRESS
+            - name: TEMPORAL_HOST_PORT
               value: {{ .Values.external.temporalAddress | quote }}
             - name: TEMPORAL_NAMESPACE
               value: {{ .Values.external.temporalNamespace | quote }}
@@ -37,6 +37,12 @@ spec:
               value: {{ .Values.sandbox.provider | quote }}
             - name: SANDBOX_MAX_CONCURRENT
               value: {{ .Values.sandbox.maxConcurrent | quote }}
+            {{- if eq .Values.sandbox.provider "kubernetes" }}
+            - name: SANDBOX_K8S_NAMESPACE
+              value: {{ default .Release.Namespace .Values.sandbox.kubernetes.namespace | quote }}
+            - name: SANDBOX_K8S_DEFAULT_IMAGE
+              value: {{ .Values.sandbox.kubernetes.defaultImage | quote }}
+            {{- end }}
             {{- if .Values.workers.metrics.enabled }}
             - name: METRICS_ENABLED
               value: "true"
@@ -81,7 +87,7 @@ spec:
             - secretRef:
                 name: {{ include "agentclash.secretName" $ }}
           env:
-            - name: TEMPORAL_ADDRESS
+            - name: TEMPORAL_HOST_PORT
               value: {{ $.Values.external.temporalAddress | quote }}
             - name: TEMPORAL_NAMESPACE
               value: {{ $.Values.external.temporalNamespace | quote }}
@@ -92,9 +98,9 @@ spec:
             - name: SANDBOX_MAX_CONCURRENT
               value: {{ $.Values.sandbox.maxConcurrent | quote }}
             {{- if eq $.Values.sandbox.provider "kubernetes" }}
-            - name: SANDBOX_KUBERNETES_NAMESPACE
+            - name: SANDBOX_K8S_NAMESPACE
               value: {{ default $.Release.Namespace $.Values.sandbox.kubernetes.namespace | quote }}
-            - name: SANDBOX_KUBERNETES_DEFAULT_IMAGE
+            - name: SANDBOX_K8S_DEFAULT_IMAGE
               value: {{ $.Values.sandbox.kubernetes.defaultImage | quote }}
             {{- end }}
             {{- if $.Values.workers.metrics.enabled }}

--- a/deploy/helm/agentclash/values.yaml
+++ b/deploy/helm/agentclash/values.yaml
@@ -106,7 +106,7 @@ secrets:
   data:
     DATABASE_URL: ""
     REDIS_URL: ""
-    TEMPORAL_ADDRESS: ""
+    TEMPORAL_HOST_PORT: ""
     # AUTH_MODE=dev for kind rehearsal
     AUTH_MODE: "dev"
 

--- a/deploy/helm/agentclash/values.yaml
+++ b/deploy/helm/agentclash/values.yaml
@@ -1,0 +1,133 @@
+# AgentClash Helm values (Fleet 12 / #1209).
+# Cloud-agnostic: no AWS/GCP services required.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: ghcr.io
+  repository: agentclash/agentclash
+  # Digests preferred in production; tag used for local/kind.
+  tag: latest
+  pullPolicy: IfNotPresent
+  # Optional: apiServerDigest / workerDigest override tag with @sha256:...
+
+apiServer:
+  enabled: true
+  replicas: 1
+  image:
+    repository: "" # defaults to image.repository-api-server naming below
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  service:
+    type: ClusterIP
+    port: 8080
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  metrics:
+    enabled: false
+    port: 9464
+
+# workers.mode=split → one Deployment per Temporal task-queue class (Fleet 2).
+# workers.mode=combined → single worker listing all queues (small installs).
+workers:
+  mode: split # split | combined
+  image:
+    repository: ""
+  env: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 2Gi
+  metrics:
+    enabled: false
+    port: 9464
+  classes:
+    execution:
+      taskQueue: execution
+      minReplicas: 0
+      maxReplicas: 20
+      targetQueueSize: "5"
+    scoring:
+      taskQueue: scoring
+      minReplicas: 0
+      maxReplicas: 10
+      targetQueueSize: "5"
+    background:
+      taskQueue: background
+      minReplicas: 0
+      maxReplicas: 5
+      targetQueueSize: "5"
+  combined:
+    taskQueues: "execution,scoring,background"
+    minReplicas: 1
+    maxReplicas: 10
+    targetQueueSize: "5"
+
+keda:
+  enabled: true
+  pollingInterval: 15
+  cooldownPeriod: 300
+  # Temporal frontend address inside the cluster (or external).
+  temporalEndpoint: ""
+  temporalNamespace: default
+
+# External dependencies (recommended for production). Set URLs via secret/env.
+external:
+  databaseUrlSecretKey: DATABASE_URL
+  redisUrlSecretKey: REDIS_URL
+  temporalAddress: temporal-frontend:7233
+  temporalNamespace: default
+
+# Optional in-cluster Temporal (disabled by default — bring your own).
+temporal:
+  deploy: false
+
+postgres:
+  deploy: false
+
+redis:
+  deploy: false
+
+secrets:
+  # Create a Secret from these values (dev only). Prefer existingSecret in prod.
+  create: false
+  existingSecret: ""
+  data:
+    DATABASE_URL: ""
+    REDIS_URL: ""
+    TEMPORAL_ADDRESS: ""
+    # AUTH_MODE=dev for kind rehearsal
+    AUTH_MODE: "dev"
+
+sandbox:
+  # e2b | kubernetes | unconfigured
+  provider: kubernetes
+  maxConcurrent: 20
+  kubernetes:
+    namespace: ""
+    defaultImage: "ghcr.io/agentclash/sandbox:latest"
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  labels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Kind rehearsal for the AgentClash Helm chart (Fleet 12 / #1209).
+# Prerequisites: kind, kubectl, helm, docker. Optional: keda installed in cluster.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-agentclash}"
+NAMESPACE="${NAMESPACE:-agentclash}"
+RELEASE="${RELEASE:-agentclash}"
+
+echo "==> ensuring kind cluster ${CLUSTER_NAME}"
+if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  kind create cluster --name "${CLUSTER_NAME}"
+fi
+kubectl cluster-info --context "kind-${CLUSTER_NAME}" >/dev/null
+
+echo "==> creating namespace ${NAMESPACE}"
+kubectl get ns "${NAMESPACE}" >/dev/null 2>&1 || kubectl create ns "${NAMESPACE}"
+
+echo "==> helm lint"
+helm lint "${ROOT}/deploy/helm/agentclash"
+
+echo "==> helm upgrade --install (external Temporal/Postgres expected via secret)"
+# Dev secret placeholders — replace before a real eval-set run.
+kubectl -n "${NAMESPACE}" create secret generic "${RELEASE}-secrets" \
+  --from-literal=DATABASE_URL="${DATABASE_URL:-postgres://agentclash:agentclash@postgres:5432/agentclash?sslmode=disable}" \
+  --from-literal=REDIS_URL="${REDIS_URL:-redis://redis:6379/0}" \
+  --from-literal=AUTH_MODE=dev \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install "${RELEASE}" "${ROOT}/deploy/helm/agentclash" \
+  --namespace "${NAMESPACE}" \
+  --set secrets.existingSecret="${RELEASE}-secrets" \
+  --set secrets.create=false \
+  --set image.tag="${IMAGE_TAG:-latest}" \
+  --set keda.enabled="${KEDA_ENABLED:-false}" \
+  --set sandbox.provider="${SANDBOX_PROVIDER:-kubernetes}" \
+  --wait --timeout 5m || true
+
+echo "==> pods"
+kubectl -n "${NAMESPACE}" get pods,deploy,svc
+
+cat <<EOF
+
+Kind rehearsal scaffold complete.
+To finish an end-to-end eval set you still need:
+  - Temporal frontend reachable at values.external.temporalAddress
+  - Postgres + Redis matching the secret
+  - KEDA installed if KEDA_ENABLED=true (scale 0→N test)
+  - Images loaded into kind: kind load docker-image <api> <worker> --name ${CLUSTER_NAME}
+
+See docs/deployment/self-host-kubernetes.md
+EOF

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -35,7 +35,7 @@ helm upgrade --install "${RELEASE}" "${ROOT}/deploy/helm/agentclash" \
   --set image.tag="${IMAGE_TAG:-latest}" \
   --set keda.enabled="${KEDA_ENABLED:-false}" \
   --set sandbox.provider="${SANDBOX_PROVIDER:-kubernetes}" \
-  --wait --timeout 5m || true
+  --wait --timeout 5m
 
 echo "==> pods"
 kubectl -n "${NAMESPACE}" get pods,deploy,svc

--- a/docs/deployment/self-host-kubernetes.md
+++ b/docs/deployment/self-host-kubernetes.md
@@ -1,0 +1,92 @@
+# Self-host AgentClash on Kubernetes
+
+Fleet 12 ships a cloud-agnostic Helm chart so any Kubernetes cluster can run the
+control plane (api-server) and execution plane (Temporal workers) without
+AWS/GCP-specific services.
+
+## Prerequisites
+
+- Kubernetes 1.27+
+- [Helm 3](https://helm.sh/)
+- A Temporal server (self-hosted or Temporal Cloud)
+- Postgres 16+ (migrations applied via `backend/scripts/migrate.sh`)
+- Redis (optional but recommended for pub/sub, sandbox budget, provider throttle)
+- [KEDA](https://keda.sh/) 2.14+ if you want queue-depth autoscaling (Temporal scaler)
+- Container images from GHCR (`ghcr.io/agentclash/agentclash-api-server`, `…-worker`)
+
+Optional for the full self-host sandbox story: in-cluster Kubernetes sandbox
+provider (Fleet 4) with a default sandbox image.
+
+## Quick install
+
+```bash
+helm upgrade --install agentclash ./deploy/helm/agentclash \
+  --namespace agentclash --create-namespace \
+  --set secrets.existingSecret=agentclash-secrets \
+  --set external.temporalAddress=temporal-frontend.temporal.svc:7233 \
+  --set sandbox.provider=kubernetes \
+  --set keda.enabled=true
+```
+
+Create the secret first:
+
+```bash
+kubectl -n agentclash create secret generic agentclash-secrets \
+  --from-literal=DATABASE_URL='postgres://…' \
+  --from-literal=REDIS_URL='redis://…' \
+  --from-literal=AUTH_MODE=dev   # local only
+```
+
+## Values reference (high level)
+
+| Key | Meaning |
+|-----|---------|
+| `workers.mode` | `split` (execution/scoring/background Deployments) or `combined` |
+| `workers.classes.*.minReplicas` / `maxReplicas` | KEDA bounds per queue class |
+| `workers.classes.*.targetQueueSize` | Temporal backlog target per replica |
+| `keda.enabled` | Install Temporal `ScaledObject`s |
+| `sandbox.provider` | `kubernetes` \| `e2b` \| `unconfigured` |
+| `sandbox.maxConcurrent` | Fleet 3 semaphore (caps sandboxes even when workers scale out) |
+| `apiServer.metrics.enabled` / `workers.metrics.enabled` | Fleet 14 `/metrics` scrape |
+| `serviceMonitor.enabled` | Prometheus Operator ServiceMonitor |
+
+Full defaults live in [`deploy/helm/agentclash/values.yaml`](../../deploy/helm/agentclash/values.yaml).
+
+## Sizing guidance
+
+- **Execution workers × sandbox budget:** KEDA may scale execution replicas to N,
+  but `SANDBOX_MAX_CONCURRENT` still caps live sandboxes cluster-wide (Redis
+  budget) or per-process (local budget). Size the budget for your provider
+  quotas (E2B concurrency or node allocatable for k8s sandboxes).
+- **Scoring / background:** Keep lower `maxReplicas`; they share Temporal but
+  should not starve execution slots.
+- **Scale-to-zero:** Set `minReplicas: 0` on execution/scoring/background. Cold
+  start latency is Temporal task backlog drain time + image pull.
+
+## Kind rehearsal
+
+```bash
+./deploy/kind/up.sh
+```
+
+Loads a kind cluster, `helm lint`s, and installs the chart. You still need
+Temporal/Postgres/Redis reachable and images loaded into kind for a full eval
+set. KEDA scale 0→N is optional (`KEDA_ENABLED=true` after installing KEDA).
+
+## Image pipeline
+
+On `v*` tags, [`.github/workflows/release-backend-images.yml`](../../.github/workflows/release-backend-images.yml)
+builds multi-arch api-server and worker images to GHCR with provenance + SBOM.
+Pin chart `image.tag` (or digests) to the release tag.
+
+## Upgrades
+
+1. Apply DB migrations (`goose` / `backend/scripts/migrate.sh`) before rolling
+   api-server/worker when the release includes schema changes.
+2. `helm upgrade` with the new chart/`appVersion`.
+3. Watch Temporal worker slot metrics (Fleet 14) and KEDA HPA events.
+
+## Out of scope
+
+Node autoscaling (Karpenter / cluster-autoscaler) remains a cluster-operator
+concern. This chart scales **pods**, not nodes.


### PR DESCRIPTION
⛔ Stacked on #1226 — do not merge out of order. Part of epic #1212.

Closes #1209.

## What & why

Adds a cloud-agnostic self-host path: Helm chart for api-server + per-queue workers (or combined mode), optional KEDA Temporal ScaledObjects for scale-to-zero on queue backlog, GHCR multi-arch image publish on `v*` tags with provenance/SBOM, a kind rehearsal script, and self-host docs. Also corrects the stale CLAUDE.md sandbox path / unconfigured-provider notes found during the Fleet audit.

## Decisions

1. **External Temporal/Postgres/Redis by default** — Chart does not force cloud-vendor addons; values point at existing endpoints. Optional in-cluster deps left as `deploy: false` hooks. Sources: hawk EKS+Karpenter (rejected as AWS-specific); bitnami optional-dependency patterns.
2. **Split worker Deployments + KEDA Temporal scaler** — One Deployment/ScaledObject per Fleet 2 queue (`execution`/`scoring`/`background`); `workers.mode=combined` for small installs. Sources: [KEDA Temporal scaler](https://keda.sh/docs/2.21/scalers/temporal/); [temporal-community/temporal-scaling-demo](https://github.com/temporal-community/temporal-scaling-demo).
3. **Sandbox budget remains the hard cap** — Documented that KEDA replica count ≠ sandbox concurrency; `SANDBOX_MAX_CONCURRENT` still gates Create. Sources: Fleet 3 capacity design.
4. **GHCR on release tags with provenance** — Mirrors CLI Trusted Publishing posture via `build-push-action` provenance + attest-build-provenance. Sources: existing `release-cli.yml` npm provenance path.
5. **Kind rehearsal as script, helm lint in CI** — Full e2e needs Temporal/Postgres images loaded; CI gates on `helm lint` + template smoke. Sources: issue AC (kind may be nightly).

## Review map

1. `deploy/helm/agentclash/values.yaml` — knobs
2. `templates/workers.yaml` + `keda-scaledobjects.yaml` — queue classes
3. `.github/workflows/release-backend-images.yml` + `helm.yml`
4. `docs/deployment/self-host-kubernetes.md`
5. `deploy/kind/up.sh`

## Verification evidence

```text
helm lint deploy/helm/agentclash          # 0 failed (icon INFO only)
helm template … workers.mode=split keda.enabled=true
  → 4 Deployments (api + 3 workers), 3 ScaledObjects
promtool/kind: unavailable on this agent host — kind e2e + KEDA 0→N deferred
```

Acceptance mapping:

- [x] Chart structure for api-server + 3 worker classes + Temporal endpoint values — templates + lint
- [x] KEDA ScaledObjects per class (scale 0→N config) — `keda-scaledobjects.yaml`; live kind scale deferred
- [x] GHCR publish workflow on `v*` — `release-backend-images.yml`
- [x] Values documented + helm lint clean — docs + lint
- [x] No required cloud-vendor services — external endpoints only
- [ ] Full kind e2e eval set with k8s sandbox — **deferred** (no kind/Temporal on agent host); script + docs provided for local/nightly

## Risk & rollback

- Chart is new; default `keda.enabled=true` but `minReplicas: 0` means workers stay at 0 until backlog — set `minReplicas: 1` for always-on.
- Image pipeline only runs on tags / workflow_dispatch — does not affect main CI.
- Uninstall: `helm uninstall agentclash -n agentclash`.