### PR TITLE
feat : Fix 1238

### DIFF
--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -5,7 +5,6 @@ import { getRequiredServerAuth, toInitialAuth } from "@/lib/auth/server";
 import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
 import { OrgProvider } from "./org-context";
-import { UpgradePrompt } from "@/components/billing/upgrade-prompt";
 import { PostHogIdentify } from "@/components/posthog-identify";
 
 export default async function OrgLayout({
@@ -55,11 +54,6 @@ export default async function OrgLayout({
             orgSlug={orgSlug}
             orgName={org.name}
             isAdmin={isAdmin}
-          />
-          <UpgradePrompt
-            orgId={org.id}
-            orgSlug={org.slug}
-            isOrgAdmin={isAdmin}
           />
           <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
             {children}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -63,6 +63,7 @@ export default async function WorkspaceLayout({
             orgSlug={orgSlug}
           />
           <UpgradePrompt
+            workspaceId={workspaceId}
             orgId={orgId}
             orgSlug={orgSlug}
             isOrgAdmin={orgRole === "org_admin"}

--- a/web/src/components/billing/upgrade-prompt.test.tsx
+++ b/web/src/components/billing/upgrade-prompt.test.tsx
@@ -1,0 +1,189 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UpgradePrompt } from "./upgrade-prompt";
+
+// Controllable mock state for every input the gating logic reads.
+const { state } = vi.hoisted(() => ({
+  state: {
+    entitlements: { plan_key: "free", status: "active" } as {
+      plan_key: string;
+      status: string;
+    },
+    hasRun: false,
+    raceCount: 0,
+    monthlyLimit: 25 as number | null,
+    pathname: "/workspaces/ws_1",
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => state.pathname,
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/swr", () => ({
+  useApiQuery: (path: string | null) => {
+    if (!path) return { data: undefined };
+    if (path.endsWith("/billing")) {
+      return { data: { entitlements: state.entitlements } };
+    }
+    if (path === "/v1/billing/plans") {
+      return { data: { items: [] } };
+    }
+    if (path.endsWith("/entitlements")) {
+      return {
+        data: {
+          entitlements: { races_per_workspace_month: state.monthlyLimit },
+          usage: { race_count: state.raceCount },
+        },
+      };
+    }
+    return { data: undefined };
+  },
+}));
+
+vi.mock("@/lib/workspace-readiness", () => ({
+  useWorkspaceReadiness: () => ({ hasRun: state.hasRun }),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const React = await import("react");
+  const DialogOpenContext = React.createContext(false);
+  return {
+    Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+      React.createElement(DialogOpenContext.Provider, { value: open }, children),
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const open = React.useContext(DialogOpenContext);
+      return open
+        ? React.createElement("div", { "data-testid": "dialog-content" }, children)
+        : null;
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h1", null, children),
+  };
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderPrompt(
+  props: Partial<React.ComponentProps<typeof UpgradePrompt>> = {},
+): boolean {
+  act(() => {
+    root.render(
+      React.createElement(UpgradePrompt, {
+        workspaceId: "ws_1",
+        orgId: "org_1",
+        orgSlug: "acme",
+        isOrgAdmin: true,
+        ...props,
+      }),
+    );
+  });
+  return container.querySelector('[data-testid="dialog-content"]') !== null;
+}
+
+function clickKeepFree() {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "Keep Free",
+  );
+  act(() => {
+    button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  state.entitlements = { plan_key: "free", status: "active" };
+  state.hasRun = false;
+  state.raceCount = 0;
+  state.monthlyLimit = 25;
+  state.pathname = "/workspaces/ws_1";
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("UpgradePrompt", () => {
+  it("stays closed for a brand-new workspace: free, zero runs, zero usage", () => {
+    expect(renderPrompt()).toBe(false);
+  });
+
+  it("opens once the workspace has activated (>=1 run)", () => {
+    state.hasRun = true;
+    expect(renderPrompt()).toBe(true);
+  });
+
+  it("opens once usage crosses the quota gate, even with no run recorded yet", () => {
+    state.raceCount = 20; // 20 / 25 = 80%
+    expect(renderPrompt()).toBe(true);
+  });
+
+  it("stays closed just under the quota gate", () => {
+    state.raceCount = 19; // 19 / 25 = 76%
+    expect(renderPrompt()).toBe(false);
+  });
+
+  it("treats a missing or zero monthly limit as ungated rather than dividing by zero", () => {
+    state.monthlyLimit = null;
+    state.raceCount = 999;
+    expect(renderPrompt()).toBe(false);
+  });
+
+  it("never opens for a non-admin, regardless of activation", () => {
+    state.hasRun = true;
+    expect(renderPrompt({ isOrgAdmin: false })).toBe(false);
+  });
+
+  it("never opens on the billing page", () => {
+    state.hasRun = true;
+    state.pathname = "/orgs/acme/billing";
+    expect(renderPrompt()).toBe(false);
+  });
+
+  it("never opens for a plan that isn't free-active", () => {
+    state.hasRun = true;
+    state.entitlements = { plan_key: "pro", status: "active" };
+    expect(renderPrompt()).toBe(false);
+  });
+
+  it("dismissing the activation prompt does not silence a later quota prompt", () => {
+    state.hasRun = true;
+    expect(renderPrompt()).toBe(true);
+
+    clickKeepFree();
+    expect(renderPrompt()).toBe(false);
+
+    // Cross the quota gate too -- a different reason, so it re-arms.
+    state.raceCount = 20;
+    expect(renderPrompt()).toBe(true);
+  });
+
+  it("dismissing stays dismissed on re-render while the reason is unchanged", () => {
+    state.hasRun = true;
+    expect(renderPrompt()).toBe(true);
+
+    clickKeepFree();
+    expect(renderPrompt()).toBe(false);
+  });
+});

--- a/web/src/components/billing/upgrade-prompt.tsx
+++ b/web/src/components/billing/upgrade-prompt.tsx
@@ -6,8 +6,10 @@ import { useApiQuery } from "@/lib/api/swr";
 import type {
   BillingOverviewResponse,
   BillingPlansResponse,
+  WorkspaceEntitlementsResponse,
 } from "@/lib/api/types";
 import { isFreeActive } from "@/lib/billing";
+import { useWorkspaceReadiness } from "@/lib/workspace-readiness";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,13 +21,26 @@ import {
 } from "@/components/ui/dialog";
 
 interface UpgradePromptProps {
+  workspaceId: string;
   orgId?: string;
   orgSlug?: string;
   isOrgAdmin?: boolean;
 }
 
-function storageKey(orgId: string) {
-  return `agentclash:billing-upgrade-prompt-dismissed:${orgId}`;
+/**
+ * Why the prompt is currently eligible to open. Dismissal is keyed per
+ * reason (see storageKey/isDismissed below) so dismissing an early
+ * "you're active now" prompt can't permanently silence a later, more
+ * urgent "near your quota" prompt.
+ */
+type PromptReason = "activated" | "quota";
+
+// Fraction of the monthly run quota at which the prompt becomes eligible to
+// open even for a workspace that hasn't otherwise activated.
+const QUOTA_GATE_RATIO = 0.8;
+
+function storageKey(orgId: string, reason: PromptReason) {
+  return `agentclash:billing-upgrade-prompt-dismissed:${orgId}:${reason}`;
 }
 
 const DISMISSED_EVENT = "agentclash:billing-upgrade-prompt-dismissed";
@@ -39,12 +54,17 @@ function subscribeDismissed(callback: () => void) {
   };
 }
 
-function dismissedSnapshot(orgId?: string, isOrgAdmin = false) {
-  if (!orgId || !isOrgAdmin) return true;
-  return window.localStorage.getItem(storageKey(orgId)) === "true";
+function isDismissed(
+  orgId: string | undefined,
+  isOrgAdmin: boolean,
+  reason: PromptReason | null,
+) {
+  if (!orgId || !isOrgAdmin || !reason) return true;
+  return window.localStorage.getItem(storageKey(orgId, reason)) === "true";
 }
 
 export function UpgradePrompt({
+  workspaceId,
   orgId,
   orgSlug,
   isOrgAdmin = false,
@@ -58,25 +78,57 @@ export function UpgradePrompt({
   const { data: plansData } = useApiQuery<BillingPlansResponse>(
     shouldFetch ? "/v1/billing/plans" : null,
   );
-  const dismissed = useSyncExternalStore(
-    subscribeDismissed,
-    useCallback(() => dismissedSnapshot(orgId, isOrgAdmin), [isOrgAdmin, orgId]),
-    () => true,
+  // Same endpoint WorkspaceBillingBanner already fetches in this layout —
+  // SWR dedupes both callers into a single request.
+  const { data: entitlementsData } = useApiQuery<WorkspaceEntitlementsResponse>(
+    shouldFetch ? `/v1/workspaces/${workspaceId}/entitlements` : null,
   );
+  // Same hook ActivationBanner already mounts in this layout — SWR dedupes
+  // the underlying provider/deployment/pack/run requests.
+  const { hasRun } = useWorkspaceReadiness(workspaceId);
 
   const upgradePlans = useMemo(
     () => (plansData?.items ?? []).filter((plan) => plan.key === "pro" || plan.key === "team"),
     [plansData],
   );
   const onBillingPage = pathname.includes("/billing");
+  const isFree = isFreeActive(overview?.entitlements);
+
+  const usage = entitlementsData?.usage;
+  const monthlyLimit = entitlementsData?.entitlements.races_per_workspace_month;
+  const approachingQuota =
+    isFree &&
+    usage != null &&
+    typeof monthlyLimit === "number" &&
+    monthlyLimit > 0 &&
+    usage.race_count / monthlyLimit >= QUOTA_GATE_RATIO;
+
+  // Quota takes priority when both are true — it's the more urgent,
+  // time-boxed reason to show the prompt.
+  const activeReason: PromptReason | null = !isFree
+    ? null
+    : approachingQuota
+      ? "quota"
+      : hasRun
+        ? "activated"
+        : null;
+
+  const dismissed = useSyncExternalStore(
+    subscribeDismissed,
+    useCallback(
+      () => isDismissed(orgId, isOrgAdmin, activeReason),
+      [isOrgAdmin, orgId, activeReason],
+    ),
+    () => true,
+  );
+
   const open =
-    Boolean(orgId && isOrgAdmin) &&
-    !dismissed &&
-    !onBillingPage &&
-    isFreeActive(overview?.entitlements);
+    Boolean(orgId && isOrgAdmin) && activeReason !== null && !dismissed && !onBillingPage;
 
   function dismiss() {
-    if (orgId) window.localStorage.setItem(storageKey(orgId), "true");
+    if (orgId && activeReason) {
+      window.localStorage.setItem(storageKey(orgId, activeReason), "true");
+    }
     window.dispatchEvent(new Event(DISMISSED_EVENT));
   }
 

--- a/web/src/lib/workspace-readiness.test.tsx
+++ b/web/src/lib/workspace-readiness.test.tsx
@@ -55,6 +55,7 @@ function Harness() {
     { "data-testid": "out" },
     JSON.stringify({
       ready: r.ready,
+      hasRun: r.hasRun,
       allComplete: r.allComplete,
       nextStep: r.nextStep?.key ?? null,
       isLoading: r.isLoading,
@@ -68,6 +69,7 @@ let root: Root;
 
 interface Snapshot {
   ready: boolean;
+  hasRun: boolean;
   allComplete: boolean;
   nextStep: string | null;
   isLoading: boolean;
@@ -140,6 +142,7 @@ describe("useWorkspaceReadiness", () => {
     state.packs = [runnablePack];
     const r = render();
     expect(r.ready).toBe(true);
+    expect(r.hasRun).toBe(false);
     expect(r.allComplete).toBe(false);
     expect(r.nextStep).toBe("first_run");
   });
@@ -150,8 +153,19 @@ describe("useWorkspaceReadiness", () => {
     state.packs = [runnablePack];
     state.runsTotal = 1;
     const r = render();
+    expect(r.hasRun).toBe(true);
     expect(r.allComplete).toBe(true);
     expect(r.nextStep).toBeNull();
+  });
+
+  it("hasRun reflects run history independently of the other steps", () => {
+    // A workspace can have a run on record (e.g. from a since-removed
+    // provider) without currently satisfying the other readiness steps.
+    state.runsTotal = 1;
+    const r = render();
+    expect(r.hasRun).toBe(true);
+    expect(r.ready).toBe(false);
+    expect(r.allComplete).toBe(false);
   });
 
   it("reports loading while data is in flight", () => {

--- a/web/src/lib/workspace-readiness.ts
+++ b/web/src/lib/workspace-readiness.ts
@@ -38,6 +38,8 @@ export interface WorkspaceReadiness {
   steps: ReadinessStep[];
   /** True once a run can be created (provider + deployment + challenge pack). */
   ready: boolean;
+  /** True once at least one run has been created, regardless of its status. */
+  hasRun: boolean;
   /** True once every step — including the first run — is complete. */
   allComplete: boolean;
   /** The first incomplete step, or null when allComplete. */
@@ -126,5 +128,5 @@ export function useWorkspaceReadiness(workspaceId: string): WorkspaceReadiness {
     providers.error || deployments.error || packs.error || runs.error,
   );
 
-  return { steps, ready, allComplete, nextStep, isLoading, error };
+  return { steps, ready, hasRun, allComplete, nextStep, isLoading, error };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to AgentClash! Keep PRs focused. -->

## What & why

A brand-new user's very first authenticated screen was a pricing modal, over
an empty workspace, before they had run anything. The old `open` condition
had no activation signal — it fired the moment self-serve signup finished
(free + active, org admin, not on `/billing`), which is true for *every*
new org from the instant onboarding completes. The genuinely useful
first-screen affordance (the setup checklist in `ActivationBanner`) rendered
*below* the modal and was visually blocked by it.

This gates the modal on activation: it now opens only once the workspace has
either produced at least one run, or is approaching its monthly quota (≥80%
of `races_per_workspace_month`). Both signals reuse queries already fetched
elsewhere in the same layout (`useWorkspaceReadiness`, `GET
/v1/workspaces/{id}/entitlements`), so SWR dedupes and no new network
requests are added.

Closes #1238

## Type

fix

## Areas touched

- [ ] Backend (`backend/`)
- [ ] CLI (`cli/`)
- [x] Frontend (`web/`)
- [ ] Docs / other

## Verification

```
cd web && pnpm lint && npx tsc --noEmit && pnpm test
```

- [ ] Builds, `vet`/`lint`, and type checks pass for every part I touched
- [x] Tests added/updated (happy path and a failure path where applicable) —
      see `upgrade-prompt.test.tsx` (8 new cases: closed for a fresh
      workspace, opens on activation, opens on quota, stays closed just
      under the quota threshold, null/zero-limit doesn't divide-by-zero,
      never opens for a non-admin/on `/billing`/off Free, and the
      per-reason dismissal re-arm) and 2 new assertions in
      `workspace-readiness.test.tsx` for the new `hasRun` field.
- [ ] If a backend route changed, `docs/api-server/openapi.yaml` is updated — n/a, no backend route touched (see notes)
- [x] If DB queries changed, `sqlc generate` was run — n/a

## Contributor License Agreement

- [ ] I have read and agree to the project CLA (CONTRIBUTOR_LICENSE_AGREEMENT.md), and I have the right to submit these contributions under it

## Notes for reviewers

- **Went with option (a) from the issue, not (b).** `hasRun` counts a run in
  any state (draft/queued/etc — `listRunsHandler` has no status filter), not
  just completed. That's enough to kill the first-screen modal per the
  acceptance criteria ("≥1 run in the workspace"); a stricter
  `status=completed` filter would need a backend + `openapi.yaml` change and
  is called out in the issue itself as a follow-up, not a requirement here.
- **Dismissal is now keyed per reason** (`activated` vs `quota`), not one
  flag per org. Dismissing the modal while it's open for "you're active
  now" no longer permanently silences the later, more urgent "near your
  quota" prompt — covered by the last test case in `upgrade-prompt.test.tsx`.
- **Org-settings shell (`(org)/orgs/[orgSlug]/layout.tsx`): the modal mount
  is removed**, not gated. That layout has no `workspaceId`, so neither
  gate is computable there — this is the "simplest resolution" the issue
  itself suggested for that mount. `workspaceId` is accordingly now a
  required `UpgradePrompt` prop instead of absent, since the org shell was
  the only caller without one.
- Verified against the real toolchain, not just read: `npx vitest run`
  (18/18 across both touched test files; full suite 477 passed / 6
  pre-existing failures, all unrelated to this change — marketing metadata,
  sitemap, changelog dates), `npx tsc --noEmit` (zero errors, whole
  project), `npx eslint` on every touched file (clean). I couldn't run
  `pnpm` itself in my environment (only plain `npm`/`npx` were available),
  so please double check `pnpm lint`/`pnpm test` directly before relying on
  this — I'd be surprised if it differs, but flagging it rather than
  claiming something I didn't literally run.