### PR TITLE
feat: promote agent tryouts into editable pack drafts

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -167,7 +167,7 @@ func main() {
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	challengePackBuilderManager := api.NewChallengePackBuilderManager(authorizer, repo, challengePackAuthoringManager)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL).WithArtifactSigner(artifactManager)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithInputAttachmentStore(artifactStore, cfg.ArtifactMaxUploadBytes).WithPublicJudgeModels(cfg.AgentTryoutJudgeModels).WithQuota(api.AgentTryoutQuotaConfig{
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithInputAttachmentStore(artifactStore, cfg.ArtifactMaxUploadBytes).WithPublicJudgeModels(cfg.AgentTryoutJudgeModels).WithPackDraftBuilder(challengePackBuilderManager).WithQuota(api.AgentTryoutQuotaConfig{
 		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
 		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,
 		HostedDailySpendCapUSD:    cfg.AgentTryoutHostedDailySpendCapUSD,

--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/challengepack"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -280,18 +281,36 @@ type PromoteAgentTryoutInput struct {
 	Title          string
 }
 
-// AgentTryoutPromotionResult references the durable workspace draft a promotion
-// produced.
+// AgentTryoutPromotionResult references the challenge-pack draft a promotion
+// produced. DraftID is a challenge_pack_drafts row, editable in the visual pack
+// builder at /workspaces/{workspace_id}/challenge-packs/builder/{draft_id}.
 type AgentTryoutPromotionResult struct {
-	Target         string    `json:"target"`
-	ConversationID uuid.UUID `json:"conversation_id"`
-	DraftID        uuid.UUID `json:"draft_id"`
+	Target      string    `json:"target"`
+	WorkspaceID uuid.UUID `json:"workspace_id"`
+	DraftID     uuid.UUID `json:"draft_id"`
 }
 
-// PromoteTryoutToEval converts a completed workspace tryout into a durable
-// Vibe Eval draft, preserving its template/input/tool-policy/evaluation-spec and
-// the template's expected artifacts so the eval can be run again later. v1
-// supports only the "vibe_eval" target.
+// AgentTryoutPackDraftCreator creates the challenge-pack draft a promotion
+// lands in. It is ChallengePackBuilderService narrowed to the single method
+// promotion needs, so promotion reuses the builder's authorization, validation,
+// and compile/publish path instead of forking a second draft model.
+type AgentTryoutPackDraftCreator interface {
+	CreateDraft(ctx context.Context, caller Caller, input CreateDraftInput) (repository.ChallengePackDraft, error)
+}
+
+// WithPackDraftBuilder attaches the challenge-pack builder that promotions
+// write into. Without it, promotion reports itself unavailable rather than
+// writing a draft nothing can read.
+func (m *AgentTryoutManager) WithPackDraftBuilder(builder AgentTryoutPackDraftCreator) *AgentTryoutManager {
+	m.packDrafts = builder
+	return m
+}
+
+// PromoteTryoutToEval converts a completed workspace tryout into an editable
+// challenge-pack draft: its template, input, tool policy, expected artifacts,
+// judges, and budget become a pack composition the author refines in the visual
+// builder, then compiles, publishes, and runs through the existing pack paths.
+// v1 supports only the "vibe_eval" target.
 func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Caller, input PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error) {
 	target := strings.TrimSpace(input.Target)
 	if target == "" {
@@ -299,6 +318,9 @@ func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Cal
 	}
 	if target != "vibe_eval" {
 		return AgentTryoutPromotionResult{}, fmt.Errorf("%w: %q", ErrAgentTryoutPromotionTargetUnsupported, target)
+	}
+	if m.packDrafts == nil {
+		return AgentTryoutPromotionResult{}, ErrAgentTryoutPromotionUnavailable
 	}
 
 	source, err := m.repo.GetAgentTryoutByID(ctx, input.SourceTryoutID)
@@ -318,86 +340,30 @@ func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Cal
 		return AgentTryoutPromotionResult{}, fmt.Errorf("%w: status %q", ErrAgentTryoutNotPromotable, source.Status)
 	}
 
-	content, err := promotionDraftContent(source)
+	packName, composition, err := agentTryoutPackDraft(source)
 	if err != nil {
 		return AgentTryoutPromotionResult{}, err
 	}
 
-	title := strings.TrimSpace(input.Title)
-	if title == "" {
-		title = fmt.Sprintf("Tryout: %s", source.TemplateSlug)
+	name := strings.TrimSpace(input.Title)
+	if name == "" {
+		name = firstNonEmpty(packName, "Tryout: "+source.TemplateSlug)
 	}
-	conversation, err := m.repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
-		OrganizationID:  *source.OrganizationID,
-		WorkspaceID:     *source.WorkspaceID,
-		CreatedByUserID: caller.UserID,
-		Title:           title,
-		Phase:           "plan",
-		Status:          "active",
+
+	// CreateDraft re-authorizes the caller for publish_challenge_pack: a
+	// promotion produces a publishable pack, so it must clear the same bar as
+	// authoring one by hand.
+	draft, err := m.packDrafts.CreateDraft(ctx, caller, CreateDraftInput{
+		WorkspaceID:   *source.WorkspaceID,
+		Name:          name,
+		ExecutionMode: challengepack.ExecutionModeNative,
+		Composition:   composition,
+		CreatedBy:     caller.UserID,
 	})
 	if err != nil {
 		return AgentTryoutPromotionResult{}, err
 	}
-
-	draft, err := m.repo.CreateVibeEvalDraft(ctx, repository.CreateVibeEvalDraftParams{
-		OrganizationID:   *source.OrganizationID,
-		WorkspaceID:      *source.WorkspaceID,
-		ConversationID:   conversation.ID,
-		DraftKind:        "eval_plan",
-		Content:          content,
-		ValidationState:  "unknown",
-		ValidationErrors: json.RawMessage(`[]`),
-		CreatedByUserID:  caller.UserID,
-		UpdatedByUserID:  caller.UserID,
-	})
-	if err != nil {
-		return AgentTryoutPromotionResult{}, err
-	}
-	return AgentTryoutPromotionResult{Target: target, ConversationID: conversation.ID, DraftID: draft.ID}, nil
-}
-
-// promotionDraftContent packs a tryout's reusable definition into a Vibe Eval
-// draft body. It includes only the durable, workspace-owned definition (no run
-// ids, costs, or identifiers) so the draft is a clean starting point for a
-// repeatable eval.
-func promotionDraftContent(source repository.AgentTryout) (json.RawMessage, error) {
-	body := map[string]any{
-		"kind":                     "agent_tryout_promotion",
-		"source_tryout_id":         source.ID.String(),
-		"template_slug":            source.TemplateSlug,
-		"input_snapshot":           rawOrNull(source.InputSnapshot),
-		"tool_policy_snapshot":     rawOrNull(source.ToolPolicySnapshot),
-		"evaluation_spec_snapshot": rawOrNull(source.EvaluationSpecSnapshot),
-		"expected_artifacts":       templateExpectedArtifacts(source.TemplateSnapshot),
-	}
-	encoded, err := json.Marshal(body)
-	if err != nil {
-		// Surface the failure instead of persisting an empty draft + false 201.
-		return nil, fmt.Errorf("marshal promotion draft content: %w", err)
-	}
-	return encoded, nil
-}
-
-// templateExpectedArtifacts extracts runtime.expected_artifacts from a stored
-// template snapshot so the promoted eval records the expected outputs. Returns
-// an empty slice when none are declared.
-func templateExpectedArtifacts(templateSnapshot json.RawMessage) []map[string]any {
-	out := []map[string]any{}
-	if len(templateSnapshot) == 0 {
-		return out
-	}
-	var snapshot struct {
-		Runtime struct {
-			ExpectedArtifacts []map[string]any `json:"expected_artifacts"`
-		} `json:"runtime"`
-	}
-	if err := json.Unmarshal(templateSnapshot, &snapshot); err != nil {
-		return out
-	}
-	if snapshot.Runtime.ExpectedArtifacts != nil {
-		return snapshot.Runtime.ExpectedArtifacts
-	}
-	return out
+	return AgentTryoutPromotionResult{Target: target, WorkspaceID: draft.WorkspaceID, DraftID: draft.ID}, nil
 }
 
 // --- HTTP handlers ---
@@ -608,11 +574,4 @@ func cloneRawJSON(raw json.RawMessage) json.RawMessage {
 	cloned := make(json.RawMessage, len(raw))
 	copy(cloned, raw)
 	return cloned
-}
-
-func rawOrNull(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return json.RawMessage(`null`)
-	}
-	return raw
 }

--- a/backend/internal/api/agent_tryout_conversions_test.go
+++ b/backend/internal/api/agent_tryout_conversions_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/challengepack"
 	"github.com/google/uuid"
 )
 
@@ -300,7 +301,7 @@ func TestAgentTryoutPromoteRejectsNonCompleted(t *testing.T) {
 	running := repo.tryouts[source.ID]
 	running.Status = repository.AgentTryoutStatusRunning
 	repo.tryouts[source.ID] = running
-	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithPackDraftBuilder(&fakePackDraftCreator{})
 
 	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{SourceTryoutID: source.ID, Target: "vibe_eval"}); !errors.Is(err, ErrAgentTryoutNotPromotable) {
 		t.Fatalf("error = %v, want ErrAgentTryoutNotPromotable", err)
@@ -326,12 +327,37 @@ func TestAgentTryoutCompareRejectsCrossWorkspace(t *testing.T) {
 	}
 }
 
-func TestAgentTryoutPromoteCreatesVibeEvalDraft(t *testing.T) {
+// fakePackDraftCreator stands in for ChallengePackBuilderManager, recording the
+// draft a promotion asks the builder to create.
+type fakePackDraftCreator struct {
+	err      error
+	received CreateDraftInput
+	calls    int
+}
+
+func (f *fakePackDraftCreator) CreateDraft(_ context.Context, _ Caller, input CreateDraftInput) (repository.ChallengePackDraft, error) {
+	f.calls++
+	f.received = input
+	if f.err != nil {
+		return repository.ChallengePackDraft{}, f.err
+	}
+	return repository.ChallengePackDraft{
+		ID:            uuid.New(),
+		WorkspaceID:   input.WorkspaceID,
+		Name:          input.Name,
+		ExecutionMode: input.ExecutionMode,
+		Composition:   input.Composition,
+		Status:        "draft",
+	}, nil
+}
+
+func TestAgentTryoutPromoteCreatesChallengePackDraft(t *testing.T) {
 	ctx := context.Background()
 	orgID, workspaceID := uuid.New(), uuid.New()
 	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
 	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
-	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	builder := &fakePackDraftCreator{}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithPackDraftBuilder(builder)
 
 	result, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{
 		SourceTryoutID: source.ID,
@@ -340,17 +366,76 @@ func TestAgentTryoutPromoteCreatesVibeEvalDraft(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PromoteTryoutToEval returned error: %v", err)
 	}
-	if result.Target != "vibe_eval" || result.ConversationID == uuid.Nil || result.DraftID == uuid.Nil {
+	if result.Target != "vibe_eval" || result.DraftID == uuid.Nil {
 		t.Fatalf("unexpected promotion result: %+v", result)
 	}
-	if repo.createdDraft.DraftKind != "eval_plan" {
-		t.Fatalf("draft kind = %q, want eval_plan", repo.createdDraft.DraftKind)
+	if result.WorkspaceID != workspaceID {
+		t.Fatalf("result workspace = %s, want %s", result.WorkspaceID, workspaceID)
 	}
-	content := string(repo.createdDraft.Content)
-	for _, want := range []string{source.ID.String(), "tiny-bugfix", "expected_artifacts", "changes.patch", "evaluation_spec_snapshot"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("promotion draft content missing %q: %s", want, content)
+	if builder.calls != 1 {
+		t.Fatalf("builder CreateDraft calls = %d, want 1", builder.calls)
+	}
+	if builder.received.WorkspaceID != workspaceID {
+		t.Fatalf("draft workspace = %s, want %s", builder.received.WorkspaceID, workspaceID)
+	}
+	if builder.received.ExecutionMode != challengepack.ExecutionModeNative {
+		t.Fatalf("draft execution mode = %q, want native", builder.received.ExecutionMode)
+	}
+	if builder.received.FromChallengePackVersionID != nil {
+		t.Fatalf("promotion must not hydrate from a published version")
+	}
+
+	// The composition the builder stored must be the one the builder can
+	// compile and publish — assert it round-trips all the way to the YAML
+	// publish path, not just that it decodes.
+	var composition challengepack.Composition
+	if err := json.Unmarshal(builder.received.Composition, &composition); err != nil {
+		t.Fatalf("decode stored composition: %v", err)
+	}
+	bundle, err := challengepack.ComposeBundle(composition, challengepack.ResolvedPieces{})
+	if err != nil {
+		t.Fatalf("ComposeBundle on promoted draft: %v", err)
+	}
+	if err := challengepack.ValidateBundle(bundle); err != nil {
+		t.Fatalf("promoted draft does not compile: %v", err)
+	}
+	yamlBytes, err := challengepack.BundleYAML(bundle)
+	if err != nil {
+		t.Fatalf("BundleYAML on promoted draft: %v", err)
+	}
+	if _, err := challengepack.ParseYAML(yamlBytes); err != nil {
+		t.Fatalf("promoted draft does not publish: %v", err)
+	}
+
+	for _, want := range []string{"tiny-bugfix", "changes.patch", "fix a nil check"} {
+		if !strings.Contains(string(builder.received.Composition), want) {
+			t.Fatalf("composition missing %q: %s", want, builder.received.Composition)
 		}
+	}
+}
+
+func TestAgentTryoutPromoteReportsUnavailableWithoutBuilder(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{SourceTryoutID: source.ID}); !errors.Is(err, ErrAgentTryoutPromotionUnavailable) {
+		t.Fatalf("error = %v, want ErrAgentTryoutPromotionUnavailable", err)
+	}
+}
+
+func TestAgentTryoutPromotePropagatesBuilderAuthorization(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	builder := &fakePackDraftCreator{err: ErrForbidden}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithPackDraftBuilder(builder)
+
+	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{SourceTryoutID: source.ID}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("error = %v, want ErrForbidden", err)
 	}
 }
 
@@ -371,7 +456,7 @@ func TestAgentTryoutPromoteRejectsAnonymousSource(t *testing.T) {
 	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
 	id := uuid.New()
 	repo.tryouts[id] = repository.AgentTryout{ID: id, TemplateSlug: "tiny-bugfix"}
-	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithPackDraftBuilder(&fakePackDraftCreator{})
 
 	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(uuid.New()), PromoteAgentTryoutInput{SourceTryoutID: id, Target: "vibe_eval"}); !errors.Is(err, ErrAgentTryoutSignInRequired) {
 		t.Fatalf("error = %v, want ErrAgentTryoutSignInRequired", err)

--- a/backend/internal/api/agent_tryout_pack_composition.go
+++ b/backend/internal/api/agent_tryout_pack_composition.go
@@ -93,9 +93,47 @@ func agentTryoutPackDraft(source repository.AgentTryout) (string, json.RawMessag
 // agentTryoutPackBundle assembles the runnable-pack shape a tryout implies. It
 // is intentionally total — a sparse tryout yields a thin but still valid pack
 // rather than an error, so promotion never dead-ends on a missing snapshot.
+//
+// Judge declarations are carried from the tryout verbatim, so one that is
+// well-formed JSON but fails the scoring spec's judge rules (unknown mode,
+// colliding key, missing rubric) would make the whole draft uncompilable.
+// Rather than let that reach the builder, the assembled bundle is validated and
+// rebuilt without judges when it does not hold — a deterministic pack an author
+// can still publish. The builder's judge editor is where judges are re-added
+// against a validated shape.
 func agentTryoutPackBundle(source repository.AgentTryout) challengepack.Bundle {
+	bundle := tryoutPackBundle(source, true)
+	if tryoutBundlePublishable(bundle) {
+		return bundle
+	}
+	return tryoutPackBundle(source, false)
+}
+
+// tryoutBundlePublishable reports whether a bundle survives the path the builder
+// actually runs on compile: BundleToComposition -> ComposeBundle ->
+// ValidateBundle. Validating the raw bundle instead would report false failures,
+// because ComposeBundle fills in fields the mapper deliberately leaves unset
+// (judge_mode is inferred from what the spec declares).
+func tryoutBundlePublishable(bundle challengepack.Bundle) bool {
+	composition, err := challengepack.BundleToComposition(bundle)
+	if err != nil {
+		return false
+	}
+	composed, err := challengepack.ComposeBundle(composition, challengepack.ResolvedPieces{})
+	if err != nil {
+		return false
+	}
+	return challengepack.ValidateBundle(composed) == nil
+}
+
+// tryoutPackBundle builds the bundle. Dropping judges also drops their scorecard
+// dimensions, since tryoutDimensions derives one dimension per declared judge.
+func tryoutPackBundle(source repository.AgentTryout, includeJudges bool) challengepack.Bundle {
 	template := decodeTryoutTemplateSnapshot(source.TemplateSnapshot)
 	evaluation := decodeTryoutEvaluationSnapshot(source.EvaluationSpecSnapshot)
+	if !includeJudges {
+		evaluation.LLMJudges = nil
+	}
 
 	challengeKey := tryoutSlugify(firstNonEmpty(source.TemplateSlug, template.Slug), "tryout")
 	title := firstNonEmpty(template.Name, source.TemplateSlug, "Agent tryout")

--- a/backend/internal/api/agent_tryout_pack_composition.go
+++ b/backend/internal/api/agent_tryout_pack_composition.go
@@ -1,0 +1,365 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/challengepack"
+	"github.com/agentclash/agentclash/runtime/scoring"
+)
+
+// Mapping a completed agent tryout onto the visual pack builder's working
+// document (challengepack.Composition). The tryout's own snapshots use a
+// deliberately looser shorthand than a runnable pack — its validators name
+// shapes like json_field / artifact_produced that the scoring engine does not
+// implement, and its scorecard is a list of display labels. So the mapper
+// re-derives the pack from the evidence the tryout genuinely carries:
+//
+//	template_snapshot.runtime.expected_artifacts -> post-execution file captures
+//	                                                + file_exists validators
+//	evaluation_spec_snapshot.llm_judges          -> judges (already the exact
+//	                                                scoring.LLMJudgeDeclaration
+//	                                                shape) + one dimension each
+//	input_snapshot                               -> the single input-set case
+//	tool_policy_snapshot                         -> version.tool_policy verbatim
+//	cost_limit_usd / max_duration_seconds        -> runtime limits + latency and
+//	                                                cost dimension normalization
+//
+// The result is a Bundle, which BundleToComposition turns into a Composition
+// for free — including the Advanced passthrough for the fields the builder UI
+// cannot render yet (post-execution checks, runtime limits).
+
+const (
+	// tryoutPackFamily groups promoted tryouts in the pack catalog. It is
+	// deliberately not "security", which would demand a security policy.
+	tryoutPackFamily = "tryout"
+	// tryoutPackDifficulty is the neutral default; the builder lets the
+	// author change it before publishing.
+	tryoutPackDifficulty  = "medium"
+	tryoutPackInputSetKey = "tryout-input"
+	tryoutPackCaseKey     = "tryout-case"
+	// tryoutPackSlugIDLength is how much of the source tryout id is folded
+	// into the pack slug so two promotions of the same template do not
+	// collide on publish.
+	tryoutPackSlugIDLength = 8
+)
+
+// tryoutTemplateSnapshotView is the slice of template_snapshot the mapper reads.
+type tryoutTemplateSnapshotView struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Runtime     struct {
+		Instructions      string                   `json:"instructions"`
+		ExpectedArtifacts []tryoutExpectedArtifact `json:"expected_artifacts"`
+	} `json:"runtime"`
+}
+
+type tryoutExpectedArtifact struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// tryoutEvaluationSnapshotView is the slice of evaluation_spec_snapshot the
+// mapper reads. Judge declarations are already stored in the exact shape
+// scoring.LLMJudgeDeclaration decodes (see agent_tryout_judge.go), so they are
+// carried over verbatim.
+type tryoutEvaluationSnapshotView struct {
+	LLMJudges []scoring.LLMJudgeDeclaration `json:"llm_judges"`
+	Scorecard struct {
+		Dimensions []scoring.DimensionDeclaration `json:"dimensions"`
+	} `json:"scorecard"`
+}
+
+// agentTryoutPackDraft renders the builder inputs for a promoted tryout: the
+// draft name and the composition JSON stored verbatim in
+// challenge_pack_drafts.composition.
+func agentTryoutPackDraft(source repository.AgentTryout) (string, json.RawMessage, error) {
+	bundle := agentTryoutPackBundle(source)
+	composition, err := challengepack.BundleToComposition(bundle)
+	if err != nil {
+		return "", nil, fmt.Errorf("build composition from tryout %s: %w", source.ID, err)
+	}
+	encoded, err := json.Marshal(composition)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal composition for tryout %s: %w", source.ID, err)
+	}
+	return bundle.Pack.Name, encoded, nil
+}
+
+// agentTryoutPackBundle assembles the runnable-pack shape a tryout implies. It
+// is intentionally total — a sparse tryout yields a thin but still valid pack
+// rather than an error, so promotion never dead-ends on a missing snapshot.
+func agentTryoutPackBundle(source repository.AgentTryout) challengepack.Bundle {
+	template := decodeTryoutTemplateSnapshot(source.TemplateSnapshot)
+	evaluation := decodeTryoutEvaluationSnapshot(source.EvaluationSpecSnapshot)
+
+	challengeKey := tryoutSlugify(firstNonEmpty(source.TemplateSlug, template.Slug), "tryout")
+	title := firstNonEmpty(template.Name, source.TemplateSlug, "Agent tryout")
+
+	bundle := challengepack.Bundle{
+		Pack: challengepack.PackMetadata{
+			Slug:        tryoutPackSlug(challengeKey, source),
+			Name:        title,
+			Family:      tryoutPackFamily,
+			Description: optionalTrimmedString(template.Description),
+		},
+		Version: challengepack.VersionMetadata{
+			Number:        1,
+			ExecutionMode: challengepack.ExecutionModeNative,
+			ToolPolicy:    decodeJSONObjectOrNil(source.ToolPolicySnapshot),
+		},
+		Challenges: []challengepack.ChallengeDefinition{{
+			Key:          challengeKey,
+			Title:        title,
+			Category:     challengeKey,
+			Difficulty:   tryoutPackDifficulty,
+			Instructions: strings.TrimSpace(template.Runtime.Instructions),
+		}},
+		InputSets: []challengepack.InputSetDefinition{{
+			Key:   tryoutPackInputSetKey,
+			Name:  "Tryout input",
+			Cases: []challengepack.CaseDefinition{{ChallengeKey: challengeKey, CaseKey: tryoutPackCaseKey, Payload: decodeJSONObjectOrNil(source.InputSnapshot)}},
+		}},
+	}
+
+	checks, validators := tryoutArtifactEvidence(template.Runtime.ExpectedArtifacts)
+	spec := scoring.EvaluationSpec{
+		Name:                bundle.Pack.Slug,
+		VersionNumber:       bundle.Version.Number,
+		Validators:          validators,
+		LLMJudges:           evaluation.LLMJudges,
+		PostExecutionChecks: checks,
+		RuntimeLimits:       tryoutRuntimeLimits(source),
+		Scorecard:           scoring.ScorecardDeclaration{Strategy: scoring.ScoringStrategyWeighted},
+	}
+	// JudgeMode is left empty on purpose: ComposeBundle infers it from what
+	// the spec actually declares when the draft is compiled.
+	spec.Scorecard.Dimensions = tryoutDimensions(evaluation, source)
+	bundle.Version.EvaluationSpec = spec
+
+	return bundle
+}
+
+// tryoutArtifactEvidence turns the template's declared output files into the
+// deterministic half of the scorecard: a file capture per artifact plus a
+// file_exists validator that asserts the agent actually produced it. When the
+// template declares no artifacts, it falls back to asserting a non-empty final
+// output so the pack still has the one validator ValidateEvaluationSpec
+// requires.
+func tryoutArtifactEvidence(artifacts []tryoutExpectedArtifact) ([]scoring.PostExecutionCheck, []scoring.ValidatorDeclaration) {
+	var checks []scoring.PostExecutionCheck
+	var validators []scoring.ValidatorDeclaration
+	seen := map[string]struct{}{}
+
+	for _, artifact := range artifacts {
+		key := tryoutSlugify(artifact.Key, "")
+		path := strings.TrimSpace(artifact.Path)
+		if key == "" || path == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		checks = append(checks, scoring.PostExecutionCheck{
+			Key:  key,
+			Type: scoring.PostExecutionCheckTypeFileCapture,
+			Path: path,
+		})
+		validators = append(validators, scoring.ValidatorDeclaration{
+			Key:    "produced_" + key,
+			Type:   scoring.ValidatorTypeFileExists,
+			Target: "file:" + key,
+		})
+	}
+
+	if len(validators) == 0 {
+		validators = append(validators, scoring.ValidatorDeclaration{
+			Key:  "final_output_not_empty",
+			Type: scoring.ValidatorTypeRegexMatch,
+			// literal: supplies the pattern inline; ".+" matches any
+			// non-empty final output.
+			Target:       "final_output",
+			ExpectedFrom: "literal:.+",
+		})
+	}
+	return checks, validators
+}
+
+// tryoutRuntimeLimits carries the tryout's enforced budget into the pack so the
+// promoted eval runs under the same ceiling the tryout did.
+func tryoutRuntimeLimits(source repository.AgentTryout) scoring.RuntimeLimits {
+	var limits scoring.RuntimeLimits
+	if source.CostLimitUSD > 0 {
+		cost := source.CostLimitUSD
+		limits.MaxCostUSD = &cost
+	}
+	if source.MaxDurationSeconds > 0 {
+		durationMS := int64(source.MaxDurationSeconds) * 1000
+		limits.MaxDurationMS = &durationMS
+	}
+	return limits
+}
+
+// tryoutDimensions wires the scorecard. Only dimensions backed by evidence the
+// promoted pack actually produces are emitted: correctness (always, since there
+// is always at least one validator), the builtin dimensions the template asked
+// for, and one llm_judge dimension per carried-over judge. The template's
+// free-text labels ("accuracy", "visuals", ...) have no source in the scoring
+// engine and are deliberately dropped — the builder's dimension editor is where
+// an author re-adds them against a real source.
+func tryoutDimensions(evaluation tryoutEvaluationSnapshotView, source repository.AgentTryout) []scoring.DimensionDeclaration {
+	requested := map[string]struct{}{scoring.ScorecardDimensionCorrectness: {}}
+	for _, dim := range evaluation.Scorecard.Dimensions {
+		if key := strings.TrimSpace(dim.Key); key != "" {
+			requested[key] = struct{}{}
+		}
+	}
+
+	dimensions := make([]scoring.DimensionDeclaration, 0, len(requested))
+	used := map[string]struct{}{}
+	appendDim := func(dim scoring.DimensionDeclaration) {
+		if _, exists := used[dim.Key]; exists {
+			return
+		}
+		used[dim.Key] = struct{}{}
+		dimensions = append(dimensions, dim)
+	}
+
+	// Emitted in a fixed order so the composition is deterministic.
+	appendDim(scoring.DimensionDeclaration{
+		Key:    scoring.ScorecardDimensionCorrectness,
+		Source: scoring.DimensionSourceValidators,
+	})
+	if _, ok := requested[scoring.ScorecardDimensionReliability]; ok {
+		appendDim(scoring.DimensionDeclaration{
+			Key:    scoring.ScorecardDimensionReliability,
+			Source: scoring.DimensionSourceReliability,
+		})
+	}
+	if _, ok := requested[scoring.ScorecardDimensionLatency]; ok && source.MaxDurationSeconds > 0 {
+		max := float64(source.MaxDurationSeconds) * 1000
+		appendDim(scoring.DimensionDeclaration{
+			Key:             scoring.ScorecardDimensionLatency,
+			Source:          scoring.DimensionSourceLatency,
+			BetterDirection: "lower",
+			Normalization:   tryoutHalfwayNormalization(max),
+		})
+	}
+	if _, ok := requested[scoring.ScorecardDimensionCost]; ok && source.CostLimitUSD > 0 {
+		appendDim(scoring.DimensionDeclaration{
+			Key:             scoring.ScorecardDimensionCost,
+			Source:          scoring.DimensionSourceCost,
+			BetterDirection: "lower",
+			Normalization:   tryoutHalfwayNormalization(source.CostLimitUSD),
+		})
+	}
+
+	for _, judge := range evaluation.LLMJudges {
+		key := strings.TrimSpace(judge.Key)
+		if key == "" {
+			continue
+		}
+		appendDim(scoring.DimensionDeclaration{
+			Key:      key,
+			Source:   scoring.DimensionSourceLLMJudge,
+			JudgeKey: key,
+		})
+	}
+
+	return dimensions
+}
+
+// tryoutHalfwayNormalization scores "half the budget" as perfect and "the whole
+// budget" as zero, which is the only defensible curve we can derive from a cap
+// alone. Authors retune it in the builder.
+func tryoutHalfwayNormalization(max float64) *scoring.DimensionNormalization {
+	target := max / 2
+	return &scoring.DimensionNormalization{Target: &target, Max: &max}
+}
+
+// tryoutPackSlug keeps promoted packs from colliding: two promotions of the
+// same template would otherwise both publish version 1 of one pack.
+func tryoutPackSlug(challengeKey string, source repository.AgentTryout) string {
+	suffix := strings.ReplaceAll(source.ID.String(), "-", "")
+	if len(suffix) > tryoutPackSlugIDLength {
+		suffix = suffix[:tryoutPackSlugIDLength]
+	}
+	if suffix == "" {
+		return "tryout-" + challengeKey
+	}
+	return "tryout-" + challengeKey + "-" + suffix
+}
+
+func decodeTryoutTemplateSnapshot(raw json.RawMessage) tryoutTemplateSnapshotView {
+	var view tryoutTemplateSnapshotView
+	if len(raw) == 0 {
+		return view
+	}
+	// A malformed snapshot degrades to an empty view rather than failing the
+	// promotion: the builder is the place to fill the gaps in.
+	_ = json.Unmarshal(raw, &view)
+	return view
+}
+
+func decodeTryoutEvaluationSnapshot(raw json.RawMessage) tryoutEvaluationSnapshotView {
+	var view tryoutEvaluationSnapshotView
+	if len(raw) == 0 {
+		return view
+	}
+	_ = json.Unmarshal(raw, &view)
+	return view
+}
+
+// decodeJSONObjectOrNil returns raw as a generic object, or nil when it is
+// absent or is not a JSON object (a non-object payload has no place in a
+// tool_policy / case payload map).
+func decodeJSONObjectOrNil(raw json.RawMessage) map[string]any {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil
+	}
+	return object
+}
+
+// tryoutSlugify reduces a value to lowercase alphanumerics plus single dashes
+// so it is safe as a pack slug, challenge key, or validator key.
+func tryoutSlugify(value, fallback string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '_':
+			b.WriteRune('_')
+			lastDash = false
+		default:
+			if b.Len() > 0 && !lastDash {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		return fallback
+	}
+	return slug
+}
+
+func optionalTrimmedString(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/backend/internal/api/agent_tryout_pack_composition_test.go
+++ b/backend/internal/api/agent_tryout_pack_composition_test.go
@@ -260,6 +260,17 @@ func TestAgentTryoutPackBundleAlwaysCompiles(t *testing.T) {
 		{"free-text dimensions only", tryoutFixture(func(tr *repository.AgentTryout) {
 			tr.EvaluationSpecSnapshot = json.RawMessage(`{"scorecard":{"dimensions":["accuracy","tone"]}}`)
 		})},
+		// A judge the scoring spec rejects must not make the whole draft
+		// uncompilable — promotion falls back to a judge-free pack.
+		{"judge with unknown mode", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.EvaluationSpecSnapshot = json.RawMessage(`{"llm_judges":[{"key":"overall","mode":"vibes","model":"claude-sonnet-4-6"}]}`)
+		})},
+		{"judge missing key", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.EvaluationSpecSnapshot = json.RawMessage(`{"llm_judges":[{"mode":"rubric","model":"claude-sonnet-4-6"}]}`)
+		})},
+		{"duplicate judge keys", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.EvaluationSpecSnapshot = json.RawMessage(`{"llm_judges":[{"key":"dup","mode":"rubric","model":"m"},{"key":"dup","mode":"rubric","model":"m"}]}`)
+		})},
 	}
 
 	for _, tc := range tests {

--- a/backend/internal/api/agent_tryout_pack_composition_test.go
+++ b/backend/internal/api/agent_tryout_pack_composition_test.go
@@ -1,0 +1,344 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/runtime/challengepack"
+	"github.com/agentclash/agentclash/runtime/scoring"
+	"github.com/google/uuid"
+)
+
+// tryoutFixture builds a completed tryout with the snapshot shapes the real
+// templates produce, then lets each case vary one dimension.
+func tryoutFixture(mutate func(*repository.AgentTryout)) repository.AgentTryout {
+	orgID, workspaceID := uuid.New(), uuid.New()
+	tryout := repository.AgentTryout{
+		ID:              uuid.MustParse("11112222-3333-4444-5555-666677778888"),
+		OrganizationID:  &orgID,
+		WorkspaceID:     &workspaceID,
+		TemplateSlug:    "meeting-minutes",
+		Status:          repository.AgentTryoutStatusCompleted,
+		RedactionStatus: repository.AgentTryoutRedactionPassed,
+		InputSnapshot:   json.RawMessage(`{"notes":"standup notes","audience":"execs"}`),
+		TemplateSnapshot: json.RawMessage(`{
+			"slug":"meeting-minutes",
+			"name":"Meeting Minutes to Action Plan",
+			"description":"Turn notes into minutes.",
+			"runtime":{
+				"instructions":"Write action-plan.md and minutes.json.",
+				"expected_artifacts":[
+					{"key":"action_plan","type":"markdown","path":"action-plan.md"},
+					{"key":"structured_minutes","type":"json","path":"minutes.json"}
+				]
+			}
+		}`),
+		ToolPolicySnapshot: json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"}}`),
+		EvaluationSpecSnapshot: json.RawMessage(`{
+			"validators":[{"key":"has_summary","type":"json_field","field":"summary"}],
+			"scorecard":{"dimensions":["correctness","reliability","latency","cost"]},
+			"judge_mode":"hybrid",
+			"llm_judges":[{
+				"key":"overall_quality","mode":"rubric","model":"gpt-5-mini",
+				"rubric":"Score 1-5.","context_from":["final_output"],
+				"samples":1,"timeout_ms":45000,"score_scale":{"min":1,"max":5}
+			}],
+			"judge_meta":{"model":"gpt-5-mini","strictness":"standard"}
+		}`),
+		CostLimitUSD:       10,
+		MaxDurationSeconds: 120,
+	}
+	if mutate != nil {
+		mutate(&tryout)
+	}
+	return tryout
+}
+
+func dimensionKeys(spec scoring.EvaluationSpec) []string {
+	keys := make([]string, 0, len(spec.Scorecard.Dimensions))
+	for _, dim := range spec.Scorecard.Dimensions {
+		keys = append(keys, dim.Key)
+	}
+	return keys
+}
+
+func validatorKeys(spec scoring.EvaluationSpec) []string {
+	keys := make([]string, 0, len(spec.Validators))
+	for _, validator := range spec.Validators {
+		keys = append(keys, validator.Key)
+	}
+	return keys
+}
+
+func TestAgentTryoutPackBundleMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		tryout repository.AgentTryout
+		assert func(t *testing.T, bundle challengepack.Bundle)
+	}{
+		{
+			name:   "expected artifacts become file captures and file_exists validators",
+			tryout: tryoutFixture(nil),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				spec := bundle.Version.EvaluationSpec
+				wantValidators := []string{"produced_action_plan", "produced_structured_minutes"}
+				if got := validatorKeys(spec); !equalStrings(got, wantValidators) {
+					t.Fatalf("validators = %v, want %v", got, wantValidators)
+				}
+				for _, validator := range spec.Validators {
+					if validator.Type != scoring.ValidatorTypeFileExists {
+						t.Fatalf("validator %s type = %q, want file_exists", validator.Key, validator.Type)
+					}
+					if !strings.HasPrefix(validator.Target, "file:") {
+						t.Fatalf("validator %s target = %q, want a file: reference", validator.Key, validator.Target)
+					}
+				}
+				if len(spec.PostExecutionChecks) != 2 {
+					t.Fatalf("post execution checks = %d, want 2", len(spec.PostExecutionChecks))
+				}
+				if spec.PostExecutionChecks[0].Path != "action-plan.md" {
+					t.Fatalf("first check path = %q, want action-plan.md", spec.PostExecutionChecks[0].Path)
+				}
+			},
+		},
+		{
+			name:   "judges carry over verbatim and each gets a dimension",
+			tryout: tryoutFixture(nil),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				spec := bundle.Version.EvaluationSpec
+				if len(spec.LLMJudges) != 1 || spec.LLMJudges[0].Key != "overall_quality" {
+					t.Fatalf("llm judges = %+v, want the tryout's overall_quality judge", spec.LLMJudges)
+				}
+				if spec.LLMJudges[0].Rubric != "Score 1-5." || spec.LLMJudges[0].Model != "gpt-5-mini" {
+					t.Fatalf("judge was not carried verbatim: %+v", spec.LLMJudges[0])
+				}
+				want := []string{"correctness", "reliability", "latency", "cost", "overall_quality"}
+				if got := dimensionKeys(spec); !equalStrings(got, want) {
+					t.Fatalf("dimensions = %v, want %v", got, want)
+				}
+			},
+		},
+		{
+			name: "unmappable template dimension labels are dropped",
+			tryout: tryoutFixture(func(tryout *repository.AgentTryout) {
+				tryout.EvaluationSpecSnapshot = json.RawMessage(`{"scorecard":{"dimensions":["accuracy","visuals","cost"]}}`)
+			}),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				want := []string{"correctness", "cost"}
+				if got := dimensionKeys(bundle.Version.EvaluationSpec); !equalStrings(got, want) {
+					t.Fatalf("dimensions = %v, want %v (accuracy/visuals have no scoring source)", got, want)
+				}
+			},
+		},
+		{
+			name: "a template with no expected artifacts still declares a validator",
+			tryout: tryoutFixture(func(tryout *repository.AgentTryout) {
+				tryout.TemplateSnapshot = json.RawMessage(`{"slug":"prompt-only","name":"Prompt only"}`)
+			}),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				spec := bundle.Version.EvaluationSpec
+				if got := validatorKeys(spec); !equalStrings(got, []string{"final_output_not_empty"}) {
+					t.Fatalf("validators = %v, want the non-empty-output fallback", got)
+				}
+				if len(spec.PostExecutionChecks) != 0 {
+					t.Fatalf("post execution checks = %d, want 0", len(spec.PostExecutionChecks))
+				}
+			},
+		},
+		{
+			name: "a zero budget drops the latency and cost dimensions",
+			tryout: tryoutFixture(func(tryout *repository.AgentTryout) {
+				tryout.CostLimitUSD = 0
+				tryout.MaxDurationSeconds = 0
+			}),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				want := []string{"correctness", "reliability", "overall_quality"}
+				if got := dimensionKeys(bundle.Version.EvaluationSpec); !equalStrings(got, want) {
+					t.Fatalf("dimensions = %v, want %v", got, want)
+				}
+				if bundle.Version.EvaluationSpec.RuntimeLimits.MaxCostUSD != nil {
+					t.Fatalf("max_cost_usd must stay unset when the tryout had no cost cap")
+				}
+			},
+		},
+		{
+			name:   "the tryout input becomes the single case payload",
+			tryout: tryoutFixture(nil),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				if len(bundle.InputSets) != 1 || len(bundle.InputSets[0].Cases) != 1 {
+					t.Fatalf("input sets = %+v, want exactly one case", bundle.InputSets)
+				}
+				payload := bundle.InputSets[0].Cases[0].Payload
+				if payload["notes"] != "standup notes" {
+					t.Fatalf("case payload = %+v, want the tryout input snapshot", payload)
+				}
+				if bundle.InputSets[0].Cases[0].ChallengeKey != bundle.Challenges[0].Key {
+					t.Fatalf("case references %q but the challenge key is %q", bundle.InputSets[0].Cases[0].ChallengeKey, bundle.Challenges[0].Key)
+				}
+			},
+		},
+		{
+			name:   "the tool policy snapshot is carried verbatim",
+			tryout: tryoutFixture(nil),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				tools, ok := bundle.Version.ToolPolicy["tools"].([]any)
+				if !ok || len(tools) != 1 || tools[0] != "file_writer" {
+					t.Fatalf("tool policy = %+v, want the tryout's snapshot", bundle.Version.ToolPolicy)
+				}
+			},
+		},
+		{
+			name: "empty snapshots degrade to a thin but complete pack",
+			tryout: tryoutFixture(func(tryout *repository.AgentTryout) {
+				tryout.TemplateSnapshot = nil
+				tryout.EvaluationSpecSnapshot = nil
+				tryout.ToolPolicySnapshot = nil
+				tryout.InputSnapshot = nil
+				tryout.TemplateSlug = ""
+			}),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				if bundle.Challenges[0].Key != "tryout" {
+					t.Fatalf("challenge key = %q, want the tryout fallback", bundle.Challenges[0].Key)
+				}
+				if bundle.Pack.Name == "" || bundle.Pack.Family == "" || bundle.Pack.Slug == "" {
+					t.Fatalf("pack metadata is incomplete: %+v", bundle.Pack)
+				}
+			},
+		},
+		{
+			name: "malformed snapshots do not abort the mapping",
+			tryout: tryoutFixture(func(tryout *repository.AgentTryout) {
+				tryout.TemplateSnapshot = json.RawMessage(`not json`)
+				tryout.EvaluationSpecSnapshot = json.RawMessage(`[1,2,3]`)
+				tryout.ToolPolicySnapshot = json.RawMessage(`"a string"`)
+				tryout.InputSnapshot = json.RawMessage(`[]`)
+			}),
+			assert: func(t *testing.T, bundle challengepack.Bundle) {
+				if bundle.Version.ToolPolicy != nil {
+					t.Fatalf("tool policy = %+v, want nil for a non-object snapshot", bundle.Version.ToolPolicy)
+				}
+				if bundle.InputSets[0].Cases[0].Payload != nil {
+					t.Fatalf("case payload = %+v, want nil for a non-object snapshot", bundle.InputSets[0].Cases[0].Payload)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := agentTryoutPackBundle(tc.tryout)
+			tc.assert(t, bundle)
+		})
+	}
+}
+
+// TestAgentTryoutPackBundleAlwaysCompiles is the contract that makes promotion
+// safe: whatever the tryout carried, the pack it produces must survive
+// ComposeBundle -> ValidateBundle -> BundleYAML -> ParseYAML, which is exactly
+// the builder's compile and publish path.
+func TestAgentTryoutPackBundleAlwaysCompiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		tryout repository.AgentTryout
+	}{
+		{"full snapshots", tryoutFixture(nil)},
+		{"no artifacts", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.TemplateSnapshot = json.RawMessage(`{"slug":"prompt-only","name":"Prompt only"}`)
+		})},
+		{"no judges", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.EvaluationSpecSnapshot = json.RawMessage(`{"validators":[],"scorecard":{"dimensions":["correctness"]}}`)
+		})},
+		{"no budget", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.CostLimitUSD = 0
+			tr.MaxDurationSeconds = 0
+		})},
+		{"everything empty", tryoutFixture(func(tr *repository.AgentTryout) {
+			*tr = repository.AgentTryout{ID: tr.ID}
+		})},
+		{"free-text dimensions only", tryoutFixture(func(tr *repository.AgentTryout) {
+			tr.EvaluationSpecSnapshot = json.RawMessage(`{"scorecard":{"dimensions":["accuracy","tone"]}}`)
+		})},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, composition, err := agentTryoutPackDraft(tc.tryout)
+			if err != nil {
+				t.Fatalf("agentTryoutPackDraft: %v", err)
+			}
+			if strings.TrimSpace(name) == "" {
+				t.Fatal("draft name must never be empty — CreateDraft rejects it")
+			}
+
+			var decoded challengepack.Composition
+			if err := json.Unmarshal(composition, &decoded); err != nil {
+				t.Fatalf("composition does not decode: %v", err)
+			}
+			bundle, err := challengepack.ComposeBundle(decoded, challengepack.ResolvedPieces{})
+			if err != nil {
+				t.Fatalf("ComposeBundle: %v", err)
+			}
+			if err := challengepack.ValidateBundle(bundle); err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			yamlBytes, err := challengepack.BundleYAML(bundle)
+			if err != nil {
+				t.Fatalf("BundleYAML: %v", err)
+			}
+			if _, err := challengepack.ParseYAML(yamlBytes); err != nil {
+				t.Fatalf("ParseYAML (publish path): %v", err)
+			}
+		})
+	}
+}
+
+func TestAgentTryoutPackSlugIsUniquePerTryout(t *testing.T) {
+	first := tryoutFixture(nil)
+	second := tryoutFixture(func(tryout *repository.AgentTryout) { tryout.ID = uuid.New() })
+
+	firstSlug := agentTryoutPackBundle(first).Pack.Slug
+	secondSlug := agentTryoutPackBundle(second).Pack.Slug
+	if firstSlug == secondSlug {
+		t.Fatalf("two promotions of the same template share slug %q; publishing the second would collide", firstSlug)
+	}
+	if !strings.HasPrefix(firstSlug, "tryout-meeting-minutes-") {
+		t.Fatalf("slug = %q, want a tryout-<template>-<id> slug", firstSlug)
+	}
+}
+
+func TestTryoutSlugify(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		fallback string
+		want     string
+	}{
+		{"already a slug", "meeting-minutes", "x", "meeting-minutes"},
+		{"underscores are kept for validator keys", "action_plan", "x", "action_plan"},
+		{"spaces and case collapse", "  Slide Deck  ", "x", "slide-deck"},
+		{"punctuation collapses to one dash", "a//b??c", "x", "a-b-c"},
+		{"empty falls back", "  ", "tryout", "tryout"},
+		{"punctuation only falls back", "!!!", "tryout", "tryout"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tryoutSlugify(tc.in, tc.fallback); got != tc.want {
+				t.Fatalf("tryoutSlugify(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -52,6 +52,7 @@ var (
 	ErrAgentTryoutCompareCardinality         = errors.New("agent tryout compare requires 2-4 tryouts")
 	ErrAgentTryoutPromotionTargetUnsupported = errors.New("agent tryout promotion target unsupported")
 	ErrAgentTryoutNotPromotable              = errors.New("agent tryout is not completed")
+	ErrAgentTryoutPromotionUnavailable       = errors.New("agent tryout promotion is not configured")
 )
 
 type AgentTryoutRepository interface {
@@ -77,8 +78,6 @@ type AgentTryoutRepository interface {
 	ClaimAgentTryout(ctx context.Context, params repository.ClaimAgentTryoutParams) (repository.AgentTryout, error)
 	CreatePublicShareLink(ctx context.Context, params repository.CreatePublicShareLinkParams) (repository.PublicShareLink, error)
 	GetActivePublicShareLinkByKey(ctx context.Context, key string) (repository.PublicShareLink, error)
-	CreateVibeEvalConversation(ctx context.Context, params repository.CreateVibeEvalConversationParams) (repository.VibeEvalConversation, error)
-	CreateVibeEvalDraft(ctx context.Context, params repository.CreateVibeEvalDraftParams) (repository.VibeEvalDraft, error)
 }
 
 type AgentTryoutService interface {
@@ -191,6 +190,7 @@ type AgentTryoutManager struct {
 	execution               *agentTryoutExecutionDispatcher
 	quota                   *AgentTryoutQuotaConfig
 	rerunGate               AgentTryoutRerunGate
+	packDrafts              AgentTryoutPackDraftCreator
 	artifactSigner          ArtifactContentSigner
 	judgeModels             []string
 	inputAttachmentStore    storage.Store
@@ -1631,6 +1631,8 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusBadRequest, "promotion_target_unsupported", err.Error())
 	case errors.Is(err, ErrAgentTryoutNotPromotable):
 		writeError(w, http.StatusConflict, "agent_tryout_not_promotable", "Only completed tryouts can be promoted to an eval.")
+	case errors.Is(err, ErrAgentTryoutPromotionUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "promotion_unavailable", "Promoting tryouts is not configured on this deployment.")
 	case errors.Is(err, ErrInvalidAgentTryoutInput):
 		writeError(w, http.StatusBadRequest, "invalid_agent_tryout_input", err.Error())
 	case errors.Is(err, ErrForbidden):

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -1062,8 +1062,6 @@ type fakeAgentTryoutRepository struct {
 	runEventsErr        error
 	artifacts           []repository.Artifact
 	artifactsErr        error
-	createdConversation repository.CreateVibeEvalConversationParams
-	createdDraft        repository.CreateVibeEvalDraftParams
 }
 
 func newFakeAgentTryoutRepository(orgID, workspaceID uuid.UUID) *fakeAgentTryoutRepository {
@@ -1432,30 +1430,6 @@ func (r *fakeAgentTryoutRepository) GetActivePublicShareLinkByKey(_ context.Cont
 		return r.share, nil
 	}
 	return repository.PublicShareLink{}, repository.ErrPublicShareLinkNotFound
-}
-
-func (r *fakeAgentTryoutRepository) CreateVibeEvalConversation(_ context.Context, params repository.CreateVibeEvalConversationParams) (repository.VibeEvalConversation, error) {
-	r.createdConversation = params
-	return repository.VibeEvalConversation{
-		ID:             uuid.New(),
-		OrganizationID: params.OrganizationID,
-		WorkspaceID:    params.WorkspaceID,
-		Title:          params.Title,
-		Phase:          params.Phase,
-		Status:         params.Status,
-	}, nil
-}
-
-func (r *fakeAgentTryoutRepository) CreateVibeEvalDraft(_ context.Context, params repository.CreateVibeEvalDraftParams) (repository.VibeEvalDraft, error) {
-	r.createdDraft = params
-	return repository.VibeEvalDraft{
-		ID:             uuid.New(),
-		OrganizationID: params.OrganizationID,
-		WorkspaceID:    params.WorkspaceID,
-		ConversationID: params.ConversationID,
-		DraftKind:      params.DraftKind,
-		Content:        params.Content,
-	}, nil
 }
 
 type fakePublicAgentTryoutWorkflowStarter struct {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6402,13 +6402,16 @@ paths:
   /v1/agent-tryouts/{id}/promote-to-eval:
     post:
       operationId: promoteAgentTryoutToEval
-      summary: Promote a workspace tryout into a repeatable eval draft
+      summary: Promote a workspace tryout into an editable challenge pack draft
       description: >-
-        Converts a completed workspace tryout into a durable Vibe Eval draft,
-        preserving its template, input, tool policy, evaluation spec, and the
-        template's expected artifacts so the eval can be run again later. v1
+        Converts a completed workspace tryout into a `challenge_pack_drafts` row
+        the visual pack builder can edit, compile, publish, and run. The tryout's
+        template instructions, input, tool policy, expected artifacts, LLM
+        judges, and cost/duration budget are mapped onto a pack composition. v1
         supports only the `vibe_eval` target; any other target returns 400. The
         request body is optional (an empty POST uses the default target).
+        Requires the `publish_challenge_pack` permission on the tryout's
+        workspace, because the result is a publishable pack.
       tags: [AgentTryouts]
       security:
         - bearerJWT: []
@@ -6435,6 +6438,12 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "503":
+          description: The challenge pack builder is not configured on this deployment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
 
   /v1/workspaces/{workspaceID}/agent-tryouts/compare:
     post:
@@ -14606,16 +14615,23 @@ components:
 
     AgentTryoutPromotionResult:
       type: object
-      required: [target, conversation_id, draft_id]
+      required: [target, workspace_id, draft_id]
       properties:
         target:
           type: string
-        conversation_id:
+        workspace_id:
           type: string
           format: uuid
+          description: Workspace that owns the created challenge pack draft.
         draft_id:
           type: string
           format: uuid
+          description: >-
+            The created `challenge_pack_drafts` row. Open it in the visual pack
+            builder at
+            `/workspaces/{workspace_id}/challenge-packs/builder/{draft_id}`, or
+            drive it through
+            `/v1/workspaces/{workspaceID}/challenge-pack-drafts/{draftID}`.
 
     CompareAgentTryoutsRequest:
       type: object

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
@@ -20,6 +20,7 @@ import {
 import { Package } from "lucide-react";
 import { PublishPackDialog } from "./publish-pack-dialog";
 import { NewPackButton } from "./new-pack-button";
+import { PromoteTryoutDialog } from "./promote-tryout-dialog";
 
 const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {
   runnable: "default",
@@ -56,6 +57,7 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
           >
             Browse library
           </Link>
+          <PromoteTryoutDialog workspaceId={workspaceId} />
           <NewPackButton workspaceId={workspaceId} />
           <PublishPackDialog workspaceId={workspaceId} />
         </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.test.tsx
@@ -1,0 +1,343 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/lib/api/errors";
+import type { AgentTryout } from "@/lib/api/types";
+import { PromoteTryoutDialog } from "./promote-tryout-dialog";
+
+const {
+  mockPush,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  mockListWorkspaceAgentTryouts,
+  mockPromoteAgentTryoutToEval,
+  toast,
+} = vi.hoisted(() => {
+  return {
+    mockPush: vi.fn(),
+    mockGetAccessToken: vi.fn(),
+    mockCreateApiClient: vi.fn(),
+    mockListWorkspaceAgentTryouts: vi.fn(),
+    mockPromoteAgentTryoutToEval: vi.fn(),
+    toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("sonner", () => ({ toast }));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/lib/api/agent-tryouts", () => ({
+  listWorkspaceAgentTryouts: (...args: unknown[]) =>
+    mockListWorkspaceAgentTryouts(...args),
+  promoteAgentTryoutToEval: (...args: unknown[]) =>
+    mockPromoteAgentTryoutToEval(...args),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+// A minimal Dialog that still honours open/onOpenChange, so the test exercises
+// the real "open the dialog, then load tryouts" sequence.
+vi.mock("@/components/ui/dialog", () => {
+  const Ctx = React.createContext<{
+    open: boolean;
+    setOpen: (value: boolean) => void;
+  }>({ open: false, setOpen: () => {} });
+
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (value: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        Ctx.Provider,
+        { value: { open, setOpen: onOpenChange } },
+        React.createElement("div", { "data-testid": "dialog-root" }, children),
+      ),
+    DialogTrigger: ({ children }: { children: React.ReactNode }) => {
+      const { setOpen } = React.useContext(Ctx);
+      return React.createElement(
+        "button",
+        { "data-testid": "dialog-trigger", onClick: () => setOpen(true) },
+        children,
+      );
+    },
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const { open } = React.useContext(Ctx);
+      return open ? React.createElement("div", null, children) : null;
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h1", null, children),
+  };
+});
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => {
+    const options = React.Children.toArray(children).flatMap((child) => {
+      if (!React.isValidElement(child)) return [];
+      return React.Children.toArray(
+        (child as React.ReactElement<{ children?: React.ReactNode }>).props
+          .children,
+      );
+    });
+    return React.createElement(
+      "select",
+      {
+        "aria-label": "Tryout",
+        value,
+        onChange: (event: React.ChangeEvent<HTMLSelectElement>) =>
+          onValueChange(event.target.value),
+      },
+      options,
+    );
+  },
+  SelectTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  SelectValue: ({ placeholder }: { placeholder?: string }) =>
+    React.createElement("option", { value: "" }, placeholder ?? "Select"),
+  SelectContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => React.createElement("option", { value }, children),
+}));
+
+function makeTryout(overrides: Partial<AgentTryout> = {}): AgentTryout {
+  return {
+    id: "tryout-1",
+    workspace_id: "ws-1",
+    template_slug: "meeting-minutes",
+    status: "completed",
+    input_snapshot: {},
+    template_snapshot: {},
+    tool_policy_snapshot: {},
+    evaluation_spec_snapshot: {},
+    selected_model_policy: { mode: "hosted_default" },
+    summary: {},
+    redaction_status: "passed",
+    cost_limit_usd: 10,
+    max_duration_seconds: 120,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  } as AgentTryout;
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushPromises();
+    }
+  }
+  throw lastError;
+}
+
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+}
+
+function findButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent === label,
+  );
+}
+
+function renderDialog() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(PromoteTryoutDialog, { workspaceId: "ws-1" }),
+    );
+  });
+
+  // The dialog only loads tryouts once opened.
+  act(() => {
+    clickElement(container.querySelector('[data-testid="dialog-trigger"]')!);
+  });
+
+  return {
+    container,
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("PromoteTryoutDialog", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockGetAccessToken.mockReset();
+    mockCreateApiClient.mockReset();
+    mockListWorkspaceAgentTryouts.mockReset();
+    mockPromoteAgentTryoutToEval.mockReset();
+    toast.error.mockReset();
+
+    mockGetAccessToken.mockResolvedValue("token");
+    mockCreateApiClient.mockReturnValue({ client: true });
+    mockListWorkspaceAgentTryouts.mockResolvedValue({
+      items: [makeTryout()],
+    });
+  });
+
+  it("promotes the selected tryout and navigates into the builder", async () => {
+    mockPromoteAgentTryoutToEval.mockResolvedValue({
+      target: "vibe_eval",
+      workspace_id: "ws-1",
+      draft_id: "draft-9",
+    });
+
+    const view = renderDialog();
+    try {
+      await waitFor(() => {
+        expect(view.container.querySelector("select")).toBeTruthy();
+      });
+
+      await act(async () => {
+        clickElement(findButton(view.container, "Open in builder")!);
+      });
+
+      await waitFor(() => {
+        expect(mockPromoteAgentTryoutToEval).toHaveBeenCalledWith(
+          { client: true },
+          "tryout-1",
+        );
+      });
+      expect(mockPush).toHaveBeenCalledWith(
+        "/workspaces/ws-1/challenge-packs/builder/draft-9",
+      );
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it("offers only completed tryouts", async () => {
+    mockListWorkspaceAgentTryouts.mockResolvedValue({
+      items: [
+        makeTryout({ id: "running-1", status: "running" }),
+        makeTryout({ id: "failed-1", status: "failed" }),
+        makeTryout({ id: "done-1", status: "completed" }),
+      ],
+    });
+
+    const view = renderDialog();
+    try {
+      await waitFor(() => {
+        const values = Array.from(
+          view.container.querySelectorAll("option"),
+        ).map((option) => option.getAttribute("value"));
+        // "" is the placeholder option.
+        expect(values).toEqual(["", "done-1"]);
+      });
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it("points at the tryouts page when the workspace has none", async () => {
+    mockListWorkspaceAgentTryouts.mockResolvedValue({ items: [] });
+
+    const view = renderDialog();
+    try {
+      await waitFor(() => {
+        expect(view.container.querySelector("a")?.getAttribute("href")).toBe(
+          "/tryouts",
+        );
+      });
+      expect(findButton(view.container, "Open in builder")?.disabled).toBe(true);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it("surfaces promotion errors verbatim", async () => {
+    mockPromoteAgentTryoutToEval.mockRejectedValue(
+      new ApiError(403, "forbidden", "caller cannot publish challenge packs"),
+    );
+
+    const view = renderDialog();
+    try {
+      await waitFor(() => {
+        expect(view.container.querySelector("select")).toBeTruthy();
+      });
+
+      await act(async () => {
+        clickElement(findButton(view.container, "Open in builder")!);
+      });
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "caller cannot publish challenge packs",
+        );
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    } finally {
+      view.unmount();
+    }
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.test.tsx
@@ -315,6 +315,39 @@ describe("PromoteTryoutDialog", () => {
     }
   });
 
+  it("pages past a full page of non-completed tryouts to find eligible ones", async () => {
+    // The list endpoint has no status filter, so a workspace whose completed
+    // tryouts sit behind a full page of running ones must still offer them.
+    const runningPage = Array.from({ length: 50 }, (_, index) =>
+      makeTryout({ id: `running-${index}`, status: "running" }),
+    );
+    mockListWorkspaceAgentTryouts.mockImplementation(
+      (_api: unknown, _ws: string, opts: { offset?: number }) =>
+        Promise.resolve({
+          items:
+            (opts?.offset ?? 0) === 0
+              ? runningPage
+              : [makeTryout({ id: "older-completed" })],
+        }),
+    );
+
+    const view = renderDialog();
+    try {
+      await waitFor(() => {
+        expect(view.container.querySelector("select")).toBeTruthy();
+      });
+      const options = Array.from(
+        view.container.querySelectorAll("select option"),
+      )
+        .map((option) => option.getAttribute("value"))
+        .filter(Boolean);
+      expect(options).toEqual(["older-completed"]);
+      expect(mockListWorkspaceAgentTryouts).toHaveBeenCalledTimes(2);
+    } finally {
+      view.unmount();
+    }
+  });
+
   it("surfaces promotion errors verbatim", async () => {
     mockPromoteAgentTryoutToEval.mockRejectedValue(
       new ApiError(403, "forbidden", "caller cannot publish challenge packs"),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Loader2, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  listWorkspaceAgentTryouts,
+  promoteAgentTryoutToEval,
+} from "@/lib/api/agent-tryouts";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { AgentTryout } from "@/lib/api/types";
+import { formatTryoutCost, tryoutModelLabel } from "@/lib/agent-tryout-status";
+
+interface PromoteTryoutDialogProps {
+  workspaceId: string;
+}
+
+function tryoutLabel(tryout: AgentTryout): string {
+  const when = new Date(tryout.created_at).toLocaleDateString();
+  return `${tryout.template_slug} · ${tryoutModelLabel(tryout)} · ${formatTryoutCost(tryout)} · ${when}`;
+}
+
+/**
+ * Turns a completed agent tryout into an editable challenge pack draft and
+ * drops the author straight into the visual builder with it loaded.
+ */
+export function PromoteTryoutDialog({ workspaceId }: PromoteTryoutDialogProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [tryouts, setTryouts] = useState<AgentTryout[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [promoting, setPromoting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    setTryouts([]);
+    setSelectedId("");
+
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const page = await listWorkspaceAgentTryouts(api, workspaceId, {
+          limit: 50,
+        });
+        if (cancelled) return;
+        // Only completed tryouts carry the evidence the backend promotes.
+        const completed = page.items.filter(
+          (tryout) => tryout.status === "completed",
+        );
+        setTryouts(completed);
+        setSelectedId(completed[0]?.id ?? "");
+      } catch (err) {
+        if (cancelled) return;
+        setLoadError(
+          err instanceof ApiError || err instanceof Error
+            ? err.message
+            : "Failed to load tryouts",
+        );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, open, workspaceId]);
+
+  async function handlePromote() {
+    if (!selectedId || promoting) return;
+
+    setPromoting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const result = await promoteAgentTryoutToEval(api, selectedId);
+      setOpen(false);
+      router.push(
+        `/workspaces/${result.workspace_id}/challenge-packs/builder/${result.draft_id}`,
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError || err instanceof Error
+          ? err.message
+          : "Couldn't promote this tryout",
+      );
+    } finally {
+      setPromoting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        <Sparkles data-icon="inline-start" className="size-4" />
+        From a tryout
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Start a pack from a tryout</DialogTitle>
+          <DialogDescription>
+            Turns a completed tryout into an editable pack draft — its task,
+            input, tool policy, expected outputs, judges, and budget — then opens
+            it in the builder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          {loading ? (
+            <div className="flex h-10 items-center rounded-lg border border-input px-3 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 size-4 animate-spin" />
+              Loading tryouts...
+            </div>
+          ) : loadError ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {loadError}
+            </div>
+          ) : tryouts.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+              <p>This workspace has no completed tryouts yet.</p>
+              <Link
+                href="/tryouts"
+                className="mt-2 inline-flex font-medium text-foreground hover:underline underline-offset-4"
+              >
+                Run a tryout
+              </Link>
+            </div>
+          ) : (
+            <Select
+              value={selectedId}
+              onValueChange={(value) => value && setSelectedId(value)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a tryout" />
+              </SelectTrigger>
+              <SelectContent>
+                {tryouts.map((tryout) => (
+                  <SelectItem key={tryout.id} value={tryout.id}>
+                    {tryoutLabel(tryout)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={promoting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handlePromote}
+            disabled={promoting || loading || !selectedId}
+          >
+            {promoting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              "Open in builder"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/promote-tryout-dialog.tsx
@@ -37,6 +37,13 @@ interface PromoteTryoutDialogProps {
   workspaceId: string;
 }
 
+// The workspace tryout list is paged and unfiltered, so the dialog scans pages
+// for completed tryouts. The bounds keep a busy workspace from issuing an
+// unbounded number of requests just to populate a picker.
+const TRYOUT_PAGE_SIZE = 50;
+const TRYOUT_OPTION_LIMIT = 50;
+const TRYOUT_SCAN_LIMIT = 500;
+
 function tryoutLabel(tryout: AgentTryout): string {
   const when = new Date(tryout.created_at).toLocaleDateString();
   return `${tryout.template_slug} · ${tryoutModelLabel(tryout)} · ${formatTryoutCost(tryout)} · ${when}`;
@@ -69,14 +76,31 @@ export function PromoteTryoutDialog({ workspaceId }: PromoteTryoutDialogProps) {
       try {
         const token = await getAccessToken();
         const api = createApiClient(token);
-        const page = await listWorkspaceAgentTryouts(api, workspaceId, {
-          limit: 50,
-        });
-        if (cancelled) return;
-        // Only completed tryouts carry the evidence the backend promotes.
-        const completed = page.items.filter(
-          (tryout) => tryout.status === "completed",
-        );
+        // Only completed tryouts carry the evidence the backend promotes, and
+        // the list endpoint has no status filter — so page through rather than
+        // filtering a single page, which would report "none" for a workspace
+        // whose completed tryouts are older than its newest page.
+        const completed: AgentTryout[] = [];
+        for (
+          let offset = 0;
+          offset < TRYOUT_SCAN_LIMIT;
+          offset += TRYOUT_PAGE_SIZE
+        ) {
+          const page = await listWorkspaceAgentTryouts(api, workspaceId, {
+            limit: TRYOUT_PAGE_SIZE,
+            offset,
+          });
+          if (cancelled) return;
+          completed.push(
+            ...page.items.filter((tryout) => tryout.status === "completed"),
+          );
+          if (
+            page.items.length < TRYOUT_PAGE_SIZE ||
+            completed.length >= TRYOUT_OPTION_LIMIT
+          ) {
+            break;
+          }
+        }
         setTryouts(completed);
         setSelectedId(completed[0]?.id ?? "");
       } catch (err) {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2765,9 +2765,14 @@ export interface PromoteAgentTryoutInput {
   title?: string;
 }
 
+/**
+ * A promotion creates a challenge pack draft. `draft_id` is a
+ * `challenge_pack_drafts` row, editable at
+ * `/workspaces/{workspace_id}/challenge-packs/builder/{draft_id}`.
+ */
 export interface AgentTryoutPromotionResult {
   target: string;
-  conversation_id: string;
+  workspace_id: string;
   draft_id: string;
 }
 


### PR DESCRIPTION
## What & why

A completed agent tryout could already be promoted via `POST /agent-tryouts/{id}/promote-to-eval`, but the `vibe_eval_draft` it produced was **unreachable** — that HTTP API was removed in #1176 — and `promoteAgentTryoutToEval()` in `web/src/lib/api/agent-tryouts.ts` had **zero callers**. The route wrote into a black hole.

Promotion now derives a `challengepack.Composition` from the tryout and creates a **`challenge_pack_draft`** through the existing `ChallengePackBuilderService`, so a promoted tryout lands in the visual pack builder: editable, compilable, publishable, runnable. The web side surfaces a "From a tryout" action on the challenge-packs page that lists completed workspace tryouts and navigates into the builder on success.

**No new endpoints, tables, migrations, permission actions, or packages.** The only genuinely new code is the mapper; everything downstream already existed.

### Why the tryout's evaluation spec can't be copied directly

`evaluation_spec_snapshot` is a *different schema* from `scoring.EvaluationSpec`, not a subset:

- Its validator types (`json_field`, `artifact_produced`, `command_exit_code`) are not valid `scoring.ValidatorType` values and carry no `target`, which `ValidateEvaluationSpec` requires.
- Its scorecard is a list of display labels. `accuracy`, `visuals`, `escalation`, `compliance`, `hallucination`, `relevance`, `tone`, `deliverability`, `exceptions` — used by 5 of the 12 built-in templates — expand to an empty `Source` and fail validation.
- `ValidateEvaluationSpec` requires at least one deterministic validator even for judge-only packs.

So the mapper rebuilds the pack from evidence the tryout genuinely carries:

| Source | Target |
| --- | --- |
| `runtime.expected_artifacts` | `file_capture` post-execution checks + one `file_exists` validator each (falls back to a non-empty-output validator when none are declared) |
| `evaluation_spec_snapshot.llm_judges` | judges verbatim — already the exact `scoring.LLMJudgeDeclaration` shape — plus one dimension each |
| `tool_policy_snapshot` | `version.tool_policy` verbatim |
| `input_snapshot` | the single input-set case payload |
| `cost_limit_usd` / `max_duration_seconds` | runtime limits + latency/cost dimension normalization |

Unmappable free-text dimensions are **dropped rather than fabricated** — no scoring source exists for them, and the builder's dimension editor is where they're re-added against a real one. `BundleToComposition` does the final conversion, which also preserves the `Advanced` passthrough for fields the builder UI can't yet render.

## Type

`feat`

## Areas touched

- [x] Backend (`backend/`)
- [ ] CLI (`cli/`)
- [x] Frontend (`web/`)
- [x] Docs / other

## Verification

```
backend  go build ./...                              PASS
backend  go vet ./...                                PASS
backend  go test -short -race -count=1 ./internal/api/...   ok (2.480s)
runtime  go build ./... && go vet ./...              PASS
cli      go build ./... && go vet ./...              PASS
web      npx eslint .                                0 errors (5 pre-existing warnings, none in touched files)
web      npx tsc --noEmit                            0 errors
web      pnpm build                                  PASS
web      vitest promote-tryout-dialog.test.tsx       4 passed
redocly  lint docs/api-server/openapi.yaml           valid (3 pre-existing warnings)
```

`TestAgentTryoutPackBundleAlwaysCompiles` drives 6 snapshot shapes (full, sparse, malformed, no artifacts, no judges, empty) through the real publish path — `ComposeBundle → ValidateBundle → BundleYAML → ParseYAML` — so a promoted draft is proven publishable rather than merely well-formed.

Pre-existing failures on this machine, verified identical on clean `main` via `git stash --include-untracked`: `internal/workflow` `TestAgentHarnessValidatorWorkdir` and `TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace` (Windows `filepath.Join` separators), plus some `runtime` provider/scoring and web snapshot tests. None are touched by this change.

- [x] Builds, `vet`/`lint`, and type checks pass for every part I touched
- [x] Tests added/updated (happy path and a failure path where applicable)
- [x] If a backend route changed, `docs/api-server/openapi.yaml` is updated
- [x] If DB queries changed, `sqlc generate` was run — n/a, no query changes

## Contributor License Agreement

- [x] I have read and agree to the project CLA (CONTRIBUTOR_LICENSE_AGREEMENT.md), and I have the right to submit these contributions under it

## Notes for reviewers

Two intentional behavior changes worth your attention:

1. **`AgentTryoutPromotionResult` response shape changed.** `conversation_id` is replaced by `workspace_id`. The old field referenced a `vibe_eval_conversations` row this path no longer creates — returning a fabricated UUID would have been dishonest, and `workspace_id` is what a caller of the non-workspace-scoped route actually needs to locate the draft. `draft_id` keeps its name but now identifies a `challenge_pack_drafts` row. Not marked `feat!` because release-please versions only `cli/`, which is untouched, and the only web caller was the zero-caller function this PR wires up.

2. **Promotion is now gated on `publish_challenge_pack`,** because `CreateDraft` re-authorizes — correct, since a promotion now produces a publishable pack. `workspace_admin` and `workspace_member` are unaffected; **`workspace_viewer` now receives 403** where it previously received a 201 that produced nothing reachable.

Follow-up, not in this PR: `vibe_eval_conversations` and `vibe_eval_drafts` now have zero writers and zero readers (verified by repo-wide grep — the only remaining references are their own definitions in `repository/vibe_eval.go` and generated `sqlc/`). They're a clean drop migration whenever you want it.
