### PR TITLE
docs: add Fleet eval-set guides to agentclash.dev/docs

### DIFF
--- a/web/content/docs/architecture/sandbox-layer.mdx
+++ b/web/content/docs/architecture/sandbox-layer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sandbox Layer
-description: Understand why AgentClash isolates execution behind a sandbox provider boundary and how E2B fits today.
-dateModified: 2026-06-01
+description: Understand why AgentClash isolates execution behind a sandbox provider boundary and how E2B, Docker, and Kubernetes fit.
+dateModified: 2026-08-09
 ---
 
 The sandbox layer is the execution boundary between AgentClash orchestration and the environment where an agent actually runs.
@@ -46,12 +46,14 @@ A clean sandbox boundary makes that diagnosis easier because provider setup and 
 
 The worker picks a sandbox provider from the `SANDBOX_PROVIDER` environment variable:
 
-- `unconfigured` (the default) — a noop provider. Runs queue but never execute. This is what the local stack uses until you supply E2B credentials.
-- `e2b` — runs each agent in an E2B sandbox. Requires `E2B_API_KEY` and `E2B_TEMPLATE_ID`; the worker fails to start if either is empty. Optional tuning: `E2B_API_BASE_URL` and `E2B_REQUEST_TIMEOUT` (default `30s`).
+- `unconfigured` (the default) — Create fails loudly so runs do not silently queue forever. Local stacks that omit E2B/k8s stay explicit about the missing provider.
+- `e2b` — runs each agent in an E2B sandbox. Requires `E2B_API_KEY` and `E2B_TEMPLATE_ID`. Optional tuning: `E2B_API_BASE_URL` and `E2B_REQUEST_TIMEOUT` (default `30s`).
+- `docker` — local/dev Docker provider (wired through the shared sandbox interface).
+- `kubernetes` — in-cluster Pod + NetworkPolicy sandboxes for self-host fleets. See [Self-host at scale](/docs/fleet/self-host-scale) and the repo doc `docs/deployment/k8s-sandbox.md`.
 
-Any other value is rejected at worker startup.
+Capacity middleware (`SANDBOX_MAX_CONCURRENT`) and optional warm pooling wrap the chosen provider for Fleet-scale concurrency.
 
-For contributors who want the wiring: `backend/internal/worker/config.go` reads the environment surface above, `backend/internal/sandbox/sandbox.go` defines the provider interface, and `docs/worker/local-development.md` covers how the local stack expects the provider to be configured.
+For contributors who want the wiring: `backend/internal/worker/config.go` reads the environment surface, `runtime/sandbox` defines the provider interface, and `docs/worker/local-development.md` covers local expectations.
 
 ## Why not bake execution directly into the web or API app
 
@@ -62,6 +64,7 @@ Because that would collapse the concerns that need to stay separate. You would t
 - [Orchestration](../architecture/orchestration)
 - [Evidence Loop](../architecture/evidence-loop)
 - [Self-Host](../getting-started/self-host)
+- [Self-host at scale](/docs/fleet/self-host-scale)
 - [Config Reference](../reference/config)
 - [Datasets overview](/docs/guides/datasets-overview)
 - [Security evaluation](/docs/guides/security-evaluation)

--- a/web/content/docs/concepts/runs-and-evals.mdx
+++ b/web/content/docs/concepts/runs-and-evals.mdx
@@ -1,7 +1,7 @@
 ---
 title: Runs and Evals
 description: The product language around runs and evals is easy to blur. The current codebase makes one distinction especially important.
-dateModified: 2026-06-01
+dateModified: 2026-08-09
 ---
 
 A **run** is the concrete execution object you create, stream, rank, compare, and inspect in AgentClash today.
@@ -26,15 +26,20 @@ The word **eval** is broader. People use it to mean “the experiment I am tryin
 - **Run** = the concrete resource you create and query.
 - **Eval** = the broader exercise or outcome you are trying to measure.
 
-You will also see **eval sessions** in the CLI and API: an eval session groups several repeated runs of the same configuration and aggregates their scores together (created by `agentclash eval start --repetitions`, backed by the `/v1/eval-sessions` endpoint). It is still built on runs underneath. The main shipped workflow today revolves around runs and ranked run results, so if you keep that in your head, the CLI and API are much easier to follow.
+You will also see **eval sessions** in the CLI and API: an eval session groups several repeated runs of the same configuration and aggregates their scores together (created by `agentclash eval start --repetitions`, backed by the `/v1/eval-sessions` endpoint). It is still built on runs underneath.
+
+**Eval sets** (Fleet) sit one layer above sessions: one manifest expands packs × agents × models × repeats into many sessions/runs under a shared set ID and `matrix_key`. Use `agentclash evalset` and the workspace Eval sets UI for that path. See [Fleet overview](/docs/fleet).
+
+The day-to-day single-comparison workflow still revolves around runs and ranked run results. Keep that noun map in your head and the CLI/API stay easier to follow.
 
 ## Practical rule of thumb
 
-Use **run** when you are talking about a real resource ID. Use **eval** when you are talking about the experiment design or the larger testing loop.
+Use **run** when you are talking about a real resource ID. Use **eval** when you are talking about the experiment design or the larger testing loop. Use **eval set** when you are sweeping a cartesian product of packs and agents.
 
 ## See also
 
 - [Hosted Quickstart](/docs/getting-started/quickstart)
+- [Fleet overview](/docs/fleet)
 - [CLI Reference](/docs/reference/cli)
 - [Datasets overview](/docs/guides/datasets-overview)
 - [Multi-turn packs](/docs/challenge-packs/multi-turn)

--- a/web/content/docs/fleet/budgets-and-scanners.mdx
+++ b/web/content/docs/fleet/budgets-and-scanners.mdx
@@ -1,0 +1,97 @@
+---
+title: Budgets and scanners
+description: Cap eval-set spend, emergency-stop a workspace, and run built-in transcript scanners after completion.
+dateModified: 2026-08-09
+---
+
+Fleet adds two optional control surfaces on top of orchestration: **budgets** (stop spending) and **scanners** (analyze finished transcripts).
+
+## Budgets
+
+Set a soft USD cap in the manifest:
+
+```yaml
+limits:
+  budget_usd: 50
+```
+
+The expand API also returns a cost **estimate** from combination count and model hints so you can confirm before submit.
+
+### Enforcement behavior
+
+- The eval-set workflow checks remaining budget before launching pack sessions **and** before launching inner runs inside a multi-combination pack.
+- When the budget is exhausted, further launches stop and the set settles with a budget-related failure/cancel path rather than silently overspending.
+- Capacity waits (workspace run concurrency) use a long enough activity timeout to cover the internal poll window (on the order of minutes), so a brief full queue does not fail the set as a 5s activity timeout.
+
+Exact settlement status strings are visible in `agentclash evalset status <id> --json`.
+
+### Workspace emergency stop
+
+Operators can cancel every active eval set in a workspace:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  "$AGENTCLASH_API_URL/v1/workspaces/$WORKSPACE_ID/emergency-stop"
+```
+
+The response includes how many sets were cancelled and an audit event name (`workspace.emergency_stop`).
+
+## Scanners
+
+Scanners are post-hoc analyzers over completed case transcripts. They do not change scoring; they emit **findings** you can triage.
+
+### Built-in catalog
+
+Shipped under `runtime/scanners/catalog/`:
+
+| Name | Intent |
+|---|---|
+| `reward-hacking` | Reward-seeking / metric gaming patterns |
+| `tool-misuse` | Unsafe or policy-breaking tool use |
+| `instruction-injection` | Prompt / instruction injection attempts |
+| `sandbox-escape-attempt` | Escape or host breakout signals |
+
+### Opt-in from the manifest
+
+```yaml
+scanners:
+  - reward-hacking
+  - tool-misuse
+```
+
+When present, a completed set can start a scan workflow for those scanners.
+
+### Manual / API scan
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"scanners":["reward-hacking","sandbox-escape-attempt"]}' \
+  "$AGENTCLASH_API_URL/v1/eval-sets/$EVAL_SET_ID/scan"
+```
+
+- Empty / omitted body may fall back to manifest-defined scanners.
+- Malformed JSON returns **400**.
+- A second overlapping scan for the same set returns **409** (`scan_already_running`).
+
+List and triage:
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  "$AGENTCLASH_API_URL/v1/eval-sets/$EVAL_SET_ID/findings"
+
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status":"dismissed"}' \
+  "$AGENTCLASH_API_URL/v1/scan-findings/$FINDING_ID"
+```
+
+Rescans that find nothing clear prior findings for that target/scanner/version so stale hits do not linger.
+
+## Next
+
+- [Self-host at scale](/docs/fleet/self-host-scale)
+- [Security evaluation](/docs/guides/security-evaluation) (stress packs; complementary to scanners)

--- a/web/content/docs/fleet/cli-evalset.mdx
+++ b/web/content/docs/fleet/cli-evalset.mdx
@@ -1,0 +1,95 @@
+---
+title: CLI evalset workflow
+description: Submit, follow, log, report, and cancel Fleet eval sets with agentclash evalset.
+dateModified: 2026-08-09
+---
+
+The `agentclash evalset` command group is the primary operator surface for Fleet.
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+# or point at your self-hosted API
+
+agentclash auth login --device
+agentclash workspace use <workspace-id>
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `evalset init [path]` | Write a commented `evalset/v1` starter manifest |
+| `evalset submit <file>` | Expand, optionally confirm, create the set |
+| `evalset list` | Recent sets in the workspace |
+| `evalset status <id>` | Roll-up status (`--watch` until terminal) |
+| `evalset logs <id>` | Multiplexed run-event streams (`-f` to follow) |
+| `evalset report <id>` | Scorecard table / json / csv |
+| `evalset cancel <id>` | Request cancellation |
+
+Global flags that matter: `--json`, `--workspace`, `--api-url`, `--non-interactive`.
+
+## Submit loop
+
+```bash
+# Expand only (no create)
+agentclash evalset submit sweep.yaml --dry-run
+
+# Create after confirmation
+agentclash evalset submit sweep.yaml
+
+# CI / agent-friendly: skip prompt and poll to completion
+agentclash evalset submit sweep.yaml --yes --follow --json
+```
+
+Useful submit flags:
+
+- `--yes` — skip the post-expansion confirmation
+- `--dry-run` — expand only
+- `--follow` — poll until terminal
+- `--poll-interval` / `--timeout` — follow timing
+
+Exit codes: non-zero when the followed set ends **failed** or **cancelled**.
+
+## Status and logs
+
+```bash
+agentclash evalset status <eval-set-id>
+agentclash evalset status <eval-set-id> --watch --json
+
+agentclash evalset logs <eval-set-id> -f
+agentclash evalset logs <eval-set-id> -f --combination '<matrix_key>'
+```
+
+`logs` fans out across child runs. Session fetch failures and status-probe errors surface as errors (they do not silently look like success).
+
+## Report
+
+```bash
+agentclash evalset report <eval-set-id>
+agentclash evalset report <eval-set-id> --format csv > scorecard.csv
+agentclash evalset report <eval-set-id> --format json
+```
+
+For full case-level warehouse export (searchable rows, filters), use the web case explorer or the warehouse HTTP APIs documented in [Matrix and warehouse](/docs/fleet/matrix-and-warehouse).
+
+## Cancel
+
+```bash
+agentclash evalset cancel <eval-set-id>
+```
+
+Cancellation asks Temporal to stop the parent workflow, then transitions the set when delivery succeeds (or the workflow is already gone). Transient Temporal errors do not mark the set cancelled while work may still be running.
+
+## Machine-readable automation
+
+```bash
+agentclash evalset submit sweep.yaml --yes --follow --json
+agentclash evalset status <id> --json --query '.eval_set.status'
+```
+
+Schema introspection for the whole CLI (including evalset) is available via `agentclash schema --json` with no auth.
+
+## Next
+
+- [Matrix and warehouse](/docs/fleet/matrix-and-warehouse)
+- [CLI reference](/docs/reference/cli) (generated command dump)

--- a/web/content/docs/fleet/eval-set-manifests.mdx
+++ b/web/content/docs/fleet/eval-set-manifests.mdx
@@ -1,0 +1,111 @@
+---
+title: Eval-set manifests
+description: Author evalset/v1 YAML for packs × agents × models × repeats, dry-run expansion, and combination caps.
+dateModified: 2026-08-09
+---
+
+An eval-set manifest is a YAML (or JSON) document with `schema: evalset/v1`. It is the only input `agentclash evalset submit` needs beyond workspace auth.
+
+Generate a starter file:
+
+```bash
+agentclash evalset init
+# or: agentclash evalset init my-sweep.yaml
+```
+
+## Minimal example
+
+```yaml
+schema: evalset/v1
+name: nightly-coding-sweep
+
+packs:
+  - catalog/code-review
+
+agents:
+  - deployment: claude-opus-default
+  - deployment: gpt-default
+
+models: []          # empty = harness default model axis (one implicit slot)
+repeats: 3
+seeds:
+  strategy: auto
+limits:
+  max_concurrent_runs: 20
+  budget_usd: 50
+case_fanout: true
+# scanners:
+#   - reward-hacking
+#   - tool-misuse
+```
+
+## Fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `schema` | yes | Must be `evalset/v1` |
+| `name` | yes | Human-readable set name |
+| `packs` | yes | Pack refs: workspace version UUID, pack slug, or `catalog/<slug>` |
+| `agents` | yes | List of `{ deployment, label? }`. `deployment` is a deployment UUID or exact name |
+| `models` | no | Optional model override axis. Empty → one implicit slot (harness defaults) |
+| `repeats` | no | Positive integer (default `1`) |
+| `seeds.strategy` | no | `auto` (default) or `explicit` |
+| `seeds.seeds` | when explicit | Positive ints, length must equal `repeats`, unique |
+| `limits.max_concurrent_runs` | no | Soft concurrency hint for orchestration |
+| `limits.budget_usd` | no | Soft USD budget (see [Budgets and scanners](/docs/fleet/budgets-and-scanners)) |
+| `case_fanout` | no | Prefer per-case Temporal activities for native packs |
+| `scanners` | no | Built-in scanner names to run after the set completes |
+
+### Agent labels
+
+Optional `label` overrides how the agent appears in `matrix_key`. Labels must stay unique after normalization (duplicate labels fail expansion).
+
+```yaml
+agents:
+  - deployment: 11111111-1111-1111-1111-111111111111
+    label: opus
+  - deployment: 22222222-2222-2222-2222-222222222222
+    label: gpt
+```
+
+## Expansion
+
+The cartesian product is:
+
+```text
+|packs| × |agents| × |models or 1| × repeats
+```
+
+Each cell gets a stable `matrix_key` used by the matrix UI, logs filter, warehouse rows, and CLI reports.
+
+Dry-run without creating anything:
+
+```bash
+agentclash evalset submit sweep.yaml --dry-run
+```
+
+Or call `POST /v1/eval-sets/expand` with the manifest JSON and optional `max_combinations`.
+
+### Caps
+
+- Default expansion cap: **2000** combinations.
+- Server hard ceiling: **2000** (`MaxAllowedCombos`). Clients cannot raise it.
+- Duplicate `matrix_key` values are rejected (usually colliding agent labels).
+
+## Resolving pack and agent refs
+
+On submit, the CLI resolves:
+
+- Pack: workspace UUID, slug, or `catalog/<slug>` (catalog instantiate only on definitive not-found).
+- Agent: deployment UUID or exact deployment name in the workspace.
+
+Prefer UUIDs in CI for stability. Use names locally when iterating.
+
+## Relation to challenge packs
+
+Manifests **reference** challenge packs; they do not replace pack YAML. Case inputs, tools, sandboxes, and scoring still come from the pack. For pack authoring see [Challenge pack reference](/docs/challenge-packs).
+
+## Next
+
+- [CLI evalset workflow](/docs/fleet/cli-evalset)
+- [Budgets and scanners](/docs/fleet/budgets-and-scanners)

--- a/web/content/docs/fleet/index.mdx
+++ b/web/content/docs/fleet/index.mdx
@@ -1,0 +1,66 @@
+---
+title: Fleet overview
+description: Run packs × agents × models × repeats as one eval set with a live matrix, warehouse exports, budgets, and transcript scanners.
+dateModified: 2026-08-09
+---
+
+**Fleet** is AgentClash's cloud-scale eval plane. You declare one manifest (packs × agents × models × repeats). AgentClash expands it into combinations, runs them with bounded concurrency and isolated sandboxes, then gives you a live matrix, queryable case results, optional budgets, and post-run transcript scanners.
+
+Use Fleet when a single `run create` or eval session is not enough: nightly sweeps, multi-agent bakeoffs, multi-pack regression, or self-hosted fleets that need worker autoscaling.
+
+## What you get
+
+| Surface | Role |
+|---|---|
+| Eval-set manifest (`evalset/v1`) | Declarative packs × agents × models × repeats |
+| CLI `agentclash evalset` | Submit, follow, logs, report, cancel |
+| Web matrix | Live cells per combination under workspace → Eval sets |
+| Case warehouse | Search, report, CSV/JSONL export of per-case outcomes |
+| Budgets | Soft USD caps and workspace emergency stop |
+| Scanners | Optional post-completion transcript analysis |
+| Self-host scale | Helm chart, KEDA queues, Kubernetes sandboxes, metrics |
+
+## Prerequisites
+
+Before you submit an eval set:
+
+1. A workspace with API access (`agentclash auth login`, workspace selected).
+2. Challenge pack versions available in the workspace (or catalog slugs).
+3. Agent deployments wired with provider credentials / BYOK.
+4. A sandbox provider configured for native packs (`e2b`, `docker`, or `kubernetes` on self-host).
+
+Hosted users typically do step 1–3 on [agentclash.dev](https://agentclash.dev). Self-hosters also need Temporal, Postgres, workers, and a sandbox path; see [Self-host at scale](/docs/fleet/self-host-scale).
+
+## Shortest path
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+
+agentclash auth login --device
+agentclash workspace use <workspace-id>
+
+agentclash evalset init
+# edit agentclash.evalset.yaml — packs, deployments, repeats, budget
+
+agentclash evalset submit agentclash.evalset.yaml --dry-run
+agentclash evalset submit agentclash.evalset.yaml --yes --follow
+agentclash evalset report <eval-set-id> --format csv
+```
+
+Open the set in the product UI: **Workspace → Eval sets →** your set for the live matrix and case explorer.
+
+## How it relates to runs and eval sessions
+
+- A **run** is still the unit of execution and scoring.
+- An **eval session** groups repeated runs of one pack lineup.
+- An **eval set** is the Fleet layer: many packs × agents × models × repeats, orchestrated as child sessions/runs under one set ID and `matrix_key` identity.
+
+See [Runs and evals](/docs/concepts/runs-and-evals) for the noun map, then continue with [Eval-set manifests](/docs/fleet/eval-set-manifests).
+
+## Docs in this section
+
+- [Eval-set manifests](/docs/fleet/eval-set-manifests) — YAML fields, expansion, limits
+- [CLI evalset workflow](/docs/fleet/cli-evalset) — submit through report
+- [Matrix and warehouse](/docs/fleet/matrix-and-warehouse) — UI + export APIs
+- [Budgets and scanners](/docs/fleet/budgets-and-scanners) — spend caps and findings
+- [Self-host at scale](/docs/fleet/self-host-scale) — Helm, sandboxes, queues, observability

--- a/web/content/docs/fleet/matrix-and-warehouse.mdx
+++ b/web/content/docs/fleet/matrix-and-warehouse.mdx
@@ -1,0 +1,72 @@
+---
+title: Matrix and warehouse
+description: Watch live eval-set cells in the web UI and export searchable case results from the warehouse.
+dateModified: 2026-08-09
+---
+
+Every eval-set combination is a cell identified by `matrix_key`. Fleet keeps two complementary views: a **live matrix** in the product UI, and a **case-results warehouse** for search and export.
+
+## Web matrix
+
+Path: **Workspace → Eval sets →** select a set.
+
+What you see:
+
+- Grid of packs / agents / models (and repeats) with live status colors
+- Completion and in-flight counts for the whole set
+- Cell drill-down with run links, counts, and status
+- Case explorer for warehouse-backed rows
+
+While a set is active, the UI polls **all** sessions for that set (not a truncated page) so late packs stay fresh. Selecting a cell keeps the drill-down bound to the same identity across poll rebuilds.
+
+Open a run from a cell to use the existing replay timeline and scorecard surfaces ([Replay and scorecards](/docs/concepts/replay-and-scorecards)).
+
+## Warehouse concepts
+
+After sessions complete, aggregation writes **case results**: one row per combination (and case when applicable) with pack ref, agent, model, `matrix_key`, verdict, and scoring signals.
+
+Verdicts prefer per-agent scorecard / run-agent outcomes over a naive "parent run completed ⇒ pass" rule.
+
+## HTTP APIs (warehouse)
+
+All routes require workspace auth. Base: `/v1`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/eval-sets/{id}/cases` | Page case results |
+| `GET` | `/eval-sets/{id}/search` | Filtered search over case results |
+| `GET` | `/eval-sets/{id}/report` | Aggregated report payload |
+| `GET` | `/eval-sets/{id}/export` | Stream CSV or JSONL (auth runs **before** status 200) |
+| `GET` | `/compare/eval-sets` | Compare two sets (query params for set IDs) |
+
+Typical filters (query params) include pack, agent, model, verdict, and cursor pagination. Prefer the web case explorer when exploring interactively; use export for offline analysis.
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  "$AGENTCLASH_API_URL/v1/eval-sets/$EVAL_SET_ID/export?format=csv" \
+  -o cases.csv
+```
+
+## CLI report vs warehouse export
+
+| Tool | Granularity |
+|---|---|
+| `agentclash evalset report` | Set-level scorecard roll-up |
+| Warehouse export / cases API | Per-case (and combination) rows |
+
+Use both: report for a quick pass/fail picture, warehouse for slicing failures by pack or agent.
+
+## Findings (scanners)
+
+If scanners ran, findings appear under the set via:
+
+- `GET /v1/eval-sets/{id}/findings`
+- `PATCH /v1/scan-findings/{findingID}` for triage status
+
+See [Budgets and scanners](/docs/fleet/budgets-and-scanners).
+
+## Next
+
+- [Budgets and scanners](/docs/fleet/budgets-and-scanners)
+- [Interpret results](/docs/guides/interpret-results)

--- a/web/content/docs/fleet/self-host-scale.mdx
+++ b/web/content/docs/fleet/self-host-scale.mdx
@@ -1,0 +1,91 @@
+---
+title: Self-host at scale
+description: Helm chart, KEDA workers, Kubernetes sandboxes, capacity limits, LLM throttle, and Fleet observability for self-hosted AgentClash.
+dateModified: 2026-08-09
+---
+
+Local `./scripts/dev/start-local-stack.sh` is enough for development. Fleet self-host is for clusters that need autoscaled workers, in-cluster sandboxes, and metrics.
+
+For the shortest local path, keep using [Self-host starter](/docs/getting-started/self-host). This page covers production-shaped Kubernetes.
+
+## Helm chart
+
+Chart path: `deploy/helm/agentclash/`.
+
+```bash
+kubectl -n agentclash create secret generic agentclash-secrets \
+  --from-literal=DATABASE_URL='postgres://…' \
+  --from-literal=REDIS_URL='redis://…' \
+  --from-literal=AUTH_MODE=dev   # local only
+
+helm upgrade --install agentclash ./deploy/helm/agentclash \
+  --namespace agentclash --create-namespace \
+  --set secrets.existingSecret=agentclash-secrets \
+  --set external.temporalAddress=temporal-frontend.temporal.svc:7233 \
+  --set sandbox.provider=kubernetes \
+  --set keda.enabled=true
+```
+
+Important env names the binaries actually read:
+
+| Chart / ops intent | Environment variable |
+|---|---|
+| Temporal address | `TEMPORAL_HOST_PORT` |
+| Sandbox namespace | `SANDBOX_K8S_NAMESPACE` |
+| Sandbox default image | `SANDBOX_K8S_DEFAULT_IMAGE` |
+
+Full narrative: [`docs/deployment/self-host-kubernetes.md`](https://github.com/agentclash/agentclash/blob/main/docs/deployment/self-host-kubernetes.md) in the repo. Kind rehearsal: `./deploy/kind/up.sh`.
+
+Images publish to GHCR on `v*` tags (`agentclash-api-server`, `agentclash-worker`).
+
+## Worker task queues
+
+Fleet splits Temporal work across three queues:
+
+| Queue | Work |
+|---|---|
+| `execution` | Eval-set / session / run / run-agent workflows + execution activities |
+| `scoring` | Scoring, scorecards, replay build |
+| `background` | Dataset generation, public tryouts |
+
+Configure with `WORKER_TASK_QUEUES=execution,scoring,background` (one process) or run split Deployments per class. Details: [`docs/deployment/worker-scaling.md`](https://github.com/agentclash/agentclash/blob/main/docs/deployment/worker-scaling.md).
+
+KEDA ScaledObjects (when enabled) target Temporal backlog per queue class.
+
+## Kubernetes sandboxes
+
+```bash
+export SANDBOX_PROVIDER=kubernetes
+export SANDBOX_K8S_NAMESPACE=agentclash-sandboxes
+export SANDBOX_K8S_DEFAULT_IMAGE=python:3.12-slim
+```
+
+Each sandbox is a Pod plus NetworkPolicy. Service-account tokens are not automounted. DNS egress (when network is enabled) targets cluster DNS pods, not every namespace. Full knobs: [`docs/deployment/k8s-sandbox.md`](https://github.com/agentclash/agentclash/blob/main/docs/deployment/k8s-sandbox.md).
+
+## Capacity, warm pool, LLM throttle
+
+| Control | Role |
+|---|---|
+| `SANDBOX_MAX_CONCURRENT` | Global/process sandbox semaphore (Redis-backed when configured) |
+| Warm pool | Reuses sandboxes only when the full request fingerprint matches |
+| Provider throttle | Per-account RPM/TPM / concurrency limits (local or Redis) |
+
+These protect provider quotas when KEDA scales execution workers out.
+
+## Observability
+
+Opt-in Prometheus metrics (`METRICS_ENABLED`) expose Fleet gauges (fan-out, cooldowns, and related signals). Deployable assets live under `deploy/observability/`:
+
+- `grafana-fleet-dashboard.json`
+- `prometheus-alerts.yaml`
+
+Stall detection lists stuck eval sets for operator follow-up. SSE admission can be gated under load so event tails degrade gracefully instead of melting the API.
+
+## Architecture reminder
+
+AgentClash keeps a **control plane** (API) and **execution plane** (Temporal workers). Fleet does not change that split; it adds eval-set workflows, queue partitions, sandbox capacity, and warehouse tables on top. See [Architecture overview](/docs/architecture/overview) and [Sandbox layer](/docs/architecture/sandbox-layer).
+
+## Next
+
+- [Fleet overview](/docs/fleet)
+- [Configure runtime resources](/docs/guides/configure-runtime-resources)

--- a/web/content/docs/getting-started/self-host.mdx
+++ b/web/content/docs/getting-started/self-host.mdx
@@ -1,15 +1,15 @@
 ---
 title: Self-Host Starter
 description: Bring up the local AgentClash stack with the repo’s existing scripts and understand which dependencies are mandatory versus optional.
-dateModified: 2026-06-01
+dateModified: 2026-08-09
 ---
 
 This is the shortest honest path to a local AgentClash environment today. It is based on the repo’s existing development scripts, not an imagined one-click installer.
 
-<Callout type="warning">
-  The repo does not currently ship a Helm chart or a polished production
-  installer. What it does ship is a local stack script plus documented Railway
-  deployment building blocks for the backend.
+<Callout type="info">
+  For Kubernetes production-shaped installs (Helm, KEDA workers, in-cluster
+  sandboxes, Fleet metrics), see [Self-host at scale](/docs/fleet/self-host-scale).
+  This page stays focused on the local developer stack.
 </Callout>
 
 ## Prerequisites
@@ -75,12 +75,14 @@ Without a real sandbox provider such as E2B, native runs can still be created, b
 
 ## Production notes
 
-The repo’s documented production building blocks today are:
+Documented production building blocks today include:
 
-- Railway for the API server and worker
-- Temporal Cloud for orchestration
+- Railway for the API server and worker (simpler hosted path)
+- Helm chart + KEDA for Kubernetes ([Self-host at scale](/docs/fleet/self-host-scale))
+- Temporal Cloud or self-hosted Temporal for orchestration
 - Vercel for `web/`
 - S3-compatible storage for artifacts
+- E2B or Kubernetes sandboxes for native execution
 
 ## Verification
 
@@ -95,6 +97,8 @@ Then open `http://localhost:3000`.
 ## See also
 
 - [Hosted Quickstart](/docs/getting-started/quickstart)
+- [Self-host at scale](/docs/fleet/self-host-scale)
+- [Fleet overview](/docs/fleet)
 - [Architecture Overview](/docs/architecture/overview)
 - [Contributor Setup](/docs/contributing/setup)
 - [Datasets overview](/docs/guides/datasets-overview)

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: AgentClash Documentation
 description: Run agents head-to-head on real tasks, inspect the telemetry, and understand the system without wading through roadmap fiction.
-dateModified: 2026-06-01
+dateModified: 2026-08-09
 ---
 
 AgentClash runs agents against the same task, with the same tools and time budget, then shows you who finished, who stalled, and where the run broke.
@@ -12,12 +12,13 @@ These docs are layered for three kinds of readers:
 - users who need to configure a workspace and run real comparisons
 - contributors who want to understand the stack and change it safely
 
-The current public surface covers behavior visible in the repo today: the CLI, the local stack, datasets and regression gates, multi-turn human takeover, security stress harnesses, and the main runtime components.
+The current public surface covers behavior visible in the repo today: the CLI, the local stack, **Fleet eval sets**, datasets and regression gates, multi-turn human takeover, security stress harnesses, and the main runtime components.
 
-Start with the [hosted quickstart](/docs/getting-started/quickstart) if you want the shortest path to a real command sequence. Start with [self-host](/docs/getting-started/self-host) if you want the full local stack on your machine. Start with [architecture](/docs/architecture/overview) if you are here to hack on the code. For **challenge pack YAML, scoring, tooling, sandboxes, judges, and CLI eval flows**, start at [Challenge pack reference](/docs/challenge-packs).
+Start with the [hosted quickstart](/docs/getting-started/quickstart) if you want the shortest path to a real command sequence. Start with [self-host](/docs/getting-started/self-host) if you want the full local stack on your machine. Start with [Fleet](/docs/fleet) if you want packs × agents × models × repeats in one manifest. Start with [architecture](/docs/architecture/overview) if you are here to hack on the code. For **challenge pack YAML, scoring, tooling, sandboxes, judges, and CLI eval flows**, start at [Challenge pack reference](/docs/challenge-packs).
 
 ## New surfaces
 
+- [Fleet overview](/docs/fleet) — eval sets, live matrix, warehouse, budgets, scanners, self-host scale
 - [Datasets overview](/docs/guides/datasets-overview) — pinned evals, baselines, and CI gates
 - [Multi-turn packs](/docs/challenge-packs/multi-turn) — human takeover and calibration
 - [Security evaluation](/docs/guides/security-evaluation) — stress-run security packs and posture scoring

--- a/web/content/docs/reference/cli.mdx
+++ b/web/content/docs/reference/cli.mdx
@@ -8,5 +8,7 @@ Intro-oriented readers should still start from [Hosted quickstart](../getting-st
 
 ## See also
 
+- [CLI evalset workflow](/docs/fleet/cli-evalset) — Fleet `evalset` commands with examples
+- [Fleet overview](/docs/fleet)
 - [Datasets overview](/docs/guides/datasets-overview)
 - [Security evaluation](/docs/guides/security-evaluation)

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -341,6 +341,55 @@ export const DOCS_NAV: DocNavSection[] = [
     ],
   },
   {
+    title: "Fleet",
+    description:
+      "Cloud-scale eval sets: one manifest for packs × agents × models × repeats, live matrix, warehouse, budgets, scanners, and self-host scale.",
+    items: [
+      {
+        title: "Fleet overview",
+        description:
+          "What Fleet is, who it is for, and the shortest path from manifest to report.",
+        slug: ["fleet"],
+        href: "/docs/fleet",
+      },
+      {
+        title: "Eval-set manifests",
+        description:
+          "evalset/v1 YAML fields, expansion rules, combination caps, and pack/agent refs.",
+        slug: ["fleet", "eval-set-manifests"],
+        href: "/docs/fleet/eval-set-manifests",
+      },
+      {
+        title: "CLI evalset workflow",
+        description:
+          "agentclash evalset init, submit, status, logs, report, and cancel.",
+        slug: ["fleet", "cli-evalset"],
+        href: "/docs/fleet/cli-evalset",
+      },
+      {
+        title: "Matrix and warehouse",
+        description:
+          "Live matrix UI, case explorer, and case-results search/export APIs.",
+        slug: ["fleet", "matrix-and-warehouse"],
+        href: "/docs/fleet/matrix-and-warehouse",
+      },
+      {
+        title: "Budgets and scanners",
+        description:
+          "USD spend caps, workspace emergency stop, and built-in transcript scanners.",
+        slug: ["fleet", "budgets-and-scanners"],
+        href: "/docs/fleet/budgets-and-scanners",
+      },
+      {
+        title: "Self-host at scale",
+        description:
+          "Helm, KEDA queues, Kubernetes sandboxes, capacity, throttle, and metrics.",
+        slug: ["fleet", "self-host-scale"],
+        href: "/docs/fleet/self-host-scale",
+      },
+    ],
+  },
+  {
     title: "Guides",
     description:
       "Task-oriented walkthroughs for authoring packs, setting up deployments, reading results, and using the docs with AI tools.",
@@ -1768,6 +1817,7 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     `- [Quickstart](${origin}/docs-md/getting-started/quickstart) - fastest path to a real run.`,
     `- [Self-Host](${origin}/docs-md/getting-started/self-host) - local stack and service dependencies.`,
     `- [First Eval](${origin}/docs-md/getting-started/first-eval) - end-to-end walkthrough of one eval path.`,
+    `- [Fleet](${origin}/docs-md/fleet) - eval sets, live matrix, warehouse, budgets, scanners, self-host scale.`,
     `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
     `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
     `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,


### PR DESCRIPTION
## Summary
- Add a **Fleet** docs section on the public docs site: overview, manifests, CLI `evalset`, matrix/warehouse, budgets/scanners, and self-host scale.
- Wire the section into `DOCS_NAV` (sidebar + `llms.txt` entrypoints) and update related pages (docs home, self-host starter, runs/evals, CLI reference, sandbox architecture).

## Test plan
- [x] `pnpm exec vitest run src/lib/docs.test.ts` (nav resolves every page)
- [ ] Preview `/docs/fleet` and each child page in the docs sidebar after deploy/preview
- [ ] Confirm self-host starter no longer claims there is no Helm chart