### PR TITLE
fix: human labels and clearer Fleet matrix UI

### DIFF
--- a/cli/cmd/evalset_resolve.go
+++ b/cli/cmd/evalset_resolve.go
@@ -30,9 +30,17 @@ func resolveEvalsetManifest(cmd *cobra.Command, rc *RunContext, workspaceID stri
 		if err != nil {
 			return nil, fmt.Errorf("agent deployment %q: %w", a.Deployment, err)
 		}
-		// Omit label: runtime/evalset.agentRef prefers label over deployment, and
-		// the API requires agent_ref to be a deployment UUID at create time.
-		agents = append(agents, map[string]string{"deployment": id})
+		entry := map[string]string{"deployment": id}
+		// Keep label for UI display. Expand uses deployment UUID as agent_ref;
+		// label is never the identity key.
+		label := strings.TrimSpace(a.Label)
+		if label == "" && strings.TrimSpace(a.Deployment) != id {
+			label = strings.TrimSpace(a.Deployment)
+		}
+		if label != "" {
+			entry["label"] = label
+		}
+		agents = append(agents, entry)
 	}
 
 	out := map[string]any{

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -8146,8 +8146,13 @@ components:
           type: string
         pack_ref:
           type: string
+          description: challenge_pack_version UUID
         agent_ref:
           type: string
+          description: agent_deployment UUID (stable identity; never the display label)
+        agent_label:
+          type: string
+          description: Optional human-readable agent axis label from the manifest
         model_ref:
           type: string
         repeat:

--- a/runtime/evalset/manifest.go
+++ b/runtime/evalset/manifest.go
@@ -53,9 +53,12 @@ type Limits struct {
 
 // Combination is one expanded cell in the cartesian product.
 type Combination struct {
-	MatrixKey  string `json:"matrix_key"`
-	PackRef    string `json:"pack_ref"`
-	AgentRef   string `json:"agent_ref"`
+	MatrixKey string `json:"matrix_key"`
+	PackRef   string `json:"pack_ref"`
+	// AgentRef is always the agent_deployment UUID (API create requires UUID refs).
+	AgentRef string `json:"agent_ref"`
+	// AgentLabel is an optional human-readable axis label from the manifest.
+	AgentLabel string `json:"agent_label,omitempty"`
 	ModelRef   string `json:"model_ref,omitempty"`
 	Repeat     int    `json:"repeat"`
 	Seed       *int64 `json:"seed,omitempty"`
@@ -189,19 +192,21 @@ func (m Manifest) Expand(maxCombos int) (ExpansionReport, error) {
 	for _, pack := range m.Packs {
 		packRef := strings.TrimSpace(pack)
 		for _, agent := range m.Agents {
-			agentRef := agentRef(agent)
+			agentRef := agentDeploymentRef(agent)
+			agentLabel := strings.TrimSpace(agent.Label)
 			for _, model := range models {
 				modelRef := strings.TrimSpace(model)
 				for rep := 1; rep <= repeats; rep++ {
 					key := matrixKey(packRef, agentRef, modelRef, rep)
 					if _, dup := seenKeys[key]; dup {
-						return ExpansionReport{}, fmt.Errorf("duplicate matrix_key %q (check agent labels and refs)", key)
+						return ExpansionReport{}, fmt.Errorf("duplicate matrix_key %q (check agent deployments and refs)", key)
 					}
 					seenKeys[key] = struct{}{}
 					c := Combination{
 						MatrixKey:  key,
 						PackRef:    packRef,
 						AgentRef:   agentRef,
+						AgentLabel: agentLabel,
 						ModelRef:   modelRef,
 						Repeat:     rep,
 						CaseFanout: m.CaseFanout,
@@ -230,10 +235,10 @@ func (m Manifest) Expand(maxCombos int) (ExpansionReport, error) {
 	}, nil
 }
 
-func agentRef(a AgentEntry) string {
-	if label := strings.TrimSpace(a.Label); label != "" {
-		return sanitizeRef(label)
-	}
+// agentDeploymentRef returns the stable identity used in matrix_key / agent_ref.
+// Labels are display-only (see Combination.AgentLabel) so create-time UUID
+// validation and warehouse joins stay keyed on deployment IDs.
+func agentDeploymentRef(a AgentEntry) string {
 	return sanitizeRef(strings.TrimSpace(a.Deployment))
 }
 

--- a/runtime/evalset/manifest_test.go
+++ b/runtime/evalset/manifest_test.go
@@ -124,16 +124,42 @@ func TestExpand_RejectsMaxAllowedCombosCeiling(t *testing.T) {
 func TestExpand_RejectsDuplicateMatrixKey(t *testing.T) {
 	m := evalset.Manifest{
 		Schema: evalset.SchemaV1,
-		Name:   "dup-labels",
+		Name:   "dup-deployments",
 		Packs:  []string{"p"},
 		Agents: []evalset.AgentEntry{
-			{Deployment: "dep-a", Label: "my agent"},
-			{Deployment: "dep-b", Label: "my-agent"},
+			{Deployment: "dep-a", Label: "alpha"},
+			{Deployment: "dep-a", Label: "alpha-again"},
 		},
 		Repeats: 1,
 	}
 	_, err := m.Expand(evalset.DefaultMaxCombos)
 	if err == nil || !strings.Contains(err.Error(), "duplicate matrix_key") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestExpand_PreservesAgentLabelWithoutUsingItAsRef(t *testing.T) {
+	m := evalset.Manifest{
+		Schema: evalset.SchemaV1,
+		Name:   "labels",
+		Packs:  []string{"pack-uuid"},
+		Agents: []evalset.AgentEntry{
+			{Deployment: "dep-uuid", Label: "Gemini Flash"},
+		},
+		Repeats: 1,
+	}
+	report, err := m.Expand(evalset.DefaultMaxCombos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := report.Combinations[0]
+	if c.AgentRef != "dep-uuid" {
+		t.Fatalf("agent_ref = %q, want deployment id", c.AgentRef)
+	}
+	if c.AgentLabel != "Gemini Flash" {
+		t.Fatalf("agent_label = %q", c.AgentLabel)
+	}
+	if c.MatrixKey != "pack-uuid/dep-uuid/1" {
+		t.Fatalf("matrix_key = %q", c.MatrixKey)
 	}
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/case-explorer.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/case-explorer.tsx
@@ -12,6 +12,11 @@ import {
   searchEvalSetCases,
 } from "@/lib/api/eval-sets";
 import type { EvalSetCaseResult } from "@/lib/api/types";
+import {
+  comboRepeatLabel,
+  displayRef,
+  type RefLabelMap,
+} from "@/lib/eval-sets";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -23,7 +28,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-export function CaseExplorer({ evalSetId }: { evalSetId: string }) {
+export function CaseExplorer({
+  evalSetId,
+  labels,
+}: {
+  evalSetId: string;
+  labels?: RefLabelMap | null;
+}) {
   const { accessToken, getAccessToken } = useAccessToken();
   const router = useRouter();
   const pathname = usePathname();
@@ -146,7 +157,9 @@ export function CaseExplorer({ evalSetId }: { evalSetId: string }) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Matrix</TableHead>
+              <TableHead>Pack</TableHead>
+              <TableHead>Case</TableHead>
+              <TableHead>Repeat</TableHead>
               <TableHead>Verdict</TableHead>
               <TableHead>Score</TableHead>
               <TableHead>Snippet</TableHead>
@@ -155,9 +168,18 @@ export function CaseExplorer({ evalSetId }: { evalSetId: string }) {
           <TableBody>
             {cases.map((c) => (
               <TableRow key={c.id}>
-                <TableCell className="font-mono text-xs">{c.matrix_key}</TableCell>
+                <TableCell
+                  className="max-w-[10rem] truncate text-xs font-medium"
+                  title={c.pack_ref}
+                >
+                  {displayRef(c.pack_ref, labels)}
+                </TableCell>
+                <TableCell className="font-mono text-xs">{c.case_key}</TableCell>
+                <TableCell className="tabular-nums text-xs text-muted-foreground">
+                  {comboRepeatLabel(c.matrix_key)}
+                </TableCell>
                 <TableCell>{c.verdict || "—"}</TableCell>
-                <TableCell>{c.score ?? "—"}</TableCell>
+                <TableCell className="tabular-nums">{c.score ?? "—"}</TableCell>
                 <TableCell className="max-w-md text-xs text-muted-foreground">
                   {highlightSnippet(
                     c.snippet || c.transcript_text?.slice(0, 160) || "—",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
@@ -500,7 +500,8 @@ function CellDetail({
       <div className="mt-4 space-y-1.5">
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>
-            {cell.passCount} passed · {cell.doneCount}/{cell.totalCount} done
+            {cell.passCount} completed · {cell.doneCount}/{cell.totalCount}{" "}
+            finished
           </span>
           <span className="tabular-nums">{progress}%</span>
         </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/eval-set-detail-client.tsx
@@ -1,23 +1,45 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { Grid3x3 } from "lucide-react";
+import {
+  ArrowUpRight,
+  Bot,
+  Clock3,
+  DollarSign,
+  Grid3x3,
+  Loader2,
+  Package,
+  Radio,
+} from "lucide-react";
 import useSWR from "swr";
 
 import { createApiClient } from "@/lib/api/client";
 import { compareEvalSets, getEvalSession } from "@/lib/api/eval-sets";
-import type { CompareEvalSetsResponse, GetEvalSetResponse } from "@/lib/api/types";
-import { useApiQuery } from "@/lib/api/swr";
+import type {
+  AgentDeployment,
+  ChallengePack,
+  CompareEvalSetsResponse,
+  EvalSetStatus,
+  GetEvalSetResponse,
+} from "@/lib/api/types";
+import { useApiListQuery, useApiQuery } from "@/lib/api/swr";
 import {
   EVAL_SET_ACTIVE,
   buildMatrixGrid,
+  buildRefLabelMap,
+  comboRepeatLabel,
   completionPercent,
+  displayRef,
+  evalSetStatusLabel,
   inFlightCount,
+  matrixCellStateLabel,
   type LiveStatusMap,
   type MatrixCell,
+  type MatrixCellState,
+  type RefLabelMap,
 } from "@/lib/eval-sets";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -32,10 +54,31 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { CaseExplorer } from "./case-explorer";
 import { MatrixGridView } from "./matrix-grid";
 
 const POLL_MS = 5000;
+
+const SET_STATUS_BADGE: Partial<
+  Record<EvalSetStatus, "default" | "secondary" | "destructive" | "outline">
+> = {
+  queued: "outline",
+  expanding: "secondary",
+  running: "default",
+  aggregating: "secondary",
+  completed: "secondary",
+  failed: "destructive",
+  cancelled: "outline",
+  budget_exceeded: "destructive",
+};
+
+const CELL_STATE_TONE: Record<MatrixCellState, string> = {
+  queued: "text-muted-foreground",
+  running: "text-amber-700 dark:text-amber-300",
+  scored: "text-emerald-700 dark:text-emerald-300",
+  failed: "text-red-700 dark:text-red-300",
+};
 
 export function EvalSetDetailClient({
   workspaceId,
@@ -77,6 +120,13 @@ function EvalSetDetailInner({
           ? POLL_MS
           : 0,
     },
+  );
+
+  const { data: deploymentsData } = useApiListQuery<AgentDeployment>(
+    `/v1/workspaces/${workspaceId}/agent-deployments`,
+  );
+  const { data: packsData } = useApiListQuery<ChallengePack>(
+    `/v1/workspaces/${workspaceId}/challenge-packs`,
   );
 
   const sessionIds = detail?.eval_session_ids ?? [];
@@ -123,6 +173,18 @@ function EvalSetDetailInner({
     [detail, live],
   );
 
+  const labels = useMemo(
+    () =>
+      detail
+        ? buildRefLabelMap(
+            detail,
+            deploymentsData?.items,
+            packsData?.items,
+          )
+        : {},
+    [detail, deploymentsData?.items, packsData?.items],
+  );
+
   const selectedLive = useMemo(() => {
     if (!selected || !grid) return selected;
     const key = `${selected.agentRef}\0${selected.packRef}`;
@@ -162,46 +224,101 @@ function EvalSetDetailInner({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <Link
-            href={`/workspaces/${workspaceId}/eval-sets`}
-            className="text-xs text-muted-foreground hover:underline"
-          >
-            ← Eval sets
-          </Link>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight">{set.name}</h1>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <Badge variant="outline">{set.status}</Badge>
-            <span className="text-sm text-muted-foreground">
-              {set.combination_count} combinations · {sessions} sessions · {runs}{" "}
-              runs
-            </span>
+      <header className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <Link
+              href={`/workspaces/${workspaceId}/eval-sets`}
+              className="text-xs text-muted-foreground transition hover:text-foreground hover:underline"
+            >
+              ← Eval sets
+            </Link>
+            <div className="mt-2 flex flex-wrap items-center gap-2.5">
+              <h1 className="text-2xl font-semibold tracking-tight">
+                {set.name}
+              </h1>
+              <Badge
+                variant={SET_STATUS_BADGE[set.status] ?? "outline"}
+                className="capitalize"
+              >
+                {active ? (
+                  <Loader2
+                    data-icon="inline-start"
+                    className="size-3 animate-spin"
+                  />
+                ) : null}
+                {evalSetStatusLabel(set.status)}
+              </Badge>
+              {active ? (
+                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Radio className="size-3 text-emerald-500" aria-hidden />
+                  Live
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              {set.combination_count} combinations · {sessions} sessions ·{" "}
+              {runs} runs
+            </p>
+          </div>
+          <div className="grid w-full grid-cols-2 gap-2 sm:w-auto sm:grid-cols-4">
+            <Stat
+              label="Complete"
+              value={`${pct}%`}
+              hint={`${Math.round((pct / 100) * set.combination_count)} / ${set.combination_count}`}
+            />
+            <Stat
+              label="In flight"
+              value={String(flight)}
+              accent={flight > 0 ? "amber" : undefined}
+            />
+            <Stat
+              label="Elapsed"
+              icon={<Clock3 className="size-3" />}
+              value={
+                set.started_at
+                  ? formatElapsed(set.started_at, set.finished_at)
+                  : "—"
+              }
+            />
+            <Stat
+              label="Spend"
+              icon={<DollarSign className="size-3" />}
+              value={
+                set.spent_usd != null || set.budget_usd != null
+                  ? `$${(set.spent_usd ?? 0).toFixed(2)}${
+                      set.budget_usd != null
+                        ? ` / $${Number(set.budget_usd).toFixed(0)}`
+                        : ""
+                    }`
+                  : "—"
+              }
+            />
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Stat label="Complete" value={`${pct}%`} />
-          <Stat label="In flight" value={String(flight)} />
-          <Stat
-            label="Elapsed"
-            value={
-              set.started_at
-                ? formatElapsed(set.started_at, set.finished_at)
-                : "—"
-            }
-          />
-          <Stat
-            label="Spend"
-            value={
-              set.spent_usd != null || set.budget_usd != null
-                ? `$${(set.spent_usd ?? 0).toFixed(2)}${
-                    set.budget_usd != null ? ` / $${set.budget_usd}` : ""
-                  }`
-                : "—"
-            }
-          />
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Overall progress</span>
+            <span className="tabular-nums font-medium text-foreground">
+              {pct}%
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn(
+                "h-full rounded-full transition-[width] duration-700 ease-out",
+                set.status === "failed" || set.status === "budget_exceeded"
+                  ? "bg-red-500"
+                  : set.status === "completed"
+                    ? "bg-emerald-500"
+                    : "bg-foreground/80",
+              )}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
         </div>
-      </div>
+      </header>
 
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
@@ -214,42 +331,23 @@ function EvalSetDetailInner({
             grid={grid}
             selectedKey={selectedKey}
             onSelect={setSelected}
+            labels={labels}
           />
           {selectedLive ? (
-            <div className="rounded-lg border border-border bg-card/40 p-4">
-              <h2 className="text-sm font-semibold">
-                {shortRef(selectedLive.agentRef)} × {shortRef(selectedLive.packRef)}
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {selectedLive.passCount}/{selectedLive.totalCount} completed · state{" "}
-                {selectedLive.state}
-              </p>
-              <ul className="mt-3 space-y-2">
-                {selectedLive.combos.map((c) => (
-                  <li
-                    key={c.matrixKey}
-                    className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs"
-                  >
-                    <span className="text-muted-foreground">{c.matrixKey}</span>
-                    <span className="flex items-center gap-2">
-                      <Badge variant="outline">{c.status || "queued"}</Badge>
-                      {c.runId ? (
-                        <Link
-                          href={`/workspaces/${workspaceId}/runs/${c.runId}`}
-                          className="underline-offset-4 hover:underline"
-                        >
-                          Open run
-                        </Link>
-                      ) : null}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+            <CellDetail
+              cell={selectedLive}
+              labels={labels}
+              workspaceId={workspaceId}
+              onClear={() => setSelected(null)}
+            />
+          ) : (
+            <div className="rounded-xl border border-dashed border-border bg-muted/10 px-4 py-6 text-center text-sm text-muted-foreground">
+              Select a matrix cell to see agent, pack, and linked runs.
             </div>
-          ) : null}
+          )}
         </TabsContent>
         <TabsContent value="cases">
-          <CaseExplorer evalSetId={evalSetId} />
+          <CaseExplorer evalSetId={evalSetId} labels={labels} />
         </TabsContent>
         <TabsContent value="compare" className="space-y-4">
           <div className="flex flex-wrap items-end gap-2">
@@ -334,13 +432,165 @@ function EvalSetDetailInner({
   );
 }
 
-function Stat({ label, value }: { label: string; value: string }) {
+function CellDetail({
+  cell,
+  labels,
+  workspaceId,
+  onClear,
+}: {
+  cell: MatrixCell;
+  labels: RefLabelMap;
+  workspaceId: string;
+  onClear: () => void;
+}) {
+  const agentName = displayRef(cell.agentRef, labels);
+  const packName = displayRef(cell.packRef, labels);
+  const progress =
+    cell.totalCount > 0
+      ? Math.round((cell.doneCount / cell.totalCount) * 100)
+      : 0;
+
   return (
-    <div className="rounded-lg border border-border bg-background/70 px-3 py-2">
-      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+    <div className="rounded-xl border border-border bg-card/50 p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold tracking-tight">
+              Cell detail
+            </h2>
+            <span
+              className={cn(
+                "text-xs font-medium",
+                CELL_STATE_TONE[cell.state],
+              )}
+            >
+              {matrixCellStateLabel(cell.state)}
+            </span>
+          </div>
+          <dl className="grid gap-2 sm:grid-cols-2">
+            <div className="flex items-start gap-2 rounded-lg bg-muted/30 px-3 py-2">
+              <Bot className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <dt className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  Agent
+                </dt>
+                <dd className="truncate text-sm font-medium" title={cell.agentRef}>
+                  {agentName}
+                </dd>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 rounded-lg bg-muted/30 px-3 py-2">
+              <Package className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <dt className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  Pack
+                </dt>
+                <dd className="truncate text-sm font-medium" title={cell.packRef}>
+                  {packName}
+                </dd>
+              </div>
+            </div>
+          </dl>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+          Clear
+        </Button>
+      </div>
+
+      <div className="mt-4 space-y-1.5">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            {cell.passCount} passed · {cell.doneCount}/{cell.totalCount} done
+          </span>
+          <span className="tabular-nums">{progress}%</span>
+        </div>
+        <div className="h-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-500",
+              cell.state === "failed"
+                ? "bg-red-500"
+                : cell.state === "scored"
+                  ? "bg-emerald-500"
+                  : cell.state === "running"
+                    ? "bg-amber-500"
+                    : "bg-muted-foreground/40",
+            )}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      <ul className="mt-4 divide-y divide-border/70 rounded-lg border border-border/80">
+        {cell.combos.map((c) => (
+          <li
+            key={c.matrixKey}
+            className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5 text-sm"
+          >
+            <div className="min-w-0">
+              <p className="font-medium">
+                Repeat {comboRepeatLabel(c.matrixKey)}
+              </p>
+              <p
+                className="truncate font-mono text-[11px] text-muted-foreground"
+                title={c.matrixKey}
+              >
+                {c.matrixKey}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="capitalize">
+                {c.status || "queued"}
+              </Badge>
+              {c.runId ? (
+                <Link
+                  href={`/workspaces/${workspaceId}/runs/${c.runId}`}
+                  className="inline-flex items-center gap-1 text-xs font-medium underline-offset-4 hover:underline"
+                >
+                  Open run
+                  <ArrowUpRight className="size-3" />
+                </Link>
+              ) : (
+                <span className="text-xs text-muted-foreground">No run yet</span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+  icon,
+  accent,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  icon?: ReactNode;
+  accent?: "amber";
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-[6.5rem] rounded-xl border border-border bg-background/80 px-3 py-2",
+        accent === "amber" && "border-amber-500/30 bg-amber-500/[0.06]",
+      )}
+    >
+      <div className="flex items-center gap-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        {icon}
         {label}
       </div>
-      <div className="mt-1 text-sm font-semibold">{value}</div>
+      <div className="mt-1 text-sm font-semibold tabular-nums">{value}</div>
+      {hint ? (
+        <div className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+          {hint}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -351,10 +601,7 @@ function formatElapsed(startedAt: string, finishedAt?: string | null): string {
   const sec = Math.max(0, Math.round((end - start) / 1000));
   if (sec < 60) return `${sec}s`;
   const min = Math.floor(sec / 60);
-  return `${min}m ${sec % 60}s`;
-}
-
-function shortRef(ref: string): string {
-  if (ref.length <= 24) return ref;
-  return `${ref.slice(0, 10)}…${ref.slice(-8)}`;
+  if (min < 60) return `${min}m ${sec % 60}s`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h ${min % 60}m`;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/matrix-grid.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/[evalSetId]/matrix-grid.tsx
@@ -1,99 +1,216 @@
 "use client";
 
-import type { MatrixCell, MatrixGrid as Grid } from "@/lib/eval-sets";
+import { Bot, Package } from "lucide-react";
+
+import type {
+  MatrixCell,
+  MatrixCellState,
+  MatrixGrid as Grid,
+  RefLabelMap,
+} from "@/lib/eval-sets";
+import {
+  countCellsByState,
+  displayRef,
+  MATRIX_CELL_STATES,
+  matrixCellStateLabel,
+} from "@/lib/eval-sets";
 import { cn } from "@/lib/utils";
+
+const STATE_DOT: Record<MatrixCellState, string> = {
+  queued: "bg-muted-foreground/40",
+  running: "bg-amber-500",
+  scored: "bg-emerald-500",
+  failed: "bg-red-500",
+};
+
+const STATE_CELL: Record<MatrixCellState, string> = {
+  queued:
+    "border-border/70 bg-muted/15 text-muted-foreground hover:bg-muted/30",
+  running:
+    "border-amber-500/45 bg-amber-500/[0.09] text-amber-950 dark:text-amber-50",
+  scored:
+    "border-emerald-500/40 bg-emerald-500/[0.08] text-emerald-950 dark:text-emerald-50",
+  failed:
+    "border-red-500/40 bg-red-500/[0.08] text-red-950 dark:text-red-50",
+};
+
+const STATE_BAR: Record<MatrixCellState, string> = {
+  queued: "bg-muted-foreground/25",
+  running: "bg-amber-500",
+  scored: "bg-emerald-500",
+  failed: "bg-red-500",
+};
 
 export function MatrixGridView({
   grid,
   onSelect,
   selectedKey,
+  labels,
 }: {
   grid: Grid;
   onSelect?: (cell: MatrixCell) => void;
   selectedKey?: string | null;
+  labels?: RefLabelMap | null;
 }) {
   if (grid.rowLabels.length === 0 || grid.colLabels.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
-        Matrix will appear once combinations are expanded.
-      </p>
+      <div className="rounded-xl border border-dashed border-border bg-muted/10 px-6 py-10 text-center">
+        <p className="text-sm font-medium">Matrix not ready yet</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Combinations appear here once the eval set finishes expanding.
+        </p>
+      </div>
     );
   }
 
+  const counts = countCellsByState(grid);
+  const rowIsAgent = grid.rowAxis === "agent";
+  const RowIcon = rowIsAgent ? Bot : Package;
+  const ColIcon = rowIsAgent ? Package : Bot;
+
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full min-w-[32rem] border-collapse text-sm">
-        <thead>
-          <tr>
-            <th className="sticky left-0 z-10 bg-background px-3 py-2 text-left text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-              {grid.rowAxis === "agent" ? "Agent \\ Pack" : "Pack \\ Agent"}
-            </th>
-            {grid.colLabels.map((col) => (
-              <th
-                key={col}
-                className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
-              >
-                <span className="line-clamp-2 max-w-[8rem] font-mono text-[11px]">
-                  {shortRef(col)}
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {grid.rowLabels.length} × {grid.colLabels.length} cells · click any
+          cell for runs
+        </p>
+        <ul className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          {MATRIX_CELL_STATES.map((state) => (
+            <li key={state} className="inline-flex items-center gap-1.5">
+              <span
+                className={cn("size-1.5 rounded-full", STATE_DOT[state])}
+                aria-hidden
+              />
+              <span>
+                {matrixCellStateLabel(state)}
+                {counts[state] > 0 ? (
+                  <span className="tabular-nums text-foreground/70">
+                    {" "}
+                    {counts[state]}
+                  </span>
+                ) : null}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-card/30 shadow-sm">
+        <table className="w-full min-w-[36rem] border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-20 bg-background/95 px-3 py-3 text-left backdrop-blur">
+                <span className="inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  <RowIcon className="size-3 opacity-70" aria-hidden />
+                  {rowIsAgent ? "Agent" : "Pack"}
+                  <span className="opacity-40">/</span>
+                  <ColIcon className="size-3 opacity-70" aria-hidden />
+                  {rowIsAgent ? "Pack" : "Agent"}
                 </span>
               </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {grid.rowLabels.map((row) => (
-            <tr key={row} className="border-t border-border">
-              <th className="sticky left-0 z-10 bg-background px-3 py-2 text-left font-mono text-[11px] font-medium">
-                {shortRef(row)}
-              </th>
-              {grid.colLabels.map((col) => {
-                const cell = grid.cells[`${row}\0${col}`];
-                const state = cell?.state ?? "queued";
-                const cellKey = cell
-                  ? `${cell.agentRef}\0${cell.packRef}`
-                  : null;
-                const active = cellKey != null && cellKey === selectedKey;
-                const passRate =
-                  cell && cell.totalCount > 0
-                    ? `${cell.passCount}/${cell.totalCount}`
-                    : "—";
-                return (
-                  <td key={col} className="px-2 py-2">
-                    <button
-                      type="button"
-                      disabled={!cell}
-                      onClick={() => cell && onSelect?.(cell)}
-                      className={cn(
-                        "flex h-14 w-full min-w-[5.5rem] flex-col items-start justify-center rounded-md border px-2 text-left transition",
-                        state === "queued" &&
-                          "border-border/60 bg-muted/20 text-muted-foreground",
-                        state === "running" &&
-                          "border-amber-600/50 bg-amber-500/10 text-amber-950 dark:text-amber-100 animate-pulse",
-                        state === "scored" &&
-                          "border-emerald-600/40 bg-emerald-500/10",
-                        state === "failed" && "border-red-600/40 bg-red-500/10",
-                        active && "ring-2 ring-foreground/30",
-                      )}
-                    >
-                      <span className="text-[10px] uppercase tracking-[0.14em] opacity-70">
-                        {state}
-                      </span>
-                      <span className="mt-0.5 font-mono text-[11px]">
-                        {passRate}
-                      </span>
-                    </button>
-                  </td>
-                );
-              })}
+              {grid.colLabels.map((col) => (
+                <th
+                  key={col}
+                  title={col}
+                  className="max-w-[9.5rem] px-2 py-3 text-left align-bottom"
+                >
+                  <span className="line-clamp-2 text-xs font-medium leading-snug text-foreground/90">
+                    {displayRef(col, labels)}
+                  </span>
+                </th>
+              ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {grid.rowLabels.map((row) => (
+              <tr key={row} className="border-t border-border/80">
+                <th
+                  title={row}
+                  className="sticky left-0 z-10 max-w-[11rem] bg-background/95 px-3 py-2 text-left align-middle backdrop-blur"
+                >
+                  <span className="line-clamp-2 text-xs font-medium leading-snug">
+                    {displayRef(row, labels)}
+                  </span>
+                </th>
+                {grid.colLabels.map((col) => {
+                  const cell = grid.cells[`${row}\0${col}`];
+                  const state = cell?.state ?? "queued";
+                  const cellKey = cell
+                    ? `${cell.agentRef}\0${cell.packRef}`
+                    : null;
+                  const active = cellKey != null && cellKey === selectedKey;
+                  const progress =
+                    cell && cell.totalCount > 0
+                      ? Math.round((cell.doneCount / cell.totalCount) * 100)
+                      : 0;
+                  const passRate =
+                    cell && cell.totalCount > 0
+                      ? `${cell.passCount}/${cell.totalCount}`
+                      : "—";
+                  const agentName = cell
+                    ? displayRef(cell.agentRef, labels)
+                    : displayRef(rowIsAgent ? row : col, labels);
+                  const packName = cell
+                    ? displayRef(cell.packRef, labels)
+                    : displayRef(rowIsAgent ? col : row, labels);
+
+                  return (
+                    <td key={col} className="p-1.5">
+                      <button
+                        type="button"
+                        disabled={!cell}
+                        onClick={() => cell && onSelect?.(cell)}
+                        aria-label={`${agentName} on ${packName}: ${matrixCellStateLabel(state)}, ${passRate} completed`}
+                        aria-pressed={active}
+                        className={cn(
+                          "relative flex h-[3.75rem] w-full min-w-[6.25rem] flex-col items-stretch justify-between overflow-hidden rounded-lg border px-2.5 py-2 text-left transition",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+                          "disabled:cursor-default disabled:opacity-40",
+                          STATE_CELL[state],
+                          state === "running" && "animate-pulse",
+                          active &&
+                            "ring-2 ring-foreground/25 border-foreground/30",
+                          cell && "hover:-translate-y-px hover:shadow-sm",
+                        )}
+                      >
+                        <span className="flex items-center gap-1.5">
+                          <span
+                            className={cn(
+                              "size-1.5 shrink-0 rounded-full",
+                              STATE_DOT[state],
+                              state === "running" && "animate-pulse",
+                            )}
+                            aria-hidden
+                          />
+                          <span className="text-[10px] font-medium uppercase tracking-[0.12em] opacity-75">
+                            {matrixCellStateLabel(state)}
+                          </span>
+                        </span>
+                        <span className="font-mono text-sm font-semibold tabular-nums tracking-tight">
+                          {passRate}
+                        </span>
+                        <span
+                          className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-border/40"
+                          aria-hidden
+                        >
+                          <span
+                            className={cn(
+                              "block h-full transition-[width] duration-500",
+                              STATE_BAR[state],
+                            )}
+                            style={{ width: `${progress}%` }}
+                          />
+                        </span>
+                      </button>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
-}
-
-function shortRef(ref: string): string {
-  if (ref.length <= 18) return ref;
-  return `${ref.slice(0, 8)}…${ref.slice(-6)}`;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/eval-sets-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sets/eval-sets-client.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Grid3x3 } from "lucide-react";
+import { Grid3x3, Loader2 } from "lucide-react";
 
-import type { ListEvalSetsResponse } from "@/lib/api/types";
+import type { EvalSetStatus, ListEvalSetsResponse } from "@/lib/api/types";
 import { useApiQuery } from "@/lib/api/swr";
-import { EVAL_SET_ACTIVE } from "@/lib/eval-sets";
+import { EVAL_SET_ACTIVE, evalSetStatusLabel } from "@/lib/eval-sets";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
@@ -18,6 +18,19 @@ import {
 } from "@/components/ui/table";
 
 const POLL_MS = 5000;
+
+const SET_STATUS_BADGE: Partial<
+  Record<EvalSetStatus, "default" | "secondary" | "destructive" | "outline">
+> = {
+  queued: "outline",
+  expanding: "secondary",
+  running: "default",
+  aggregating: "secondary",
+  completed: "secondary",
+  failed: "destructive",
+  cancelled: "outline",
+  budget_exceeded: "destructive",
+};
 
 export function EvalSetsClient({ workspaceId }: { workspaceId: string }) {
   const { data, error, isLoading } = useApiQuery<ListEvalSetsResponse>(
@@ -64,7 +77,7 @@ export function EvalSetsClient({ workspaceId }: { workspaceId: string }) {
           Multi-pack matrices filling in live as combinations complete.
         </p>
       </div>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto rounded-xl border border-border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -75,25 +88,41 @@ export function EvalSetsClient({ workspaceId }: { workspaceId: string }) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {sets.map((set) => (
-              <TableRow key={set.id}>
-                <TableCell>
-                  <Link
-                    href={`/workspaces/${workspaceId}/eval-sets/${set.id}`}
-                    className="font-medium text-foreground underline-offset-4 hover:underline"
-                  >
-                    {set.name}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Badge variant="outline">{set.status}</Badge>
-                </TableCell>
-                <TableCell>{set.combination_count}</TableCell>
-                <TableCell className="text-muted-foreground">
-                  {new Date(set.created_at).toLocaleString()}
-                </TableCell>
-              </TableRow>
-            ))}
+            {sets.map((set) => {
+              const live = EVAL_SET_ACTIVE.includes(set.status);
+              return (
+                <TableRow key={set.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/eval-sets/${set.id}`}
+                      className="font-medium text-foreground underline-offset-4 hover:underline"
+                    >
+                      {set.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={SET_STATUS_BADGE[set.status] ?? "outline"}
+                      className="capitalize"
+                    >
+                      {live ? (
+                        <Loader2
+                          data-icon="inline-start"
+                          className="size-3 animate-spin"
+                        />
+                      ) : null}
+                      {evalSetStatusLabel(set.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="tabular-nums">
+                    {set.combination_count}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(set.created_at).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </div>

--- a/web/src/lib/__tests__/eval-sets.test.ts
+++ b/web/src/lib/__tests__/eval-sets.test.ts
@@ -11,6 +11,7 @@ import {
   displayRef,
   evalSetStatusLabel,
   inFlightCount,
+  matrixCellStateLabel,
   shortRef,
 } from "../eval-sets";
 
@@ -206,5 +207,7 @@ describe("displayRef / buildRefLabelMap", () => {
     expect(counts.queued).toBe(12);
     expect(comboRepeatLabel("pack/agent/3")).toBe("3");
     expect(evalSetStatusLabel("budget_exceeded")).toBe("Budget exceeded");
+    // scored = runs finished, not case-verdict pass
+    expect(matrixCellStateLabel("scored")).toBe("Complete");
   });
 });

--- a/web/src/lib/__tests__/eval-sets.test.ts
+++ b/web/src/lib/__tests__/eval-sets.test.ts
@@ -4,8 +4,14 @@ import type { GetEvalSetResponse } from "@/lib/api/types";
 import {
   agentRefFromMatrixKey,
   buildMatrixGrid,
+  buildRefLabelMap,
+  comboRepeatLabel,
   completionPercent,
+  countCellsByState,
+  displayRef,
+  evalSetStatusLabel,
   inFlightCount,
+  shortRef,
 } from "../eval-sets";
 
 function detailFixture(): GetEvalSetResponse {
@@ -130,5 +136,75 @@ describe("completionPercent / inFlightCount", () => {
     }
     expect(completionPercent(detail, live)).toBe(50);
     expect(inFlightCount(live)).toBe(1);
+  });
+});
+
+describe("displayRef / buildRefLabelMap", () => {
+  it("shortens UUIDs and keeps human names", () => {
+    expect(shortRef("code-exec-smoke")).toBe("code-exec-smoke");
+    expect(shortRef("037535f2-8b36-4ce0-9ee5-21a2984f5e47")).toBe(
+      "037535f2…4f5e47",
+    );
+  });
+
+  it("resolves deployment and pack version names", () => {
+    const detail = detailFixture();
+    detail.eval_set.expansion = {
+      combinations: [
+        {
+          matrix_key: "pv-1/dep-1/1",
+          pack_ref: "pv-1",
+          agent_ref: "dep-1",
+          agent_label: "From Manifest",
+          repeat: 1,
+        },
+      ],
+      count: 1,
+    };
+    const labels = buildRefLabelMap(
+      detail,
+      [
+        {
+          id: "dep-1",
+          organization_id: "o",
+          workspace_id: "w",
+          current_build_version_id: "bv",
+          name: "Gemini Flash",
+          status: "active",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+      [
+        {
+          id: "pack-1",
+          name: "Code Exec Smoke",
+          slug: "code-exec-smoke",
+          versions: [
+            {
+              id: "pv-1",
+              challenge_pack_id: "pack-1",
+              version_number: 2,
+              lifecycle_status: "runnable",
+              created_at: "",
+              updated_at: "",
+            },
+          ],
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+    );
+    // manifest agent_label wins over deployment name
+    expect(displayRef("dep-1", labels)).toBe("From Manifest");
+    expect(displayRef("pv-1", labels)).toBe("Code Exec Smoke v2");
+  });
+
+  it("counts cell states and formats helpers", () => {
+    const grid = buildMatrixGrid(detailFixture());
+    const counts = countCellsByState(grid);
+    expect(counts.queued).toBe(12);
+    expect(comboRepeatLabel("pack/agent/3")).toBe("3");
+    expect(evalSetStatusLabel("budget_exceeded")).toBe("Budget exceeded");
   });
 });

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2841,6 +2841,7 @@ export interface EvalSet {
       matrix_key: string;
       pack_ref: string;
       agent_ref: string;
+      agent_label?: string;
       model_ref?: string;
       repeat: number;
       status?: string;

--- a/web/src/lib/eval-sets.ts
+++ b/web/src/lib/eval-sets.ts
@@ -1,4 +1,8 @@
-import type { GetEvalSetResponse } from "@/lib/api/types";
+import type {
+  AgentDeployment,
+  ChallengePack,
+  GetEvalSetResponse,
+} from "@/lib/api/types";
 
 export type EvalSetStatus =
   | "queued"
@@ -235,4 +239,132 @@ export function inFlightCount(live?: LiveStatusMap): number {
     const s = v.status.toLowerCase();
     return s === "running" || s === "provisioning" || s === "scoring";
   }).length;
+}
+
+/** Map of pack_ref / agent_ref UUID → human label for matrix axes. */
+export type RefLabelMap = Record<string, string>;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isLikelyUUID(ref: string): boolean {
+  return UUID_RE.test(ref);
+}
+
+/** Truncate opaque refs only; leave short/human names intact. */
+export function shortRef(ref: string, max = 18): string {
+  if (ref.length <= max) return ref;
+  if (isLikelyUUID(ref)) {
+    return `${ref.slice(0, 8)}…${ref.slice(-6)}`;
+  }
+  return `${ref.slice(0, max - 1)}…`;
+}
+
+export function displayRef(ref: string, labels?: RefLabelMap | null): string {
+  const named = labels?.[ref]?.trim();
+  if (named) return named;
+  return shortRef(ref);
+}
+
+/**
+ * Build display names for matrix axes from workspace deployments/packs plus
+ * optional agent_label on expansion combinations.
+ */
+export function buildRefLabelMap(
+  detail: GetEvalSetResponse,
+  deployments?: AgentDeployment[] | null,
+  packs?: ChallengePack[] | null,
+): RefLabelMap {
+  const labels: RefLabelMap = {};
+
+  for (const d of deployments ?? []) {
+    if (d.id && d.name) labels[d.id] = d.name;
+  }
+
+  for (const pack of packs ?? []) {
+    const base = pack.name || pack.slug;
+    if (!base) continue;
+    for (const v of pack.versions ?? []) {
+      if (!v.id) continue;
+      labels[v.id] =
+        v.version_number != null ? `${base} v${v.version_number}` : base;
+    }
+  }
+
+  // Manifest agent_label wins over deployment name when authors set an axis label.
+  for (const c of detail.eval_set.expansion?.combinations ?? []) {
+    const agentLabel = c.agent_label?.trim();
+    if (agentLabel && c.agent_ref) {
+      labels[c.agent_ref] = agentLabel;
+    }
+  }
+
+  return labels;
+}
+
+export const MATRIX_CELL_STATES: MatrixCellState[] = [
+  "queued",
+  "running",
+  "scored",
+  "failed",
+];
+
+export function matrixCellStateLabel(state: MatrixCellState): string {
+  switch (state) {
+    case "queued":
+      return "Queued";
+    case "running":
+      return "Running";
+    case "scored":
+      return "Passed";
+    case "failed":
+      return "Failed";
+  }
+}
+
+export function countCellsByState(
+  grid: MatrixGrid,
+): Record<MatrixCellState, number> {
+  const counts: Record<MatrixCellState, number> = {
+    queued: 0,
+    running: 0,
+    scored: 0,
+    failed: 0,
+  };
+  for (const cell of Object.values(grid.cells)) {
+    counts[cell.state] += 1;
+  }
+  return counts;
+}
+
+/** Last `/N` segment of a matrix_key when it is a repeat index. */
+export function comboRepeatLabel(matrixKey: string): string {
+  const last = matrixKey.lastIndexOf("/");
+  if (last < 0) return "1";
+  const n = matrixKey.slice(last + 1);
+  return /^\d+$/.test(n) ? n : "1";
+}
+
+/** Friendly set-status copy for the detail header. */
+export function evalSetStatusLabel(status: string): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "expanding":
+      return "Expanding";
+    case "running":
+      return "Running";
+    case "aggregating":
+      return "Aggregating";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    case "budget_exceeded":
+      return "Budget exceeded";
+    default:
+      return status;
+  }
 }

--- a/web/src/lib/eval-sets.ts
+++ b/web/src/lib/eval-sets.ts
@@ -316,7 +316,8 @@ export function matrixCellStateLabel(state: MatrixCellState): string {
     case "running":
       return "Running";
     case "scored":
-      return "Passed";
+      // Execution finished (runs completed). Not an evaluation pass/fail verdict.
+      return "Complete";
     case "failed":
       return "Failed";
   }


### PR DESCRIPTION
## Summary
- Keep `agent_ref` as the deployment UUID in eval-set expansion and store optional `agent_label` for display; CLI no longer strips labels when resolving manifests.
- Matrix UI resolves pack versions and deployments to human names instead of truncated UUIDs.
- Redesign the eval-set detail matrix: status legend, cell progress bars, overall progress, richer cell detail panel, and friendlier case explorer columns.

## Test plan
- [ ] Open an existing eval set in the workspace UI and confirm axis headers show pack/agent names (not UUID stubs)
- [ ] Click a cell and confirm Agent/Pack labels, repeat list, and run links render cleanly
- [ ] Submit a new eval set with named deployments / labels and confirm `agent_label` appears in expansion JSON
- [ ] `cd runtime && go test ./evalset/`
- [ ] `cd web && pnpm exec vitest run src/lib/__tests__/eval-sets.test.ts`