### PR TITLE
feat : Resolve Issue # 1242

### DIFF
--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -22,6 +22,7 @@ import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block"
 import { TrackBox } from "@/components/marketing/track-box";
 import { AgentPromoBanner } from "@/components/marketing/agent-promo-banner";
 import { MatrixMark } from "@/components/marketing/matrix-mark";
+import { CURATED_REPLAY_SHARE_URL } from "@/lib/curated-replay";
 import { COMPARISON_COLUMNS, COMPARISON_ROWS } from "@/lib/comparison-data";
 import { HOME_FAQ } from "@/lib/home-faq";
 
@@ -1607,6 +1608,17 @@ export default function HomePage({
               the tool it called, the state it worked from. Debug production
               issues with a full replay, not a log dump.
             </p>
+            {CURATED_REPLAY_SHARE_URL && (
+              <a
+                href={CURATED_REPLAY_SHARE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-6 inline-flex items-center gap-1.5 text-sm text-white/55 transition-colors hover:text-white/85"
+              >
+                See a real replay
+                <ArrowRight className="size-3.5" />
+              </a>
+            )}
           </div>
           <div>
             <LightFlowArrows />

--- a/web/src/lib/curated-replay.test.ts
+++ b/web/src/lib/curated-replay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { CURATED_REPLAY_SHARE_URL } from "./curated-replay";
+
+describe("CURATED_REPLAY_SHARE_URL", () => {
+  it("starts unset -- no share token can be minted from a PR (see #1242)", () => {
+    // If this ever fails because someone filled in a real token, that's
+    // expected and this assertion should be updated/removed at the same
+    // time the landing page link is verified against production.
+    expect(CURATED_REPLAY_SHARE_URL).toBeNull();
+  });
+
+  it("is shaped like a /share/ path whenever it is set", () => {
+    if (CURATED_REPLAY_SHARE_URL === null) return;
+    expect(CURATED_REPLAY_SHARE_URL).toMatch(/\/share\//);
+  });
+});

--- a/web/src/lib/curated-replay.ts
+++ b/web/src/lib/curated-replay.ts
@@ -1,0 +1,30 @@
+/**
+ * Curated public replay linked from the landing page and (separately) the
+ * benchmark report frontmatter, as zero-signup proof of the product.
+ * See: https://github.com/agentclash/agentclash/issues/1242
+ *
+ * This is deliberately `null` until a maintainer completes the *manual*,
+ * non-code half of #1242 -- there is no API or CLI path to mint a share
+ * token, so this cannot be filled in from a PR alone:
+ *
+ *   1. Run a real eval (the Expression Evaluator Arena benchmark run is the
+ *      obvious candidate -- it already has a published narrative) and open
+ *      the winning agent's replay.
+ *   2. Click Share. Leave the expiry unset (a UI-minted share never
+ *      expires) and decide once whether to mint with
+ *      `search_indexing: true` -- doing so also requires a robots.ts
+ *      carve-out, since "/share/" is currently disallowed for every
+ *      crawler. See the "indexing" acceptance criterion on #1242.
+ *   3. Set CURATED_REPLAY_SHARE_URL below to that share URL. Afterwards,
+ *      never revoke or re-share the same replay:
+ *      public_share_links_active_resource_unique means doing so mints a
+ *      *new* token, silently breaking this link.
+ *   4. Separately, set `runShareUrl` in
+ *      web/content/benchmarks/gpt-generations-expression-evaluator.mdx to
+ *      the same URL -- that page already renders a link the moment the
+ *      field is non-empty, no code change needed there.
+ *
+ * Every consumer must treat this as possibly null and render nothing (not
+ * a broken link) until it is set -- see the usage in landing.tsx.
+ */
+export const CURATED_REPLAY_SHARE_URL: string | null = null;


### PR DESCRIPTION
<!-- Thanks for contributing to AgentClash! Keep PRs focused. -->

## ⚠️ Draft / partial — needs a maintainer before this closes anything

**This PR does not satisfy #1242's acceptance criteria on its own and I'm
not asking to merge it as a fix.** Minting the actual share link requires
authenticating to production, running a real eval, and clicking Share
(`backend/internal/api/public_shares.go:92-122` — there's no API/CLI mint
path). I don't have production access, and I'm not going to paste in a
fake token pretending it's real. What follows is the code half only —
opening this as a draft so the wiring is ready the moment someone with
access completes the other half. **A maintainer needs to do that part; see
"Notes for reviewers" below for exactly what.**

## What & why

Adds a `CURATED_REPLAY_SHARE_URL` constant (currently `null`) and wires a
conditional "See a real replay" link into the landing page's Replay
section. The link renders nothing until the constant is set, so this is
safe to merge as-is without shipping a broken link — but it also means
merging this alone doesn't add the visible link #1242 asks for.

Refs #1242 (does not close it)

## Type

chore

## Areas touched

- [ ] Backend (`backend/`)
- [ ] CLI (`cli/`)
- [x] Frontend (`web/`)
- [ ] Docs / other

## Verification

```
cd web && pnpm lint && npx tsc --noEmit && pnpm test
```

- [ ] Builds, `vet`/`lint`, and type checks pass for every part I touched
- [x] Tests added/updated — `curated-replay.test.ts`: documents the
      constant starts `null`, and guards its shape once it's set.
- [ ] If a backend route changed — n/a, no backend touched
- [ ] If DB queries changed — n/a

## Contributor License Agreement

- [ ] I have read and agree to the project CLA (CONTRIBUTOR_LICENSE_AGREEMENT.md), and I have the right to submit these contributions under it

## Notes for reviewers

**To actually finish #1242, a maintainer needs to:**

1. Run a real eval (issue suggests the Expression Evaluator Arena
   benchmark run — it already has a published narrative) and open the
   winning agent's replay.
2. Click Share. Leave expiry unset (a UI-minted share never expires).
   Decide once whether to mint with `search_indexing: true` — that also
   needs a `robots.ts` carve-out since `/share/` is currently disallowed
   for every crawler (see the "indexing" acceptance criterion on #1242).
3. Set `CURATED_REPLAY_SHARE_URL` in `web/src/lib/curated-replay.ts` to
   that URL. **Never revoke or re-share the same replay afterwards** —
   `public_share_links_active_resource_unique` means doing so mints a
   *new* token and silently breaks this link.
4. Separately, set `runShareUrl` in
   `web/content/benchmarks/gpt-generations-expression-evaluator.mdx` to
   the same URL — `web/src/app/benchmarks/[slug]/page.tsx:118-128`
   already renders that link the moment the field is non-empty, so I
   deliberately left that file and the MDX frontmatter untouched rather
   than filling in a value I can't verify.
5. Load the share URL in a clean, logged-out browser profile against
   **production** and confirm it renders the timeline (per the issue's
   own acceptance criteria — this can't be verified locally).

I'd rather hand you a smaller, honestly-scoped PR than a bigger one that
quietly doesn't do what it claims. Happy to also just close this without
merging if you'd rather land the real link and the code wiring in the
same maintainer-authored commit — I don't have a strong preference.