### PR TITLE
feat: make AgentClash agent-readable

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -42,11 +42,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          binary="$(find dist -type f -path '*linux_amd64*' -name agentclash -perm -111 | head -n 1)"
-          if [ -z "${binary}" ]; then
-            echo "released linux/amd64 binary not found" >&2
+          archive="dist/agentclash_linux_amd64.tar.gz"
+          if [ ! -f "${archive}" ]; then
+            echo "released linux/amd64 archive not found" >&2
             exit 1
           fi
+          extraction_dir="$(mktemp -d)"
+          tar -xzf "${archive}" -C "${extraction_dir}"
+          binary="${extraction_dir}/agentclash"
+          test -x "${binary}"
           "${binary}" schema --json > cli-schema.json
           expected="${GITHUB_REF_NAME#v}"
           actual="$(jq -r '.cli_version' cli-schema.json)"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -38,6 +38,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+      - name: Publish machine-readable CLI schema
+        shell: bash
+        run: |
+          set -euo pipefail
+          binary="$(find dist -type f -path '*linux_amd64*' -name agentclash -perm -111 | head -n 1)"
+          if [ -z "${binary}" ]; then
+            echo "released linux/amd64 binary not found" >&2
+            exit 1
+          fi
+          "${binary}" schema --json > cli-schema.json
+          expected="${GITHUB_REF_NAME#v}"
+          actual="$(jq -r '.cli_version' cli-schema.json)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "cli-schema.json version ${actual} does not match release ${expected}" >&2
+            exit 1
+          fi
+          jq -e '.schema_version > 0 and (.commands | length > 0)' cli-schema.json >/dev/null
+          gh release upload "${GITHUB_REF_NAME}" cli-schema.json --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-npm:
     name: Publish to npm
     needs: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ scoring. To drive it from a coding agent in *your* project:
    ```
 
 4. Humans do one-time setup on the **web** (sign in, add provider API keys /
-   BYOK, deployments) at https://agentclash.dev. The CLI is the
+   BYOK, deployments) at https://www.agentclash.dev. The CLI is the
    iterate-on-challenge-packs loop; there are no built-in packs — you author
    your own.
 

--- a/backend/db/migrations/00069_indexable_public_share_links.sql
+++ b/backend/db/migrations/00069_indexable_public_share_links.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+CREATE INDEX public_share_links_indexable_cursor_idx
+ON public_share_links (id)
+WHERE is_active AND search_indexing AND revoked_at IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS public_share_links_indexable_cursor_idx;

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -1170,6 +1170,7 @@ type agentTryoutResponse struct {
 }
 
 type publicAgentTryoutResponse struct {
+	Type                   string                                `json:"type,omitempty"`
 	ID                     uuid.UUID                             `json:"id"`
 	TemplateSlug           string                                `json:"template_slug"`
 	Status                 repository.AgentTryoutStatus          `json:"status"`
@@ -1716,6 +1717,7 @@ func mapAgentTryoutResponse(tryout repository.AgentTryout) agentTryoutResponse {
 
 func mapPublicAgentTryoutResponse(tryout repository.AgentTryout) publicAgentTryoutResponse {
 	return publicAgentTryoutResponse{
+		Type:                   string(repository.PublicShareResourceAgentTryout),
 		ID:                     tryout.ID,
 		TemplateSlug:           tryout.TemplateSlug,
 		Status:                 tryout.Status,

--- a/backend/internal/api/middleware.go
+++ b/backend/internal/api/middleware.go
@@ -56,15 +56,96 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(recorder, r)
 
-			logger.Info("http request completed",
+			attributes := []any{
 				"request_id", RequestIDFromContext(r.Context()).String(),
 				"method", r.Method,
-				"path", r.URL.Path,
+				"path", safeRequestLogPath(r.URL.Path),
 				"status", recorder.Status(),
+				"response_bytes", recorder.BytesWritten(),
 				"duration_ms", time.Since(startedAt).Milliseconds(),
-			)
+			}
+			if shouldLogAgentReadableAPIRequest(r) {
+				attributes = append(attributes,
+					"agent_family", classifyAgentAPIUserAgent(r.UserAgent()),
+					"accept_class", classifyAgentAPIAccept(r.Header.Get("Accept")),
+					"requested_representation", requestedAPIRepresentation(r.Header.Get("Accept")),
+					"served_representation", "json",
+					"route_kind", agentAPIRouteKind(r.URL.Path),
+				)
+			}
+			logger.Info("http request completed", attributes...)
 		})
 	}
+}
+
+func safeRequestLogPath(path string) string {
+	if strings.HasPrefix(path, "/public/shares/") {
+		return "/public/shares/{token}"
+	}
+	return path
+}
+
+func shouldLogAgentReadableAPIRequest(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, "/public/publications") ||
+		classifyAgentAPIUserAgent(r.UserAgent()) != "unclassified" ||
+		strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/markdown")
+}
+
+func classifyAgentAPIUserAgent(raw string) string {
+	normalized := strings.ToLower(raw)
+	families := []struct{ needle, label string }{
+		{"gptbot", "GPTBot"},
+		{"oai-searchbot", "OAI-SearchBot"},
+		{"chatgpt-user", "ChatGPT-User"},
+		{"claude-searchbot", "Claude-SearchBot"},
+		{"claude-user", "Claude-User"},
+		{"claudebot", "ClaudeBot"},
+		{"perplexitybot", "PerplexityBot"},
+		{"perplexity-user", "Perplexity-User"},
+		{"google-extended", "Google-Extended"},
+		{"ccbot", "CCBot"},
+		{"bytespider", "Bytespider"},
+		{"meta-externalagent", "meta-externalagent"},
+		{"applebot-extended", "Applebot-Extended"},
+		{"amazonbot", "Amazonbot"},
+	}
+	for _, family := range families {
+		if strings.Contains(normalized, family.needle) {
+			return family.label
+		}
+	}
+	return "unclassified"
+}
+
+func classifyAgentAPIAccept(accept string) string {
+	normalized := strings.ToLower(accept)
+	if normalized == "" {
+		return "missing"
+	}
+	if strings.Contains(normalized, "text/markdown") {
+		return "markdown"
+	}
+	if strings.Contains(normalized, "text/html") {
+		return "html"
+	}
+	if strings.Contains(normalized, "application/json") {
+		return "json"
+	}
+	return "generic"
+}
+
+func requestedAPIRepresentation(accept string) string {
+	if strings.Contains(strings.ToLower(accept), "text/markdown") {
+		return "markdown"
+	}
+	return "json"
+}
+
+func agentAPIRouteKind(path string) string {
+	if strings.HasPrefix(path, "/public/publications") {
+		return "publication_api"
+	}
+	return "api"
 }
 
 // userAgentPattern matches our CLI's User-Agent header. The leaf binary sets
@@ -301,7 +382,7 @@ func recoverer(logger *slog.Logger) func(http.Handler) http.Handler {
 				if recovered := recover(); recovered != nil {
 					logger.Error("panic recovered from http handler",
 						"method", r.Method,
-						"path", r.URL.Path,
+						"path", safeRequestLogPath(r.URL.Path),
 						"panic", fmt.Sprint(recovered),
 						"stack", string(debug.Stack()),
 					)

--- a/backend/internal/api/middleware.go
+++ b/backend/internal/api/middleware.go
@@ -79,8 +79,26 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 }
 
 func safeRequestLogPath(path string) string {
-	if strings.HasPrefix(path, "/public/shares/") {
-		return "/public/shares/{token}"
+	for _, prefix := range []string{
+		"/public/shares/",
+		"/agent-tryouts/shared/",
+		"/v1/agent-tryouts/shared/",
+		"/invites/organization/",
+		"/invites/workspace/",
+		"/v1/invites/organization/",
+		"/v1/invites/workspace/",
+	} {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		remainder := strings.TrimPrefix(path, prefix)
+		if remainder == "" {
+			return path
+		}
+		if slash := strings.IndexByte(remainder, '/'); slash >= 0 {
+			return prefix + "{token}" + remainder[slash:]
+		}
+		return prefix + "{token}"
 	}
 	return path
 }

--- a/backend/internal/api/middleware_test.go
+++ b/backend/internal/api/middleware_test.go
@@ -68,6 +68,52 @@ func TestShouldSkipTracking(t *testing.T) {
 	}
 }
 
+func TestAgentReadableRequestLogClassifiers(t *testing.T) {
+	t.Run("redacts capability token paths", func(t *testing.T) {
+		if got := safeRequestLogPath("/public/shares/a-secret-token"); got != "/public/shares/{token}" {
+			t.Fatalf("safeRequestLogPath() = %q, want redacted token path", got)
+		}
+		if got := safeRequestLogPath("/public/publications/123"); got != "/public/publications/123" {
+			t.Fatalf("safeRequestLogPath() = %q, want publication path", got)
+		}
+	})
+
+	t.Run("classifies known agents without storing raw user agents", func(t *testing.T) {
+		cases := map[string]string{
+			"Mozilla/5.0 compatible; GPTBot/1.2": "GPTBot",
+			"ClaudeBot/1.0":                      "ClaudeBot",
+			"ordinary-browser":                   "unclassified",
+		}
+		for raw, want := range cases {
+			if got := classifyAgentAPIUserAgent(raw); got != want {
+				t.Errorf("classifyAgentAPIUserAgent(%q) = %q, want %q", raw, got, want)
+			}
+		}
+	})
+
+	t.Run("classifies representation requests", func(t *testing.T) {
+		if got := classifyAgentAPIAccept("text/markdown, text/html;q=0.5"); got != "markdown" {
+			t.Fatalf("classifyAgentAPIAccept() = %q, want markdown", got)
+		}
+		if got := requestedAPIRepresentation("application/json"); got != "json" {
+			t.Fatalf("requestedAPIRepresentation() = %q, want json", got)
+		}
+	})
+
+	t.Run("targets publication and agent requests", func(t *testing.T) {
+		publication := httptest.NewRequest(http.MethodGet, "/public/publications", nil)
+		if !shouldLogAgentReadableAPIRequest(publication) {
+			t.Fatal("publication request should receive enriched request logging")
+		}
+
+		agent := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		agent.Header.Set("User-Agent", "OAI-SearchBot/1.0")
+		if !shouldLogAgentReadableAPIRequest(agent) {
+			t.Fatal("known AI agent request should receive enriched request logging")
+		}
+	})
+}
+
 // captureFor builds a minimal chi router that injects the given caller (and
 // optional workspace-id context) ahead of trackUsage, serves a GET to
 // requestPath matched by routePattern, and returns the single captured event

--- a/backend/internal/api/middleware_test.go
+++ b/backend/internal/api/middleware_test.go
@@ -70,8 +70,20 @@ func TestShouldSkipTracking(t *testing.T) {
 
 func TestAgentReadableRequestLogClassifiers(t *testing.T) {
 	t.Run("redacts capability token paths", func(t *testing.T) {
-		if got := safeRequestLogPath("/public/shares/a-secret-token"); got != "/public/shares/{token}" {
-			t.Fatalf("safeRequestLogPath() = %q, want redacted token path", got)
+		cases := map[string]string{
+			"/public/shares/a-secret-token":                  "/public/shares/{token}",
+			"/agent-tryouts/shared/a-secret-token/events":    "/agent-tryouts/shared/{token}/events",
+			"/v1/agent-tryouts/shared/a-secret-token/events": "/v1/agent-tryouts/shared/{token}/events",
+			"/invites/organization/a-secret-token":           "/invites/organization/{token}",
+			"/invites/workspace/a-secret-token":              "/invites/workspace/{token}",
+			"/v1/invites/organization/a-secret-token":        "/v1/invites/organization/{token}",
+			"/v1/invites/workspace/a-secret-token":           "/v1/invites/workspace/{token}",
+			"/public/shares/a-secret-token/extra":            "/public/shares/{token}/extra",
+		}
+		for path, want := range cases {
+			if got := safeRequestLogPath(path); got != want {
+				t.Errorf("safeRequestLogPath(%q) = %q, want %q", path, got, want)
+			}
 		}
 		if got := safeRequestLogPath("/public/publications/123"); got != "/public/publications/123" {
 			t.Fatalf("safeRequestLogPath() = %q, want publication path", got)

--- a/backend/internal/api/permissions.go
+++ b/backend/internal/api/permissions.go
@@ -27,6 +27,7 @@ const (
 	ActionManageDatasets              Action = "manage_datasets"
 	ActionSelectIntegrationRepository Action = "select_integration_repository"
 	ActionPublishChallengePack        Action = "publish_challenge_pack"
+	ActionPublishPublicArtifact       Action = "publish_public_artifact"
 	ActionUploadArtifact              Action = "upload_artifact"
 
 	// Admin-level actions — allowed for workspace_admin only.
@@ -63,6 +64,7 @@ var permissionMatrix = map[string]map[Action]bool{
 		ActionManageDatasets:              true,
 		ActionSelectIntegrationRepository: true,
 		ActionPublishChallengePack:        true,
+		ActionPublishPublicArtifact:       true,
 		ActionUploadArtifact:              true,
 		ActionManageInfrastructure:        true,
 		ActionManageIntegrations:          true,
@@ -82,6 +84,7 @@ var permissionMatrix = map[string]map[Action]bool{
 		ActionManageDatasets:              true,
 		ActionSelectIntegrationRepository: true,
 		ActionPublishChallengePack:        true,
+		ActionPublishPublicArtifact:       true,
 		ActionUploadArtifact:              true,
 	},
 	RoleWorkspaceViewer: {

--- a/backend/internal/api/permissions_test.go
+++ b/backend/internal/api/permissions_test.go
@@ -38,6 +38,7 @@ func TestRequireWorkspaceRole_AdminAllowedForAllActions(t *testing.T) {
 		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
+		ActionPublishPublicArtifact,
 		ActionUploadArtifact,
 		ActionManageInfrastructure,
 		ActionManageSecrets,
@@ -70,6 +71,7 @@ func TestRequireWorkspaceRole_MemberAllowedForBusinessActions(t *testing.T) {
 		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
+		ActionPublishPublicArtifact,
 		ActionUploadArtifact,
 	}
 
@@ -138,6 +140,7 @@ func TestRequireWorkspaceRole_ViewerDeniedWrites(t *testing.T) {
 		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
+		ActionPublishPublicArtifact,
 		ActionUploadArtifact,
 		ActionManageInfrastructure,
 		ActionManageSecrets,

--- a/backend/internal/api/public_shares.go
+++ b/backend/internal/api/public_shares.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +24,10 @@ import (
 type PublicShareRepository interface {
 	CreatePublicShareLink(ctx context.Context, params repository.CreatePublicShareLinkParams) (repository.PublicShareLink, error)
 	RevokePublicShareLink(ctx context.Context, id uuid.UUID) error
+	SetPublicShareSearchIndexing(ctx context.Context, id uuid.UUID, enabled bool) error
 	GetPublicShareLinkByID(ctx context.Context, id uuid.UUID) (repository.PublicShareLink, error)
+	GetIndexablePublicShareLinkByID(ctx context.Context, id uuid.UUID) (repository.PublicShareLink, error)
+	ListIndexablePublicShareLinks(ctx context.Context, after *uuid.UUID, limit int) ([]repository.PublicShareLink, error)
 	GetActivePublicShareLinkByKey(ctx context.Context, key string) (repository.PublicShareLink, error)
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
 	GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error)
@@ -43,7 +48,10 @@ type PublicShareRepository interface {
 type PublicShareService interface {
 	CreateShareLink(ctx context.Context, caller Caller, input CreateShareLinkInput) (CreateShareLinkResult, error)
 	RevokeShareLink(ctx context.Context, caller Caller, shareID uuid.UUID) error
+	SetShareSearchIndexing(ctx context.Context, caller Caller, shareID uuid.UUID, enabled bool) error
 	GetPublicShare(ctx context.Context, token string, baseURL string) (PublicSharePayload, error)
+	GetPublication(ctx context.Context, id uuid.UUID) (PublicPublicationPayload, error)
+	ListPublications(ctx context.Context, cursor *uuid.UUID, limit int) (PublicPublicationList, error)
 }
 
 type CreateShareLinkInput struct {
@@ -54,14 +62,34 @@ type CreateShareLinkInput struct {
 }
 
 type CreateShareLinkResult struct {
-	Share repository.PublicShareLink
-	Token string
-	URL   string
+	Share          repository.PublicShareLink
+	Token          string
+	URL            string
+	PublicationURL string
 }
 
 type PublicSharePayload struct {
 	Share    publicShareLinkResponse `json:"share"`
 	Resource any                     `json:"resource"`
+}
+
+type PublicPublicationPayload struct {
+	Publication publicPublicationResponse `json:"publication"`
+	Resource    any                       `json:"resource"`
+}
+
+type PublicPublicationList struct {
+	Items      []PublicPublicationPayload `json:"items"`
+	NextCursor *string                    `json:"next_cursor,omitempty"`
+}
+
+type publicPublicationResponse struct {
+	ID            uuid.UUID  `json:"id"`
+	ResourceType  string     `json:"resource_type"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+	CanonicalPath string     `json:"canonical_path"`
 }
 
 type PublicShareManager struct {
@@ -94,6 +122,11 @@ func (m *PublicShareManager) CreateShareLink(ctx context.Context, caller Caller,
 	if err != nil {
 		return CreateShareLinkResult{}, err
 	}
+	if input.SearchIndexing {
+		if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionPublishPublicArtifact); err != nil {
+			return CreateShareLinkResult{}, err
+		}
+	}
 
 	key, err := newShareKey()
 	if err != nil {
@@ -114,11 +147,15 @@ func (m *PublicShareManager) CreateShareLink(ctx context.Context, caller Caller,
 		return CreateShareLinkResult{}, err
 	}
 
-	return CreateShareLinkResult{
+	result := CreateShareLinkResult{
 		Share: share,
 		Token: share.Key,
 		URL:   m.shareURL(share.Key),
-	}, nil
+	}
+	if share.SearchIndexing {
+		result.PublicationURL = m.publicationURL(share.ID)
+	}
+	return result, nil
 }
 
 func (m *PublicShareManager) RevokeShareLink(ctx context.Context, caller Caller, shareID uuid.UUID) error {
@@ -132,6 +169,21 @@ func (m *PublicShareManager) RevokeShareLink(ctx context.Context, caller Caller,
 	return m.repo.RevokePublicShareLink(ctx, shareID)
 }
 
+func (m *PublicShareManager) SetShareSearchIndexing(ctx context.Context, caller Caller, shareID uuid.UUID, enabled bool) error {
+	share, err := m.repo.GetPublicShareLinkByID(ctx, shareID)
+	if err != nil {
+		return err
+	}
+	if enabled {
+		if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, share.WorkspaceID, ActionPublishPublicArtifact); err != nil {
+			return err
+		}
+	} else if err := m.authorizer.AuthorizeWorkspace(ctx, caller, share.WorkspaceID); err != nil {
+		return err
+	}
+	return m.repo.SetPublicShareSearchIndexing(ctx, shareID, enabled)
+}
+
 func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string, baseURL string) (PublicSharePayload, error) {
 	key := strings.TrimSpace(token)
 	if key == "" {
@@ -142,7 +194,7 @@ func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string, b
 		return PublicSharePayload{}, err
 	}
 
-	resource, err := m.publicResource(ctx, share, baseURL)
+	resource, err := m.publicResource(ctx, share, baseURL, true)
 	if err != nil {
 		return PublicSharePayload{}, err
 	}
@@ -150,6 +202,95 @@ func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string, b
 		Share:    mapPublicShareLink(share, ""),
 		Resource: resource,
 	}, nil
+}
+
+func (m *PublicShareManager) GetPublication(ctx context.Context, id uuid.UUID) (PublicPublicationPayload, error) {
+	if id == uuid.Nil {
+		return PublicPublicationPayload{}, repository.ErrPublicShareLinkNotFound
+	}
+	share, err := m.repo.GetIndexablePublicShareLinkByID(ctx, id)
+	if err != nil {
+		return PublicPublicationPayload{}, err
+	}
+	return m.publicationPayload(ctx, share)
+}
+
+func (m *PublicShareManager) ListPublications(ctx context.Context, cursor *uuid.UUID, limit int) (PublicPublicationList, error) {
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	shares, err := m.repo.ListIndexablePublicShareLinks(ctx, cursor, limit)
+	if err != nil {
+		return PublicPublicationList{}, err
+	}
+
+	items := make([]PublicPublicationPayload, 0, len(shares))
+	for _, share := range shares {
+		payload, payloadErr := m.publicationPayload(ctx, share)
+		if payloadErr != nil {
+			if publicationUnavailable(payloadErr) {
+				continue
+			}
+			return PublicPublicationList{}, payloadErr
+		}
+		items = append(items, payload)
+	}
+
+	var nextCursor *string
+	if len(shares) == limit && len(shares) > 0 {
+		value := shares[len(shares)-1].ID.String()
+		nextCursor = &value
+	}
+	return PublicPublicationList{Items: items, NextCursor: nextCursor}, nil
+}
+
+func publicationUnavailable(err error) bool {
+	return errors.Is(err, repository.ErrPublicShareLinkNotFound) ||
+		errors.Is(err, repository.ErrChallengePackVersionNotFound) ||
+		errors.Is(err, repository.ErrRunNotFound) ||
+		errors.Is(err, repository.ErrRunScorecardNotFound) ||
+		errors.Is(err, repository.ErrRunAgentNotFound) ||
+		errors.Is(err, repository.ErrRunAgentScorecardNotFound) ||
+		errors.Is(err, repository.ErrRunAgentReplayNotFound) ||
+		errors.Is(err, repository.ErrAgentTryoutNotFound)
+}
+
+func (m *PublicShareManager) publicationPayload(ctx context.Context, share repository.PublicShareLink) (PublicPublicationPayload, error) {
+	if !m.publicationEligible(share) {
+		return PublicPublicationPayload{}, repository.ErrPublicShareLinkNotFound
+	}
+	resource, resourceUpdatedAt, err := m.publicationResource(ctx, share)
+	if err != nil {
+		return PublicPublicationPayload{}, err
+	}
+	updatedAt := share.UpdatedAt
+	if resourceUpdatedAt.After(updatedAt) {
+		updatedAt = resourceUpdatedAt
+	}
+	return PublicPublicationPayload{
+		Publication: publicPublicationResponse{
+			ID:            share.ID,
+			ResourceType:  string(share.ResourceType),
+			ExpiresAt:     share.ExpiresAt,
+			CreatedAt:     share.CreatedAt,
+			UpdatedAt:     updatedAt,
+			CanonicalPath: "/publications/" + share.ID.String(),
+		},
+		Resource: resource,
+	}, nil
+}
+
+func (m *PublicShareManager) publicationEligible(share repository.PublicShareLink) bool {
+	if !share.IsActive || !share.SearchIndexing || share.RevokedAt != nil {
+		return false
+	}
+	if share.ExpiresAt != nil && !share.ExpiresAt.After(m.clock()) {
+		return false
+	}
+	return validPublicShareResourceType(share.ResourceType)
 }
 
 func (m *PublicShareManager) authorizedResourceScope(ctx context.Context, caller Caller, input CreateShareLinkInput) (uuid.UUID, uuid.UUID, error) {
@@ -226,7 +367,7 @@ func (m *PublicShareManager) authorizedResourceScope(ctx context.Context, caller
 	}
 }
 
-func (m *PublicShareManager) publicResource(ctx context.Context, share repository.PublicShareLink, baseURL string) (any, error) {
+func (m *PublicShareManager) publicResource(ctx context.Context, share repository.PublicShareLink, baseURL string, includeSignedArtifactURLs bool) (any, error) {
 	switch share.ResourceType {
 	case repository.PublicShareResourceChallengePackVersion:
 		snapshot, err := m.repo.GetPublicChallengePackVersionSnapshot(ctx, share.ResourceID)
@@ -266,17 +407,134 @@ func (m *PublicShareManager) publicResource(ctx context.Context, share repositor
 		if !tryout.RedactionStatus.ShareReady() {
 			return nil, repository.ErrPublicShareLinkNotFound
 		}
-		return m.publicAgentTryout(ctx, tryout, baseURL)
+		return m.publicAgentTryout(ctx, tryout, baseURL, includeSignedArtifactURLs)
 	default:
 		return nil, repository.ErrPublicShareLinkNotFound
 	}
+}
+
+// publicationResource is deliberately separate from capability-share
+// serialization. Publication URLs are enumerable and indexable, so they expose
+// only presentation fields and stable public aliases. Database UUIDs,
+// evaluation-spec identifiers, capability material, and signed artifact URLs
+// never cross this boundary.
+func (m *PublicShareManager) publicationResource(ctx context.Context, share repository.PublicShareLink) (any, time.Time, error) {
+	switch share.ResourceType {
+	case repository.PublicShareResourceChallengePackVersion:
+		snapshot, err := m.repo.GetPublicChallengePackVersionSnapshot(ctx, share.ResourceID)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if !publicationJSONObjectValid(snapshot.Manifest) {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		return mapPublicationChallengePackVersion(snapshot), snapshot.UpdatedAt, nil
+	case repository.PublicShareResourceRunScorecard:
+		snapshot, err := m.repo.GetPublicRunScorecardSnapshot(ctx, share.ResourceID)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if !publicationScorecardsValid(snapshot.Scorecard.Scorecard, snapshot.AgentScorecards) {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		return mapPublicationRunScorecard(snapshot), runScorecardSnapshotUpdatedAt(snapshot), nil
+	case repository.PublicShareResourceRunAgentScorecard:
+		snapshot, err := m.repo.GetPublicRunAgentScorecardSnapshot(ctx, share.ResourceID)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if !publicationJSONObjectValid(snapshot.Scorecard.Scorecard) || !publicationAgentScorecardsValid(snapshot.AgentScorecards) {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		return mapPublicationRunAgentScorecard(snapshot), runAgentScorecardSnapshotUpdatedAt(snapshot), nil
+	case repository.PublicShareResourceRunAgentReplay:
+		snapshot, err := m.repo.GetPublicRunAgentReplaySnapshot(ctx, share.ResourceID)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if !publicationJSONObjectValid(snapshot.Replay.Summary) {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		return mapPublicationRunAgentReplay(snapshot), latestTime(snapshot.Run.UpdatedAt, snapshot.RunAgent.UpdatedAt, snapshot.Replay.UpdatedAt), nil
+	case repository.PublicShareResourceAgentTryout:
+		tryout, err := m.repo.GetAgentTryoutByID(ctx, share.ResourceID)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if !tryout.RedactionStatus.ShareReady() {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		if !publicationJSONObjectValid(tryout.InputSnapshot) || !publicationJSONObjectValid(tryout.Summary) {
+			return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+		}
+		publicTryout, err := m.publicAgentTryout(ctx, tryout, "", false)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		return mapPublicationAgentTryout(publicTryout), tryout.UpdatedAt, nil
+	default:
+		return nil, time.Time{}, repository.ErrPublicShareLinkNotFound
+	}
+}
+
+func publicationJSONObjectValid(raw json.RawMessage) bool {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return false
+	}
+	var object map[string]any
+	return json.Unmarshal(raw, &object) == nil && object != nil
+}
+
+func publicationAgentScorecardsValid(scorecards []repository.RunAgentScorecard) bool {
+	for _, scorecard := range scorecards {
+		if !publicationJSONObjectValid(scorecard.Scorecard) {
+			return false
+		}
+	}
+	return true
+}
+
+func publicationScorecardsValid(runScorecard json.RawMessage, agentScorecards []repository.RunAgentScorecard) bool {
+	return publicationJSONObjectValid(runScorecard) && publicationAgentScorecardsValid(agentScorecards)
+}
+
+func runScorecardSnapshotUpdatedAt(snapshot repository.PublicRunScorecardSnapshot) time.Time {
+	values := []time.Time{snapshot.Run.UpdatedAt, snapshot.Scorecard.UpdatedAt}
+	for _, agent := range snapshot.Agents {
+		values = append(values, agent.UpdatedAt)
+	}
+	for _, scorecard := range snapshot.AgentScorecards {
+		values = append(values, scorecard.UpdatedAt)
+	}
+	return latestTime(values...)
+}
+
+func runAgentScorecardSnapshotUpdatedAt(snapshot repository.PublicRunAgentScorecardSnapshot) time.Time {
+	values := []time.Time{snapshot.Run.UpdatedAt, snapshot.RunAgent.UpdatedAt, snapshot.Scorecard.UpdatedAt}
+	for _, agent := range snapshot.SiblingAgents {
+		values = append(values, agent.UpdatedAt)
+	}
+	for _, scorecard := range snapshot.AgentScorecards {
+		values = append(values, scorecard.UpdatedAt)
+	}
+	return latestTime(values...)
+}
+
+func latestTime(values ...time.Time) time.Time {
+	var latest time.Time
+	for _, value := range values {
+		if value.After(latest) {
+			latest = value
+		}
+	}
+	return latest
 }
 
 // publicAgentTryout builds the redaction-safe, shareable view of a tryout:
 // the public payload (no org/workspace/user identifiers) with a defensively
 // re-redacted summary, plus the template-allowlisted, redacted artifact
 // descriptors (with signed download URLs when a signer is configured).
-func (m *PublicShareManager) publicAgentTryout(ctx context.Context, tryout repository.AgentTryout, baseURL string) (sharedAgentTryoutResponse, error) {
+func (m *PublicShareManager) publicAgentTryout(ctx context.Context, tryout repository.AgentTryout, baseURL string, includeSignedArtifactURLs bool) (sharedAgentTryoutResponse, error) {
 	payload := mapPublicAgentTryoutResponse(tryout)
 	payload.Summary = redactTryoutSummaryForPublic(payload.Summary)
 	resp := sharedAgentTryoutResponse{publicAgentTryoutResponse: payload}
@@ -289,7 +547,11 @@ func (m *PublicShareManager) publicAgentTryout(ctx context.Context, tryout repos
 	if err != nil {
 		return sharedAgentTryoutResponse{}, err
 	}
-	resp.Artifacts = buildSharedTryoutArtifacts(artifacts, allow, m.artifactSigner, baseURL, m.clock())
+	var signer ArtifactContentSigner
+	if includeSignedArtifactURLs {
+		signer = m.artifactSigner
+	}
+	resp.Artifacts = buildSharedTryoutArtifacts(artifacts, allow, signer, baseURL, m.clock())
 	return resp, nil
 }
 
@@ -303,13 +565,34 @@ func (m *PublicShareManager) clock() time.Time {
 func (m *PublicShareManager) shareURL(token string) string {
 	base := m.frontendURL
 	if base == "" {
-		base = "https://agentclash.dev"
+		base = "https://www.agentclash.dev"
 	}
 	parsed, err := url.Parse(base)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "https://agentclash.dev/share/" + token
+		return "https://www.agentclash.dev/share/" + token
+	}
+	if parsed.Hostname() == "agentclash.dev" {
+		parsed.Host = "www.agentclash.dev"
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/share/" + token
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func (m *PublicShareManager) publicationURL(id uuid.UUID) string {
+	base := m.frontendURL
+	if base == "" {
+		base = "https://www.agentclash.dev"
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "https://www.agentclash.dev/publications/" + id.String()
+	}
+	if parsed.Hostname() == "agentclash.dev" {
+		parsed.Host = "www.agentclash.dev"
+	}
+	parsed.Path = "/publications/" + id.String()
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
@@ -323,9 +606,10 @@ type createShareLinkRequest struct {
 }
 
 type createShareLinkResponse struct {
-	Share publicShareLinkResponse `json:"share"`
-	Token string                  `json:"token"`
-	URL   string                  `json:"url"`
+	Share          publicShareLinkResponse `json:"share"`
+	Token          string                  `json:"token"`
+	URL            string                  `json:"url"`
+	PublicationURL string                  `json:"publication_url,omitempty"`
 }
 
 type publicShareLinkResponse struct {
@@ -368,9 +652,10 @@ func createShareLinkHandler(logger *slog.Logger, service PublicShareService) htt
 			return
 		}
 		writeJSON(w, http.StatusCreated, createShareLinkResponse{
-			Share: mapPublicShareLink(result.Share, result.URL),
-			Token: result.Token,
-			URL:   result.URL,
+			Share:          mapPublicShareLink(result.Share, result.URL),
+			Token:          result.Token,
+			URL:            result.URL,
+			PublicationURL: result.PublicationURL,
 		})
 	}
 }
@@ -395,10 +680,86 @@ func revokeShareLinkHandler(logger *slog.Logger, service PublicShareService) htt
 	}
 }
 
+type updateShareLinkRequest struct {
+	SearchIndexing *bool `json:"search_indexing"`
+}
+
+func updateShareLinkHandler(logger *slog.Logger, service PublicShareService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		shareID, err := uuid.Parse(chi.URLParam(r, "shareID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_share_id", "share id must be a valid UUID")
+			return
+		}
+		var request updateShareLinkRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request.SearchIndexing == nil {
+			writeError(w, http.StatusBadRequest, "invalid_share_request", "search_indexing is required")
+			return
+		}
+		if err := service.SetShareSearchIndexing(r.Context(), caller, shareID, *request.SearchIndexing); err != nil {
+			writeShareError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusNoContent, nil)
+	}
+}
+
 func getPublicShareHandler(logger *slog.Logger, service PublicShareService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := chi.URLParam(r, "token")
 		result, err := service.GetPublicShare(r.Context(), token, requestBaseURL(r))
+		if err != nil {
+			writeShareError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func getPublicationHandler(logger *slog.Logger, service PublicShareService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		id, err := uuid.Parse(chi.URLParam(r, "publicationID"))
+		if err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "publication not found")
+			return
+		}
+		result, err := service.GetPublication(r.Context(), id)
+		if err != nil {
+			writeShareError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func listPublicationsHandler(logger *slog.Logger, service PublicShareService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		var cursor *uuid.UUID
+		if value := strings.TrimSpace(r.URL.Query().Get("cursor")); value != "" {
+			parsed, err := uuid.Parse(value)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "invalid_cursor", "cursor must be a publication ID")
+				return
+			}
+			cursor = &parsed
+		}
+		limit := 20
+		if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+			parsed, err := strconv.Atoi(value)
+			if err != nil || parsed < 1 || parsed > 100 {
+				writeError(w, http.StatusBadRequest, "invalid_limit", "limit must be between 1 and 100")
+				return
+			}
+			limit = parsed
+		}
+		result, err := service.ListPublications(r.Context(), cursor, limit)
 		if err != nil {
 			writeShareError(w, logger, r, err)
 			return
@@ -426,7 +787,7 @@ func writeShareError(w http.ResponseWriter, logger *slog.Logger, r *http.Request
 	case errors.Is(err, ErrAgentTryoutRedactionNotReady):
 		writeError(w, http.StatusConflict, "agent_tryout_redaction_not_ready", "This tryout's evidence is still being redacted for safe sharing. Try again once it has finished.")
 	default:
-		logger.Error("public share request failed", "method", r.Method, "path", r.URL.Path, "error", err)
+		logger.Error("public share request failed", "method", r.Method, "path", safeRequestLogPath(r.URL.Path), "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
 	}
 }
@@ -466,6 +827,270 @@ func mapPublicShareLink(share repository.PublicShareLink, shareURL string) publi
 		UpdatedAt:      share.UpdatedAt,
 		URL:            shareURL,
 	}
+}
+
+func mapPublicationChallengePackVersion(snapshot repository.PublicChallengePackVersionSnapshot) any {
+	inputSets := make([]map[string]any, 0, len(snapshot.InputSets))
+	for _, inputSet := range snapshot.InputSets {
+		inputSets = append(inputSets, map[string]any{
+			"input_key": inputSet.InputKey,
+			"name":      inputSet.Name,
+		})
+	}
+	return map[string]any{
+		"type": "challenge_pack_version",
+		"pack": map[string]any{
+			"slug":        snapshot.PackSlug,
+			"name":        snapshot.PackName,
+			"family":      snapshot.PackFamily,
+			"description": snapshot.PackDescription,
+		},
+		"version": map[string]any{
+			"version_number":   snapshot.VersionNumber,
+			"lifecycle_status": snapshot.LifecycleStatus,
+			"manifest":         sanitizePublicationJSON(snapshot.Manifest),
+			"input_sets":       inputSets,
+			"created_at":       snapshot.CreatedAt,
+			"updated_at":       snapshot.UpdatedAt,
+		},
+	}
+}
+
+func mapPublicationRunScorecard(snapshot repository.PublicRunScorecardSnapshot) any {
+	aliases := publicationAgentAliases(snapshot.Agents)
+	agents := make([]map[string]any, 0, len(snapshot.Agents))
+	for _, agent := range snapshot.Agents {
+		agents = append(agents, mapPublicationRunAgent(agent, aliases[agent.ID]))
+	}
+	scorecards := make([]map[string]any, 0, len(snapshot.AgentScorecards))
+	for _, scorecard := range snapshot.AgentScorecards {
+		alias, ok := aliases[scorecard.RunAgentID]
+		if !ok {
+			continue
+		}
+		scorecards = append(scorecards, mapPublicationRunAgentScorecardValue(scorecard, alias))
+	}
+	return map[string]any{
+		"type":             "run_scorecard",
+		"run":              mapPublicationRun(snapshot.Run),
+		"agents":           agents,
+		"agent_scorecards": scorecards,
+		"scorecard":        mapPublicationRunScorecardValue(snapshot.Scorecard, aliases),
+	}
+}
+
+func mapPublicationRunAgentScorecard(snapshot repository.PublicRunAgentScorecardSnapshot) any {
+	allAgents := append([]domain.RunAgent{snapshot.RunAgent}, snapshot.SiblingAgents...)
+	aliases := publicationAgentAliases(allAgents)
+	currentAlias := aliases[snapshot.RunAgent.ID]
+	siblings := make([]map[string]any, 0, len(snapshot.SiblingAgents))
+	for _, agent := range snapshot.SiblingAgents {
+		if agent.ID == snapshot.RunAgent.ID {
+			continue
+		}
+		siblings = append(siblings, mapPublicationRunAgent(agent, aliases[agent.ID]))
+	}
+	scorecards := make([]map[string]any, 0, len(snapshot.AgentScorecards))
+	for _, scorecard := range snapshot.AgentScorecards {
+		alias, ok := aliases[scorecard.RunAgentID]
+		if !ok {
+			continue
+		}
+		scorecards = append(scorecards, mapPublicationRunAgentScorecardValue(scorecard, alias))
+	}
+	return map[string]any{
+		"type":             "run_agent_scorecard",
+		"run":              mapPublicationRun(snapshot.Run),
+		"run_agent":        mapPublicationRunAgent(snapshot.RunAgent, currentAlias),
+		"sibling_agents":   siblings,
+		"agent_scorecards": scorecards,
+		"scorecard":        mapPublicationRunAgentScorecardValue(snapshot.Scorecard, currentAlias),
+	}
+}
+
+func mapPublicationRunAgentReplay(snapshot repository.PublicRunAgentReplaySnapshot) any {
+	return map[string]any{
+		"type":      "run_agent_replay",
+		"run":       mapPublicationRun(snapshot.Run),
+		"run_agent": mapPublicationRunAgent(snapshot.RunAgent, "agent-1"),
+		"replay": map[string]any{
+			"summary":                sanitizePublicationJSON(snapshot.Replay.Summary),
+			"latest_sequence_number": snapshot.Replay.LatestSequenceNumber,
+			"event_count":            snapshot.Replay.EventCount,
+			"created_at":             snapshot.Replay.CreatedAt,
+			"updated_at":             snapshot.Replay.UpdatedAt,
+		},
+	}
+}
+
+func mapPublicationAgentTryout(tryout sharedAgentTryoutResponse) any {
+	artifacts := make([]map[string]any, 0, len(tryout.Artifacts))
+	for _, artifact := range tryout.Artifacts {
+		artifacts = append(artifacts, map[string]any{
+			"key":             artifact.Key,
+			"type":            artifact.Type,
+			"path":            artifact.Path,
+			"content_type":    artifact.ContentType,
+			"size_bytes":      artifact.SizeBytes,
+			"checksum_sha256": artifact.ChecksumSHA256,
+		})
+	}
+	return map[string]any{
+		"type":                 "agent_tryout",
+		"template_slug":        tryout.TemplateSlug,
+		"status":               tryout.Status,
+		"input_snapshot":       sanitizePublicationJSON(tryout.InputSnapshot),
+		"summary":              sanitizePublicationJSON(tryout.Summary),
+		"redaction_status":     tryout.RedactionStatus,
+		"cost_limit_usd":       tryout.CostLimitUSD,
+		"actual_cost_usd":      tryout.ActualCostUSD,
+		"latency_ms":           tryout.LatencyMS,
+		"max_duration_seconds": tryout.MaxDurationSeconds,
+		"created_at":           tryout.CreatedAt,
+		"updated_at":           tryout.UpdatedAt,
+		"artifacts":            artifacts,
+	}
+}
+
+func publicationAgentAliases(agents []domain.RunAgent) map[uuid.UUID]string {
+	aliases := make(map[uuid.UUID]string, len(agents))
+	for _, agent := range agents {
+		if _, exists := aliases[agent.ID]; exists {
+			continue
+		}
+		aliases[agent.ID] = fmt.Sprintf("agent-%d", len(aliases)+1)
+	}
+	return aliases
+}
+
+func mapPublicationRun(run domain.Run) map[string]any {
+	return map[string]any{
+		"id":             "run",
+		"name":           run.Name,
+		"status":         run.Status,
+		"execution_mode": run.ExecutionMode,
+		"started_at":     run.StartedAt,
+		"finished_at":    run.FinishedAt,
+		"created_at":     run.CreatedAt,
+	}
+}
+
+func mapPublicationRunAgent(agent domain.RunAgent, alias string) map[string]any {
+	return map[string]any{
+		"id":          alias,
+		"run_id":      "run",
+		"lane_index":  agent.LaneIndex,
+		"label":       agent.Label,
+		"status":      agent.Status,
+		"started_at":  agent.StartedAt,
+		"finished_at": agent.FinishedAt,
+	}
+}
+
+func mapPublicationRunAgentScorecardValue(scorecard repository.RunAgentScorecard, agentAlias string) map[string]any {
+	return map[string]any{
+		"id":                "scorecard-" + agentAlias,
+		"run_agent_id":      agentAlias,
+		"overall_score":     scorecard.OverallScore,
+		"correctness_score": scorecard.CorrectnessScore,
+		"reliability_score": scorecard.ReliabilityScore,
+		"latency_score":     scorecard.LatencyScore,
+		"cost_score":        scorecard.CostScore,
+		"behavioral_score":  scorecard.BehavioralScore,
+		"passed":            scorecard.Passed,
+		"scorecard":         sanitizePublicationJSON(scorecard.Scorecard),
+		"created_at":        scorecard.CreatedAt,
+		"updated_at":        scorecard.UpdatedAt,
+	}
+}
+
+func mapPublicationRunScorecardValue(scorecard repository.RunScorecard, aliases map[uuid.UUID]string) map[string]any {
+	winner := ""
+	if scorecard.WinningRunAgentID != nil {
+		winner = aliases[*scorecard.WinningRunAgentID]
+	}
+	return map[string]any{
+		"winner":     winner,
+		"scorecard":  sanitizePublicationJSON(scorecard.Scorecard),
+		"created_at": scorecard.CreatedAt,
+		"updated_at": scorecard.UpdatedAt,
+	}
+}
+
+func sanitizePublicationJSON(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil
+	}
+	return sanitizePublicationValue(decoded)
+}
+
+func sanitizePublicationValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		clean := make(map[string]any, len(typed))
+		for key, child := range typed {
+			if publicationSensitiveKey(key) {
+				continue
+			}
+			clean[key] = sanitizePublicationValue(child)
+		}
+		return clean
+	case []any:
+		clean := make([]any, len(typed))
+		for index, child := range typed {
+			clean[index] = sanitizePublicationValue(child)
+		}
+		return clean
+	case string:
+		return redactPublicationSecretValues(typed)
+	default:
+		return typed
+	}
+}
+
+var publicationSecretValuePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}`),
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}`),
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`),
+	regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+}
+
+func redactPublicationSecretValues(value string) string {
+	if strings.Contains(value, "-----BEGIN PRIVATE KEY-----") ||
+		strings.Contains(value, "-----BEGIN RSA PRIVATE KEY-----") ||
+		strings.Contains(value, "-----BEGIN OPENSSH PRIVATE KEY-----") {
+		return "[REDACTED]"
+	}
+	redacted := value
+	for _, pattern := range publicationSecretValuePatterns {
+		redacted = pattern.ReplaceAllString(redacted, "[REDACTED]")
+	}
+	return redacted
+}
+
+func publicationSensitiveKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "id" || normalized == "token" || normalized == "authorization" ||
+		normalized == "env" || normalized == "env_vars" || normalized == "environment" ||
+		normalized == "environment_variables" ||
+		strings.HasPrefix(normalized, "env_") || strings.HasSuffix(normalized, "_env") ||
+		strings.Contains(normalized, "environment") || strings.HasSuffix(normalized, "_token") ||
+		strings.HasSuffix(normalized, "_id") || strings.HasSuffix(normalized, "_ids") {
+		return true
+	}
+	for _, fragment := range []string{
+		"email", "phone", "postal_address", "street_address", "display_name",
+		"profile_image", "avatar", "username",
+	} {
+		if strings.Contains(normalized, fragment) {
+			return true
+		}
+	}
+	return sensitiveSummaryKey(normalized)
 }
 
 func mapPublicChallengePackVersion(snapshot repository.PublicChallengePackVersionSnapshot) any {

--- a/backend/internal/api/public_shares.go
+++ b/backend/internal/api/public_shares.go
@@ -1059,10 +1059,13 @@ var publicationSecretValuePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
 }
 
+// Match every PEM-style private-key marker, including EC, encrypted, and PGP
+// blocks. The payload is intentionally replaced in full rather than trying to
+// preserve surrounding text that may still contain key material.
+var publicationPrivateKeyMarker = regexp.MustCompile(`(?is)-----BEGIN[^\r\n-]{0,100}PRIVATE KEY[^\r\n-]{0,100}-----`)
+
 func redactPublicationSecretValues(value string) string {
-	if strings.Contains(value, "-----BEGIN PRIVATE KEY-----") ||
-		strings.Contains(value, "-----BEGIN RSA PRIVATE KEY-----") ||
-		strings.Contains(value, "-----BEGIN OPENSSH PRIVATE KEY-----") {
+	if publicationPrivateKeyMarker.MatchString(value) {
 		return "[REDACTED]"
 	}
 	redacted := value

--- a/backend/internal/api/public_shares_test.go
+++ b/backend/internal/api/public_shares_test.go
@@ -697,6 +697,18 @@ func TestSanitizePublicationValueRedactsSecretValuesAndEnvironmentFields(t *test
 	}
 }
 
+func TestSanitizePublicationValueRedactsAllPEMPrivateKeyMarkers(t *testing.T) {
+	for _, marker := range []string{
+		"-----BEGIN EC PRIVATE KEY-----\nsecret\n-----END EC PRIVATE KEY-----",
+		"-----BEGIN ENCRYPTED PRIVATE KEY-----\nsecret\n-----END ENCRYPTED PRIVATE KEY-----",
+		"-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret\n-----END PGP PRIVATE KEY BLOCK-----",
+	} {
+		if got := redactPublicationSecretValues("prefix " + marker + " suffix"); got != "[REDACTED]" {
+			t.Fatalf("redactPublicationSecretValues(%q) = %q, want full redaction", marker, got)
+		}
+	}
+}
+
 func TestPublicShareManager_GetPublicationFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)

--- a/backend/internal/api/public_shares_test.go
+++ b/backend/internal/api/public_shares_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +45,66 @@ func TestPublicShareManager_CreateChallengePackShareAuthorizesWorkspace(t *testi
 	}
 	if !strings.Contains(result.URL, "/share/") || result.Token == "" {
 		t.Fatalf("token/url should be populated: token=%q url=%q", result.Token, result.URL)
+	}
+}
+
+func TestPublicShareManager_ViewerCanCreatePrivateShareButCannotPublish(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	versionID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.version = repository.RunnableChallengePackVersion{
+		ID:              versionID,
+		ChallengePackID: uuid.New(),
+		WorkspaceID:     &workspaceID,
+	}
+	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://agentclash.dev")
+	viewer := callerWithWorkspaceRole(workspaceID, RoleWorkspaceViewer)
+
+	if _, err := manager.CreateShareLink(ctx, viewer, CreateShareLinkInput{
+		ResourceType: repository.PublicShareResourceChallengePackVersion,
+		ResourceID:   versionID,
+	}); err != nil {
+		t.Fatalf("viewer private CreateShareLink returned error: %v", err)
+	}
+
+	if _, err := manager.CreateShareLink(ctx, viewer, CreateShareLinkInput{
+		ResourceType:   repository.PublicShareResourceChallengePackVersion,
+		ResourceID:     versionID,
+		SearchIndexing: true,
+	}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("viewer indexable CreateShareLink error = %v, want ErrForbidden", err)
+	}
+}
+
+func TestPublicShareManager_CreateIndexableShareReturnsCanonicalPublicationURL(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	versionID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.version = repository.RunnableChallengePackVersion{
+		ID:              versionID,
+		ChallengePackID: uuid.New(),
+		WorkspaceID:     &workspaceID,
+	}
+	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://agentclash.dev")
+
+	result, err := manager.CreateShareLink(ctx, callerWithWorkspace(workspaceID), CreateShareLinkInput{
+		ResourceType:   repository.PublicShareResourceChallengePackVersion,
+		ResourceID:     versionID,
+		SearchIndexing: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateShareLink returned error: %v", err)
+	}
+	want := "https://www.agentclash.dev/publications/" + result.Share.ID.String()
+	if result.PublicationURL != want {
+		t.Fatalf("publication URL = %q, want %q", result.PublicationURL, want)
+	}
+	if strings.Contains(result.PublicationURL, result.Token) {
+		t.Fatalf("publication URL leaked capability token: %q", result.PublicationURL)
 	}
 }
 
@@ -350,12 +414,501 @@ func TestPublicShareManager_GetPublicShareAgentTryoutReturnsNarrowPayload(t *tes
 	}
 }
 
+func TestPublicShareManager_GetPublicationUsesShareIDAndOmitsCapabilityData(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	scorecardID := uuid.New()
+	evaluationSpecID := uuid.New()
+	nestedPrivateID := uuid.New()
+	shareID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.share = repository.PublicShareLink{
+		ID:             shareID,
+		Key:            "secret-capability-token",
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     runID,
+		IsActive:       true,
+		SearchIndexing: true,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	repo.run = domain.Run{
+		ID:             runID,
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           "Published scorecard",
+		Status:         domain.RunStatusCompleted,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	repo.runAgent = domain.RunAgent{
+		ID:        runAgentID,
+		RunID:     runID,
+		LaneIndex: 0,
+		Label:     "candidate",
+		Status:    domain.RunAgentStatusCompleted,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	repo.agentScorecard = repository.RunAgentScorecard{
+		ID:               scorecardID,
+		RunAgentID:       runAgentID,
+		EvaluationSpecID: evaluationSpecID,
+		Scorecard:        json.RawMessage(`{"passed":true,"workspace_id":"` + nestedPrivateID.String() + `"}`),
+	}
+	repo.runScorecard = repository.RunScorecard{
+		ID:               scorecardID,
+		RunID:            runID,
+		EvaluationSpecID: evaluationSpecID,
+		Scorecard:        json.RawMessage(`{"passed":true,"run_id":"` + runID.String() + `"}`),
+	}
+
+	payload, err := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://www.agentclash.dev").GetPublication(ctx, shareID)
+	if err != nil {
+		t.Fatalf("GetPublication returned error: %v", err)
+	}
+	if payload.Publication.CanonicalPath != "/publications/"+shareID.String() {
+		t.Fatalf("canonical path = %q", payload.Publication.CanonicalPath)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal publication: %v", err)
+	}
+	for _, privateValue := range []string{
+		"secret-capability-token",
+		orgID.String(),
+		workspaceID.String(),
+		runID.String(),
+		runAgentID.String(),
+		scorecardID.String(),
+		evaluationSpecID.String(),
+		nestedPrivateID.String(),
+	} {
+		if strings.Contains(string(encoded), privateValue) {
+			t.Fatalf("publication leaked private value %q: %s", privateValue, encoded)
+		}
+	}
+}
+
+func TestPublicShareManager_PublicationUpdatedAtTracksRenderedResource(t *testing.T) {
+	ctx := context.Background()
+	shareUpdatedAt := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+	resourceUpdatedAt := shareUpdatedAt.Add(2 * time.Hour)
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.share = repository.PublicShareLink{
+		ID:             uuid.New(),
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     runID,
+		IsActive:       true,
+		SearchIndexing: true,
+		CreatedAt:      shareUpdatedAt,
+		UpdatedAt:      shareUpdatedAt,
+	}
+	repo.run = domain.Run{
+		ID:             runID,
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           "Resource freshness",
+		Status:         domain.RunStatusCompleted,
+		UpdatedAt:      resourceUpdatedAt,
+	}
+	repo.runScorecard = repository.RunScorecard{
+		ID:        uuid.New(),
+		RunID:     runID,
+		Scorecard: json.RawMessage(`{"passed":true}`),
+		UpdatedAt: resourceUpdatedAt,
+	}
+
+	payload, err := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "").GetPublication(ctx, repo.share.ID)
+	if err != nil {
+		t.Fatalf("GetPublication returned error: %v", err)
+	}
+	if !payload.Publication.UpdatedAt.Equal(resourceUpdatedAt) {
+		t.Fatalf("publication updated_at = %s, want resource update %s", payload.Publication.UpdatedAt, resourceUpdatedAt)
+	}
+}
+
+func TestPublicShareManager_PublicationSerializerAllowlistByResourceType(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	resourceTypes := []repository.PublicShareResourceType{
+		repository.PublicShareResourceChallengePackVersion,
+		repository.PublicShareResourceRunScorecard,
+		repository.PublicShareResourceRunAgentScorecard,
+		repository.PublicShareResourceRunAgentReplay,
+		repository.PublicShareResourceAgentTryout,
+	}
+
+	for _, resourceType := range resourceTypes {
+		t.Run(string(resourceType), func(t *testing.T) {
+			orgID := uuid.New()
+			workspaceID := uuid.New()
+			runID := uuid.New()
+			runAgentID := uuid.New()
+			resourceID := uuid.New()
+			internalScorecardID := uuid.New()
+			internalEvaluationID := uuid.New()
+			repo := newFakePublicShareRepository(orgID, workspaceID)
+			repo.share = repository.PublicShareLink{
+				ID:             uuid.New(),
+				Key:            "capability-secret",
+				OrganizationID: orgID,
+				WorkspaceID:    workspaceID,
+				ResourceType:   resourceType,
+				ResourceID:     resourceID,
+				IsActive:       true,
+				SearchIndexing: true,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+			repo.version.ID = resourceID
+			repo.run = domain.Run{
+				ID:             runID,
+				OrganizationID: orgID,
+				WorkspaceID:    workspaceID,
+				Name:           "Published run",
+				Status:         domain.RunStatusCompleted,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+			repo.runAgent = domain.RunAgent{
+				ID:             runAgentID,
+				OrganizationID: orgID,
+				WorkspaceID:    workspaceID,
+				RunID:          runID,
+				Label:          "candidate",
+				Status:         domain.RunAgentStatusCompleted,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+			repo.runScorecard = repository.RunScorecard{
+				ID:               internalScorecardID,
+				RunID:            runID,
+				EvaluationSpecID: internalEvaluationID,
+				Scorecard:        json.RawMessage(`{"passed":true,"api_key":"nested-secret","run_id":"` + runID.String() + `"}`),
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}
+			repo.agentScorecard = repository.RunAgentScorecard{
+				ID:               internalScorecardID,
+				RunAgentID:       runAgentID,
+				EvaluationSpecID: internalEvaluationID,
+				Scorecard:        json.RawMessage(`{"passed":true,"credential":"nested-secret"}`),
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}
+			repo.replay = repository.RunAgentReplay{
+				ID:         internalScorecardID,
+				RunAgentID: runAgentID,
+				Summary:    json.RawMessage(`{"steps":[],"workspace_id":"` + workspaceID.String() + `"}`),
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			}
+			repo.agentTryout = repository.AgentTryout{
+				ID:              resourceID,
+				OrganizationID:  &orgID,
+				WorkspaceID:     &workspaceID,
+				TemplateSlug:    "meeting-minutes",
+				Status:          repository.AgentTryoutStatusCompleted,
+				InputSnapshot:   json.RawMessage(`{"brief":"public","authorization":"nested-secret"}`),
+				Summary:         json.RawMessage(`{"result":"public","user_id":"` + uuid.NewString() + `"}`),
+				RedactionStatus: repository.AgentTryoutRedactionPassed,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}
+
+			switch resourceType {
+			case repository.PublicShareResourceChallengePackVersion:
+				repo.share.ResourceID = repo.version.ID
+			case repository.PublicShareResourceRunScorecard:
+				repo.share.ResourceID = runID
+			case repository.PublicShareResourceRunAgentScorecard, repository.PublicShareResourceRunAgentReplay:
+				repo.share.ResourceID = runAgentID
+			case repository.PublicShareResourceAgentTryout:
+				repo.share.ResourceID = resourceID
+			}
+
+			payload, err := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "").GetPublication(ctx, repo.share.ID)
+			if err != nil {
+				t.Fatalf("GetPublication returned error: %v", err)
+			}
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal publication: %v", err)
+			}
+			if !strings.Contains(string(encoded), `"type":"`+string(resourceType)+`"`) {
+				t.Fatalf("publication type missing from payload: %s", encoded)
+			}
+			for _, privateValue := range []string{
+				"capability-secret",
+				"nested-secret",
+				orgID.String(),
+				workspaceID.String(),
+				resourceID.String(),
+				runID.String(),
+				runAgentID.String(),
+				internalScorecardID.String(),
+				internalEvaluationID.String(),
+			} {
+				if strings.Contains(string(encoded), privateValue) {
+					t.Fatalf("publication leaked private value %q: %s", privateValue, encoded)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizePublicationValueRedactsSecretValuesAndEnvironmentFields(t *testing.T) {
+	cleaned := sanitizePublicationValue(map[string]any{
+		"summary":                 "called with Bearer abcdefghijklmnop",
+		"provider_environment":    map[string]any{"region": "private"},
+		"deployment_access_token": "must-not-appear",
+		"reviewer_email":          "private@example.test",
+		"nested": []any{
+			map[string]any{"note": "key sk-abcdefghijklmnopqrstuvwxyz"},
+		},
+	})
+	encoded, err := json.Marshal(cleaned)
+	if err != nil {
+		t.Fatalf("marshal sanitized publication value: %v", err)
+	}
+	text := string(encoded)
+	for _, secret := range []string{
+		"abcdefghijklmnop",
+		"provider_environment",
+		"deployment_access_token",
+		"private@example.test",
+		"sk-abcdefghijklmnopqrstuvwxyz",
+	} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("sanitized publication leaked %q: %s", secret, text)
+		}
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Fatalf("sanitized publication should preserve explicit redaction markers: %s", text)
+	}
+}
+
+func TestPublicShareManager_GetPublicationFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)
+	base := repository.PublicShareLink{
+		ID:             uuid.New(),
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     uuid.New(),
+		IsActive:       true,
+		SearchIndexing: true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	revokedAt := now.Add(-time.Minute)
+	expiredAt := now.Add(-time.Second)
+
+	cases := map[string]func(*repository.PublicShareLink){
+		"inactive":          func(share *repository.PublicShareLink) { share.IsActive = false },
+		"indexing disabled": func(share *repository.PublicShareLink) { share.SearchIndexing = false },
+		"revoked":           func(share *repository.PublicShareLink) { share.RevokedAt = &revokedAt },
+		"expired":           func(share *repository.PublicShareLink) { share.ExpiresAt = &expiredAt },
+		"unsupported": func(share *repository.PublicShareLink) {
+			share.ResourceType = repository.PublicShareResourceType("unsupported")
+		},
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := newFakePublicShareRepository(uuid.New(), uuid.New())
+			repo.share = base
+			mutate(&repo.share)
+			manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "")
+			manager.now = func() time.Time { return now }
+			_, err := manager.GetPublication(ctx, repo.share.ID)
+			if !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+				t.Fatalf("GetPublication error = %v, want not found", err)
+			}
+		})
+	}
+}
+
+func TestPublicShareManager_GetPublicationRejectsMalformedRenderedJSON(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.share = repository.PublicShareLink{
+		ID:             uuid.New(),
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     runID,
+		IsActive:       true,
+		SearchIndexing: true,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	repo.run = domain.Run{
+		ID:             runID,
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           "Malformed scorecard",
+		Status:         domain.RunStatusCompleted,
+	}
+	repo.runScorecard = repository.RunScorecard{
+		ID:        uuid.New(),
+		RunID:     runID,
+		Scorecard: json.RawMessage(`{"unterminated":`),
+	}
+
+	_, err := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "").GetPublication(ctx, repo.share.ID)
+	if !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+		t.Fatalf("GetPublication error = %v, want not found for malformed JSON", err)
+	}
+}
+
+func TestPublicShareManager_DisablingIndexingImmediatelyHidesPublication(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	shareID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.share = repository.PublicShareLink{
+		ID:             shareID,
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     uuid.New(),
+		IsActive:       true,
+		SearchIndexing: true,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "")
+	if err := manager.SetShareSearchIndexing(ctx, callerWithWorkspace(workspaceID), shareID, false); err != nil {
+		t.Fatalf("SetShareSearchIndexing returned error: %v", err)
+	}
+	if _, err := manager.GetPublication(ctx, shareID); !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+		t.Fatalf("GetPublication error = %v, want not found", err)
+	}
+}
+
+func TestPublicShareManager_ViewerCannotEnableIndexingButCanDisableIt(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	shareID := uuid.New()
+	repo := newFakePublicShareRepository(orgID, workspaceID)
+	repo.share = repository.PublicShareLink{
+		ID:             shareID,
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		ResourceType:   repository.PublicShareResourceRunScorecard,
+		ResourceID:     uuid.New(),
+		IsActive:       true,
+		SearchIndexing: false,
+	}
+	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "")
+	viewer := callerWithWorkspaceRole(workspaceID, RoleWorkspaceViewer)
+
+	if err := manager.SetShareSearchIndexing(ctx, viewer, shareID, true); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("viewer enable indexing error = %v, want ErrForbidden", err)
+	}
+	if repo.share.SearchIndexing {
+		t.Fatal("viewer enable indexing changed repository state")
+	}
+
+	repo.share.SearchIndexing = true
+	if err := manager.SetShareSearchIndexing(ctx, viewer, shareID, false); err != nil {
+		t.Fatalf("viewer disable indexing returned error: %v", err)
+	}
+	if repo.share.SearchIndexing {
+		t.Fatal("viewer disable indexing did not change repository state")
+	}
+}
+
+func TestPublicShareManager_ListPublicationsSkipsIneligibleRecords(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)
+	repo := newFakePublicShareRepository(uuid.New(), uuid.New())
+	eligibleID := uuid.New()
+	ineligibleID := uuid.New()
+	resourceID := uuid.New()
+	repo.publications = []repository.PublicShareLink{
+		{
+			ID:             eligibleID,
+			ResourceType:   repository.PublicShareResourceChallengePackVersion,
+			ResourceID:     resourceID,
+			IsActive:       true,
+			SearchIndexing: true,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		{
+			ID:             ineligibleID,
+			ResourceType:   repository.PublicShareResourceChallengePackVersion,
+			ResourceID:     resourceID,
+			IsActive:       true,
+			SearchIndexing: false,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	repo.version.ID = resourceID
+	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "")
+	manager.now = func() time.Time { return now }
+
+	result, err := manager.ListPublications(ctx, nil, 2)
+	if err != nil {
+		t.Fatalf("ListPublications returned error: %v", err)
+	}
+	if len(result.Items) != 1 || result.Items[0].Publication.ID != eligibleID {
+		t.Fatalf("items = %#v, want eligible publication only", result.Items)
+	}
+	if result.NextCursor == nil || *result.NextCursor != ineligibleID.String() {
+		t.Fatalf("next cursor = %v, want final scanned record", result.NextCursor)
+	}
+}
+
+func TestPublicationHandlersDisableCaching(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("list", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "/public/publications", nil)
+		response := httptest.NewRecorder()
+		listPublicationsHandler(logger, noopPublicShareService{}).ServeHTTP(response, request)
+		if got := response.Header().Get("Cache-Control"); got != "no-store" {
+			t.Fatalf("Cache-Control = %q, want no-store", got)
+		}
+	})
+
+	t.Run("detail 404", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "/public/publications/not-a-uuid", nil)
+		response := httptest.NewRecorder()
+		getPublicationHandler(logger, noopPublicShareService{}).ServeHTTP(response, request)
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", response.Code)
+		}
+		if got := response.Header().Get("Cache-Control"); got != "no-store" {
+			t.Fatalf("Cache-Control = %q, want no-store", got)
+		}
+	})
+}
+
 func callerWithWorkspace(workspaceID uuid.UUID) Caller {
+	return callerWithWorkspaceRole(workspaceID, RoleWorkspaceAdmin)
+}
+
+func callerWithWorkspaceRole(workspaceID uuid.UUID, role string) Caller {
 	userID := uuid.New()
 	return Caller{
 		UserID: userID,
 		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
-			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+			workspaceID: {WorkspaceID: workspaceID, Role: role},
 		},
 		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{},
 	}
@@ -406,6 +959,7 @@ type fakePublicShareRepository struct {
 	replay         repository.RunAgentReplay
 	agentTryout    repository.AgentTryout
 	runArtifacts   []repository.Artifact
+	publications   []repository.PublicShareLink
 }
 
 func (r *fakePublicShareRepository) ListArtifactsByRunID(_ context.Context, _ uuid.UUID) ([]repository.Artifact, error) {
@@ -442,11 +996,33 @@ func (r *fakePublicShareRepository) RevokePublicShareLink(_ context.Context, id 
 	return nil
 }
 
+func (r *fakePublicShareRepository) SetPublicShareSearchIndexing(_ context.Context, id uuid.UUID, enabled bool) error {
+	if r.share.ID != id || !r.share.IsActive {
+		return repository.ErrPublicShareLinkNotFound
+	}
+	r.share.SearchIndexing = enabled
+	return nil
+}
+
 func (r *fakePublicShareRepository) GetPublicShareLinkByID(_ context.Context, id uuid.UUID) (repository.PublicShareLink, error) {
 	if r.share.ID != id {
 		return repository.PublicShareLink{}, repository.ErrPublicShareLinkNotFound
 	}
 	return r.share, nil
+}
+
+func (r *fakePublicShareRepository) GetIndexablePublicShareLinkByID(_ context.Context, id uuid.UUID) (repository.PublicShareLink, error) {
+	if r.share.ID != id {
+		return repository.PublicShareLink{}, repository.ErrPublicShareLinkNotFound
+	}
+	return r.share, nil
+}
+
+func (r *fakePublicShareRepository) ListIndexablePublicShareLinks(_ context.Context, _ *uuid.UUID, limit int) ([]repository.PublicShareLink, error) {
+	if len(r.publications) <= limit {
+		return append([]repository.PublicShareLink(nil), r.publications...), nil
+	}
+	return append([]repository.PublicShareLink(nil), r.publications[:limit]...), nil
 }
 
 func (r *fakePublicShareRepository) GetActivePublicShareLinkByKey(_ context.Context, key string) (repository.PublicShareLink, error) {
@@ -543,7 +1119,15 @@ func (r *fakePublicShareRepository) GetPublicRunScorecardSnapshot(_ context.Cont
 	if r.run.ID != runID {
 		return repository.PublicRunScorecardSnapshot{}, repository.ErrRunNotFound
 	}
-	return repository.PublicRunScorecardSnapshot{Run: r.run, Agents: []domain.RunAgent{r.runAgent}, AgentScorecards: []repository.RunAgentScorecard{r.agentScorecard}, Scorecard: r.runScorecard}, nil
+	agents := []domain.RunAgent{}
+	if r.runAgent.ID != uuid.Nil {
+		agents = append(agents, r.runAgent)
+	}
+	scorecards := []repository.RunAgentScorecard{}
+	if r.agentScorecard.ID != uuid.Nil {
+		scorecards = append(scorecards, r.agentScorecard)
+	}
+	return repository.PublicRunScorecardSnapshot{Run: r.run, Agents: agents, AgentScorecards: scorecards, Scorecard: r.runScorecard}, nil
 }
 
 func (r *fakePublicShareRepository) GetPublicRunAgentScorecardSnapshot(_ context.Context, runAgentID uuid.UUID) (repository.PublicRunAgentScorecardSnapshot, error) {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -150,6 +150,7 @@ func registerProtectedRoutes(
 	router.Get("/replays/{runAgentID}/transcript", getRunAgentTranscriptHandler(logger, replayReadService))
 	router.Get("/scorecards/{runAgentID}", getRunAgentScorecardHandler(logger, replayReadService))
 	router.Post("/share-links", createShareLinkHandler(logger, publicShareService))
+	router.Patch("/share-links/{shareID}", updateShareLinkHandler(logger, publicShareService))
 	router.Delete("/share-links/{shareID}", revokeShareLinkHandler(logger, publicShareService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/auth-check", workspaceAccessCheckHandler)

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -382,6 +382,10 @@ func buildRouter(opts routerOptions) http.Handler {
 	})
 	router.With(rateLimiter.Middleware("default", extractWorkspaceID)).
 		Get("/public/shares/{token}", getPublicShareHandler(logger, publicShareService))
+	router.With(rateLimiter.Middleware("default", extractWorkspaceID)).
+		Get("/public/publications", listPublicationsHandler(logger, publicShareService))
+	router.With(rateLimiter.Middleware("default", extractWorkspaceID)).
+		Get("/public/publications/{publicationID}", getPublicationHandler(logger, publicShareService))
 	registerPublicRoutes(router, logger, artifactService)
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
 	registerGitHubWebhookRoute(router, logger, githubIntegrationService)
@@ -418,8 +422,20 @@ func (noopPublicShareService) RevokeShareLink(context.Context, Caller, uuid.UUID
 	return errors.New("public share service is not configured")
 }
 
+func (noopPublicShareService) SetShareSearchIndexing(context.Context, Caller, uuid.UUID, bool) error {
+	return errors.New("public share service is not configured")
+}
+
 func (noopPublicShareService) GetPublicShare(context.Context, string, string) (PublicSharePayload, error) {
 	return PublicSharePayload{}, errors.New("public share service is not configured")
+}
+
+func (noopPublicShareService) GetPublication(context.Context, uuid.UUID) (PublicPublicationPayload, error) {
+	return PublicPublicationPayload{}, errors.New("public share service is not configured")
+}
+
+func (noopPublicShareService) ListPublications(context.Context, *uuid.UUID, int) (PublicPublicationList, error) {
+	return PublicPublicationList{Items: []PublicPublicationPayload{}}, nil
 }
 
 type noopAgentTryoutService struct{}

--- a/backend/internal/repository/public_share_links.go
+++ b/backend/internal/repository/public_share_links.go
@@ -101,7 +101,32 @@ func (r *Repository) CreatePublicShareLink(ctx context.Context, params CreatePub
 		)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (resource_type, resource_id) WHERE is_active
-		DO UPDATE SET updated_at = public_share_links.updated_at
+		DO UPDATE SET
+			search_indexing = CASE
+				WHEN public_share_links.expires_at IS NOT NULL AND public_share_links.expires_at <= now()
+				THEN EXCLUDED.search_indexing
+				ELSE public_share_links.search_indexing OR EXCLUDED.search_indexing
+			END,
+			key = CASE
+				WHEN public_share_links.expires_at IS NOT NULL AND public_share_links.expires_at <= now()
+				THEN EXCLUDED.key
+				ELSE public_share_links.key
+			END,
+			expires_at = CASE
+				WHEN public_share_links.expires_at IS NOT NULL AND public_share_links.expires_at <= now()
+				THEN EXCLUDED.expires_at
+				ELSE public_share_links.expires_at
+			END,
+			view_count = CASE
+				WHEN public_share_links.expires_at IS NOT NULL AND public_share_links.expires_at <= now()
+				THEN 0
+				ELSE public_share_links.view_count
+			END,
+			last_accessed_at = CASE
+				WHEN public_share_links.expires_at IS NOT NULL AND public_share_links.expires_at <= now()
+				THEN NULL
+				ELSE public_share_links.last_accessed_at
+			END
 		RETURNING id, key, organization_id, workspace_id, resource_type, resource_id, created_by_user_id, is_active, search_indexing, view_count, last_accessed_at, expires_at, created_at, updated_at, revoked_at
 	`, params.Key, params.OrganizationID, params.WorkspaceID, string(params.ResourceType), params.ResourceID, params.CreatedByUserID, params.SearchIndexing, params.ExpiresAt)
 
@@ -129,6 +154,23 @@ func (r *Repository) RevokePublicShareLink(ctx context.Context, id uuid.UUID) er
 	return nil
 }
 
+func (r *Repository) SetPublicShareSearchIndexing(ctx context.Context, id uuid.UUID, enabled bool) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE public_share_links
+		SET search_indexing = $2
+		WHERE id = $1
+		  AND is_active
+		  AND revoked_at IS NULL
+	`, id, enabled)
+	if err != nil {
+		return fmt.Errorf("set public share search indexing: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrPublicShareLinkNotFound
+	}
+	return nil
+}
+
 func (r *Repository) GetPublicShareLinkByID(ctx context.Context, id uuid.UUID) (PublicShareLink, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT id, key, organization_id, workspace_id, resource_type, resource_id, created_by_user_id, is_active, search_indexing, view_count, last_accessed_at, expires_at, created_at, updated_at, revoked_at
@@ -144,6 +186,65 @@ func (r *Repository) GetPublicShareLinkByID(ctx context.Context, id uuid.UUID) (
 		return PublicShareLink{}, fmt.Errorf("get public share link by id: %w", err)
 	}
 	return share, nil
+}
+
+// GetIndexablePublicShareLinkByID resolves the non-secret share record ID used
+// by publication URLs. It never increments capability-share view counters and
+// fails closed when indexing is disabled, revoked, inactive, or expired.
+func (r *Repository) GetIndexablePublicShareLinkByID(ctx context.Context, id uuid.UUID) (PublicShareLink, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, key, organization_id, workspace_id, resource_type, resource_id, created_by_user_id, is_active, search_indexing, view_count, last_accessed_at, expires_at, created_at, updated_at, revoked_at
+		FROM public_share_links
+		WHERE id = $1
+		  AND is_active
+		  AND search_indexing
+		  AND revoked_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > now())
+		LIMIT 1
+	`, id)
+	share, err := scanPublicShareLink(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PublicShareLink{}, ErrPublicShareLinkNotFound
+		}
+		return PublicShareLink{}, fmt.Errorf("get indexable public share link by id: %w", err)
+	}
+	return share, nil
+}
+
+// ListIndexablePublicShareLinks returns a stable UUID-ordered page without
+// exposing capability tokens. Eligibility is rechecked by the service before
+// serialization so repository fakes and future storage implementations also
+// fail closed.
+func (r *Repository) ListIndexablePublicShareLinks(ctx context.Context, after *uuid.UUID, limit int) ([]PublicShareLink, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, key, organization_id, workspace_id, resource_type, resource_id, created_by_user_id, is_active, search_indexing, view_count, last_accessed_at, expires_at, created_at, updated_at, revoked_at
+		FROM public_share_links
+		WHERE is_active
+		  AND search_indexing
+		  AND revoked_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > now())
+		  AND ($1::uuid IS NULL OR id > $1)
+		ORDER BY id ASC
+		LIMIT $2
+	`, after, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list indexable public share links: %w", err)
+	}
+	defer rows.Close()
+
+	shares := make([]PublicShareLink, 0, limit)
+	for rows.Next() {
+		share, scanErr := scanPublicShareLink(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan indexable public share link: %w", scanErr)
+		}
+		shares = append(shares, share)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate indexable public share links: %w", err)
+	}
+	return shares, nil
 }
 
 func (r *Repository) GetActivePublicShareLinkByKey(ctx context.Context, key string) (PublicShareLink, error) {

--- a/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
@@ -125,7 +125,7 @@ Read skills in this order when multiple apply:
 25. `agentclash-security-evaluation`
 
 > To author or change skills, browse the web catalog at
-> https://agentclash.dev/docs/agent-skills — it is documentation, not an
+> https://www.agentclash.dev/docs/agent-skills — it is documentation, not an
 > installable skill.
 
 Each skill folder name matches its `name` in frontmatter. When a skill lists **Related Skills**, load those before mutating remote state.
@@ -164,20 +164,20 @@ Nested folders: `agent-build-skills/` and `challenge-pack-skills/` mirror the ta
 
 ## Product UI — Where To Send The User
 
-Base URL: **https://agentclash.dev**
+Base URL: **https://www.agentclash.dev**
 
 | User goal | UI path |
 | --- | --- |
-| Sign in / account | https://agentclash.dev |
-| Docs home | https://agentclash.dev/docs |
-| Quickstart | https://agentclash.dev/docs/getting-started/quickstart |
-| First eval walkthrough | https://agentclash.dev/docs/getting-started/first-eval |
-| Agent skills (web catalog) | https://agentclash.dev/docs/agent-skills |
-| CLI reference | https://agentclash.dev/docs/reference/cli |
-| Challenge packs guide | https://agentclash.dev/docs/guides/write-a-challenge-pack |
-| Multi-turn packs | https://agentclash.dev/docs/challenge-packs/multi-turn |
-| Interpret results | https://agentclash.dev/docs/guides/interpret-results |
-| CI/CD gates | https://agentclash.dev/docs/guides/ci-cd-agent-gates |
+| Sign in / account | https://www.agentclash.dev |
+| Docs home | https://www.agentclash.dev/docs |
+| Quickstart | https://www.agentclash.dev/docs/getting-started/quickstart |
+| First eval walkthrough | https://www.agentclash.dev/docs/getting-started/first-eval |
+| Agent skills (web catalog) | https://www.agentclash.dev/docs/agent-skills |
+| CLI reference | https://www.agentclash.dev/docs/reference/cli |
+| Challenge packs guide | https://www.agentclash.dev/docs/guides/write-a-challenge-pack |
+| Multi-turn packs | https://www.agentclash.dev/docs/challenge-packs/multi-turn |
+| Interpret results | https://www.agentclash.dev/docs/guides/interpret-results |
+| CI/CD gates | https://www.agentclash.dev/docs/guides/ci-cd-agent-gates |
 | Workspace runs (after login) | App dashboard → Runs list |
 | Live run events | Run detail page while status is running |
 | Scorecards & comparisons | Run detail → scorecard / ranking views after completion |
@@ -185,7 +185,7 @@ Base URL: **https://agentclash.dev**
 When you create a run via CLI, tell the user:
 
 ```text
-Open https://agentclash.dev and navigate to your workspace runs, or search for run ID <RUN_ID> after signing in.
+Open https://www.agentclash.dev and navigate to your workspace runs, or search for run ID <RUN_ID> after signing in.
 ```
 
 ## AgentClash Concepts (30-Second Model)
@@ -217,7 +217,7 @@ After loading this skill you can name the next skill, 1–3 CLI commands, and th
 Hub loaded: yes
 Next skill: <skill-folder-name>
 CLI status: <auth/workspace/doctor summary>
-UI for user: <https://agentclash.dev/...>
+UI for user: <https://www.agentclash.dev/...>
 Next commands: <1-3 commands>
 ```
 

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "ebfdcf026705",
+  "snapshot_version": "f9723775deee",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -101,7 +101,7 @@
       "name": "agentclash-hub",
       "role": "hub",
       "requires_cli": false,
-      "sha256": "90813adc0753b190a2a5614a4dfefa39670f643de04a1f8f4c5a25fc2de4c36d"
+      "sha256": "7a29ca9daae0974139373b33e0d7a83e963870b47487bce85a05c5386adc72b3"
     },
     {
       "name": "agentclash-multi-turn-operator",

--- a/docs/agentclash-ci-github.md
+++ b/docs/agentclash-ci-github.md
@@ -25,7 +25,7 @@ The manifest points at workspace resources that define the gate:
 
 ## Setup From The UI
 
-1. Open `https://agentclash.dev`.
+1. Open `https://www.agentclash.dev`.
 2. Choose a workspace, then open **CI setup**.
 3. Connect or select an installed GitHub repository.
 4. Choose the agent build, runtime profile, challenge pack, baseline, and gate

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -12,6 +12,8 @@ info:
     url: https://github.com/agentclash/agentclash
 
 servers:
+  - url: https://api.agentclash.dev
+    description: AgentClash hosted API
   - url: http://localhost:8080
     description: Local development
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -59,6 +59,8 @@ tags:
     description: External hosted agent event ingestion
   - name: AgentTryouts
     description: Public and workspace agent tryout templates, sandbox runs, claiming, and sharing
+  - name: Publications
+    description: Explicitly indexable, redacted public artifacts addressed by non-secret share record IDs
   - name: UserProfile
     description: Current user profile with org/workspace hierarchy
   - name: Onboarding
@@ -85,6 +87,70 @@ tags:
     description: Routing and spend policy configuration
 
 paths:
+  /public/publications:
+    get:
+      operationId: listPublications
+      tags: [Publications]
+      summary: List active indexable publications
+      description: >
+        Returns only active, unexpired, search-indexing-enabled artifacts that
+        successfully pass a supported redacted public serializer. Capability
+        tokens are never returned.
+      security: []
+      parameters:
+        - name: cursor
+          in: query
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Publication page.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicPublicationList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /public/publications/{publicationID}:
+    get:
+      operationId: getPublication
+      tags: [Publications]
+      summary: Get one active indexable publication
+      description: >
+        Resolves the non-secret public share record ID. Returns 404 when the
+        share is inactive, revoked, expired, indexing-disabled, unsupported,
+        malformed, or no longer serializable through its redacted renderer.
+      security: []
+      parameters:
+        - name: publicationID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Redacted publication.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicPublicationPayload"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}/cancel:
     post:
       operationId: cancelAgentHarnessExecution
@@ -6759,6 +6825,61 @@ components:
   # Schemas
   # ---------------------------------------------------------------------------
   schemas:
+    PublicPublication:
+      type: object
+      required: [id, resource_type, created_at, updated_at, canonical_path]
+      properties:
+        id:
+          type: string
+          format: uuid
+        resource_type:
+          type: string
+          enum:
+            - challenge_pack_version
+            - run_scorecard
+            - run_agent_scorecard
+            - run_agent_replay
+            - agent_tryout
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        canonical_path:
+          type: string
+          pattern: ^/publications/[0-9a-f-]+$
+
+    PublicPublicationPayload:
+      type: object
+      required: [publication, resource]
+      properties:
+        publication:
+          $ref: "#/components/schemas/PublicPublication"
+        resource:
+          type: object
+          description: Type-specific, explicitly allowlisted redacted public resource.
+          required: [type]
+          properties:
+            type:
+              type: string
+          additionalProperties: true
+
+    PublicPublicationList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicPublicationPayload"
+        next_cursor:
+          type: string
+          format: uuid
+
     # --- Shared ---
 
     Dataset:

--- a/docs/deployment/agent-readable-observability.md
+++ b/docs/deployment/agent-readable-observability.md
@@ -1,0 +1,73 @@
+# Agent-readable request observability
+
+AgentClash measures crawler and agent access from server-side request data, not
+PostHog or other browser analytics. The first rollout uses Vercel Runtime Logs
+and the backend API request logger. An external Log Drain is intentionally
+deferred.
+
+## Emitted events
+
+The web routing middleware emits `agent_readable_request` for known AI crawler
+families, explicit Markdown requests, and machine-contract routes. Node route
+handlers emit `agent_readable_response` when they can report status, response
+bytes, and duration. The backend request logger enriches public publication API
+requests with the same representation and crawler classifications.
+
+Allowlisted fields are:
+
+- normalized pathname without a query string
+- HTTP method and status
+- known user-agent family, never the full user-agent string
+- accept class and requested/served representation
+- request ID and route kind
+- response bytes and duration where the handler can measure them
+- Vercel platform fields such as cache state, deployment ID, and environment
+
+The application logs never include cookies, authorization values, capability
+tokens, raw query strings, IP addresses, submitted content, or private share
+paths. `/share/{token}` is logged only as `/share/{token}`.
+
+## Runtime Logs queries
+
+Open the web project in Vercel, choose **Logs**, set `environment:production`,
+and save or retain these searches. Vercel stores recent per-project queries,
+and the route, request path, resource, method, status, cache, deployment, and
+request ID are available as filters.
+
+| Query name | Runtime Logs filters and search text | Use |
+| --- | --- | --- |
+| AI-agent volume | Search `agent_readable_request`; method `GET` or `HEAD` | Group by request path or route and inspect `agent_family` in the JSON message. |
+| Markdown delivery | Search `agent_readable_request`; then search `served_representation` | Compare direct `/md` requests with canonical requests served as Markdown. |
+| Agent 404 guesses | Search `agent_readable_request`; status `404` | Group by Request Path. Known capability paths remain redacted in the application message. |
+| Contract failures | Request Path `/llms.txt`, `/llms-full.txt`, `/openapi.yaml`, `/cli-schema.json`, or `/schemas/*`; status `4xx` or `5xx` | Detect broken discovery and contract endpoints. |
+| Publication failures | Route `/publications/[id]`, `/md/[[...path]]`, or backend `/public/publications/{publicationID}`; status `4xx` or `5xx` | Confirm fail-closed removals and investigate unexpected serializer failures. |
+| Cache verification | Request Path `/md/*`, `/llms*`, `/openapi.yaml`, `/schemas/*`, or `/cli-schema.json` | Group by cache state and verify HIT/MISS/STALE behavior after rollout. |
+
+For repeatable aggregation, the Vercel CLI can export JSON. The structured
+application payload is stored in the log message:
+
+```bash
+vercel logs --environment production --since 24h \
+  --query agent_readable_request --json \
+  | jq -r '(.message | fromjson? // empty) | [.agent_family, .path, .served_representation] | @tsv' \
+  | sort | uniq -c | sort -nr
+```
+
+Use Vercel request IDs to correlate a middleware request event, a route-handler
+response event, and the platform request record. The platform record supplies
+status, cache behavior, deployment, and runtime timing when application code
+cannot measure them directly.
+
+## Rollout checks
+
+1. Enable `MARKDOWN_NEGOTIATION_ENABLED=true` in Preview only.
+2. Request one canonical page with HTML, direct Markdown, negotiated Markdown,
+   wildcard Accept, and `text/markdown;q=0`.
+3. Verify `Vary`, `Link`, `Content-Location`, robots, and cache headers in the
+   response and confirm the three structured events in Runtime Logs.
+4. Confirm query strings and capability tokens are absent from log messages.
+5. Enable the flag in Production and retain the queries above for the first
+   rollout window.
+
+Vercel's Runtime Logs documentation is the source of truth for available
+filters and retention: <https://vercel.com/docs/logs/runtime>.

--- a/docs/schemas/prompt-eval-result.schema.json
+++ b/docs/schemas/prompt-eval-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/prompt-eval-result.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/prompt-eval-result.schema.json",
   "title": "AgentClash Prompt Eval Validation Result",
   "type": "object",
   "required": ["schemaVersion", "path", "valid", "model_count", "test_count", "case_count", "max_cases", "assertion_signatures", "exit_code"],

--- a/docs/schemas/prompt-eval.schema.json
+++ b/docs/schemas/prompt-eval.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/prompt-eval.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/prompt-eval.schema.json",
   "title": "AgentClash Prompt Eval Config",
   "type": "object",
   "required": ["schemaVersion", "name", "prompt", "models", "tests"],

--- a/docs/schemas/voice-artifact-manifest.schema.json
+++ b/docs/schemas/voice-artifact-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/voice-artifact-manifest.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/voice-artifact-manifest.schema.json",
   "title": "AgentClash Voice Artifact Manifest",
   "type": "object",
   "required": ["schema_version", "run_id", "run_agent_id", "voice_session_id", "artifacts"],

--- a/docs/schemas/voice-live-continuity-report.schema.json
+++ b/docs/schemas/voice-live-continuity-report.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/voice-live-continuity-report.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/voice-live-continuity-report.schema.json",
   "title": "AgentClash Voice Live Continuity Report",
   "type": "object",
   "required": ["schema_version", "type", "status", "passed", "metrics"],

--- a/docs/schemas/voice-source-separation-report.schema.json
+++ b/docs/schemas/voice-source-separation-report.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/voice-source-separation-report.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/voice-source-separation-report.schema.json",
   "title": "AgentClash Voice Source Separation Report",
   "type": "object",
   "required": ["schema_version", "type", "status", "passed", "metrics"],

--- a/docs/schemas/voice-video-sync-report.schema.json
+++ b/docs/schemas/voice-video-sync-report.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentclash.dev/schemas/voice-video-sync-report.schema.json",
+  "$id": "https://www.agentclash.dev/schemas/voice-video-sync-report.schema.json",
   "title": "AgentClash Voice Video Sync Report",
   "type": "object",
   "required": ["summary"],

--- a/testing/codex-agent-readable-web.md
+++ b/testing/codex-agent-readable-web.md
@@ -1,0 +1,92 @@
+# codex/agent-readable-web - Test Contract
+
+## Functional Behavior
+
+- Every indexable public URL represented by the public-content registry resolves to semantic HTML and non-empty Markdown.
+- `GET /md/{canonical-path}` returns the explicit Markdown representation. `GET /md` represents the homepage.
+- Existing `GET /docs-md/*` URLs continue to return the same document content through the shared renderer.
+- Canonical public URLs return HTML by default. They return Markdown only for public `GET` or `HEAD` requests whose exact `text/markdown` quality is positive and strictly preferred over exact `text/html`.
+- Missing `Accept`, wildcard-only ranges, media-type wildcards, ties, and `text/markdown;q=0` return HTML.
+- Negotiation never rewrites private/authenticated, API, ingestion, framework-internal, token-share, or mutation requests and never forwards query parameters to Markdown renderers.
+- Eligible HTML and Markdown responses advertise canonical and Markdown representations through `Link` and `Vary: Accept` headers.
+- Direct `/md` responses are `noindex, follow`; negotiated Markdown at the canonical URL is not marked `noindex`.
+- `/llms.txt`, `/llms-full.txt`, sitemap entries, docs search, and IndexNow discovery use the shared public-content registry.
+- `/llms.txt` links to exact Markdown and machine-contract URLs. `/llms-full.txt` excludes user-generated publication bodies.
+- `/openapi.yaml`, `/schemas/*.json`, and `/cli-schema.json` expose the supported machine contracts with correct content types and canonical production URLs.
+- Generic `/share/{token}` pages remain disallowed and always noindex, including when the share has `search_indexing=true`.
+- `/publications` and `/publications/{id}` expose only active, unexpired, search-indexing-enabled resources serialized through supported redacted public renderers.
+- Publication lookups use the non-secret share record ID, never the capability token. Ineligible and unsupported resources return `404` without existence disclosure.
+- Publication Markdown labels and structurally escapes user-supplied content. It never contains capability tokens, credentials, environment values, or private user data.
+- `/try` and `/try/{slug}` include catalog/detail content in the server response. A GET never creates or resumes a sandbox; that mutation requires an explicit user action.
+- `/tryouts` server-renders public templates, tools, selected public inputs, and completed public results when available. Query-based sessions remain noindex.
+- `/agent-opportunity` documents its POST contract in Markdown. Generation remains POST-only and transient output is not indexable without explicit publication.
+- Pricing HTML and Markdown include both monthly and annual values from one pricing source.
+- Agent request measurement uses structured server logs, not product-analytics events, and omits query strings, cookies, authorization data, tokens, IP addresses, and submitted content.
+- The canonical public host is `https://www.agentclash.dev`.
+
+## Unit Tests
+
+- Public-path normalization accepts canonical paths and rejects traversal, malformed encoding, duplicate separators, private prefixes, and unknown paths.
+- The content registry resolves every supported static and dynamic route family and produces an H1, canonical source, and semantic body.
+- Registry inclusion flags drive llms, full-bundle, search, sitemap, and IndexNow behavior consistently.
+- The `Accept` parser covers missing headers, exact Markdown, exact HTML, wildcards, quality values, ties, invalid quality values, and `q=0`.
+- Negotiation classification covers public/private paths, `GET`, `HEAD`, mutation methods, explicit `/md`, `/docs-md`, machine contracts, and query stripping.
+- Markdown response headers distinguish direct from internally negotiated responses.
+- Markdown escaping neutralizes raw HTML and delimiter injection while retaining readable user content.
+- Agent user-agent classification covers every named crawler allowed by robots plus unknown/generic clients.
+- Structured log payloads contain only allowlisted fields and normalized pathnames.
+- Publication eligibility covers active, expired, revoked, indexing-disabled, unsupported, and malformed shares.
+- Every supported public-share resource type has a redacted semantic serializer, including agent tryouts.
+
+## Integration / Functional Tests
+
+- Every link emitted by `/llms.txt` resolves with the declared content type.
+- `/llms-full.txt` renders all included static content and contains no publication body or share token.
+- The canonical sitemap contains registry-backed HTML URLs only, with real modification dates, and excludes `/md`, `/docs-md`, machine artifacts, token shares, and private routes.
+- HTML metadata and response headers advertise the matching `/md` alternate without overwriting existing RSS alternates.
+- Direct and negotiated Markdown contain equivalent titles, key facts, tables, pricing periods, and important links to the HTML source.
+- OpenAPI lists `https://api.agentclash.dev`; every published JSON Schema has a resolvable canonical `$id` under `https://www.agentclash.dev/schemas/`.
+- The release workflow generates a parseable CLI schema whose `cli_version` matches the release tag before upload.
+- Publication list/detail APIs and HTML/Markdown routes return identical redacted semantics and immediately return `404` after revocation, expiry, or indexing opt-out.
+- The existing `/docs-md` route and new `/md/docs` route share one renderer and stay content-equivalent.
+
+## Smoke Tests
+
+- `pnpm lint`, `pnpm test`, and `pnpm build` succeed under `web/`.
+- `go test -short -race -count=1 ./...` succeeds under `backend/` and `cli/` for affected packages.
+- A production-mode server returns 200 for `/llms.txt`, `/llms-full.txt`, `/md`, `/md/docs`, `/openapi.yaml`, one JSON Schema, and `/cli-schema.json`.
+- A canonical public page returns HTML for normal browser headers and Markdown for an explicit preferred `text/markdown` header when negotiation is enabled.
+- Plain HTTP responses for `/try`, one demo detail, and `/tryouts` contain meaningful catalog/template text before JavaScript executes.
+
+## E2E Tests
+
+- Visit `/try/{slug}` without clicking the start control and verify no sandbox-creation request occurs; click the control and verify exactly one creation/resume request occurs.
+- Open a valid opted-in publication in HTML and Markdown, then revoke or disable indexing and verify both URLs return `404`.
+- Fetch a private route with `Accept: text/markdown` and verify it is not rewritten or exposed.
+
+## Manual / cURL Tests
+
+Run against a local production server with negotiation enabled:
+
+```bash
+curl -i http://localhost:3000/pricing
+curl -i -H 'Accept: text/markdown' http://localhost:3000/pricing
+curl -i -H 'Accept: text/html, text/markdown;q=0.5' http://localhost:3000/pricing
+curl -i -H 'Accept: */*' http://localhost:3000/pricing
+curl -I -H 'Accept: text/markdown' http://localhost:3000/docs
+curl -i http://localhost:3000/md/pricing
+curl -i http://localhost:3000/docs-md
+curl -i http://localhost:3000/llms.txt
+curl -i http://localhost:3000/openapi.yaml
+curl -i http://localhost:3000/cli-schema.json
+curl -i -H 'Accept: text/markdown' http://localhost:3000/workspaces
+```
+
+Publication checks require a known eligible and ineligible share ID:
+
+```bash
+curl -i http://localhost:3000/publications/PUBLIC_SHARE_ID
+curl -i http://localhost:3000/md/publications/PUBLIC_SHARE_ID
+curl -i http://localhost:8080/public/publications/PUBLIC_SHARE_ID
+curl -i http://localhost:8080/public/publications/INELIGIBLE_SHARE_ID
+```

--- a/web/content/agent-skills/agentclash-hub/SKILL.md
+++ b/web/content/agent-skills/agentclash-hub/SKILL.md
@@ -125,7 +125,7 @@ Read skills in this order when multiple apply:
 25. `agentclash-security-evaluation`
 
 > To author or change skills, browse the web catalog at
-> https://agentclash.dev/docs/agent-skills — it is documentation, not an
+> https://www.agentclash.dev/docs/agent-skills — it is documentation, not an
 > installable skill.
 
 Each skill folder name matches its `name` in frontmatter. When a skill lists **Related Skills**, load those before mutating remote state.
@@ -164,20 +164,20 @@ Nested folders: `agent-build-skills/` and `challenge-pack-skills/` mirror the ta
 
 ## Product UI — Where To Send The User
 
-Base URL: **https://agentclash.dev**
+Base URL: **https://www.agentclash.dev**
 
 | User goal | UI path |
 | --- | --- |
-| Sign in / account | https://agentclash.dev |
-| Docs home | https://agentclash.dev/docs |
-| Quickstart | https://agentclash.dev/docs/getting-started/quickstart |
-| First eval walkthrough | https://agentclash.dev/docs/getting-started/first-eval |
-| Agent skills (web catalog) | https://agentclash.dev/docs/agent-skills |
-| CLI reference | https://agentclash.dev/docs/reference/cli |
-| Challenge packs guide | https://agentclash.dev/docs/guides/write-a-challenge-pack |
-| Multi-turn packs | https://agentclash.dev/docs/challenge-packs/multi-turn |
-| Interpret results | https://agentclash.dev/docs/guides/interpret-results |
-| CI/CD gates | https://agentclash.dev/docs/guides/ci-cd-agent-gates |
+| Sign in / account | https://www.agentclash.dev |
+| Docs home | https://www.agentclash.dev/docs |
+| Quickstart | https://www.agentclash.dev/docs/getting-started/quickstart |
+| First eval walkthrough | https://www.agentclash.dev/docs/getting-started/first-eval |
+| Agent skills (web catalog) | https://www.agentclash.dev/docs/agent-skills |
+| CLI reference | https://www.agentclash.dev/docs/reference/cli |
+| Challenge packs guide | https://www.agentclash.dev/docs/guides/write-a-challenge-pack |
+| Multi-turn packs | https://www.agentclash.dev/docs/challenge-packs/multi-turn |
+| Interpret results | https://www.agentclash.dev/docs/guides/interpret-results |
+| CI/CD gates | https://www.agentclash.dev/docs/guides/ci-cd-agent-gates |
 | Workspace runs (after login) | App dashboard → Runs list |
 | Live run events | Run detail page while status is running |
 | Scorecards & comparisons | Run detail → scorecard / ranking views after completion |
@@ -185,7 +185,7 @@ Base URL: **https://agentclash.dev**
 When you create a run via CLI, tell the user:
 
 ```text
-Open https://agentclash.dev and navigate to your workspace runs, or search for run ID <RUN_ID> after signing in.
+Open https://www.agentclash.dev and navigate to your workspace runs, or search for run ID <RUN_ID> after signing in.
 ```
 
 ## AgentClash Concepts (30-Second Model)
@@ -217,7 +217,7 @@ After loading this skill you can name the next skill, 1–3 CLI commands, and th
 Hub loaded: yes
 Next skill: <skill-folder-name>
 CLI status: <auth/workspace/doctor summary>
-UI for user: <https://agentclash.dev/...>
+UI for user: <https://www.agentclash.dev/...>
 Next commands: <1-3 commands>
 ```
 

--- a/web/content/blog/introducing-datasmith-synthetic-agent-data.mdx
+++ b/web/content/blog/introducing-datasmith-synthetic-agent-data.mdx
@@ -73,7 +73,7 @@ See the [GSM8K + Qwen DPO benchmark writeup](https://github.com/Atharva-Kanherka
 
 ## DataSmith inside AgentClash
 
-DataSmith is the **local, training-oriented** layer. [AgentClash](https://agentclash.dev) is the **hosted eval and regression** layer.
+DataSmith is the **local, training-oriented** layer. [AgentClash](https://www.agentclash.dev) is the **hosted eval and regression** layer.
 
 Inside AgentClash workspaces you can run the same weak-vs-strong loop as **Agentic Self-Instruct** generation on pinned datasets. Accepted synthetic rows become eval examples you can baseline, gate in CI, and promote into regression suites.
 
@@ -96,7 +96,7 @@ MIT licensed. Alpha (`0.1.0`). Feedback and contributions welcome on [GitHub](ht
 ## Get started
 
 1. **Local SDK:** `pip install datasmith` and follow the [README quickstart](https://github.com/Atharva-Kanherkar/datasmith).
-2. **Hosted generation:** Sign in at [agentclash.dev](https://agentclash.dev), open a dataset, and start **Agentic Self-Instruct** generation from the workspace UI.
+2. **Hosted generation:** Sign in at [agentclash.dev](https://www.agentclash.dev), open a dataset, and start **Agentic Self-Instruct** generation from the workspace UI.
 3. **Read the platform overview:** [/platform/datasmith](/platform/datasmith) for the full AgentClash + DataSmith story.
 
 Tell us what domain you want to generate data for first. That feedback shapes the next seed-constructor templates and export presets.

--- a/web/content/blog/when-the-us-government-banned-fable-5.mdx
+++ b/web/content/blog/when-the-us-government-banned-fable-5.mdx
@@ -60,4 +60,4 @@ The model you can't replace isn't an asset. It's a single point of failure with 
 
 ---
 
-We're building model-agnostic evaluation in the open. Every commit is public on [GitHub](https://github.com/agentclash/agentclash). If you don't want a regulator picking your model for you, [come run a clash](https://agentclash.dev).
+We're building model-agnostic evaluation in the open. Every commit is public on [GitHub](https://github.com/agentclash/agentclash). If you don't want a regulator picking your model for you, [come run a clash](https://www.agentclash.dev).

--- a/web/content/blog/why-we-built-agentclash.mdx
+++ b/web/content/blog/why-we-built-agentclash.mdx
@@ -31,6 +31,6 @@ We're building this in the open. Every commit is public. Every design decision i
 
 ## What's next
 
-We're in private beta. If you're shipping agents and you're tired of guessing which model to use, [join the waitlist](https://agentclash.dev).
+We're in private beta. If you're shipping agents and you're tired of guessing which model to use, [join the waitlist](https://www.agentclash.dev).
 
 Follow the build on [GitHub](https://github.com/agentclash/agentclash).

--- a/web/content/docs/concepts/voice-artifact-contracts.mdx
+++ b/web/content/docs/concepts/voice-artifact-contracts.mdx
@@ -81,7 +81,7 @@ An `object_storage` artifact looks like this:
 
 Some checksum tools print uppercase hex. Normalize those values to lowercase before writing the manifest so schema preflight and AgentClash ingestion agree.
 
-Producers can validate the manifest shape with `docs/schemas/voice-artifact-manifest.schema.json`. The schema covers required artifact kinds, supported artifact kinds, artifact locations, checksums, UUID fields, and common reference mistakes before upload.
+Producers can validate the manifest shape with `https://www.agentclash.dev/schemas/voice-artifact-manifest.schema.json`. The schema covers required artifact kinds, supported artifact kinds, artifact locations, checksums, UUID fields, and common reference mistakes before upload.
 
 The CLI can run the same preflight without requiring a repository checkout:
 

--- a/web/content/docs/fleet/index.mdx
+++ b/web/content/docs/fleet/index.mdx
@@ -29,7 +29,7 @@ Before you submit an eval set:
 3. Agent deployments wired with provider credentials / BYOK.
 4. A sandbox provider configured for native packs (`e2b`, `docker`, or `kubernetes` on self-host).
 
-Hosted users typically do step 1–3 on [agentclash.dev](https://agentclash.dev). Self-hosters also need Temporal, Postgres, workers, and a sandbox path; see [Self-host at scale](/docs/fleet/self-host-scale).
+Hosted users typically do step 1–3 on [agentclash.dev](https://www.agentclash.dev). Self-hosters also need Temporal, Postgres, workers, and a sandbox path; see [Self-host at scale](/docs/fleet/self-host-scale).
 
 ## Shortest path
 

--- a/web/content/docs/guides/dataset-ci-gates.mdx
+++ b/web/content/docs/guides/dataset-ci-gates.mdx
@@ -133,7 +133,7 @@ For full agent release gates (build spec, deployment, regression suites, and rel
 | `GET` | `/v1/workspaces/{workspaceID}/datasets/{datasetID}/regression-suite` | Fetch dataset ⇄ suite link |
 | `POST` | `/v1/workspaces/{workspaceID}/datasets/{datasetID}/regression-suite/sync` | Promote version examples into regression cases |
 
-See the [OpenAPI spec](https://github.com/agentclash/agentclash/blob/main/docs/api-server/openapi.yaml) for request and response schemas.
+See the [deployed OpenAPI spec](https://www.agentclash.dev/openapi.yaml) for request and response schemas.
 
 ## See also
 

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -20,6 +20,7 @@ AgentClash exposes explicit content and contract surfaces for agents:
 - `/md/...`: page-level Markdown exports that mirror every public page
 - `/docs-md/...`: compatibility URLs for existing docs integrations
 - `/openapi.yaml`, `/schemas/...`, and `/cli-schema.json`: API, artifact, and CLI contracts
+- `/publications` and `/publications/sitemap.xml`: explicitly published, redacted evaluation artifacts
 
 Use them differently:
 
@@ -77,6 +78,13 @@ You should now be able to hand any of these URLs to a tool and get grounded answ
 - `https://www.agentclash.dev/md/docs/getting-started/quickstart`
 - `https://www.agentclash.dev/openapi.yaml`
 - `https://www.agentclash.dev/cli-schema.json`
+- `https://www.agentclash.dev/schemas/prompt-eval.schema.json`
+- `https://www.agentclash.dev/schemas/prompt-eval-result.schema.json`
+- `https://www.agentclash.dev/schemas/voice-artifact-manifest.schema.json`
+- `https://www.agentclash.dev/schemas/voice-live-continuity-report.schema.json`
+- `https://www.agentclash.dev/schemas/voice-source-separation-report.schema.json`
+- `https://www.agentclash.dev/schemas/voice-video-sync-report.schema.json`
+- `https://www.agentclash.dev/publications`
 
 ## Troubleshooting
 

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use with AI Tools
 description: Feed AgentClash docs into ChatGPT, Codex, Claude Code, and similar tools using llms.txt and markdown exports, and install the AgentClash Agent Skills.
-dateModified: 2026-06-02
+dateModified: 2026-08-14
 ---
 
 Goal: give an assistant or coding agent enough AgentClash context to answer questions, draft workflows, or transform the docs into internal runbooks.
@@ -13,25 +13,28 @@ Prerequisites:
 
 ## Pick the right docs export
 
-AgentClash now exposes three AI-friendly surfaces:
+AgentClash exposes explicit content and contract surfaces for agents:
 
 - `/llms.txt`: a compact index of the shipped docs set
 - `/llms-full.txt`: one bundled markdown-oriented export of the full docs corpus
-- `/docs-md/...`: page-level markdown exports that mirror `/docs/...`
+- `/md/...`: page-level Markdown exports that mirror every public page
+- `/docs-md/...`: compatibility URLs for existing docs integrations
+- `/openapi.yaml`, `/schemas/...`, and `/cli-schema.json`: API, artifact, and CLI contracts
 
 Use them differently:
 
 - use `llms.txt` when the tool needs a map first
 - use `llms-full.txt` when you want one-shot context for a larger prompt
-- use `/docs-md/...` when you only need one focused page, like quickstart or config
+- use `/md/...` when you only need one focused page, like quickstart or config
+- use the machine contracts when an agent needs exact API, artifact, command, flag, or exit-code shapes
 
 ## Fastest workflow in ChatGPT, Codex, or Claude Code
 
-1. Start with `https://agentclash.dev/llms.txt`.
+1. Start with `https://www.agentclash.dev/llms.txt`.
 2. If the tool can fetch URLs directly, give it that URL first.
 3. If the tool cannot fetch URLs, open the file yourself and paste the contents.
 4. Ask the tool which page it needs next.
-5. Feed the relevant `/docs-md/...` page or the full bundle, depending on scope.
+5. Feed the relevant `/md/...` page or the full bundle, depending on scope.
 
 That keeps the context tight. Do not dump the full bundle into every prompt by default.
 
@@ -40,15 +43,15 @@ That keeps the context tight. Do not dump the full bundle into every prompt by d
 Use prompts that ask the model to stay anchored to the supplied docs. Examples:
 
 ```text
-Using https://agentclash.dev/llms.txt, tell me which docs pages I should read to self-host AgentClash and understand the worker architecture.
+Using https://www.agentclash.dev/llms.txt, tell me which docs pages I should read to self-host AgentClash and understand the worker architecture.
 ```
 
 ```text
-Use the markdown from https://agentclash.dev/docs-md/guides/interpret-results and turn it into a short incident-review checklist for my eval team.
+Use the Markdown from https://www.agentclash.dev/md/docs/guides/interpret-results and turn it into a short incident-review checklist for my eval team.
 ```
 
 ```text
-Use https://agentclash.dev/llms-full.txt as the product docs corpus and answer only from that material: what is the difference between a run, an eval, and a challenge pack?
+Use https://www.agentclash.dev/llms-full.txt as the product docs corpus and answer only from that material: what is the difference between a run, an eval, and a challenge pack?
 ```
 
 ## When to use page-level exports instead of the full bundle
@@ -69,9 +72,11 @@ Prefer the full bundle when:
 
 You should now be able to hand any of these URLs to a tool and get grounded answers:
 
-- `https://agentclash.dev/llms.txt`
-- `https://agentclash.dev/llms-full.txt`
-- `https://agentclash.dev/docs-md/getting-started/quickstart`
+- `https://www.agentclash.dev/llms.txt`
+- `https://www.agentclash.dev/llms-full.txt`
+- `https://www.agentclash.dev/md/docs/getting-started/quickstart`
+- `https://www.agentclash.dev/openapi.yaml`
+- `https://www.agentclash.dev/cli-schema.json`
 
 ## Troubleshooting
 
@@ -81,7 +86,7 @@ Open the relevant endpoint yourself and paste the content directly.
 
 ### The answer is too vague
 
-Use a narrower `/docs-md/...` page instead of the full bundle.
+Use a narrower `/md/...` page instead of the full bundle.
 
 ### The answer mixes product claims with guesses
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
       "../docs/api-server/openapi.yaml",
       "../docs/schemas/**/*.json",
       "../cli/cmd/testdata/schema_snapshot.json",
+      "../try-cli/demos/*.trycli.yml",
     ],
   },
   // Force blocking metadata for every user agent (including Googlebot).

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -12,7 +12,6 @@ const nextConfig: NextConfig = {
     "/*": [
       "../docs/api-server/openapi.yaml",
       "../docs/schemas/**/*.json",
-      "../cli/cmd/testdata/schema_snapshot.json",
       "../try-cli/demos/*.trycli.yml",
     ],
   },

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 // PostHog reverse-proxy upstreams. Default to PostHog US Cloud; override via
 // env if the project lives in the EU region.
@@ -6,6 +7,14 @@ const POSTHOG_INGEST = process.env.POSTHOG_CLOUD_HOST ?? "https://us.i.posthog.c
 const POSTHOG_ASSETS = process.env.POSTHOG_ASSETS_HOST ?? "https://us-assets.i.posthog.com";
 
 const nextConfig: NextConfig = {
+  outputFileTracingRoot: path.join(process.cwd(), ".."),
+  outputFileTracingIncludes: {
+    "/*": [
+      "../docs/api-server/openapi.yaml",
+      "../docs/schemas/**/*.json",
+      "../cli/cmd/testdata/schema_snapshot.json",
+    ],
+  },
   // Force blocking metadata for every user agent (including Googlebot).
   // Without this, Next 15 streams <title>/OG tags into <body> on dynamic
   // pages (homepage, enterprise, blog). Crawlers that race the stream then

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -7,6 +7,9 @@ import { OrgSettingsSidebar } from "./org-settings-sidebar";
 import { OrgProvider } from "./org-context";
 import { UpgradePrompt } from "@/components/billing/upgrade-prompt";
 import { PostHogIdentify } from "@/components/posthog-identify";
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
 
 export default async function OrgLayout({
   children,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -6,6 +6,9 @@ import { UpgradePrompt } from "@/components/billing/upgrade-prompt";
 import { WorkspaceBillingBanner } from "@/components/billing/workspace-billing-banner";
 import { ActivationBanner } from "@/components/onboarding/activation-banner";
 import { PostHogIdentify } from "@/components/posthog-identify";
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
 
 export default async function WorkspaceLayout({
   children,

--- a/web/src/app/agent-opportunity/agent-opportunity-client.tsx
+++ b/web/src/app/agent-opportunity/agent-opportunity-client.tsx
@@ -6,12 +6,14 @@ import {
   ChevronDown,
   Download,
   Loader2,
+  Printer,
   Search,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
 import { captureWebEvent } from "@/lib/analytics/posthog-client";
 import { WEB_EVENTS } from "@/lib/analytics/events";
+import { renderAgentOpportunityMarkdown } from "@/lib/agent-opportunity-markdown";
 import { DimensionRadar } from "./components/dimension-radar";
 import { OpportunityMap } from "./components/opportunity-map";
 import { RiskHeatmap } from "./components/risk-heatmap";
@@ -86,6 +88,18 @@ function reportHostname(analyzedUrl: string): string {
   } catch {
     return analyzedUrl;
   }
+}
+
+function downloadReportMarkdown(report: AgentOpportunityReport) {
+  const markdown = renderAgentOpportunityMarkdown(report);
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  const company = report.companyName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  link.href = url;
+  link.download = `${company || "agent-opportunity"}-report.md`;
+  link.click();
+  URL.revokeObjectURL(url);
 }
 
 function useEntranceFrame(): boolean {
@@ -316,14 +330,24 @@ export function ReportDashboard({
               {report.summary}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => window.print()}
-            className="inline-flex items-center gap-2 border border-white/[0.15] px-3 py-2 font-mono text-2xs uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/35 hover:text-white print:hidden"
-          >
-            <Download className="size-3.5" />
-            Save report
-          </button>
+          <div className="flex flex-wrap gap-2 print:hidden">
+            <button
+              type="button"
+              onClick={() => downloadReportMarkdown(report)}
+              className="inline-flex items-center gap-2 border border-white/[0.15] px-3 py-2 font-mono text-2xs uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/35 hover:text-white"
+            >
+              <Download className="size-3.5" />
+              Download Markdown
+            </button>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex items-center gap-2 border border-white/[0.15] px-3 py-2 font-mono text-2xs uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/35 hover:text-white"
+            >
+              <Printer className="size-3.5" />
+              Print report
+            </button>
+          </div>
         </div>
       </header>
 

--- a/web/src/app/agent-opportunity/page.tsx
+++ b/web/src/app/agent-opportunity/page.tsx
@@ -7,7 +7,7 @@ import {
   SITE_URL,
 } from "@/components/marketing/json-ld";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 import { AgentOpportunityClient } from "./agent-opportunity-client";
 import {
   AGENT_OPPORTUNITY_DESCRIPTION,
@@ -27,7 +27,10 @@ export const metadata: Metadata = {
   title: AGENT_OPPORTUNITY_TITLE,
   description: AGENT_OPPORTUNITY_DESCRIPTION,
   keywords: [...AGENT_OPPORTUNITY_KEYWORDS],
-  alternates: { canonical: AGENT_OPPORTUNITY_PATH },
+  alternates: {
+    canonical: AGENT_OPPORTUNITY_PATH,
+    types: markdownAlternate(AGENT_OPPORTUNITY_PATH),
+  },
   openGraph: {
     title: AGENT_OPPORTUNITY_TITLE,
     description: AGENT_OPPORTUNITY_DESCRIPTION,

--- a/web/src/app/api/indexnow/publication/route.test.ts
+++ b/web/src/app/api/indexnow/publication/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const withAuthMock = vi.hoisted(() => vi.fn());
+const submitIndexNowMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: withAuthMock,
+}));
+
+vi.mock("@/lib/indexnow", () => ({
+  submitIndexNow: submitIndexNowMock,
+}));
+
+import { POST } from "./route";
+
+const PUBLICATION_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("POST /api/indexnow/publication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    withAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+    submitIndexNowMock.mockResolvedValue({ status: 202, body: "" });
+  });
+
+  it("requires an authenticated publisher", async () => {
+    withAuthMock.mockResolvedValue({ user: null });
+    const response = await POST(
+      new Request("https://www.agentclash.dev/api/indexnow/publication", {
+        method: "POST",
+        body: JSON.stringify({ publication_id: PUBLICATION_ID }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(submitIndexNowMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects values that are not publication UUIDs", async () => {
+    const response = await POST(
+      new Request("https://www.agentclash.dev/api/indexnow/publication", {
+        method: "POST",
+        body: JSON.stringify({ publication_id: "../../private" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(submitIndexNowMock).not.toHaveBeenCalled();
+  });
+
+  it("submits only the canonical publication URL", async () => {
+    const response = await POST(
+      new Request("https://www.agentclash.dev/api/indexnow/publication?token=ignored", {
+        method: "POST",
+        body: JSON.stringify({ publication_id: PUBLICATION_ID }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(submitIndexNowMock).toHaveBeenCalledWith([
+      `https://www.agentclash.dev/publications/${PUBLICATION_ID}`,
+    ]);
+  });
+});

--- a/web/src/app/api/indexnow/publication/route.ts
+++ b/web/src/app/api/indexnow/publication/route.ts
@@ -1,0 +1,28 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+import { submitIndexNow } from "@/lib/indexnow";
+import { PUBLIC_ORIGIN } from "@/lib/public-content";
+
+const PUBLICATION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function POST(request: Request) {
+  const { user } = await withAuth();
+  if (!user) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const payload = await request.json().catch(() => null);
+  const id = payload && typeof payload === "object"
+    ? (payload as { publication_id?: unknown }).publication_id
+    : null;
+  if (typeof id !== "string" || !PUBLICATION_ID.test(id)) {
+    return NextResponse.json({ ok: false, error: "invalid_publication_id" }, { status: 400 });
+  }
+
+  const result = await submitIndexNow([`${PUBLIC_ORIGIN}/publications/${id}`]);
+  const accepted = result.status === 200 || result.status === 202;
+  return NextResponse.json(
+    { ok: accepted, indexnowStatus: result.status },
+    { status: accepted ? 202 : 502 },
+  );
+}

--- a/web/src/app/api/indexnow/route.ts
+++ b/web/src/app/api/indexnow/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildUrlList, submitIndexNow } from "@/lib/indexnow";
+import { listAllPublicPublications } from "@/lib/publication-data";
 
 // Pings IndexNow with the current sitemap URLs. Driven by a Vercel Cron (see
 // vercel.json). When CRON_SECRET is set, Vercel sends it as a Bearer token and
@@ -19,7 +20,10 @@ export async function GET(request: Request): Promise<Response> {
     }
   }
 
-  const urlList = buildUrlList();
+  const publications = await listAllPublicPublications().catch(() => []);
+  const urlList = buildUrlList(
+    publications.map((item) => item.publication.canonical_path),
+  );
   if (urlList.length === 0) {
     return NextResponse.json({ ok: true, submitted: 0 });
   }

--- a/web/src/app/api/waitlist/route.test.ts
+++ b/web/src/app/api/waitlist/route.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { POST } from "./route";
+
+describe("waitlist native form fallback", () => {
+  it("redirects an invalid native form submission without requiring JavaScript", async () => {
+    const response = await POST(
+      new Request("https://www.agentclash.dev/api/waitlist", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          email: "not-an-email",
+          source: "eval-checklist",
+          resource: "eval-checklist",
+          intent: "resource-download",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain(
+      "/resources/eval-checklist?form_error=Enter+a+valid+email.",
+    );
+  });
+});

--- a/web/src/app/api/waitlist/route.ts
+++ b/web/src/app/api/waitlist/route.ts
@@ -158,13 +158,36 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const payload = await request.json().catch(() => null);
+  const contentType = request.headers.get("content-type") ?? "";
+  const nativeForm =
+    contentType.includes("application/x-www-form-urlencoded") ||
+    contentType.includes("multipart/form-data");
+  const payload = nativeForm
+    ? Object.fromEntries((await request.formData()).entries())
+    : await request.json().catch(() => null);
+
+  const invalid = (message: string, status = 400) => {
+    if (nativeForm) {
+      const url = new URL("/resources/eval-checklist", request.url);
+      url.searchParams.set("form_error", message);
+      url.hash = "download";
+      return NextResponse.redirect(url, 303);
+    }
+    return NextResponse.json({ error: message }, { status });
+  };
+
+  const success = (body: Record<string, unknown>) => {
+    if (nativeForm) {
+      return NextResponse.redirect(
+        new URL("/resources/eval-checklist/thank-you", request.url),
+        303,
+      );
+    }
+    return NextResponse.json(body);
+  };
 
   if (!payload || typeof payload !== "object") {
-    return NextResponse.json(
-      { error: "Invalid request body." },
-      { status: 400 },
-    );
+    return invalid("Invalid request body.");
   }
 
   const email =
@@ -173,10 +196,7 @@ export async function POST(request: Request) {
       : "";
 
   if (!isValidEmail(email)) {
-    return NextResponse.json(
-      { error: "Enter a valid email." },
-      { status: 400 },
-    );
+    return invalid("Enter a valid email.");
   }
 
   const records = await readWaitlistRecords();
@@ -205,7 +225,7 @@ export async function POST(request: Request) {
       await writeWaitlistRecords(records);
       sendLeadNotification(email, leadSource);
     }
-    return NextResponse.json({
+    return success({
       ok: true,
       duplicate: true,
       position,
@@ -228,7 +248,7 @@ export async function POST(request: Request) {
   sendWelcomeEmail(email, position);
   if (leadSource) sendLeadNotification(email, leadSource);
 
-  return NextResponse.json({
+  return success({
     ok: true,
     duplicate: false,
     position,

--- a/web/src/app/auth/layout.tsx
+++ b/web/src/app/auth/layout.tsx
@@ -1,0 +1,7 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/benchmarks/[slug]/page.tsx
+++ b/web/src/app/benchmarks/[slug]/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/marketing/json-ld";
 import { getAllSlugs, getReportBySlug } from "@/lib/benchmarks";
 import { mdxRemoteOptions } from "@/lib/mdx-options";
-import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
+import { benchmarkRssAlternate, markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     robots: report.sample ? { index: false, follow: true } : undefined,
     alternates: {
       canonical: `/benchmarks/${report.slug}`,
-      types: benchmarkRssAlternate,
+      types: markdownAlternate(`/benchmarks/${report.slug}`, benchmarkRssAlternate),
     },
     openGraph: {
       type: "article",

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -5,7 +5,7 @@ import { BenchmarksHubContent } from "@/components/marketing/benchmarks/benchmar
 import { JsonLd, benchmarkHubSchema } from "@/components/marketing/json-ld";
 import { getAllReports } from "@/lib/benchmarks";
 import { BENCHMARKS_HUB_FAQ } from "@/lib/benchmarks-hub";
-import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
+import { benchmarkRssAlternate, markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_TITLE = "AI Agent Benchmarks Hub | Reproducible Evals | AgentClash";
 const PAGE_DESCRIPTION =
@@ -22,7 +22,7 @@ export function generateMetadata(): Metadata {
     description: PAGE_DESCRIPTION,
     alternates: {
       canonical: "/benchmarks",
-      types: benchmarkRssAlternate,
+      types: markdownAlternate("/benchmarks", benchmarkRssAlternate),
     },
     openGraph: {
       title: PAGE_TITLE,

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -14,7 +14,7 @@ import { ResourcePackCTA } from "@/components/marketing/resource-pack-cta";
 import { getBlogRelatedResources } from "@/lib/blog-related-resources";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { mdxRemoteOptions } from "@/lib/mdx-options";
-import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
+import { blogRssAlternate, markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: post.description,
     alternates: {
       canonical: `/blog/${post.slug}`,
-      types: blogRssAlternate,
+      types: markdownAlternate(`/blog/${post.slug}`, blogRssAlternate),
     },
     openGraph: {
       type: "article",

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -6,7 +6,7 @@ import { AgentPromoBanner } from "@/components/marketing/agent-promo-banner";
 import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
 import { ResourcePackCTA } from "@/components/marketing/resource-pack-cta";
 import { getAllPosts } from "@/lib/blog";
-import { blogRssAlternate } from "@/lib/seo";
+import { blogRssAlternate, markdownAlternate } from "@/lib/seo";
 
 const PAGE_TITLE = "AI Agent Evaluation Blog - AgentClash";
 const PAGE_DESCRIPTION =
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: "/blog",
-    types: blogRssAlternate,
+    types: markdownAlternate("/blog", blogRssAlternate),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/app/changelog/[slug]/page.tsx
+++ b/web/src/app/changelog/[slug]/page.tsx
@@ -10,7 +10,7 @@ import {
   getChangelogPeriodPullRequests,
   getChangelogPullRequestUrl,
 } from "@/lib/changelog";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: { canonical },
+    alternates: { canonical, types: markdownAlternate(canonical) },
     openGraph: {
       title,
       description,

--- a/web/src/app/changelog/metadata.ts
+++ b/web/src/app/changelog/metadata.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_TITLE = "Changelog - AgentClash";
 const PAGE_DESCRIPTION =
@@ -24,6 +24,7 @@ export const changelogMetadata: Metadata = {
   ],
   alternates: {
     canonical: "/changelog",
+    types: markdownAlternate("/changelog"),
   },
   robots: {
     index: true,

--- a/web/src/app/cli-schema.json/route.ts
+++ b/web/src/app/cli-schema.json/route.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+const RELEASE_SCHEMA_URL =
+  "https://github.com/agentclash/agentclash/releases/latest/download/cli-schema.json";
+const NPM_LATEST_URL = "https://registry.npmjs.org/agentclash/latest";
+const FALLBACK_SCHEMA_PATH = path.join(
+  process.cwd(),
+  "..",
+  "cli",
+  "cmd",
+  "testdata",
+  "schema_snapshot.json",
+);
+
+type CliSchema = {
+  schema_version: number;
+  cli_version: string;
+  commands: unknown[];
+  [key: string]: unknown;
+};
+
+function isCliSchema(value: unknown): value is CliSchema {
+  if (!value || typeof value !== "object") return false;
+  const schema = value as Partial<CliSchema>;
+  return (
+    typeof schema.schema_version === "number" &&
+    typeof schema.cli_version === "string" &&
+    Array.isArray(schema.commands)
+  );
+}
+
+async function releasedSchema(): Promise<{ schema: CliSchema; source: string }> {
+  const releaseResponse = await fetch(RELEASE_SCHEMA_URL, {
+    headers: { Accept: "application/json" },
+    next: { revalidate: 3600 },
+  });
+  if (releaseResponse.ok) {
+    const candidate: unknown = await releaseResponse.json();
+    if (isCliSchema(candidate)) return { schema: candidate, source: "release-asset" };
+  }
+
+  const fallbackCandidate: unknown = JSON.parse(
+    await readFile(FALLBACK_SCHEMA_PATH, "utf8"),
+  );
+  if (!isCliSchema(fallbackCandidate)) {
+    throw new Error("Repository CLI schema fallback is invalid");
+  }
+
+  let version = process.env.AGENTCLASH_CLI_SCHEMA_FALLBACK_VERSION ?? "2.1.1";
+  try {
+    const npmResponse = await fetch(NPM_LATEST_URL, {
+      headers: { Accept: "application/json" },
+      next: { revalidate: 3600 },
+    });
+    if (npmResponse.ok) {
+      const npmPackage = (await npmResponse.json()) as { version?: unknown };
+      if (typeof npmPackage.version === "string" && npmPackage.version) {
+        version = npmPackage.version;
+      }
+    }
+  } catch {
+    // The checked fallback version keeps this endpoint available during a
+    // transient npm outage. Release assets remain the authoritative source.
+  }
+  return {
+    schema: { ...fallbackCandidate, cli_version: version },
+    source: "repository-fallback",
+  };
+}
+
+async function cliSchemaResponse(request: Request, head: boolean) {
+  const startedAt = Date.now();
+  try {
+    const { schema, source } = await releasedSchema();
+    const body = `${JSON.stringify(schema, null, 2)}\n`;
+    console.log(
+      JSON.stringify({
+        level: "info",
+        event: "agent_readable_response",
+        path: "/cli-schema.json",
+        representation: "machine",
+        status: 200,
+        bytes: Buffer.byteLength(body, "utf8"),
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+        contract_source: source,
+      }),
+    );
+    return new Response(head ? null : body, {
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=604800",
+        "X-AgentClash-Schema-Source": source,
+        "X-Content-Type-Options": "nosniff",
+        "X-Robots-Tag": "noindex, follow",
+      },
+    });
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "agent_readable_response",
+        path: "/cli-schema.json",
+        representation: "machine",
+        status: 503,
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return new Response(head ? null : "CLI schema unavailable", {
+      status: 503,
+      headers: { "Retry-After": "300" },
+    });
+  }
+}
+
+export function GET(request: Request) {
+  return cliSchemaResponse(request, false);
+}
+
+export function HEAD(request: Request) {
+  return cliSchemaResponse(request, true);
+}

--- a/web/src/app/cli-schema.json/route.ts
+++ b/web/src/app/cli-schema.json/route.ts
@@ -1,19 +1,7 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-
 export const dynamic = "force-dynamic";
 
 const RELEASE_SCHEMA_URL =
   "https://github.com/agentclash/agentclash/releases/latest/download/cli-schema.json";
-const NPM_LATEST_URL = "https://registry.npmjs.org/agentclash/latest";
-const FALLBACK_SCHEMA_PATH = path.join(
-  process.cwd(),
-  "..",
-  "cli",
-  "cmd",
-  "testdata",
-  "schema_snapshot.json",
-);
 
 type CliSchema = {
   schema_version: number;
@@ -40,35 +28,11 @@ async function releasedSchema(): Promise<{ schema: CliSchema; source: string }> 
   if (releaseResponse.ok) {
     const candidate: unknown = await releaseResponse.json();
     if (isCliSchema(candidate)) return { schema: candidate, source: "release-asset" };
+    throw new Error("Latest release CLI schema is invalid");
   }
-
-  const fallbackCandidate: unknown = JSON.parse(
-    await readFile(FALLBACK_SCHEMA_PATH, "utf8"),
+  throw new Error(
+    `Latest release CLI schema returned ${releaseResponse.status}`,
   );
-  if (!isCliSchema(fallbackCandidate)) {
-    throw new Error("Repository CLI schema fallback is invalid");
-  }
-
-  let version = process.env.AGENTCLASH_CLI_SCHEMA_FALLBACK_VERSION ?? "2.1.1";
-  try {
-    const npmResponse = await fetch(NPM_LATEST_URL, {
-      headers: { Accept: "application/json" },
-      next: { revalidate: 3600 },
-    });
-    if (npmResponse.ok) {
-      const npmPackage = (await npmResponse.json()) as { version?: unknown };
-      if (typeof npmPackage.version === "string" && npmPackage.version) {
-        version = npmPackage.version;
-      }
-    }
-  } catch {
-    // The checked fallback version keeps this endpoint available during a
-    // transient npm outage. Release assets remain the authoritative source.
-  }
-  return {
-    schema: { ...fallbackCandidate, cli_version: version },
-    source: "repository-fallback",
-  };
 }
 
 async function cliSchemaResponse(request: Request, head: boolean) {

--- a/web/src/app/compare/[competitor]/page.tsx
+++ b/web/src/app/compare/[competitor]/page.tsx
@@ -15,7 +15,7 @@ import {
   competitorRows,
   getCompetitorBySlug,
 } from "@/lib/comparison-data";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import { CompareShell } from "../_components/compare-shell";
 
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: { canonical: path },
+    alternates: { canonical: path, types: markdownAlternate(path) },
     openGraph: {
       title,
       description,

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -14,7 +14,7 @@ import {
   COMPETITORS,
   MARK_LABEL,
 } from "@/lib/comparison-data";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import { CompareShell } from "./_components/compare-shell";
 
@@ -56,7 +56,7 @@ const faqItems = [
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  alternates: { canonical: PAGE_PATH, types: markdownAlternate(PAGE_PATH) },
   openGraph: {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,7 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/docs-md/[[...slug]]/route.ts
+++ b/web/src/app/docs-md/[[...slug]]/route.ts
@@ -1,4 +1,5 @@
-import { getDocBySlug, renderDocMarkdown } from "@/lib/docs";
+import { resolvePublicContent } from "@/lib/public-content";
+import { representationLinkHeader } from "@/lib/public-http";
 
 type Context = {
   params: Promise<{
@@ -9,7 +10,8 @@ type Context = {
 export async function GET(_request: Request, context: Context) {
   const params = await context.params;
   const slug = params.slug ?? [];
-  const doc = getDocBySlug(slug);
+  const canonicalPath = slug.length === 0 ? "/docs" : `/docs/${slug.join("/")}`;
+  const doc = resolvePublicContent(canonicalPath);
 
   if (!doc) {
     return new Response("Not found", {
@@ -20,9 +22,15 @@ export async function GET(_request: Request, context: Context) {
     });
   }
 
-  return new Response(renderDocMarkdown(doc), {
+  return new Response(doc.renderMarkdown(), {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
+      "Content-Language": "en",
+      "Content-Location": doc.markdownPath,
+      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      "Link": representationLinkHeader(doc.canonicalPath, "https://www.agentclash.dev"),
+      "Vary": "Accept",
+      "X-Content-Type-Options": "nosniff",
       "X-Robots-Tag": "noindex, follow",
     },
   });

--- a/web/src/app/docs-md/[[...slug]]/route.ts
+++ b/web/src/app/docs-md/[[...slug]]/route.ts
@@ -7,7 +7,7 @@ type Context = {
   }>;
 };
 
-export async function GET(_request: Request, context: Context) {
+async function docsMarkdownResponse(_request: Request, context: Context, head: boolean) {
   const params = await context.params;
   const slug = params.slug ?? [];
   const canonicalPath = slug.length === 0 ? "/docs" : `/docs/${slug.join("/")}`;
@@ -22,7 +22,7 @@ export async function GET(_request: Request, context: Context) {
     });
   }
 
-  return new Response(doc.renderMarkdown(), {
+  return new Response(head ? null : doc.renderMarkdown(), {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
       "Content-Language": "en",
@@ -34,4 +34,12 @@ export async function GET(_request: Request, context: Context) {
       "X-Robots-Tag": "noindex, follow",
     },
   });
+}
+
+export function GET(request: Request, context: Context) {
+  return docsMarkdownResponse(request, context, false);
+}
+
+export function HEAD(request: Request, context: Context) {
+  return docsMarkdownResponse(request, context, true);
 }

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -12,7 +12,7 @@ import {
   getDocNeighbors,
 } from "@/lib/docs";
 import { mdxRemoteOptions } from "@/lib/mdx-options";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 import { docsSchemaId } from "../docs-schema-id";
 
 type Props = {
@@ -61,6 +61,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: doc.description,
     alternates: {
       canonical: doc.href,
+      types: markdownAlternate(doc.href),
     },
     openGraph: {
       title,

--- a/web/src/app/docs/search.json/route.ts
+++ b/web/src/app/docs/search.json/route.ts
@@ -1,9 +1,9 @@
-import { getDocsSearchIndex } from "@/lib/docs";
+import { getPublicSearchIndex } from "@/lib/public-content";
 
 export const revalidate = 3600;
 
 export function GET() {
-  return Response.json(getDocsSearchIndex(), {
+  return Response.json(getPublicSearchIndex(), {
     headers: {
       "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
     },

--- a/web/src/app/enterprise/page.tsx
+++ b/web/src/app/enterprise/page.tsx
@@ -11,7 +11,7 @@ import {
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { ResourcePackCTA } from "@/components/marketing/resource-pack-cta";
 import { PRICING_TIERS } from "@/lib/pricing-data";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_PATH = "/enterprise";
 const PAGE_TITLE =
@@ -160,7 +160,7 @@ const crossLinks = [
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  alternates: { canonical: PAGE_PATH, types: markdownAlternate(PAGE_PATH) },
   openGraph: {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,

--- a/web/src/app/github/layout.tsx
+++ b/web/src/app/github/layout.tsx
@@ -1,0 +1,7 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function GitHubLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/invites/layout.tsx
+++ b/web/src/app/invites/layout.tsx
@@ -1,0 +1,7 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function InviteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/llms-full.txt/route.ts
+++ b/web/src/app/llms-full.txt/route.ts
@@ -2,12 +2,32 @@ import { buildPublicLlmsFull } from "@/lib/public-content";
 
 export const revalidate = 3600;
 
-export function GET() {
-  return new Response(buildPublicLlmsFull(), {
+function llmsFullResponse(request: Request, head: boolean) {
+  const startedAt = Date.now();
+  const body = buildPublicLlmsFull();
+  console.log(JSON.stringify({
+    level: "info",
+    event: "agent_readable_response",
+    path: "/llms-full.txt",
+    representation: "machine",
+    status: 200,
+    bytes: Buffer.byteLength(body, "utf8"),
+    duration_ms: Date.now() - startedAt,
+    request_id: request.headers.get("x-vercel-id"),
+  }));
+  return new Response(head ? null : body, {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
       "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
       "X-Content-Type-Options": "nosniff",
     },
   });
+}
+
+export function GET(request: Request) {
+  return llmsFullResponse(request, false);
+}
+
+export function HEAD(request: Request) {
+  return llmsFullResponse(request, true);
 }

--- a/web/src/app/llms-full.txt/route.ts
+++ b/web/src/app/llms-full.txt/route.ts
@@ -1,12 +1,13 @@
-import { buildLlmsFull } from "@/lib/docs";
+import { buildPublicLlmsFull } from "@/lib/public-content";
 
 export const revalidate = 3600;
 
 export function GET() {
-  return new Response(buildLlmsFull(), {
+  return new Response(buildPublicLlmsFull(), {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      "X-Content-Type-Options": "nosniff",
     },
   });
 }

--- a/web/src/app/llms-routes.test.ts
+++ b/web/src/app/llms-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { GET as getIndex, HEAD as headIndex } from "@/app/llms.txt/route";
 import { GET as getFull, HEAD as headFull } from "@/app/llms-full.txt/route";
+import { PUBLIC_MACHINE_CONTRACTS } from "@/lib/public-contracts";
 
 describe("LLM discovery routes", () => {
   it.each([
@@ -38,5 +39,17 @@ describe("LLM discovery routes", () => {
     expect(links.length).toBeGreaterThan(10);
     expect(links.every((url) => url.host === "www.agentclash.dev")).toBe(true);
     expect(body).not.toContain("https://agentclash.dev");
+  });
+
+  it("advertises every registered machine contract", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const response = getIndex(
+      new Request("https://www.agentclash.dev/llms.txt"),
+    );
+    const body = await response.text();
+
+    for (const contract of PUBLIC_MACHINE_CONTRACTS) {
+      expect(body).toContain(`https://www.agentclash.dev${contract.path}`);
+    }
   });
 });

--- a/web/src/app/llms-routes.test.ts
+++ b/web/src/app/llms-routes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { GET as getIndex, HEAD as headIndex } from "@/app/llms.txt/route";
+import { GET as getFull, HEAD as headFull } from "@/app/llms-full.txt/route";
+
+describe("LLM discovery routes", () => {
+  it.each([
+    ["/llms.txt", getIndex, headIndex],
+    ["/llms-full.txt", getFull, headFull],
+  ] as const)("serves GET and HEAD for %s", async (pathname, get, head) => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const request = new Request(`https://www.agentclash.dev${pathname}`);
+
+    const getResponse = get(request);
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect((await getResponse.text()).length).toBeGreaterThan(100);
+
+    const headResponse = head(request);
+    expect(headResponse.status).toBe(200);
+    expect(headResponse.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(await headResponse.text()).toBe("");
+  });
+
+  it("advertises only canonical-host HTTPS links", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const response = getIndex(
+      new Request("https://www.agentclash.dev/llms.txt"),
+    );
+    const body = await response.text();
+    const links = [...body.matchAll(/\]\((https:\/\/[^)]+)\)/g)].map(
+      (match) => new URL(match[1]),
+    );
+
+    expect(links.length).toBeGreaterThan(10);
+    expect(links.every((url) => url.host === "www.agentclash.dev")).toBe(true);
+    expect(body).not.toContain("https://agentclash.dev");
+  });
+});

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -1,12 +1,13 @@
-import { buildLlmsIndex } from "@/lib/docs";
+import { buildPublicLlmsIndex } from "@/lib/public-content";
 
 export const revalidate = 3600;
 
 export function GET() {
-  return new Response(buildLlmsIndex(), {
+  return new Response(buildPublicLlmsIndex(), {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      "X-Content-Type-Options": "nosniff",
     },
   });
 }

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -2,12 +2,32 @@ import { buildPublicLlmsIndex } from "@/lib/public-content";
 
 export const revalidate = 3600;
 
-export function GET() {
-  return new Response(buildPublicLlmsIndex(), {
+function llmsResponse(request: Request, head: boolean) {
+  const startedAt = Date.now();
+  const body = buildPublicLlmsIndex();
+  console.log(JSON.stringify({
+    level: "info",
+    event: "agent_readable_response",
+    path: "/llms.txt",
+    representation: "machine",
+    status: 200,
+    bytes: Buffer.byteLength(body, "utf8"),
+    duration_ms: Date.now() - startedAt,
+    request_id: request.headers.get("x-vercel-id"),
+  }));
+  return new Response(head ? null : body, {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
       "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
       "X-Content-Type-Options": "nosniff",
     },
   });
+}
+
+export function GET(request: Request) {
+  return llmsResponse(request, false);
+}
+
+export function HEAD(request: Request) {
+  return llmsResponse(request, true);
 }

--- a/web/src/app/machine-contract-routes.test.ts
+++ b/web/src/app/machine-contract-routes.test.ts
@@ -2,15 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET as getOpenAPI, HEAD as headOpenAPI } from "@/app/openapi.yaml/route";
 import { GET as getSchema, HEAD as headSchema } from "@/app/schemas/[...path]/route";
 import { GET as getCliSchema, HEAD as headCliSchema } from "@/app/cli-schema.json/route";
+import { PUBLIC_MACHINE_CONTRACTS } from "@/lib/public-contracts";
 
-const SCHEMAS = [
-  "prompt-eval-result.schema.json",
-  "prompt-eval.schema.json",
-  "voice-artifact-manifest.schema.json",
-  "voice-live-continuity-report.schema.json",
-  "voice-source-separation-report.schema.json",
-  "voice-video-sync-report.schema.json",
-] as const;
+const SCHEMAS = PUBLIC_MACHINE_CONTRACTS
+  .filter((contract) => contract.path.startsWith("/schemas/"))
+  .map((contract) => contract.path.slice("/schemas/".length));
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/web/src/app/machine-contract-routes.test.ts
+++ b/web/src/app/machine-contract-routes.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET as getOpenAPI, HEAD as headOpenAPI } from "@/app/openapi.yaml/route";
+import { GET as getSchema, HEAD as headSchema } from "@/app/schemas/[...path]/route";
+import { GET as getCliSchema, HEAD as headCliSchema } from "@/app/cli-schema.json/route";
+
+const SCHEMAS = [
+  "prompt-eval-result.schema.json",
+  "prompt-eval.schema.json",
+  "voice-artifact-manifest.schema.json",
+  "voice-live-continuity-report.schema.json",
+  "voice-source-separation-report.schema.json",
+  "voice-video-sync-report.schema.json",
+] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("machine contract routes", () => {
+  it("serves the checked OpenAPI source for GET and HEAD", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const request = new Request("https://www.agentclash.dev/openapi.yaml");
+    const response = await getOpenAPI(request);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/yaml; charset=utf-8",
+    );
+    expect(body).toContain('openapi: "3.1.0"');
+    expect(body).toContain("https://api.agentclash.dev");
+
+    const head = await headOpenAPI(request);
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+  });
+
+  it.each(SCHEMAS)("serves %s with its deployed canonical ID", async (name) => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const request = new Request(`https://www.agentclash.dev/schemas/${name}`);
+    const context = { params: Promise.resolve({ path: [name] }) };
+    const response = await getSchema(request, context);
+    const body = (await response.json()) as { $id?: string };
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/schema+json; charset=utf-8",
+    );
+    expect(body.$id).toBe(`https://www.agentclash.dev/schemas/${name}`);
+
+    const head = await headSchema(request, context);
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+  });
+
+  it("rejects schemas outside the allowlist", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const response = await getSchema(
+      new Request("https://www.agentclash.dev/schemas/../private.json"),
+      { params: Promise.resolve({ path: ["..", "private.json"] }) },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("proxies the released CLI schema with one-hour caching", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () =>
+        new Response(
+          JSON.stringify({
+            schema_version: 1,
+            cli_version: "9.8.7",
+            commands: [{ name: "version" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const response = await getCliSchema(
+      new Request("https://www.agentclash.dev/cli-schema.json"),
+    );
+    const body = (await response.json()) as { cli_version: string };
+    expect(response.status).toBe(200);
+    expect(body.cli_version).toBe("9.8.7");
+    expect(response.headers.get("cache-control")).toContain("s-maxage=3600");
+    expect(response.headers.get("x-agentclash-schema-source")).toBe(
+      "release-asset",
+    );
+
+    const head = await headCliSchema(
+      new Request("https://www.agentclash.dev/cli-schema.json"),
+    );
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+  });
+
+  it("fails honestly when the released CLI asset is unavailable", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("missing", { status: 404 })),
+    );
+
+    const response = await getCliSchema(
+      new Request("https://www.agentclash.dev/cli-schema.json"),
+    );
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("300");
+  });
+});

--- a/web/src/app/md/[[...path]]/route.ts
+++ b/web/src/app/md/[[...path]]/route.ts
@@ -1,0 +1,95 @@
+import {
+  canonicalPathFromMarkdownSegments,
+  resolvePublicContent,
+} from "@/lib/public-content";
+import {
+  CANONICAL_PATH_HEADER,
+  NEGOTIATED_MARKDOWN_HEADER,
+  representationLinkHeader,
+} from "@/lib/public-http";
+
+export const revalidate = 3600;
+
+type Context = {
+  params: Promise<{ path?: string[] }>;
+};
+
+function appendVary(headers: Headers, value: string) {
+  const values = new Set(
+    (headers.get("Vary") ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  values.add(value);
+  headers.set("Vary", [...values].join(", "));
+}
+
+async function markdownResponse(request: Request, context: Context, head: boolean) {
+  const startedAt = Date.now();
+  const { path = [] } = await context.params;
+  const rewrittenCanonical = request.headers.get(CANONICAL_PATH_HEADER);
+  const canonicalPath = rewrittenCanonical ?? canonicalPathFromMarkdownSegments(path);
+  const negotiated = request.headers.get(NEGOTIATED_MARKDOWN_HEADER) === "1";
+  const content = canonicalPath ? resolvePublicContent(canonicalPath) : null;
+
+  if (!content) {
+    console.log(
+      JSON.stringify({
+        level: "info",
+        event: "agent_readable_response",
+        path: canonicalPath ?? "/invalid",
+        representation: "markdown",
+        status: 404,
+        bytes: 0,
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+      }),
+    );
+    return new Response(head ? null : "Not found", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Robots-Tag": "noindex, follow",
+      },
+    });
+  }
+
+  const body = content.renderMarkdown();
+  const headers = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "Content-Language": "en",
+    "Content-Location": content.markdownPath,
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control":
+      content.kind === "publication"
+        ? "no-store"
+        : "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    Link: representationLinkHeader(content.canonicalPath, "https://www.agentclash.dev"),
+  });
+  appendVary(headers, "Accept");
+  if (!negotiated) headers.set("X-Robots-Tag", "noindex, follow");
+
+  console.log(
+    JSON.stringify({
+      level: "info",
+      event: "agent_readable_response",
+      path: content.canonicalPath,
+      content_kind: content.kind,
+      representation: "markdown",
+      status: 200,
+      bytes: Buffer.byteLength(body, "utf8"),
+      duration_ms: Date.now() - startedAt,
+      request_id: request.headers.get("x-vercel-id"),
+    }),
+  );
+  return new Response(head ? null : body, { headers });
+}
+
+export function GET(request: Request, context: Context) {
+  return markdownResponse(request, context, false);
+}
+
+export function HEAD(request: Request, context: Context) {
+  return markdownResponse(request, context, true);
+}

--- a/web/src/app/md/[[...path]]/route.ts
+++ b/web/src/app/md/[[...path]]/route.ts
@@ -3,6 +3,11 @@ import {
   resolvePublicContent,
 } from "@/lib/public-content";
 import {
+  listAllPublicPublications,
+  resolvePublicPublicationAdapter,
+} from "@/lib/publication-data";
+import { renderPublicationCatalogMarkdown } from "@/lib/publications";
+import {
   CANONICAL_PATH_HEADER,
   NEGOTIATED_MARKDOWN_HEADER,
   representationLinkHeader,
@@ -31,7 +36,9 @@ async function markdownResponse(request: Request, context: Context, head: boolea
   const rewrittenCanonical = request.headers.get(CANONICAL_PATH_HEADER);
   const canonicalPath = rewrittenCanonical ?? canonicalPathFromMarkdownSegments(path);
   const negotiated = request.headers.get(NEGOTIATED_MARKDOWN_HEADER) === "1";
-  const content = canonicalPath ? resolvePublicContent(canonicalPath) : null;
+  const content = canonicalPath
+    ? resolvePublicContent(canonicalPath) ?? (await resolvePublicPublicationAdapter(canonicalPath))
+    : null;
 
   if (!content) {
     console.log(
@@ -55,7 +62,11 @@ async function markdownResponse(request: Request, context: Context, head: boolea
     });
   }
 
-  const body = content.renderMarkdown();
+  const body = content.canonicalPath === "/publications"
+    ? renderPublicationCatalogMarkdown(
+        await listAllPublicPublications().catch(() => []),
+      )
+    : content.renderMarkdown();
   const headers = new Headers({
     "Content-Type": "text/markdown; charset=utf-8",
     "Content-Language": "en",

--- a/web/src/app/md/[[...path]]/route.ts
+++ b/web/src/app/md/[[...path]]/route.ts
@@ -64,7 +64,7 @@ async function markdownResponse(request: Request, context: Context, head: boolea
 
   const body = content.canonicalPath === "/publications"
     ? renderPublicationCatalogMarkdown(
-        await listAllPublicPublications().catch(() => []),
+        await listAllPublicPublications(),
       )
     : content.renderMarkdown();
   const headers = new Headers({

--- a/web/src/app/onboard/layout.tsx
+++ b/web/src/app/onboard/layout.tsx
@@ -1,0 +1,7 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function OnboardLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/openapi.yaml/route.ts
+++ b/web/src/app/openapi.yaml/route.ts
@@ -1,0 +1,61 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const revalidate = 3600;
+
+const OPENAPI_PATH = path.join(
+  process.cwd(),
+  "..",
+  "docs",
+  "api-server",
+  "openapi.yaml",
+);
+
+async function openApiResponse(request: Request, head: boolean) {
+  const startedAt = Date.now();
+  try {
+    const body = await readFile(OPENAPI_PATH, "utf8");
+    console.log(
+      JSON.stringify({
+        level: "info",
+        event: "agent_readable_response",
+        path: "/openapi.yaml",
+        representation: "machine",
+        status: 200,
+        bytes: Buffer.byteLength(body, "utf8"),
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+      }),
+    );
+    return new Response(head ? null : body, {
+      headers: {
+        "Content-Type": "application/yaml; charset=utf-8",
+        "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+        "X-Content-Type-Options": "nosniff",
+        "X-Robots-Tag": "noindex, follow",
+      },
+    });
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "agent_readable_response",
+        path: "/openapi.yaml",
+        representation: "machine",
+        status: 500,
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return new Response(head ? null : "OpenAPI contract unavailable", { status: 500 });
+  }
+}
+
+export function GET(request: Request) {
+  return openApiResponse(request, false);
+}
+
+export function HEAD(request: Request) {
+  return openApiResponse(request, true);
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -14,6 +14,7 @@ import { getChangelogPeriods } from "@/lib/changelog";
 import { HOME_FAQ } from "@/lib/home-faq";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import { isReturningVisitor } from "@/lib/auth/returning";
+import { markdownAlternate } from "@/lib/seo";
 import HomePage from "./landing";
 
 // Homepage title/meta lead with the category buyers search, not just the
@@ -29,6 +30,7 @@ export const metadata: Metadata = {
   description: HOME_DESCRIPTION,
   alternates: {
     canonical: "/",
+    types: markdownAlternate("/"),
   },
   keywords: [
     "AI agent evals",

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -18,6 +18,7 @@ import {
   productSchema,
 } from "@/components/marketing/json-ld";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
+import { markdownAlternate } from "@/lib/seo";
 
 const PAGE_PATH = "/platform/agent-evaluation";
 const PAGE_TITLE = "AI Agent Evaluation Platform for Real Tasks - AgentClash";
@@ -79,6 +80,7 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: PAGE_PATH,
+    types: markdownAlternate(PAGE_PATH),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -17,6 +17,7 @@ import {
   faqSchema,
   productSchema,
 } from "@/components/marketing/json-ld";
+import { markdownAlternate } from "@/lib/seo";
 
 const PAGE_PATH = "/platform/agent-regression-testing";
 const PAGE_TITLE = "AI Agent Regression Testing from Traces to CI Gates - AgentClash";
@@ -86,6 +87,7 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: PAGE_PATH,
+    types: markdownAlternate(PAGE_PATH),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/app/platform/datasmith/page.tsx
+++ b/web/src/app/platform/datasmith/page.tsx
@@ -17,6 +17,7 @@ import {
   faqSchema,
   productSchema,
 } from "@/components/marketing/json-ld";
+import { markdownAlternate } from "@/lib/seo";
 
 const PAGE_PATH = "/platform/datasmith";
 const PAGE_TITLE =
@@ -88,6 +89,7 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: PAGE_PATH,
+    types: markdownAlternate(PAGE_PATH),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -77,12 +77,12 @@ describe("platform pages structured data", () => {
       applicationCategory: "DeveloperApplication",
       applicationSubCategory: "AI agent evaluation platform",
       featureList: [
-        "Sandboxed real-tool execution",
-        "Head-to-head runs with fair constraints",
-        "Scorecards for correctness, cost, latency, and tool strategy",
-        "Replay trails for every important action",
-        "Challenge packs that turn failures into reusable tests",
-        "CI gates for baseline versus candidate decisions",
+        "OpenTelemetry-compatible trace import",
+        "Pinned datasets and golden test cases",
+        "Baseline versus candidate regression checks",
+        "Replay trails for tool calls, outputs, and artifacts",
+        "Scorecards for correctness, cost, latency, and evidence",
+        "CI gates for prompt, model, RAG, and tool changes",
       ],
       offers: {
         name: "Open-source self-hosted edition",
@@ -108,19 +108,20 @@ describe("platform pages structured data", () => {
       "SoftwareApplication",
     ]);
     expect(software).toMatchObject({
-      name: "AI Agent Regression Testing and CI Gates - AgentClash",
+      name: "AI Agent Regression Testing from Traces to CI Gates - AgentClash",
       description:
-        "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.",
+        "Turn production traces and pinned datasets into AI agent regression tests with baselines, replay evidence, scorecards, and pull request gates.",
       url: "https://www.agentclash.dev/platform/agent-regression-testing",
       applicationCategory: "DeveloperApplication",
       applicationSubCategory: "AI agent regression testing software",
       featureList: [
+        "OTel-compatible trace import",
+        "Pinned datasets and golden examples",
         "Baseline versus candidate scorecards",
         "Replay timelines for every failed gate",
         "Artifact checks for files, logs, and evidence",
         "Cost and latency thresholds for production budgets",
-        "Challenge packs that make failures repeatable",
-        "Pull request gates for model, prompt, and tool changes",
+        "Pull request gates for model, prompt, RAG, and tool changes",
       ],
       offers: {
         name: "Open-source self-hosted edition",
@@ -198,9 +199,9 @@ describe("platform page social metadata", () => {
   });
 
   it("adds explicit social image metadata for regression testing", () => {
-    const title = "AI Agent Regression Testing and CI Gates - AgentClash";
+    const title = "AI Agent Regression Testing from Traces to CI Gates - AgentClash";
     const description =
-      "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.";
+      "Turn production traces and pinned datasets into AI agent regression tests with baselines, replay evidence, scorecards, and pull request gates.";
 
     expect(agentRegressionTestingMetadata).toMatchObject({
       title,

--- a/web/src/app/pricing/page.tsx
+++ b/web/src/app/pricing/page.tsx
@@ -8,7 +8,7 @@ import {
   pricingSchema,
 } from "@/components/marketing/json-ld";
 import { PricingBlock } from "@/components/marketing/pricing-block";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 import { CompareShell } from "../compare/_components/compare-shell";
 
 const PAGE_PATH = "/pricing";
@@ -49,7 +49,7 @@ const faqItems = [
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  alternates: { canonical: PAGE_PATH, types: markdownAlternate(PAGE_PATH) },
   openGraph: {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -9,7 +9,7 @@ import { generateMetadata as generateDocsMetadata } from "./docs/[[...slug]]/pag
 import { metadata as enterpriseMetadata } from "./enterprise/page";
 import { metadata as evalChecklistMetadata } from "./resources/eval-checklist/page";
 import { metadata as servicesMetadata } from "./services/page";
-import { metadata as tryoutsMetadata } from "./tryouts/page";
+import { generateMetadata as generateTryoutsMetadata } from "./tryouts/page";
 import { metadata as agentOpportunityMetadata } from "./agent-opportunity/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
 import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
@@ -60,14 +60,17 @@ function expectCanonical(metadata: Metadata, canonical: string) {
 }
 
 describe("public canonical metadata", () => {
-  it("locks static public page canonicals", () => {
+  it("locks static public page canonicals", async () => {
     expectCanonical(homeMetadata, "/");
     expectCanonical(blogMetadata, "/blog");
     expectCanonical(generateBenchmarksIndexMetadata(), "/benchmarks");
     expectCanonical(enterpriseMetadata, "/enterprise");
     expectCanonical(evalChecklistMetadata, "/resources/eval-checklist");
     expectCanonical(servicesMetadata, "/services");
-    expectCanonical(tryoutsMetadata, "/tryouts");
+    expectCanonical(
+      await generateTryoutsMetadata({ searchParams: Promise.resolve({}) }),
+      "/tryouts",
+    );
     expectCanonical(agentOpportunityMetadata, "/agent-opportunity");
     expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
     expectCanonical(
@@ -78,6 +81,13 @@ describe("public canonical metadata", () => {
     expectCanonical(whyMetadata, "/why");
     expectCanonical(teamMetadata, "/team");
     expectCanonical(changelogMetadata, "/changelog");
+  });
+
+  it("keeps query-based tryout sessions out of the index", async () => {
+    const metadata = await generateTryoutsMetadata({
+      searchParams: Promise.resolve({ tryout: "transient-run" }),
+    });
+    expect(metadata.robots).toMatchObject({ index: false, follow: false });
   });
 
   it("locks blog post canonical metadata", async () => {

--- a/web/src/app/publications/[id]/page.tsx
+++ b/web/src/app/publications/[id]/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PublicShareRenderer } from "@/components/share/public-share-renderers";
+import { ApiError } from "@/lib/api/errors";
+import { getPublicPublication } from "@/lib/publication-data";
+import { publicationDescription, publicationTitle } from "@/lib/publications";
+import { markdownAlternate } from "@/lib/seo";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type Props = { params: Promise<{ id: string }> };
+
+async function loadPublication(id: string) {
+  try {
+    return await getPublicPublication(id);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) notFound();
+    if (error instanceof Error && error.message === "Invalid publication ID") notFound();
+    throw error;
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const publication = await loadPublication(id);
+  const canonicalPath = publication.publication.canonical_path;
+  return {
+    title: `${publicationTitle(publication)} | AgentClash`,
+    description: publicationDescription(publication),
+    alternates: {
+      canonical: canonicalPath,
+      types: markdownAlternate(canonicalPath),
+    },
+    openGraph: {
+      title: publicationTitle(publication),
+      description: publicationDescription(publication),
+      url: canonicalPath,
+    },
+  };
+}
+
+export default async function PublicationPage({ params }: Props) {
+  const { id } = await params;
+  const publication = await loadPublication(id);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
+        <header className="border-b border-border pb-5">
+          <Link
+            href="/publications"
+            className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground hover:text-foreground"
+          >
+            AgentClash publications
+          </Link>
+          <h1 className="mt-3 text-3xl font-sans font-semibold tracking-tight">
+            {publicationTitle(publication)}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            User-published content. This read-only artifact passed an allowlisted,
+            redacted public serializer.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground">
+            <span>Type: {publication.publication.resource_type.replaceAll("_", " ")}</span>
+            <span>Updated: {new Date(publication.publication.updated_at).toISOString()}</span>
+            <Link
+              href={`/md${publication.publication.canonical_path}`}
+              className="underline-offset-4 hover:text-foreground hover:underline"
+            >
+              Markdown version
+            </Link>
+          </div>
+        </header>
+
+        <PublicShareRenderer resource={publication.resource as Record<string, unknown>} />
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { listPublicPublications } from "@/lib/publication-data";
+import { publicationDescription, publicationTitle } from "@/lib/publications";
+import { markdownAlternate } from "@/lib/seo";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Published Agent Evaluation Artifacts | AgentClash",
+  description:
+    "Browse explicitly published, redacted AgentClash challenge packs, scorecards, replays, and agent tryouts.",
+  alternates: {
+    canonical: "/publications",
+    types: markdownAlternate("/publications"),
+  },
+};
+
+type Props = { searchParams: Promise<{ cursor?: string }> };
+
+export default async function PublicationsPage({ searchParams }: Props) {
+  const { cursor } = await searchParams;
+  const result = await listPublicPublications({ cursor, limit: 50 }).catch(() => ({
+    items: [],
+    next_cursor: undefined,
+  }));
+
+  return (
+    <MarketingShell>
+      <section className="px-6 py-20 sm:px-12 sm:py-28">
+        <div className="mx-auto max-w-[1080px]">
+          <p className="font-mono text-2xs uppercase tracking-[0.14em] text-white/40">
+            Public evidence
+          </p>
+          <h1 className="mt-5 max-w-[18ch] text-[clamp(2.5rem,6vw,4.75rem)] font-sans font-semibold leading-[1.04] tracking-tight text-white">
+            Published agent evaluation artifacts
+          </h1>
+          <p className="mt-7 max-w-[64ch] text-lg leading-8 text-white/60">
+            Every item here was explicitly opted into search indexing and passed
+            its redacted public serializer. Capability-token shares never appear.
+          </p>
+
+          {result.items.length > 0 ? (
+            <div className="mt-12 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08] md:grid-cols-2">
+              {result.items.map((item) => (
+                <article key={item.publication.id} className="bg-[#060606] p-6">
+                  <p className="font-mono text-2xs uppercase tracking-[0.12em] text-white/35">
+                    {item.publication.resource_type.replaceAll("_", " ")}
+                  </p>
+                  <h2 className="mt-3 text-xl font-sans font-semibold tracking-tight text-white">
+                    <Link
+                      href={item.publication.canonical_path}
+                      className="underline-offset-4 hover:underline"
+                    >
+                      {publicationTitle(item)}
+                    </Link>
+                  </h2>
+                  <p className="mt-3 text-sm leading-6 text-white/50">
+                    {publicationDescription(item)}
+                  </p>
+                  <p className="mt-5 text-xs text-white/30">
+                    Updated {new Date(item.publication.updated_at).toLocaleDateString("en", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      timeZone: "UTC",
+                    })}
+                  </p>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-12 rounded-xl border border-white/[0.08] bg-white/[0.025] p-8">
+              <h2 className="text-lg font-semibold text-white">No active publications yet</h2>
+              <p className="mt-3 max-w-[56ch] text-sm leading-6 text-white/50">
+                Public artifacts appear here only after their owner enables search
+                indexing. Private and token-based shares remain excluded.
+              </p>
+            </div>
+          )}
+
+          {result.next_cursor ? (
+            <div className="mt-8">
+              <Link
+                href={`/publications?cursor=${encodeURIComponent(result.next_cursor)}`}
+                rel="next"
+                className="inline-flex min-h-11 items-center rounded-md border border-white/[0.12] px-5 text-sm font-medium text-white transition-colors hover:bg-white/[0.06]"
+              >
+                More publications
+              </Link>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </MarketingShell>
+  );
+}

--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -21,10 +21,7 @@ type Props = { searchParams: Promise<{ cursor?: string }> };
 
 export default async function PublicationsPage({ searchParams }: Props) {
   const { cursor } = await searchParams;
-  const result = await listPublicPublications({ cursor, limit: 50 }).catch(() => ({
-    items: [],
-    next_cursor: undefined,
-  }));
+  const result = await listPublicPublications({ cursor, limit: 50 });
 
   return (
     <MarketingShell>

--- a/web/src/app/publications/sitemap.xml/route.ts
+++ b/web/src/app/publications/sitemap.xml/route.ts
@@ -1,0 +1,34 @@
+import { listAllPublicPublications } from "@/lib/publication-data";
+import { PUBLIC_ORIGIN } from "@/lib/public-content";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function xml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const publications = await listAllPublicPublications().catch(() => []);
+  const urls = publications.map(
+    (item) => `  <url>\n    <loc>${xml(`${PUBLIC_ORIGIN}${item.publication.canonical_path}`)}</loc>\n    <lastmod>${xml(item.publication.updated_at)}</lastmod>\n  </url>`,
+  );
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    "</urlset>",
+  ].join("\n");
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/web/src/app/publications/sitemap.xml/route.ts
+++ b/web/src/app/publications/sitemap.xml/route.ts
@@ -14,7 +14,27 @@ function xml(value: string): string {
 }
 
 export async function GET() {
-  const publications = await listAllPublicPublications().catch(() => []);
+  let publications: Awaited<ReturnType<typeof listAllPublicPublications>>;
+  try {
+    publications = await listAllPublicPublications();
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "publications_sitemap_unavailable",
+        status: 503,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return new Response("Publication sitemap temporarily unavailable", {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+        "Retry-After": "60",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
   const urls = publications.map(
     (item) => `  <url>\n    <loc>${xml(`${PUBLIC_ORIGIN}${item.publication.canonical_path}`)}</loc>\n    <lastmod>${xml(item.publication.updated_at)}</lastmod>\n  </url>`,
   );

--- a/web/src/app/resources/eval-checklist/page.tsx
+++ b/web/src/app/resources/eval-checklist/page.tsx
@@ -7,7 +7,7 @@ import {
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { ResourceLeadForm } from "@/components/marketing/resource-lead-form";
 import { PRIMARY_RESOURCE, RESOURCE_LIBRARY } from "@/lib/resource-library";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_PATH = "/resources/eval-checklist";
 const PAGE_TITLE =
@@ -31,7 +31,7 @@ const proofPoints = [
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  alternates: { canonical: PAGE_PATH, types: markdownAlternate(PAGE_PATH) },
   openGraph: {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,

--- a/web/src/app/robots.test.ts
+++ b/web/src/app/robots.test.ts
@@ -11,7 +11,10 @@ describe("robots", () => {
       allow: "/",
       disallow: expect.arrayContaining(["/dashboard", "/workspaces/", "/auth/"]),
     });
-    expect(result.sitemap).toBe("https://www.agentclash.dev/sitemap.xml");
+    expect(result.sitemap).toEqual([
+      "https://www.agentclash.dev/sitemap.xml",
+      "https://www.agentclash.dev/publications/sitemap.xml",
+    ]);
   });
 
   it("explicitly allows every AI crawler (training + answer engines)", () => {

--- a/web/src/app/robots.test.ts
+++ b/web/src/app/robots.test.ts
@@ -39,6 +39,9 @@ describe("robots", () => {
       "/auth/",
       "/invites/",
       "/github/",
+      "/api/",
+      "/ingest/",
+      "/onboard",
       "/share/",
     ]);
   });

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -54,6 +54,9 @@ export default function robots(): MetadataRoute.Robots {
         disallow: [...APP_SHELL_DISALLOW],
       })),
     ],
-    sitemap: "https://www.agentclash.dev/sitemap.xml",
+    sitemap: [
+      "https://www.agentclash.dev/sitemap.xml",
+      "https://www.agentclash.dev/publications/sitemap.xml",
+    ],
   };
 }

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -34,6 +34,9 @@ export const APP_SHELL_DISALLOW = [
   "/auth/",
   "/invites/",
   "/github/",
+  "/api/",
+  "/ingest/",
+  "/onboard",
   "/share/",
 ] as const;
 

--- a/web/src/app/schemas/[...path]/route.ts
+++ b/web/src/app/schemas/[...path]/route.ts
@@ -1,0 +1,75 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const revalidate = 3600;
+
+const SCHEMA_ROOT = path.join(process.cwd(), "..", "docs", "schemas");
+const ALLOWED_SCHEMAS = new Set([
+  "prompt-eval-result.schema.json",
+  "prompt-eval.schema.json",
+  "voice-artifact-manifest.schema.json",
+  "voice-live-continuity-report.schema.json",
+  "voice-source-separation-report.schema.json",
+  "voice-video-sync-report.schema.json",
+]);
+
+type Context = { params: Promise<{ path: string[] }> };
+
+async function schemaResponse(request: Request, context: Context, head: boolean) {
+  const startedAt = Date.now();
+  const { path: segments } = await context.params;
+  const relativePath = segments.join("/");
+  if (!ALLOWED_SCHEMAS.has(relativePath)) {
+    return new Response(head ? null : "Not found", {
+      status: 404,
+      headers: { "X-Robots-Tag": "noindex, follow" },
+    });
+  }
+
+  try {
+    const body = await readFile(path.join(SCHEMA_ROOT, relativePath), "utf8");
+    JSON.parse(body);
+    console.log(
+      JSON.stringify({
+        level: "info",
+        event: "agent_readable_response",
+        path: `/schemas/${relativePath}`,
+        representation: "machine",
+        status: 200,
+        bytes: Buffer.byteLength(body, "utf8"),
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+      }),
+    );
+    return new Response(head ? null : body, {
+      headers: {
+        "Content-Type": "application/schema+json; charset=utf-8",
+        "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+        "X-Content-Type-Options": "nosniff",
+        "X-Robots-Tag": "noindex, follow",
+      },
+    });
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "agent_readable_response",
+        path: `/schemas/${relativePath}`,
+        representation: "machine",
+        status: 500,
+        duration_ms: Date.now() - startedAt,
+        request_id: request.headers.get("x-vercel-id"),
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return new Response(head ? null : "Schema unavailable", { status: 500 });
+  }
+}
+
+export function GET(request: Request, context: Context) {
+  return schemaResponse(request, context, false);
+}
+
+export function HEAD(request: Request, context: Context) {
+  return schemaResponse(request, context, true);
+}

--- a/web/src/app/schemas/[...path]/route.ts
+++ b/web/src/app/schemas/[...path]/route.ts
@@ -1,17 +1,11 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { PUBLIC_SCHEMA_FILENAMES } from "@/lib/public-contracts";
 
 export const revalidate = 3600;
 
 const SCHEMA_ROOT = path.join(process.cwd(), "..", "docs", "schemas");
-const ALLOWED_SCHEMAS = new Set([
-  "prompt-eval-result.schema.json",
-  "prompt-eval.schema.json",
-  "voice-artifact-manifest.schema.json",
-  "voice-live-continuity-report.schema.json",
-  "voice-source-separation-report.schema.json",
-  "voice-video-sync-report.schema.json",
-]);
+const ALLOWED_SCHEMAS = new Set(PUBLIC_SCHEMA_FILENAMES);
 
 type Context = { params: Promise<{ path: string[] }> };
 

--- a/web/src/app/schemas/[...path]/route.ts
+++ b/web/src/app/schemas/[...path]/route.ts
@@ -20,6 +20,16 @@ async function schemaResponse(request: Request, context: Context, head: boolean)
   const { path: segments } = await context.params;
   const relativePath = segments.join("/");
   if (!ALLOWED_SCHEMAS.has(relativePath)) {
+    console.log(JSON.stringify({
+      level: "info",
+      event: "agent_readable_response",
+      path: "/schemas/{unrecognized}",
+      representation: "machine",
+      status: 404,
+      bytes: 0,
+      duration_ms: Date.now() - startedAt,
+      request_id: request.headers.get("x-vercel-id"),
+    }));
     return new Response(head ? null : "Not found", {
       status: 404,
       headers: { "X-Robots-Tag": "noindex, follow" },

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -9,7 +9,7 @@ import {
   productSchema,
 } from "@/components/marketing/json-ld";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
-import { ogImageUrl } from "@/lib/seo";
+import { markdownAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_PATH = "/services";
 const PAGE_TITLE = "Agent Evaluation Services — Fixed Offerings | AgentClash";
@@ -130,7 +130,7 @@ const faqItems = [
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
-  alternates: { canonical: PAGE_PATH },
+  alternates: { canonical: PAGE_PATH, types: markdownAlternate(PAGE_PATH) },
   openGraph: {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,

--- a/web/src/app/share/[token]/layout.tsx
+++ b/web/src/app/share/[token]/layout.tsx
@@ -1,0 +1,11 @@
+import { PRIVATE_ROBOTS_METADATA } from "@/lib/private-metadata";
+
+export const metadata = PRIVATE_ROBOTS_METADATA;
+
+export default function PublicShareLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/web/src/app/share/[token]/page.tsx
+++ b/web/src/app/share/[token]/page.tsx
@@ -51,7 +51,7 @@ export default async function PublicSharePage({
               {publicTitle(share)}
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Public read-only share
+              Private read-only capability share
             </p>
           </div>
           <Badge variant="outline">{share.resource.type}</Badge>
@@ -97,6 +97,9 @@ function publicTitle(share: PublicShareResponse) {
     const agent = resource.run_agent as { label?: string } | undefined;
     return `${agent?.label ?? "Agent"} replay`;
   }
+  if (resource.type === "agent_tryout") {
+    return `${String(resource.template_slug ?? "Agent")} tryout`;
+  }
   return "Shared AgentClash artifact";
 }
 
@@ -107,8 +110,8 @@ function PublicResourceSummary({ share }: { share: PublicShareResponse }) {
       <SummaryItem label="Shared" value={created} />
       <SummaryItem label="Views" value={String(share.share.view_count)} />
       <SummaryItem
-        label="Indexing"
-        value={share.share.search_indexing ? "Allowed" : "Noindex"}
+        label="Search"
+        value={share.share.search_indexing ? "Published separately" : "Noindex"}
       />
     </section>
   );

--- a/web/src/app/share/[token]/page.tsx
+++ b/web/src/app/share/[token]/page.tsx
@@ -15,13 +15,16 @@ export async function generateMetadata({
 }) {
   const { token } = await params;
   const share = await loadPublicShare(token).catch(() => null);
-  if (!share) return { title: "Shared AgentClash artifact" };
+  if (!share) {
+    return {
+      title: "Shared AgentClash artifact",
+      robots: { index: false, follow: false },
+    };
+  }
 
   return {
     title: publicTitle(share),
-    robots: share.share.search_indexing
-      ? { index: true, follow: true }
-      : { index: false, follow: false },
+    robots: { index: false, follow: false },
   };
 }
 

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,345 +1,131 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getChangelogLatestModified, getChangelogPeriods } from "@/lib/changelog";
+import { describe, expect, it, vi } from "vitest";
+import type { PublicContentDescriptor } from "@/lib/public-content";
+
+const getAllPublicContentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/public-content", () => ({
+  PUBLIC_ORIGIN: "https://www.agentclash.dev",
+  getAllPublicContent: getAllPublicContentMock,
+}));
+
 import sitemap from "./sitemap";
 
-vi.mock("@/lib/blog", () => ({
-  getAllPosts: vi.fn(() => [
-    {
-      slug: "ai-agent-evaluation-regression-testing",
-      title: "AI agent evaluation and regression testing",
-      date: "2026-05-07",
-      description: "How AgentClash turns failed agent runs into regression tests.",
+function descriptor(
+  overrides: Partial<PublicContentDescriptor> &
+    Pick<PublicContentDescriptor, "canonicalPath" | "title">,
+): PublicContentDescriptor {
+  return {
+    canonicalPath: overrides.canonicalPath,
+    markdownPath:
+      overrides.canonicalPath === "/"
+        ? "/md"
+        : `/md${overrides.canonicalPath}`,
+    title: overrides.title,
+    description: overrides.description ?? "Fixture description",
+    kind: overrides.kind ?? "marketing",
+    lastModified: overrides.lastModified ?? "2026-08-14",
+    indexable: overrides.indexable ?? true,
+    includeIn: overrides.includeIn ?? {
+      sitemap: true,
+      llms: true,
+      llmsFull: true,
+      search: true,
+      indexNow: true,
     },
-  ]),
-}));
-
-vi.mock("@/lib/docs", () => ({
-  DOCS_ORIGIN: "https://www.agentclash.dev",
-  getAllDocPaths: vi.fn(() => [
-    "/docs",
-    "/docs/getting-started/quickstart",
-  ]),
-}));
-
-vi.mock("@/lib/benchmarks", () => ({
-  getAllReports: vi.fn(() => [
-    {
-      slug: "claude-opus-4-8-vs-the-field",
-      title: "Claude Opus 4.8 vs the field",
-      date: "2026-06-06",
-      verdict: "Opus 4.8 took 4 of 5.",
-      sample: false,
-    },
-    {
-      slug: "sample-illustrative",
-      title: "Sample illustrative report",
-      date: "2026-06-06",
-      verdict: "Representative numbers only.",
-      sample: true,
-    },
-    {
-      slug: "bad-date-report",
-      title: "Report with an unparseable date",
-      date: "Q2 2026",
-      verdict: "Date will not parse.",
-      sample: false,
-    },
-  ]),
-}));
+    sitemapPriority: overrides.sitemapPriority ?? 0.7,
+    changeFrequency: overrides.changeFrequency ?? "monthly",
+    renderMarkdown: () => `# ${overrides.title}`,
+  };
+}
 
 describe("sitemap", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  it("serializes canonical registry URLs with real dates and metadata", () => {
+    getAllPublicContentMock.mockReturnValue([
+      descriptor({
+        canonicalPath: "/",
+        title: "AgentClash",
+        lastModified: "2026-08-12",
+        sitemapPriority: 1,
+        changeFrequency: "weekly",
+      }),
+      descriptor({
+        canonicalPath: "/docs",
+        title: "Docs",
+        lastModified: "2026-07-10",
+        sitemapPriority: 0.85,
+        changeFrequency: "weekly",
+      }),
+    ]);
 
-  it("keeps core public discovery surfaces indexed", () => {
     const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
-
-    expect(byUrl.get("https://www.agentclash.dev")).toMatchObject({
-      changeFrequency: "weekly",
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      url: "https://www.agentclash.dev",
+      lastModified: new Date("2026-08-12"),
       priority: 1,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/blog")).toMatchObject({
       changeFrequency: "weekly",
-      priority: 0.8,
     });
-    expect(byUrl.get("https://www.agentclash.dev/changelog")).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.75,
-      lastModified: new Date(getChangelogLatestModified()),
-    });
-    for (const period of getChangelogPeriods()) {
-      expect(
-        byUrl.get(`https://www.agentclash.dev/changelog/${period.id}`),
-      ).toMatchObject({
-        changeFrequency: "monthly",
-        priority: 0.65,
-        lastModified: new Date(period.endDate),
-      });
-    }
-    expect(byUrl.get("https://www.agentclash.dev/why")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.7,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/team")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.5,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/sitemap")).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.5,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/enterprise")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.82,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/resources/eval-checklist"),
-    ).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.77,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/services")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.78,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/platform/agent-evaluation"),
-    ).toMatchObject({
-      changeFrequency: "monthly",
+    expect(entries[1]).toMatchObject({
+      url: "https://www.agentclash.dev/docs",
+      lastModified: new Date("2026-07-10"),
       priority: 0.85,
     });
-    expect(
-      byUrl.get(
-        "https://www.agentclash.dev/platform/agent-regression-testing",
-      ),
-    ).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.82,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/platform/datasmith"),
-    ).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.84,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/agent-evals"),
-    ).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.84,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/features/agent-replay"),
-    ).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.76,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/use-cases")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.78,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/industries")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.78,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/glossary")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.78,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/features")).toMatchObject({
-      changeFrequency: "monthly",
-      priority: 0.78,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/llms.txt")).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.6,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/llms-full.txt"),
-    ).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.55,
-    });
-    expect(byUrl.get("https://www.agentclash.dev/tryouts")).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.9,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/agent-opportunity"),
-    ).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.91,
-    });
   });
 
-  it("includes docs pages and blog posts from source readers", () => {
-    const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
+  it("excludes non-indexable and sitemap-disabled content", () => {
+    getAllPublicContentMock.mockReturnValue([
+      descriptor({ canonicalPath: "/public", title: "Public" }),
+      descriptor({
+        canonicalPath: "/sample",
+        title: "Sample",
+        indexable: false,
+      }),
+      descriptor({
+        canonicalPath: "/machine",
+        title: "Machine",
+        includeIn: {
+          sitemap: false,
+          llms: true,
+          llmsFull: true,
+          search: false,
+          indexNow: false,
+        },
+      }),
+    ]);
 
-    expect(byUrl.get("https://www.agentclash.dev/docs")).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.85,
-    });
-    expect(
-      byUrl.get("https://www.agentclash.dev/docs/getting-started/quickstart"),
-    ).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.75,
-    });
-    expect(
-      byUrl.get(
-        "https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing",
-      ),
-    ).toMatchObject({
-      lastModified: new Date("2026-05-07"),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    });
+    expect(sitemap().map((entry) => entry.url)).toEqual([
+      "https://www.agentclash.dev/public",
+    ]);
   });
 
-  it("always includes the benchmarks hub index", () => {
-    const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
-
-    expect(
-      byUrl.get("https://www.agentclash.dev/benchmarks"),
-    ).toMatchObject({
-      changeFrequency: "weekly",
-      priority: 0.8,
-    });
+  it("never emits Markdown or machine-artifact URLs", () => {
+    getAllPublicContentMock.mockReturnValue([
+      descriptor({ canonicalPath: "/pricing", title: "Pricing" }),
+    ]);
+    const urls = sitemap().map((entry) => entry.url);
+    expect(urls).not.toContain("https://www.agentclash.dev/md/pricing");
+    expect(urls).not.toContain("https://www.agentclash.dev/llms.txt");
+    expect(urls).not.toContain("https://www.agentclash.dev/openapi.yaml");
   });
 
-  it("includes per-report pages when measured reports exist", () => {
-    const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
-    const report = byUrl.get(
-      "https://www.agentclash.dev/benchmarks/claude-opus-4-8-vs-the-field",
-    );
-    expect(report).toMatchObject({
-      lastModified: new Date("2026-06-06"),
-      changeFrequency: "monthly",
-      priority: 0.75,
-    });
-    const image = report?.images?.[0] ?? "";
+  it("escapes ampersands in absolute Open Graph image URLs", () => {
+    getAllPublicContentMock.mockReturnValue([
+      descriptor({ canonicalPath: "/compare", title: "A & B" }),
+    ]);
+    const image = sitemap()[0]?.images?.[0] ?? "";
     expect(image.startsWith("https://www.agentclash.dev/og?")).toBe(true);
-    expect(image).toContain("kind=Benchmark");
+    expect(image).toContain("&amp;");
+    expect(image).not.toMatch(/&(?!amp;|lt;|gt;|quot;|#39;)/);
   });
 
-  it("includes the comparison hub and per-competitor pages", () => {
-    const entries = sitemap();
-    const urls = new Set(entries.map((entry) => entry.url));
-
-    expect(urls.has("https://www.agentclash.dev/compare")).toBe(true);
-    expect(
-      urls.has("https://www.agentclash.dev/compare/agentclash-vs-langsmith"),
-    ).toBe(true);
-  });
-
-  it("attaches an absolute /og image to the compare hub entry", () => {
-    const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
-
-    const compare = byUrl.get("https://www.agentclash.dev/compare");
-    expect(compare?.images).toHaveLength(1);
-    const image = compare?.images?.[0] ?? "";
-    // Must be ABSOLUTE (DOCS_ORIGIN prefix present) — metadataBase does not
-    // rewrite sitemap image strings, and Google rejects a relative <image:loc>.
-    expect(image.startsWith("https://www.agentclash.dev/og?")).toBe(true);
-    expect(image).toContain("kind=Compare");
-  });
-
-  it("keeps imageless entries valid and never emits an empty images array", () => {
-    const entries = sitemap();
-    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
-
-    // .txt endpoints are intentionally imageless (not HTML pages).
-    expect(
-      byUrl.get("https://www.agentclash.dev/llms.txt")?.images,
-    ).toBeUndefined();
-    expect(
-      byUrl.get("https://www.agentclash.dev/llms-full.txt")?.images,
-    ).toBeUndefined();
-
-    // Every entry is still a valid sitemap entry: a string url, and images —
-    // when present — is a non-empty array of absolute URLs (no `images: []`).
-    for (const entry of entries) {
-      expect(typeof entry.url).toBe("string");
-      if (entry.images !== undefined) {
-        expect(entry.images.length).toBeGreaterThan(0);
-        for (const img of entry.images) {
-          expect(img.startsWith("https://")).toBe(true);
-        }
-      }
-    }
-    expect(() => JSON.stringify(entries)).not.toThrow();
-  });
-
-  it("includes every SEO registry path from getAllSeoPagePaths", async () => {
-    const { getAllSeoPagePaths } = await import("@/lib/seo-pages");
-    const entries = sitemap();
-    const urls = new Set(entries.map((entry) => entry.url));
-
-    for (const path of getAllSeoPagePaths()) {
-      expect(urls.has(`https://www.agentclash.dev${path}`)).toBe(true);
-    }
-  });
-
-  it("serializes to well-formed sitemap XML with escaped image URLs", () => {
-    const entries = sitemap();
-
-    // Mirror Next's sitemap serializer (resolve-route-data.js): it interpolates
-    // url + image URLs into <loc>/<image:loc> WITHOUT XML-escaping, so the
-    // strings we hand it must already be XML-safe. A raw `&` (from
-    // URLSearchParams) would make the document non-well-formed and break crawler
-    // parsing of the entire sitemap — this is invisible to assertions on the
-    // in-memory array, so validate the serialized artifact.
-    const body = entries
-      .map((e) => {
-        const imgs = (e.images ?? [])
-          .map(
-            (img) =>
-              `<image:image><image:loc>${img}</image:loc></image:image>`,
-          )
-          .join("");
-        return `<url><loc>${e.url}</loc>${imgs}</url>`;
-      })
-      .join("");
-    const xml =
-      `<?xml version="1.0" encoding="UTF-8"?>` +
-      `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ` +
-      `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">${body}</urlset>`;
-
-    const doc = new DOMParser().parseFromString(xml, "text/xml");
-    expect(doc.querySelector("parsererror")).toBeNull();
-
-    // Directly guard the regression: a multi-param image URL exists and its
-    // ampersands are entity-escaped (no bare `&`).
-    const multi = entries
-      .flatMap((e) => e.images ?? [])
-      .find((img) => img.includes("kind=") && img.includes("title="));
-    expect(multi).toBeDefined();
-    expect(multi).toContain("&amp;");
-    expect(/&(?!amp;|lt;|gt;|quot;|#39;)/.test(multi ?? "")).toBe(false);
-  });
-
-  it("excludes sample reports so fabricated numbers are never indexed", () => {
-    const urls = new Set(sitemap().map((entry) => entry.url));
-    expect(
-      urls.has("https://www.agentclash.dev/benchmarks/sample-illustrative"),
-    ).toBe(false);
-  });
-
-  it("survives an unparseable report date without crashing the whole sitemap", () => {
-    const byUrl = new Map(sitemap().map((entry) => [entry.url, entry]));
-    const bad = byUrl.get(
-      "https://www.agentclash.dev/benchmarks/bad-date-report",
-    );
-    // Still listed, but with no Invalid Date lastModified that would make Next's
-    // serializer throw on .toISOString() and take down the entire sitemap.xml.
-    expect(bad).toBeDefined();
-    expect(bad?.lastModified).toBeUndefined();
-    expect(() => JSON.stringify(sitemap())).not.toThrow();
+  it("omits invalid dates without failing the whole sitemap", () => {
+    getAllPublicContentMock.mockReturnValue([
+      descriptor({
+        canonicalPath: "/bad-date",
+        title: "Bad date",
+        lastModified: "not-a-date",
+      }),
+    ]);
+    expect(sitemap()[0]?.lastModified).toBeUndefined();
   });
 });

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,29 +1,7 @@
 import type { MetadataRoute } from "next";
-import { getAllPosts } from "@/lib/blog";
-import { getAllReports } from "@/lib/benchmarks";
-import {
-  getChangelogLatestModified,
-  getChangelogPeriodHref,
-  getChangelogPeriods,
-} from "@/lib/changelog";
-import { COMPETITORS } from "@/lib/comparison-data";
-import { DOCS_ORIGIN, getAllDocPaths } from "@/lib/docs";
-import { SEO_PAGE_REGISTRY, seoPageSitemapPriority } from "@/lib/seo-pages";
+import { getAllPublicContent, PUBLIC_ORIGIN } from "@/lib/public-content";
 import { ogImageUrl } from "@/lib/seo";
 
-// `MetadataRoute.Sitemap` `images` entries must be ABSOLUTE URLs, and the
-// metadataBase that upgrades ogImageUrl()'s root-relative `/og` path inside page
-// metadata does NOT apply to sitemap entries — so prefix DOCS_ORIGIN here. Each
-// image points at the existing dynamic OG card route, reusing the same cached
-// card a page already renders for its social preview.
-//
-// Critical: Next's sitemap serializer interpolates the image URL into
-// `<image:loc>…</image:loc>` WITHOUT XML-escaping, and ogImageUrl() joins query
-// params with a raw `&` (URLSearchParams). A raw `&` is not well-formed XML and
-// would corrupt the entire sitemap.xml, so XML-escape the URL here. This matters
-// only for the sitemap; page metadata uses ogImageUrl() unescaped. (The `url`
-// field needs no escaping — route paths carry no query string / XML-special
-// chars.)
 function xmlEscape(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -33,311 +11,42 @@ function xmlEscape(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function ogImage(args: {
+function sitemapImage(args: {
   title: string;
-  subtitle?: string;
-  kind?: string;
+  subtitle: string;
+  kind: string;
 }): string {
-  return xmlEscape(`${DOCS_ORIGIN}${ogImageUrl(args)}`);
+  return xmlEscape(
+    `${PUBLIC_ORIGIN}${ogImageUrl({
+      title: args.title,
+      subtitle: args.subtitle,
+      kind: args.kind,
+    })}`,
+  );
 }
 
-// Shared generic card for pages without a tailored OG image — one cached render.
-const DEFAULT_OG = ogImage({
-  title: "AgentClash",
-  subtitle: "Open-source AI agent evaluation platform",
-});
-
 export default function sitemap(): MetadataRoute.Sitemap {
-  const posts = getAllPosts().map((post) => ({
-    url: `${DOCS_ORIGIN}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
-    changeFrequency: "monthly" as const,
-    priority: 0.7,
-    images: [
-      ogImage({ title: post.title, subtitle: post.description, kind: "Blog" }),
-    ],
-  }));
-  // Only list measured reports in the sitemap. Sample reports stay reachable but
-  // out of the index; guard dates so Invalid Date cannot take down sitemap.xml.
-  const benchmarks = getAllReports()
-    .filter((report) => !report.sample)
-    .map((report) => {
-      const lastModified = new Date(report.date);
+  return getAllPublicContent()
+    .filter((item) => item.indexable && item.includeIn.sitemap)
+    .map((item) => {
+      const parsedDate = new Date(item.lastModified);
       return {
-        url: `${DOCS_ORIGIN}/benchmarks/${report.slug}`,
-        ...(Number.isNaN(lastModified.getTime()) ? {} : { lastModified }),
-        changeFrequency: "monthly" as const,
-        priority: 0.75,
+        url:
+          item.canonicalPath === "/"
+            ? PUBLIC_ORIGIN
+            : `${PUBLIC_ORIGIN}${item.canonicalPath}`,
+        ...(Number.isNaN(parsedDate.getTime())
+          ? {}
+          : { lastModified: parsedDate }),
+        changeFrequency: item.changeFrequency ?? "monthly",
+        priority: item.sitemapPriority ?? 0.7,
         images: [
-          ogImage({
-            title: report.title,
-            subtitle: report.verdict,
-            kind: "Benchmark",
+          sitemapImage({
+            title: item.title,
+            subtitle: item.description,
+            kind: item.kind,
           }),
         ],
       };
     });
-  const benchmarkIndex = [
-    {
-      url: `${DOCS_ORIGIN}/benchmarks`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.8,
-      images: [
-        ogImage({
-          title: "AI Agent Benchmarks",
-          subtitle: "Frozen packs, same-task eval runs, replay evidence",
-          kind: "Benchmark",
-        }),
-      ],
-    },
-  ];
-  const docs = getAllDocPaths().map((docPath) => ({
-    url: `${DOCS_ORIGIN}${docPath}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: docPath === "/docs" ? 0.85 : 0.75,
-    images: [ogImage({ title: "AgentClash Docs", kind: "Docs" })],
-  }));
-  const compare = [
-    {
-      url: `${DOCS_ORIGIN}/compare`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
-      images: [
-        ogImage({
-          title: "AgentClash vs prompt-eval tools",
-          subtitle: "Agent evaluation, not prompt evaluation",
-          kind: "Compare",
-        }),
-      ],
-    },
-    ...COMPETITORS.map((competitor) => ({
-      url: `${DOCS_ORIGIN}/compare/${competitor.slug}`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.75,
-      images: [
-        ogImage({
-          title: `AgentClash vs ${competitor.name}`,
-          subtitle: "Agent eval vs prompt eval",
-          kind: "Compare",
-        }),
-      ],
-    })),
-  ];
-  return [
-    {
-      url: DOCS_ORIGIN,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-      images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/blog`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-      images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/changelog`,
-      lastModified: new Date(getChangelogLatestModified()),
-      changeFrequency: "weekly",
-      priority: 0.75,
-      images: [DEFAULT_OG],
-    },
-    ...getChangelogPeriods().map((period) => ({
-      url: `${DOCS_ORIGIN}${getChangelogPeriodHref(period.id)}`,
-      lastModified: new Date(period.endDate),
-      changeFrequency: "monthly" as const,
-      priority: 0.65,
-      images: [DEFAULT_OG],
-    })),
-    {
-      url: `${DOCS_ORIGIN}/why`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-      images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/team`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-      images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/pricing`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-      images: [
-        ogImage({
-          title: "AgentClash Pricing",
-          subtitle: "Free and open-source, with hosted Pro, Team & Enterprise",
-          kind: "Pricing",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/enterprise`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.82,
-      images: [
-        ogImage({
-          title: "Enterprise Agent Evaluation",
-          subtitle: "Governed release gates for platform teams",
-          kind: "Enterprise",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/resources/eval-checklist`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.77,
-      images: [
-        ogImage({
-          title: "Enterprise AI Agent Eval Checklist",
-          subtitle: "Free PDFs for release gates, pilots, and procurement",
-          kind: "Resource",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/services`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.78,
-      images: [
-        ogImage({
-          title: "Agent Evaluation Services",
-          subtitle: "Fixed offerings for platform adoption",
-          kind: "Services",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/platform/agent-evaluation`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.85,
-      images: [
-        ogImage({ title: "AI Agent Evaluation Platform", kind: "Platform" }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/platform/agent-regression-testing`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.82,
-      images: [
-        ogImage({ title: "AI Agent Regression Testing", kind: "Platform" }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/platform/datasmith`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.84,
-      images: [
-        ogImage({
-          title: "DataSmith Synthetic Data Generation",
-          subtitle: "Weak-vs-strong Agentic Self-Instruct for AI agents",
-          kind: "Platform",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/use-cases`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.78,
-      images: [ogImage({ title: "Agent Evaluation Use Cases", kind: "SEO" })],
-    },
-    {
-      url: `${DOCS_ORIGIN}/features`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.78,
-      images: [ogImage({ title: "Agent Evaluation Features", kind: "SEO" })],
-    },
-    {
-      url: `${DOCS_ORIGIN}/industries`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.78,
-      images: [ogImage({ title: "Agent Evaluation by Industry", kind: "SEO" })],
-    },
-    {
-      url: `${DOCS_ORIGIN}/glossary`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.78,
-      images: [ogImage({ title: "Agent Evaluation Glossary", kind: "SEO" })],
-    },
-    ...SEO_PAGE_REGISTRY.map((page) => ({
-      url: `${DOCS_ORIGIN}${page.path}`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: seoPageSitemapPriority(page.tier),
-      images: [ogImage({ title: page.sitemapTitle, kind: "SEO" })],
-    })),
-    {
-      url: `${DOCS_ORIGIN}/try`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.88,
-      images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/tryouts`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.9,
-      images: [
-        ogImage({
-          title: "Try an AI agent on office work",
-          subtitle: "Public task-gated agent tryouts with trace export",
-          kind: "Tryouts",
-        }),
-      ],
-    },
-    {
-      url: `${DOCS_ORIGIN}/agent-opportunity`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.91,
-      images: [
-        ogImage({
-          title: "AI agent ROI calculator",
-          subtitle: "Build vs buy assessment from a company URL",
-          kind: "Report",
-        }),
-      ],
-    },
-    // .txt endpoints are intentionally imageless — they are not HTML pages.
-    {
-      url: `${DOCS_ORIGIN}/llms.txt`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.6,
-    },
-    {
-      url: `${DOCS_ORIGIN}/llms-full.txt`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.55,
-    },
-    ...compare,
-    ...docs,
-    ...posts,
-    ...benchmarkIndex,
-    ...benchmarks,
-  ];
 }

--- a/web/src/app/team/metadata.ts
+++ b/web/src/app/team/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { markdownAlternate } from "@/lib/seo";
 
 const PAGE_TITLE = "Team - AgentClash";
 const PAGE_DESCRIPTION =
@@ -10,6 +11,7 @@ export const teamMetadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: "/team",
+    types: markdownAlternate("/team"),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/app/try/[slug]/page.tsx
+++ b/web/src/app/try/[slug]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { TryCliDemoClient } from "@/components/try-cli/demo-client";
+import { getPublicTryCliDemo } from "@/lib/public-page-data";
+import { markdownAlternate } from "@/lib/seo";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -6,13 +10,29 @@ interface Props {
 
 export default async function TryCliDemoPage({ params }: Props) {
   const { slug } = await params;
-  return <TryCliDemoClient slug={slug} />;
+  const demo = await getPublicTryCliDemo(slug);
+  if (!demo) notFound();
+  return <TryCliDemoClient slug={slug} initialDemo={demo} />;
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
+  const demo = await getPublicTryCliDemo(slug);
+  if (!demo) return { title: "CLI demo not found | AgentClash", robots: { index: false } };
+  const canonicalPath = `/try/${demo.slug}`;
   return {
-    title: `Try ${slug} in browser | AgentClash`,
-    description: `Interactive terminal demo for ${slug}. No install required.`,
+    title: `Try ${demo.name} in browser | AgentClash`,
+    description:
+      demo.tagline ?? `Run ${demo.name} in a disposable browser sandbox. No install required.`,
+    alternates: {
+      canonical: canonicalPath,
+      types: markdownAlternate(canonicalPath),
+    },
+    openGraph: {
+      title: `Try ${demo.name} in browser | AgentClash`,
+      description:
+        demo.tagline ?? `Run ${demo.name} in a disposable browser sandbox.`,
+      url: canonicalPath,
+    },
   };
 }

--- a/web/src/app/try/layout.tsx
+++ b/web/src/app/try/layout.tsx
@@ -2,11 +2,16 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Star } from "lucide-react";
 import { GridBackdrop, Wordmark } from "@/components/try-cli/chrome";
+import { markdownAlternate } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Try CLI — Interactive terminal demos | AgentClash",
   description:
     "Run any CLI in a disposable cloud terminal before you install it. AI coding agents and dev tools, zero setup, powered by E2B sandboxes.",
+  alternates: {
+    canonical: "/try",
+    types: markdownAlternate("/try"),
+  },
   openGraph: {
     title: "AgentClash Try CLI",
     description: "Run any CLI in a disposable cloud terminal — zero install.",

--- a/web/src/app/try/page.tsx
+++ b/web/src/app/try/page.tsx
@@ -1,5 +1,7 @@
 import { TryCliLandingClient } from "@/components/try-cli/landing-client";
+import { getPublicTryCliDemos } from "@/lib/public-page-data";
 
-export default function TryCliPage() {
-  return <TryCliLandingClient />;
+export default async function TryCliPage() {
+  const demos = await getPublicTryCliDemos();
+  return <TryCliLandingClient initialDemos={demos} />;
 }

--- a/web/src/app/tryouts/page.tsx
+++ b/web/src/app/tryouts/page.tsx
@@ -70,6 +70,7 @@ export default async function PublicTryoutsPage({ searchParams }: Props) {
       }
     >
       <PublicTryoutsClient
+        key={tryoutId ?? "catalog"}
         initialTemplates={initialData.templates}
         initialTools={initialData.tools}
         initialTryout={initialData.tryout}

--- a/web/src/app/tryouts/page.tsx
+++ b/web/src/app/tryouts/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 
 import { PublicTryoutsClient } from "./tryouts-client";
+import { markdownAlternate } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Free AI Agent Tryout",
@@ -21,6 +22,7 @@ export const metadata: Metadata = {
   ],
   alternates: {
     canonical: "/tryouts",
+    types: markdownAlternate("/tryouts"),
   },
   openGraph: {
     title: "Free AI Agent Tryout for Business Workflows | AgentClash",

--- a/web/src/app/tryouts/page.tsx
+++ b/web/src/app/tryouts/page.tsx
@@ -3,8 +3,9 @@ import { Suspense } from "react";
 
 import { PublicTryoutsClient } from "./tryouts-client";
 import { markdownAlternate } from "@/lib/seo";
+import { getPublicTryoutPageData } from "@/lib/public-page-data";
 
-export const metadata: Metadata = {
+const baseMetadata: Metadata = {
   title: "Free AI Agent Tryout",
   description:
     "Write what you would reject in production, run a sandboxed tryout on real work, and get a scored verdict with outputs before you deploy.",
@@ -32,7 +33,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default function PublicTryoutsPage() {
+type Props = {
+  searchParams: Promise<{ tryout?: string | string[] }>;
+};
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+  const { tryout } = await searchParams;
+  if (!tryout) return baseMetadata;
+  return {
+    ...baseMetadata,
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PublicTryoutsPage({ searchParams }: Props) {
+  const value = (await searchParams).tryout;
+  const tryoutId = typeof value === "string" ? value : undefined;
+  const initialData = await getPublicTryoutPageData(tryoutId);
+
   return (
     <Suspense
       fallback={
@@ -51,7 +69,12 @@ export default function PublicTryoutsPage() {
         </main>
       }
     >
-      <PublicTryoutsClient />
+      <PublicTryoutsClient
+        initialTemplates={initialData.templates}
+        initialTools={initialData.tools}
+        initialTryout={initialData.tryout}
+        initialEvents={initialData.events}
+      />
     </Suspense>
   );
 }

--- a/web/src/app/tryouts/tryouts-client.tsx
+++ b/web/src/app/tryouts/tryouts-client.tsx
@@ -434,13 +434,23 @@ const api = createApiClient();
 const SERIF = "[font-family:var(--font-race-display)]";
 const MICRO = "font-mono text-2xs uppercase tracking-[0.22em]";
 
-export function PublicTryoutsClient() {
+export function PublicTryoutsClient({
+  initialTemplates,
+  initialTools,
+  initialTryout,
+  initialEvents,
+}: {
+  initialTemplates: AgentTryoutTemplate[];
+  initialTools: AgentTool[];
+  initialTryout: AgentTryout | null;
+  initialEvents: TryoutTimelineEvent[];
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const urlTryoutId = searchParams.get("tryout") ?? "";
 
-  const [templates, setTemplates] = useState<AgentTryoutTemplate[]>([]);
-  const [templateSlug, setTemplateSlug] = useState("");
+  const [templates, setTemplates] = useState<AgentTryoutTemplate[]>(initialTemplates);
+  const [templateSlug, setTemplateSlug] = useState(initialTemplates[0]?.slug ?? "");
   const [selectedModelKey, setSelectedModelKey] = useState("auto");
   const [judgeModel, setJudgeModel] = useState(JUDGE_OPTIONS[0].value);
   const [judgeStrictness, setJudgeStrictness] =
@@ -450,7 +460,7 @@ export function PublicTryoutsClient() {
   const [agentName, setAgentName] = useState("");
   const [agentInstructions, setAgentInstructions] = useState("");
   const [agentToolSlugs, setAgentToolSlugs] = useState<string[]>([]);
-  const [toolLibrary, setToolLibrary] = useState<AgentTool[]>([]);
+  const [toolLibrary, setToolLibrary] = useState<AgentTool[]>(initialTools);
   const prefillRef = useRef<RerunPrefill | null>(null);
 
   // Apply a rerun handoff (same brief, different agent/judge) exactly once.
@@ -476,6 +486,7 @@ export function PublicTryoutsClient() {
   // Tool library powers the "abilities" picker in the agent designer. Public,
   // best-effort — if it fails the picker just stays empty.
   useEffect(() => {
+    if (initialTools.length > 0) return;
     let cancelled = false;
     api
       .get<{ items: Array<{ slug: string; name: string; category?: string; description?: string }> }>(
@@ -498,12 +509,14 @@ export function PublicTryoutsClient() {
     return () => {
       cancelled = true;
     };
-  }, []);
-  const [templatesLoading, setTemplatesLoading] = useState(true);
+  }, [initialTools.length]);
+  const [templatesLoading, setTemplatesLoading] = useState(initialTemplates.length === 0);
   const [launching, setLaunching] = useState(false);
-  const [tryout, setTryout] = useState<AgentTryout | null>(null);
-  const [events, setEvents] = useState<TryoutTimelineEvent[]>([]);
-  const [tryoutLoading, setTryoutLoading] = useState(false);
+  const [tryout, setTryout] = useState<AgentTryout | null>(initialTryout);
+  const [events, setEvents] = useState<TryoutTimelineEvent[]>(initialEvents);
+  const [tryoutLoading, setTryoutLoading] = useState(
+    Boolean(urlTryoutId) && !initialTryout,
+  );
   const [message, setMessage] = useState<string | null>(null);
   const [quotaMessage, setQuotaMessage] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<AgentTryoutInputAttachment[]>([]);
@@ -511,6 +524,7 @@ export function PublicTryoutsClient() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    if (initialTemplates.length > 0) return;
     let cancelled = false;
     async function loadTemplates() {
       setTemplatesLoading(true);
@@ -539,7 +553,7 @@ export function PublicTryoutsClient() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [initialTemplates.length]);
 
   useEffect(() => {
     const pending = prefillRef.current;
@@ -579,8 +593,11 @@ export function PublicTryoutsClient() {
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
-    let nextCursor = 0;
-    const seen = new Set<number>();
+    let nextCursor = initialEvents.reduce(
+      (highest, event) => Math.max(highest, event.cursor),
+      0,
+    );
+    const seen = new Set<number>(initialEvents.map((event) => event.cursor));
 
     async function pollTryout() {
       setTryoutLoading(true);
@@ -622,14 +639,14 @@ export function PublicTryoutsClient() {
       }
     }
 
-    setEvents([]);
+    if (initialTryout?.id !== urlTryoutId) setEvents([]);
     setMessage(null);
     void pollTryout();
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [urlTryoutId]);
+  }, [urlTryoutId, initialEvents, initialTryout?.id]);
 
   const template = useMemo(
     () => templates.find((item) => item.slug === templateSlug) ?? null,

--- a/web/src/app/why/metadata.ts
+++ b/web/src/app/why/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { markdownAlternate } from "@/lib/seo";
 
 const PAGE_TITLE = "Why AgentClash Exists - AI Agent Evaluation for Real Tasks";
 const PAGE_DESCRIPTION =
@@ -10,6 +11,7 @@ export const whyMetadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: {
     canonical: "/why",
+    types: markdownAlternate("/why"),
   },
   openGraph: {
     title: PAGE_TITLE,

--- a/web/src/components/marketing/demo-button.tsx
+++ b/web/src/components/marketing/demo-button.tsx
@@ -13,14 +13,14 @@ export function DemoButton({
   label = "Book a demo",
 }: Props) {
   return (
-    <button
-      type="button"
+    <a
+      href={`https://cal.com/${DEMO_LINK}`}
       data-cal-link={DEMO_LINK}
       data-cal-config={DEMO_BUTTON_CONFIG}
       className={className}
     >
       <Calendar className="size-4" />
       {label}
-    </button>
+    </a>
   );
 }

--- a/web/src/components/marketing/pricing-block.tsx
+++ b/web/src/components/marketing/pricing-block.tsx
@@ -31,6 +31,37 @@ export function PricingBlock() {
             </div>
           </div>
 
+          <noscript>
+            <div className="mt-10 overflow-x-auto rounded-xl border border-white/10 bg-white/[0.03] p-5">
+              <table className="w-full min-w-[640px] text-left text-sm text-white/75">
+                <caption className="mb-4 text-left text-base font-semibold text-white">
+                  Monthly and annual pricing
+                </caption>
+                <thead>
+                  <tr className="border-b border-white/10 text-white/45">
+                    <th className="py-2 pr-4">Plan</th>
+                    <th className="py-2 pr-4">Monthly</th>
+                    <th className="py-2">Annual billing</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {PRICING_TIERS.map((tier) => (
+                    <tr key={tier.name} className="border-b border-white/[0.06] last:border-0">
+                      <th className="py-3 pr-4 font-medium text-white">{tier.name}</th>
+                      <td className="py-3 pr-4">
+                        {tier.prices.monthly.value}{tier.prices.monthly.suffix}
+                      </td>
+                      <td className="py-3">
+                        {tier.prices.yearly.value}{tier.prices.yearly.suffix}
+                        {tier.prices.yearly.note ? ` (${tier.prices.yearly.note})` : ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </noscript>
+
           <div className="mt-14 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {PRICING_TIERS.map((tier) => (
               <TierCard key={tier.name} tier={tier} period={period} />

--- a/web/src/components/marketing/resource-lead-form.tsx
+++ b/web/src/components/marketing/resource-lead-form.tsx
@@ -61,7 +61,6 @@ export function ResourceLeadForm({
       });
 
       const params = new URLSearchParams({
-        email: email.trim().toLowerCase(),
         source,
       });
       router.push(`/resources/eval-checklist/thank-you?${params.toString()}`);
@@ -74,9 +73,14 @@ export function ResourceLeadForm({
 
   return (
     <form
+      action="/api/waitlist"
+      method="post"
       onSubmit={submit}
       className={`rounded-lg border border-white/[0.1] bg-white/[0.03] p-4 sm:p-5 ${className}`}
     >
+      <input type="hidden" name="source" value={source} />
+      <input type="hidden" name="resource" value={resource} />
+      <input type="hidden" name="intent" value="resource-download" />
       <label
         htmlFor={`resource-email-${source}`}
         className="sr-only"
@@ -87,6 +91,7 @@ export function ResourceLeadForm({
         <input
           id={`resource-email-${source}`}
           type="email"
+          name="email"
           required
           autoComplete="email"
           value={email}

--- a/web/src/components/marketing/seo-collection-page.tsx
+++ b/web/src/components/marketing/seo-collection-page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { markdownAlternate } from "@/lib/seo";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { ClashMark } from "@/components/marketing/clash-mark";
@@ -33,6 +34,7 @@ export function createSeoCollectionMetadata({
     description,
     alternates: {
       canonical: path,
+      types: markdownAlternate(path),
     },
     openGraph: {
       title,

--- a/web/src/components/share/create-public-share-button.tsx
+++ b/web/src/components/share/create-public-share-button.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { Copy, Loader2, Share2 } from "lucide-react";
+import { Copy, EyeOff, Globe2, Loader2, Share2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -30,20 +30,26 @@ export function CreatePublicShareButton({
   disabled,
 }: CreatePublicShareButtonProps) {
   const { getAccessToken } = useAccessToken();
-  const [sharing, setSharing] = useState(false);
-  const [url, setUrl] = useState<string | null>(null);
+  const [sharing, setSharing] = useState<"private" | "publication" | "unpublish" | null>(null);
+  const [privateURL, setPrivateURL] = useState<string | null>(null);
+  const [publicationURL, setPublicationURL] = useState<string | null>(null);
+  const [shareID, setShareID] = useState<string | null>(null);
 
   useEffect(() => {
-    setUrl(null);
+    setPrivateURL(null);
+    setPublicationURL(null);
+    setShareID(null);
   }, [resourceType, resourceId]);
 
-  async function handleShare() {
-    if (url) {
-      await copyURL(url);
+  async function handleShare(searchIndexing: boolean) {
+    const mode = searchIndexing ? "publication" : "private";
+    const existingURL = searchIndexing ? publicationURL : privateURL;
+    if (existingURL) {
+      await copyURL(existingURL, searchIndexing);
       return;
     }
 
-    setSharing(true);
+    setSharing(mode);
     try {
       const token = await getAccessToken();
       const api = createApiClient(token);
@@ -52,46 +58,120 @@ export function CreatePublicShareButton({
         {
           resource_type: resourceType,
           resource_id: resourceId,
+          search_indexing: searchIndexing,
         },
       );
-      setUrl(result.url);
-      await copyURL(result.url);
+      setShareID(result.share.id);
+      setPrivateURL(result.url);
+      if (searchIndexing && result.publication_url) {
+        setPublicationURL(result.publication_url);
+        void notifyPublicationChange(result.share.id);
+        await copyURL(result.publication_url, true);
+      } else {
+        await copyURL(result.url, false);
+      }
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to create share link",
       );
     } finally {
-      setSharing(false);
+      setSharing(null);
+    }
+  }
+
+  async function handleUnpublish() {
+    if (!shareID) return;
+    setSharing("unpublish");
+    try {
+      const token = await getAccessToken();
+      await createApiClient(token).patch(`/v1/share-links/${shareID}`, {
+        search_indexing: false,
+      });
+      setPublicationURL(null);
+      void notifyPublicationChange(shareID);
+      toast.success("Publication removed from the public index");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to unpublish artifact");
+    } finally {
+      setSharing(null);
     }
   }
 
   return (
-    <Button
-      type="button"
-      variant={variant}
-      size={size}
-      onClick={handleShare}
-      disabled={disabled || sharing}
-      title={url ? "Copy public link" : "Create public read-only link"}
-    >
-      {sharing ? (
-        <Loader2 className="size-3.5 animate-spin" />
-      ) : url ? (
-        <Copy className="size-3.5" />
-      ) : (
-        <Share2 className="size-3.5" />
-      )}
-      {url ? "Copy link" : label}
-    </Button>
+    <span className="inline-flex items-center gap-1.5">
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        onClick={() => void handleShare(false)}
+        disabled={disabled || sharing !== null}
+        title={privateURL ? "Copy private capability link" : "Create private capability link"}
+      >
+        {sharing === "private" ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : privateURL ? (
+          <Copy className="size-3.5" />
+        ) : (
+          <Share2 className="size-3.5" />
+        )}
+        {privateURL ? "Copy link" : label}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size={size}
+        onClick={() => void handleShare(true)}
+        disabled={disabled || sharing !== null}
+        title="Publish a redacted, indexable artifact"
+      >
+        {sharing === "publication" ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : publicationURL ? (
+          <Copy className="size-3.5" />
+        ) : (
+          <Globe2 className="size-3.5" />
+        )}
+        {publicationURL ? "Copy publication" : "Publish"}
+      </Button>
+      {publicationURL ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={() => void handleUnpublish()}
+          disabled={disabled || sharing !== null}
+          title="Remove this artifact from the public index"
+        >
+          {sharing === "unpublish" ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <EyeOff className="size-3.5" />
+          )}
+          Unpublish
+        </Button>
+      ) : null}
+    </span>
   );
 }
 
-async function copyURL(url: string) {
+async function notifyPublicationChange(publicationID: string) {
+  try {
+    await fetch("/api/indexnow/publication", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ publication_id: publicationID }),
+    });
+  } catch {
+    // Best-effort discovery hint. Publication state is already committed.
+  }
+}
+
+async function copyURL(url: string, publication: boolean) {
   try {
     await navigator.clipboard.writeText(url);
-    toast.success("Public link copied");
+    toast.success(publication ? "Publication link copied" : "Private share link copied");
   } catch {
-    toast.success("Public link created", {
+    toast.success(publication ? "Publication created" : "Private share created", {
       description: url,
     });
   }

--- a/web/src/components/share/public-share-renderers.tsx
+++ b/web/src/components/share/public-share-renderers.tsx
@@ -91,12 +91,80 @@ export function PublicShareRenderer({ resource }: { resource: SharedResource }) 
   if (resource.type === "run_agent_scorecard") {
     return <PublicScorecard resource={resource} />;
   }
+  if (resource.type === "agent_tryout") {
+    return <PublicAgentTryout resource={resource} />;
+  }
   return (
     <EmptyState
       icon={<AlertTriangle className="size-10 text-muted-foreground" />}
       title="Unsupported share"
       description="This shared AgentClash artifact type is not available yet."
     />
+  );
+}
+
+function PublicAgentTryout({ resource }: { resource: SharedResource }) {
+  const artifacts = asArray<Record<string, unknown>>(resource.artifacts);
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-border bg-card p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">
+              {String(resource.template_slug ?? "Agent tryout")}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Redacted agent tryout result
+            </p>
+          </div>
+          <Badge variant="outline">{String(resource.status ?? "unknown")}</Badge>
+        </div>
+        <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-muted-foreground">Redaction</dt>
+            <dd className="mt-1 font-medium">{String(resource.redaction_status ?? "unknown")}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Latency</dt>
+            <dd className="mt-1 font-medium">{String(resource.latency_ms ?? "N/A")} ms</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Artifacts</dt>
+            <dd className="mt-1 font-medium">{artifacts.length}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <PublicJSONSection title="Redacted input" value={resource.input_snapshot} />
+      <PublicJSONSection title="Redacted result" value={resource.summary} />
+
+      {artifacts.length > 0 ? (
+        <section className="rounded-lg border border-border bg-card p-5">
+          <h2 className="text-sm font-semibold">Approved artifacts</h2>
+          <ul className="mt-3 space-y-2">
+            {artifacts.map((artifact, index) => (
+              <li key={`${String(artifact.key ?? "artifact")}-${index}`} className="text-sm">
+                <span className="font-medium">{String(artifact.key ?? "Artifact")}</span>
+                <span className="ml-2 text-muted-foreground">
+                  {String(artifact.type ?? artifact.content_type ?? "file")}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function PublicJSONSection({ title, value }: { title: string; value: unknown }) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-border bg-card">
+      <h2 className="border-b border-border px-5 py-3 text-sm font-semibold">{title}</h2>
+      <pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap p-5 font-[family-name:var(--font-mono)] text-xs leading-6">
+        {JSON.stringify(value ?? {}, null, 2)}
+      </pre>
+    </section>
   );
 }
 

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   KeyRound,
   LogIn,
+  Play,
   RotateCcw,
   Sparkles,
   TimerReset,
@@ -26,7 +27,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   const apiBase = getTryCliApiBase();
   const [demo, setDemo] = useState<DemoMeta | null>(initialDemo);
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [status, setStatus] = useState("loading");
+  const [status, setStatus] = useState(initialDemo ? "idle" : "loading");
   const [expiresAt, setExpiresAt] = useState(0);
   const [remaining, setRemaining] = useState("");
   const [low, setLow] = useState(false);
@@ -137,18 +138,22 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const res = await fetch(`${apiBase}/demos/${slug}`);
-      const d = (await res.json()) as DemoMeta & { error?: string };
-      if (cancelled) return;
-      if (d.error || !res.ok) {
-        setError("Demo not found");
-        setStatus("error");
-        return;
+      let currentDemo = initialDemo;
+      if (!currentDemo) {
+        const res = await fetch(`${apiBase}/demos/${slug}`);
+        const fetched = (await res.json()) as DemoMeta & { error?: string };
+        if (cancelled) return;
+        if (fetched.error || !res.ok) {
+          setError("Demo not found");
+          setStatus("error");
+          return;
+        }
+        currentDemo = fetched;
+        setDemo(fetched);
       }
-      setDemo(d);
 
-      // Resume an existing live session for this demo on reload (so a refresh
-      // doesn't burn the one free demo); otherwise start a fresh one.
+      // A refresh may resume a sandbox that the visitor already started. Page
+      // visits never create a new sandbox: that remains an explicit action.
       let saved: { id: string; slug: string; expiresAt: number } | null = null;
       try {
         const raw = localStorage.getItem(SESSION_KEY);
@@ -175,13 +180,12 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
         }
         if (cancelled) return;
       }
-      await createSession();
+      setStatus("idle");
     })();
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slug, apiBase, createSession]);
+  }, [slug, apiBase, initialDemo, pollSession]);
 
   useEffect(() => {
     if (!expiresAt) return;
@@ -324,7 +328,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
           </div>
         </div>
         <div className="flex items-center gap-3">
-          {tier === "anonymous" ? (
+          {sessionId && tier === "anonymous" ? (
             <span
               className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-[family-name:var(--font-mono)] text-2xs transition-colors ${
                 low
@@ -346,20 +350,32 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
               </span>
               Free demo · {remaining || "—"}
             </span>
-          ) : (
+          ) : sessionId ? (
             <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
               <TimerReset className="size-3.5" />
               {remaining || "—"}
             </span>
+          ) : null}
+          {sessionId ? (
+            <button
+              type="button"
+              onClick={() => void reset()}
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/70 transition-colors hover:border-white/20 hover:text-white"
+            >
+              <RotateCcw className="size-3" />
+              Reset
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void createSession()}
+              disabled={status === "starting"}
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-[#060606] transition-colors hover:bg-white/90 disabled:opacity-60"
+            >
+              <Play className="size-3" />
+              Start sandbox
+            </button>
           )}
-          <button
-            type="button"
-            onClick={() => void reset()}
-            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/70 transition-colors hover:border-white/20 hover:text-white"
-          >
-            <RotateCcw className="size-3" />
-            Reset
-          </button>
         </div>
       </div>
 
@@ -480,8 +496,29 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
           </div>
         </aside>
 
-        <main className="min-h-0 flex-1 p-4 sm:p-5">
+        <main className="relative min-h-0 flex-1 p-4 sm:p-5">
           <TryCliTerminal sessionId={sessionId} status={status} />
+          {!sessionId && status !== "starting" ? (
+            <div className="absolute inset-4 flex items-center justify-center rounded-xl bg-[#0a0a0a]/90 px-6 text-center backdrop-blur-sm sm:inset-5">
+              <div className="max-w-sm">
+                <h2 className="text-xl font-semibold tracking-tight text-white">
+                  Start a disposable sandbox
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-white/55">
+                  Review the commands and authentication steps first. A sandbox is
+                  created only after you choose to start it.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void createSession()}
+                  className="mt-6 inline-flex items-center gap-2 rounded-md bg-white px-5 py-2.5 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+                >
+                  <Play className="size-4" />
+                  Start sandbox
+                </button>
+              </div>
+            </div>
+          ) : null}
         </main>
       </div>
     </div>

--- a/web/src/components/try-cli/landing-client.tsx
+++ b/web/src/components/try-cli/landing-client.tsx
@@ -13,18 +13,19 @@ function categoryRank(category: string): number {
   return i === -1 ? CATEGORY_ORDER.length : i;
 }
 
-export function TryCliLandingClient() {
-  const [demos, setDemos] = useState<DemoMeta[]>([]);
-  const [loaded, setLoaded] = useState(false);
+export function TryCliLandingClient({ initialDemos }: { initialDemos: DemoMeta[] }) {
+  const [demos, setDemos] = useState<DemoMeta[]>(initialDemos);
+  const [loaded, setLoaded] = useState(initialDemos.length > 0);
   const apiBase = getTryCliApiBase();
 
   useEffect(() => {
+    if (initialDemos.length > 0) return;
     fetch(`${apiBase}/demos`)
       .then((r) => r.json())
       .then((d) => setDemos(Array.isArray(d) ? d : []))
       .catch(() => setDemos([]))
       .finally(() => setLoaded(true));
-  }, [apiBase]);
+  }, [apiBase, initialDemos.length]);
 
   const groups = useMemo(() => {
     const byCat = new Map<string, DemoMeta[]>();

--- a/web/src/components/try-cli/server-readable.test.tsx
+++ b/web/src/components/try-cli/server-readable.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { TryCliDemoClient } from "./demo-client";
+import { TryCliLandingClient } from "./landing-client";
+import type { DemoMeta } from "@/lib/try-cli/types";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>{children}</a>
+  ),
+}));
+
+const demo: DemoMeta = {
+  slug: "codex",
+  name: "Codex CLI",
+  tagline: "OpenAI coding agent",
+  category: "AI coding agents",
+  commands: [
+    { label: "Show version", run: "codex --version" },
+    { label: "Start Codex", run: "codex" },
+  ],
+  sessionMinutes: 10,
+};
+
+describe("server-readable Try CLI", () => {
+  it("renders the supplied demo catalog before hydration", () => {
+    const html = renderToStaticMarkup(<TryCliLandingClient initialDemos={[demo]} />);
+    expect(html).toContain("Codex CLI");
+    expect(html).toContain("OpenAI coding agent");
+    expect(html).toContain('href="/try/codex"');
+  });
+
+  it("renders demo metadata and an explicit sandbox action without creating a session", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const html = renderToStaticMarkup(
+      <TryCliDemoClient slug="codex" initialDemo={demo} />,
+    );
+
+    expect(html).toContain("codex --version");
+    expect(html).toContain("Start sandbox");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/web/src/lib/agent-opportunity-markdown.test.ts
+++ b/web/src/lib/agent-opportunity-markdown.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { escapeMarkdownText, renderAgentOpportunityMarkdown } from "./agent-opportunity-markdown";
+
+describe("agent opportunity Markdown", () => {
+  it("escapes report content that could change document structure", () => {
+    expect(escapeMarkdownText("# injected\n<script>alert(1)</script> | value")).toBe(
+      "\\# injected &lt;script&gt;alert\\(1\\)&lt;/script&gt; \\| value",
+    );
+  });
+
+  it("renders a portable report with fixed semantic sections", () => {
+    const markdown = renderAgentOpportunityMarkdown({
+      analyzedUrl: "https://example.com",
+      companyName: "Example",
+      generatedAt: "2026-08-14T00:00:00.000Z",
+      agentFitScore: 72,
+      fitLevel: "high",
+      shouldBuildAgent: "narrow_pilot",
+      honestVerdict: "Pilot support triage.",
+      summary: "A repeatable workflow exists.",
+      useCases: [{
+        title: "Support triage",
+        workflow: "Classify tickets.",
+        fit: "high",
+        estimatedMonthlyHoursSaved: "20",
+        estimatedMonthlySavingsUsd: "$2,000",
+        complexity: "medium",
+        why: "High volume.",
+        firstEvalTasks: ["Refund escalation"],
+      }],
+      risks: [{ risk: "Wrong policy", severity: "high", mitigation: "Require review." }],
+      evaluationPack: {
+        name: "Support",
+        recommendedCases: 20,
+        adversarialCases: 5,
+        successCriteria: ["No policy hallucinations"],
+      },
+      nextSteps: ["Collect tickets"],
+      evidenceLimitations: ["Public pages only"],
+    });
+
+    expect(markdown).toContain("# Example agent opportunity report");
+    expect(markdown).toContain("## Candidate workflows");
+    expect(markdown).toContain("## Evidence limitations");
+  });
+});

--- a/web/src/lib/agent-opportunity-markdown.ts
+++ b/web/src/lib/agent-opportunity-markdown.ts
@@ -1,0 +1,78 @@
+import type { AgentOpportunityReport } from "@/lib/agent-opportunity";
+
+export function escapeMarkdownText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([`*_{}\[\]()#+.!|~-])/g, "\\$1")
+    .replace(/[\r\n]+/g, " ")
+    .trim();
+}
+
+export function renderAgentOpportunityMarkdown(
+  report: AgentOpportunityReport,
+): string {
+  const text = escapeMarkdownText;
+  const lines = [
+    `# ${text(report.companyName)} agent opportunity report`,
+    "",
+    `Analyzed URL: ${text(report.analyzedUrl)}`,
+    `Generated: ${text(report.generatedAt)}`,
+    `Agent fit: ${report.agentFitScore}/100 (${text(report.fitLevel)})`,
+    `Recommendation: ${text(report.shouldBuildAgent)}`,
+    "",
+    text(report.summary),
+    "",
+    "## Verdict",
+    "",
+    text(report.honestVerdict),
+    "",
+    "## Candidate workflows",
+  ];
+
+  for (const useCase of report.useCases) {
+    lines.push(
+      "",
+      `### ${text(useCase.title)}`,
+      "",
+      text(useCase.workflow),
+      "",
+      `- Fit: ${text(useCase.fit)}`,
+      `- Complexity: ${text(useCase.complexity)}`,
+      `- Estimated monthly hours saved: ${text(useCase.estimatedMonthlyHoursSaved)}`,
+      `- Estimated monthly savings: ${text(useCase.estimatedMonthlySavingsUsd)}`,
+      `- Rationale: ${text(useCase.why)}`,
+      ...useCase.firstEvalTasks.map((task) => `- First eval task: ${text(task)}`),
+    );
+  }
+
+  lines.push("", "## Risks", "");
+  for (const risk of report.risks) {
+    lines.push(
+      `- **${text(risk.severity)}**: ${text(risk.risk)}. Mitigation: ${text(risk.mitigation)}`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Evaluation pack",
+    "",
+    `- Name: ${text(report.evaluationPack.name)}`,
+    `- Realistic cases: ${report.evaluationPack.recommendedCases}`,
+    `- Adversarial cases: ${report.evaluationPack.adversarialCases}`,
+    ...report.evaluationPack.successCriteria.map(
+      (criterion) => `- Success criterion: ${text(criterion)}`,
+    ),
+    "",
+    "## Evidence limitations",
+    "",
+    ...report.evidenceLimitations.map((limit) => `- ${text(limit)}`),
+    "",
+    "## Next steps",
+    "",
+    ...report.nextSteps.map((step, index) => `${index + 1}. ${text(step)}`),
+  );
+
+  return lines.join("\n").trim();
+}

--- a/web/src/lib/agent-opportunity.ts
+++ b/web/src/lib/agent-opportunity.ts
@@ -79,7 +79,7 @@ const MAX_URL_LENGTH = 2048;
 const MAX_TEXT_CHARS = 12000;
 const MAX_HTML_BYTES = 256 * 1024;
 const USER_AGENT =
-  "AgentClash-Agent-Opportunity-Report/1.0 (+https://agentclash.dev)";
+  "AgentClash-Agent-Opportunity-Report/1.0 (+https://www.agentclash.dev)";
 
 export function isPrivateIPAddress(address: string): boolean {
   const mappedV4 = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -25,6 +25,8 @@ interface RequestOptions {
   headers?: Record<string, string>;
   /** AbortSignal for cancellation. */
   signal?: AbortSignal;
+  /** Explicit Fetch cache policy for server-rendered, revocable resources. */
+  cache?: RequestCache;
   /** Non-2xx status codes that should be parsed as JSON instead of throwing. */
   allowedStatuses?: number[];
 }
@@ -145,6 +147,7 @@ async function requestWithMeta<T>(
             : JSON.stringify(body)
           : undefined,
       signal: opts.signal,
+      cache: opts.cache,
     });
   } catch (err) {
     throw new NetworkError(

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -600,7 +600,8 @@ export type PublicShareResourceType =
   | "challenge_pack_version"
   | "run_scorecard"
   | "run_agent_scorecard"
-  | "run_agent_replay";
+  | "run_agent_replay"
+  | "agent_tryout";
 
 export interface PublicShareLink {
   id: string;
@@ -618,6 +619,7 @@ export interface CreatePublicShareLinkResponse {
   share: PublicShareLink;
   token: string;
   url: string;
+  publication_url?: string;
 }
 
 export interface PublicShareResponse {
@@ -626,6 +628,28 @@ export interface PublicShareResponse {
     type: PublicShareResourceType;
     [key: string]: unknown;
   };
+}
+
+export interface PublicPublication {
+  id: string;
+  resource_type: PublicShareResourceType;
+  expires_at?: string;
+  created_at: string;
+  updated_at: string;
+  canonical_path: string;
+}
+
+export interface PublicPublicationResponse {
+  publication: PublicPublication;
+  resource: {
+    type: PublicShareResourceType;
+    [key: string]: unknown;
+  };
+}
+
+export interface PublicPublicationListResponse {
+  items: PublicPublicationResponse[];
+  next_cursor?: string;
 }
 
 /** POST /v1/workspaces/{id}/challenge-packs/validate response */

--- a/web/src/lib/changelog.test.ts
+++ b/web/src/lib/changelog.test.ts
@@ -11,7 +11,7 @@ describe("getChangelogPeriods", () => {
     const periods = getChangelogPeriods();
 
     expect(periods.length).toBeGreaterThan(0);
-    expect(periods[0]?.id).toBe("2026-06-02");
+    expect(periods[0]?.id).toBe("2026-06-22");
     expect(periods.at(-1)?.id).toBe("2026-04-15");
     expect(
       periods.every(
@@ -25,7 +25,7 @@ describe("getChangelogPeriods", () => {
 
 describe("getChangelogLatestModified", () => {
   it("returns the newest period end date", () => {
-    expect(getChangelogLatestModified()).toBe("2026-06-11");
+    expect(getChangelogLatestModified()).toBe("2026-07-01");
   });
 });
 

--- a/web/src/lib/deployment-headers.test.ts
+++ b/web/src/lib/deployment-headers.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Vercel representation cache headers", () => {
+  it("varies deployed responses on Accept without dropping Next router keys", () => {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "vercel.json"), "utf8"),
+    ) as {
+      headers?: Array<{
+        source: string;
+        headers: Array<{ key: string; value: string }>;
+      }>;
+    };
+    const globalRule = config.headers?.find((rule) => rule.source === "/(.*)");
+    const vary = globalRule?.headers.find(
+      (header) => header.key.toLowerCase() === "vary",
+    )?.value;
+
+    expect(vary?.split(/,\s*/)).toEqual(
+      expect.arrayContaining([
+        "Accept",
+        "Accept-Encoding",
+        "RSC",
+        "Next-Router-State-Tree",
+        "Next-Router-Prefetch",
+        "Next-Router-Segment-Prefetch",
+      ]),
+    );
+  });
+});

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -88,7 +88,7 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("agentclash-quickstart");
     expect(doc?.content).toContain("agentclash-compare-and-triage");
     expect(doc?.content).toContain("agentclash-dataset-workflows");
-    expect(doc?.content).toContain("https://agentclash.dev/docs/agent-skills");
+    expect(doc?.content).toContain("https://www.agentclash.dev/docs/agent-skills");
   });
 
   it("generates the agent harness setup skill", () => {

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildLlmsFull,
-  buildLlmsIndex,
   DOCS_NAV,
   getAllDocMarkdownPaths,
   getDocBySlug,
-  getDocsSearchIndex,
 } from "./docs";
+import {
+  buildPublicLlmsFull,
+  buildPublicLlmsIndex,
+  getPublicSearchIndex,
+} from "./public-content";
 
 const skillSlugs = [
   "agent-build-skills/agentclash-agent-build-author",
@@ -586,40 +588,39 @@ describe("agent skill docs", () => {
   });
 
   it("includes platform pages, blog posts, and agent skills in llms.txt", () => {
-    const index = buildLlmsIndex("https://example.test");
+    const index = buildPublicLlmsIndex("https://example.test");
 
-    expect(index).toContain("https://example.test/platform/agent-evaluation");
+    expect(index).toContain("https://example.test/md/platform/agent-evaluation");
     expect(index).toContain(
-      "https://example.test/platform/agent-regression-testing",
+      "https://example.test/md/platform/agent-regression-testing",
     );
     expect(index).toContain(
-      "https://example.test/blog/ai-agent-evaluation-regression-testing",
+      "https://example.test/md/blog/ai-agent-evaluation-regression-testing",
     );
-    expect(index).toContain("https://example.test/changelog");
-    expect(index.match(/https:\/\/example\.test\/changelog/g)?.length).toBe(1);
+    expect(index).toContain("https://example.test/md/changelog");
     expect(index).toContain(
       "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
     );
-    expect(index).toContain("https://example.test/docs-md/agent-skills");
+    expect(index).toContain("https://example.test/md/docs/agent-skills");
     expect(index).toContain(
-      "https://example.test/docs-md/agent-skills/agentclash-cli-setup",
+      "https://example.test/md/docs/agent-skills/agentclash-cli-setup",
     );
     expect(index).toContain(
-      "https://example.test/docs-md/agent-skills/agentclash-hub",
+      "https://example.test/md/docs/agent-skills/agentclash-hub",
     );
     expect(index).toContain(
-      "https://example.test/docs-md/agent-skills/agentclash-quickstart",
+      "https://example.test/md/docs/agent-skills/agentclash-quickstart",
     );
     expect(index).toContain(
-      "https://example.test/docs-md/agent-skills/agentclash-compare-and-triage",
+      "https://example.test/md/docs/agent-skills/agentclash-compare-and-triage",
     );
     expect(index).toContain(
-      "https://example.test/docs-md/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author",
+      "https://example.test/md/docs/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author",
     );
   });
 
   it("includes platform pages in docs search data", () => {
-    const index = getDocsSearchIndex();
+    const index = getPublicSearchIndex();
     const evaluation = index.find(
       (item) => item.href === "/platform/agent-evaluation",
     );
@@ -627,23 +628,17 @@ describe("agent skill docs", () => {
       (item) => item.href === "/platform/agent-regression-testing",
     );
 
-    expect(index.slice(0, 2).map((item) => item.href)).toEqual([
-      "/platform/agent-evaluation",
-      "/platform/agent-regression-testing",
-    ]);
     const changelog = index.find((item) => item.href === "/changelog");
-    expect(changelog?.title).toBe("Product Changelog");
-    expect(changelog?.searchText).toContain("release notes");
+    expect(changelog?.title).toBe("AgentClash Changelog");
+    expect(changelog?.searchText).toContain("product updates");
     expect(evaluation?.title).toBe("AI Agent Evaluation Platform");
-    expect(evaluation?.searchText).toContain("platform/agent-evaluation");
     expect(evaluation?.searchText).toContain("ai agent evaluation");
     expect(evaluation?.searchText).toContain("challenge packs");
     expect(evaluation?.searchText).toContain("ci regression gates");
     expect(regression?.title).toBe("AI Agent Regression Testing");
-    expect(regression?.searchText).toContain("platform/agent-regression-testing");
     expect(regression?.searchText).toContain("ai agent regression testing");
-    expect(regression?.searchText).toContain("pull request gates");
-    expect(regression?.searchText).toContain("scorecards");
+    expect(regression?.searchText).toContain("release gates");
+    expect(regression?.searchText).toContain("replay evidence");
   });
 
   it("resolves revamp doc pages from navigation", () => {
@@ -658,11 +653,11 @@ describe("agent skill docs", () => {
   });
 
   it("includes platform pages, blog posts, skill catalog, and skill bodies in llms-full.txt", () => {
-    const bundle = buildLlmsFull("https://example.test");
+    const bundle = buildPublicLlmsFull("https://example.test");
 
-    expect(bundle).toContain("https://example.test/platform/agent-evaluation");
+    expect(bundle).toContain("https://example.test/md/platform/agent-evaluation");
     expect(bundle).toContain(
-      "https://example.test/platform/agent-regression-testing",
+      "https://example.test/md/platform/agent-regression-testing",
     );
     expect(bundle).toContain(
       "# AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
@@ -673,22 +668,22 @@ describe("agent skill docs", () => {
     expect(bundle).toContain("# AgentClash Changelog");
     expect(bundle).toContain("Source: https://example.test/changelog");
     expect(bundle).toContain(
-      "[AI agent evaluation platform](https://example.test/platform/agent-evaluation)",
+      "# AI Agent Evaluation Platform",
     );
     expect(bundle).toContain(
-      "[AI agent regression testing](https://example.test/platform/agent-regression-testing)",
+      "# AI Agent Regression Testing",
     );
     expect(bundle).toContain(
-      "[CI/CD agent gates](https://example.test/docs-md/guides/ci-cd-agent-gates)",
+      "[CI/CD agent gates](https://example.test/md/docs/guides/ci-cd-agent-gates)",
     );
     expect(bundle).toContain(
-      "https://example.test/docs-md/guides/datasets-overview",
+      "https://example.test/md/docs/guides/datasets-overview",
     );
     expect(bundle).toContain(
-      "https://example.test/docs-md/challenge-packs/multi-turn",
+      "https://example.test/md/docs/challenge-packs/multi-turn",
     );
     expect(bundle).toContain(
-      "https://example.test/docs-md/guides/security-evaluation",
+      "https://example.test/md/docs/guides/security-evaluation",
     );
     expect(bundle).toContain("# Agent Skills");
     expect(bundle).toContain("name: agentclash-skill-catalog");
@@ -701,19 +696,18 @@ describe("agent skill docs", () => {
     expect(bundle).toContain("credential_reference: \"workspace-secret://KEY\"");
   });
 
-  it("includes a Highlights block and the comparison page in llms.txt", () => {
-    const index = buildLlmsIndex("https://example.test");
+  it("includes core entrypoints and the comparison page in llms.txt", () => {
+    const index = buildPublicLlmsIndex("https://example.test");
 
-    expect(index).toContain("## Highlights");
-    expect(index).toContain("Agent evaluation, not prompt evaluation");
-    expect(index).toContain("https://example.test/compare");
+    expect(index).toContain("## Core entrypoints");
+    expect(index).toContain("https://example.test/md/compare");
   });
 
   it("lists the comparison hub as a public product page in search data", () => {
-    const index = getDocsSearchIndex();
+    const index = getPublicSearchIndex();
     const compare = index.find((item) => item.href === "/compare");
 
-    expect(compare?.title).toBe("AgentClash vs prompt-eval tools");
-    expect(compare?.searchText).toContain("alternative");
+    expect(compare?.title).toBe("AgentClash vs prompt-evaluation tools");
+    expect(compare?.searchText).toContain("prompt evaluation");
   });
 });

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1,13 +1,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import {
-  getAllPosts,
-  getPostBySlug,
-  type BlogPostWithContent,
-} from "./blog";
-import { renderChangelogMarkdown } from "./changelog";
-import { SEO_PAGE_REGISTRY } from "./seo-pages";
+import type { BlogPostWithContent } from "./blog";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "docs");
 const AGENT_SKILLS_DIR = path.join(process.cwd(), "content", "agent-skills");
@@ -43,62 +37,6 @@ export const DOCS_ORIGIN = "https://www.agentclash.dev";
 // references and agent-skill pages) are regenerated from source on each build,
 // so "last generated" is a truthful freshness signal for answer engines.
 export const SITE_GENERATED_AT = new Date().toISOString();
-
-type PublicProductPage = {
-  title: string;
-  href: string;
-  description: string;
-  searchKeywords: string;
-};
-
-const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
-  {
-    title: "AI Agent Evaluation Platform",
-    href: "/platform/agent-evaluation",
-    description:
-      "Public page for real-task AI agent evaluation, replay evidence, scorecards, challenge packs, and CI regression gates.",
-    searchKeywords:
-      "AI agent evaluation agent evals real task agent benchmark coding agent evaluation LLM agent evaluation sandboxed agent workloads replay evidence scorecards challenge packs CI regression gates",
-  },
-  {
-    title: "AI Agent Regression Testing",
-    href: "/platform/agent-regression-testing",
-    description:
-      "Public page for baseline-versus-candidate agent regression testing, pull request gates, and release evidence.",
-    searchKeywords:
-      "AI agent regression testing agent evaluation CI gates pull request gates release gates baseline candidate comparisons replay evidence scorecards challenge packs agent eval regression suite",
-  },
-  {
-    title: "AgentClash vs prompt-eval tools",
-    href: "/compare",
-    description:
-      "Compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals — agent evaluation versus prompt evaluation.",
-    searchKeywords:
-      "compare comparison alternative alternatives AgentClash vs Braintrust LangSmith Promptfoo Langfuse Arize Phoenix OpenAI Evals Maxim AI MLflow DeepEval Galileo Patronus Ragas agent evaluation prompt evaluation best AI agent eval tools 2026",
-  },
-  {
-    title: "AgentClash Pricing",
-    href: "/pricing",
-    description:
-      "AgentClash pricing — a free hosted tier and open-source self-hosting, paid Pro ($49/mo) and Team ($100/mo) tiers, and custom Enterprise. Bring your own LLM keys on every tier.",
-    searchKeywords:
-      "AgentClash pricing cost plans tiers free open source self-host Pro Team Enterprise workspace BYOK bring your own key managed hosted",
-  },
-  {
-    title: "Product Changelog",
-    href: "/changelog",
-    description:
-      "Public release notes for AgentClash — features, improvements, fixes, and security updates grouped every ten days since launch.",
-    searchKeywords:
-      "AgentClash changelog release notes product updates what's new shipped features AI agent evaluation platform updates",
-  },
-  ...SEO_PAGE_REGISTRY.map((page) => ({
-    title: page.sitemapTitle,
-    href: page.path,
-    description: page.sitemapDescription,
-    searchKeywords: page.searchKeywords,
-  })),
-];
 
 export type DocNavItem = {
   title: string;
@@ -1614,11 +1552,11 @@ function uniqueSlugs(slugs: string[][]) {
 
 function docHrefToMarkdownHref(href: string, origin: string) {
   if (href === "/docs") {
-    return `${origin}/docs-md`;
+    return `${origin}/md/docs`;
   }
 
   if (href.startsWith("/docs/")) {
-    return `${origin}/docs-md${href.slice("/docs".length)}`;
+    return `${origin}/md${href}`;
   }
 
   return href.startsWith("http") ? href : `${origin}${href}`;
@@ -1735,30 +1673,6 @@ export function getAllDocMarkdownPaths() {
   return getAllDocSlugs().map((slug) => getDocMarkdownPath(slug));
 }
 
-export function getDocsSearchIndex(): DocSearchItem[] {
-  const docsSearchItems = getAllDocSlugs()
-    .map((slug) => getDocBySlug(slug))
-    .filter((doc): doc is DocPage => Boolean(doc))
-    .map((doc) => ({
-      title: doc.title,
-      description: doc.description,
-      href: doc.href,
-      searchText: `${doc.title} ${doc.description} ${doc.headings
-        .map((heading) => heading.text)
-        .join(" ")} ${stripInlineMarkdown(doc.content).slice(0, 900)}`.toLowerCase(),
-    }));
-
-  const productPageSearchItems = PUBLIC_PRODUCT_PAGES.map((page) => ({
-    title: page.title,
-    description: page.description,
-    href: page.href,
-    searchText:
-      `${page.title} ${page.description} ${page.href} ${page.searchKeywords}`.toLowerCase(),
-  }));
-
-  return [...productPageSearchItems, ...docsSearchItems];
-}
-
 export function renderDocMarkdown(doc: DocPage, origin = DOCS_ORIGIN) {
   const lines = [
     `# ${doc.title}`,
@@ -1766,7 +1680,7 @@ export function renderDocMarkdown(doc: DocPage, origin = DOCS_ORIGIN) {
     doc.description,
     "",
     `Source: ${origin}${doc.href}`,
-    `Markdown export: ${origin}${getDocMarkdownPath(doc.slug)}`,
+    `Markdown export: ${origin}${doc.href === "/" ? "/md" : `/md${doc.href}`}`,
     "",
     normalizeMarkdownForExport(doc.content, origin),
   ];
@@ -1784,127 +1698,12 @@ export function renderBlogMarkdown(
     post.description,
     "",
     `Source: ${origin}/blog/${post.slug}`,
+    `Markdown export: ${origin}/md/blog/${post.slug}`,
     `Published: ${post.date}`,
     `Author: ${post.author}`,
     "",
     normalizeBlogMarkdownForExport(post.content, origin),
   ];
-
-  return lines.join("\n").trim();
-}
-
-export function buildLlmsIndex(origin = DOCS_ORIGIN) {
-  const blogPosts = getAllPosts();
-  const lines = [
-    "# AgentClash",
-    "",
-    "> AgentClash runs agents against repeatable challenge packs, captures replay evidence, and shows where a run won, failed, or drifted.",
-    "",
-    "Use this index when you want the shortest machine-readable map of the public docs and selected product pages. Fetch `/llms-full.txt` for the bundled corpus, or use the `/docs-md/...` links below for page-level markdown exports.",
-    "",
-    "## Highlights",
-    "",
-    "- Open-source (MIT), self-hostable AI agent evaluation platform; CLI on npm as `agentclash`.",
-    "- Runs agents on the same task, tools, and time budget in a fresh per-agent sandbox (microVM), with replayable failure evidence.",
-    "- 300+ models via OpenRouter, plus first-class OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter providers.",
-    "- Scores the whole trajectory — correctness, cost, latency, and tool strategy — with replay evidence and scorecards.",
-    "- Promotes failures into reusable regression tests and gates CI on baseline-versus-candidate comparisons.",
-    `- Agent evaluation, not prompt evaluation — compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals at ${origin}/compare.`,
-    "",
-    "## Core entrypoints",
-    "",
-    `- [Docs home](${origin}/docs-md) - overview, navigation, and starting points.`,
-    `- [Quickstart](${origin}/docs-md/getting-started/quickstart) - fastest path to a real run.`,
-    `- [Self-Host](${origin}/docs-md/getting-started/self-host) - local stack and service dependencies.`,
-    `- [First Eval](${origin}/docs-md/getting-started/first-eval) - end-to-end walkthrough of one eval path.`,
-    `- [Fleet](${origin}/docs-md/fleet) - eval sets, live matrix, warehouse, budgets, scanners, self-host scale.`,
-    `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
-    `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
-    `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,
-    `- [Integration setup](${origin}/docs-md/guides/use-with-ai-tools) - \`npm i -g agentclash && agentclash integration <agent> install\` (claude, codex, cursor, openclaw, hermes, opencode).`,
-    `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
-    "",
-    "## Public product pages",
-    "",
-    ...PUBLIC_PRODUCT_PAGES.map(
-      (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
-    ),
-    "",
-    "## Blog posts",
-    "",
-    ...blogPosts.map(
-      (post) => `- [${post.title}](${origin}/blog/${post.slug}) - ${post.description}`,
-    ),
-    "",
-  ];
-
-  for (const section of DOCS_NAV) {
-    lines.push(`## ${section.title}`, "");
-    for (const item of section.items) {
-      lines.push(
-        `- [${item.title}](${origin}${getDocMarkdownPath(item.slug)}) - ${item.description}`,
-      );
-    }
-    lines.push("");
-  }
-
-  lines.push("## Agent Skill Pages", "");
-  for (const skill of readAgentSkills()) {
-    lines.push(
-      `- [${skill.name}](${origin}/docs-md/agent-skills/${skill.relativePath}) - ${skill.description}`,
-    );
-  }
-
-  return lines.join("\n").trim();
-}
-
-export function buildLlmsFull(origin = DOCS_ORIGIN) {
-  const orderedSlugs = uniqueSlugs([
-    [],
-    ...flattenDocsNav().map((item) => item.slug),
-    ...getAgentSkillDocSlugs(),
-  ]);
-  const docs = orderedSlugs
-    .map((slug) => getDocBySlug(slug))
-    .filter((doc): doc is DocPage => Boolean(doc));
-  const blogPosts = getAllPosts()
-    .map((post) => getPostBySlug(post.slug))
-    .filter((post): post is BlogPostWithContent => Boolean(post));
-
-  const lines = [
-    "# AgentClash Docs Bundle",
-    "",
-    `Canonical docs home: ${origin}/docs`,
-    `Machine-readable index: ${origin}/llms.txt`,
-    "",
-    "This file concatenates the currently shipped AgentClash docs pages and selected product page links into one markdown-oriented bundle for assistants, coding agents, and local retrieval pipelines.",
-    "",
-    "AgentClash is an open-source (MIT) AI agent evaluation platform: it runs agents on the same task, tools, and time budget in a fresh per-agent sandbox, captures replayable failures, promotes regressions, and gates CI on scorecards. It is agent evaluation, not prompt evaluation.",
-    "",
-    "## Public product pages",
-    "",
-    ...PUBLIC_PRODUCT_PAGES.map(
-      (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
-    ),
-    "",
-    "## Blog posts",
-    "",
-    ...blogPosts.map(
-      (post) => `- [${post.title}](${origin}/blog/${post.slug}) - ${post.description}`,
-    ),
-    "",
-    "## Changelog bundle",
-    "",
-    renderChangelogMarkdown(origin),
-  ];
-
-  for (const post of blogPosts) {
-    lines.push("", "---", "", renderBlogMarkdown(post, origin));
-  }
-
-  for (const doc of docs) {
-    lines.push("", "---", "", renderDocMarkdown(doc, origin));
-  }
 
   return lines.join("\n").trim();
 }

--- a/web/src/lib/indexnow.test.ts
+++ b/web/src/lib/indexnow.test.ts
@@ -21,6 +21,20 @@ describe("buildUrlList", () => {
       "https://www.agentclash.dev/compare",
     ]);
   });
+
+  it("adds active publication URLs without changing the canonical host", () => {
+    expect(buildUrlList(["/publications/pub-1"])).toContain(
+      "https://www.agentclash.dev/publications/pub-1",
+    );
+  });
+
+  it("deduplicates URLs and stays within the IndexNow protocol limit", () => {
+    const paths = Array.from({ length: 10_100 }, (_, index) => `/publications/${index}`);
+    paths.push("/compare");
+    const urls = buildUrlList(paths);
+    expect(urls).toHaveLength(10_000);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
 });
 
 describe("submitIndexNow", () => {

--- a/web/src/lib/indexnow.ts
+++ b/web/src/lib/indexnow.ts
@@ -20,11 +20,15 @@ export const KEY_LOCATION = `${DOCS_ORIGIN}/${KEY}.txt`;
 // Protocol-generic submission endpoint; one POST fans out to all participating
 // engines. IndexNow accepts up to 10,000 URLs per request.
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/IndexNow";
+const INDEXNOW_MAX_URLS = 10_000;
 
 // The canonical public URLs to (re)submit — reuse the sitemap so this never
 // drifts from what we actually publish. sitemap() already returns absolute URLs.
-export function buildUrlList(): string[] {
-  return sitemap().map((entry) => entry.url);
+export function buildUrlList(publicationPaths: string[] = []): string[] {
+  return [...new Set([
+    ...sitemap().map((entry) => entry.url),
+    ...publicationPaths.map((path) => `${DOCS_ORIGIN}${path}`),
+  ])].slice(0, INDEXNOW_MAX_URLS);
 }
 
 export type IndexNowResult = { status: number; body: string };

--- a/web/src/lib/private-metadata.ts
+++ b/web/src/lib/private-metadata.ts
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const PRIVATE_ROBOTS_METADATA: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      noarchive: true,
+      noimageindex: true,
+    },
+  },
+};

--- a/web/src/lib/public-content.test.ts
+++ b/web/src/lib/public-content.test.ts
@@ -8,6 +8,7 @@ import {
   normalizePublicPath,
   resolvePublicContent,
 } from "./public-content";
+import { isMarkdownNegotiablePath } from "./public-http";
 
 describe("public content registry", () => {
   it("has unique canonical and Markdown paths", () => {
@@ -23,6 +24,7 @@ describe("public content registry", () => {
       expect(markdown, item.canonicalPath).toContain("Source: https://example.test");
       expect(markdown, item.canonicalPath).not.toContain("<nav");
       expect(markdown, item.canonicalPath).not.toContain("<footer");
+      expect(isMarkdownNegotiablePath(item.canonicalPath), item.canonicalPath).toBe(true);
     }
   });
 

--- a/web/src/lib/public-content.test.ts
+++ b/web/src/lib/public-content.test.ts
@@ -37,6 +37,7 @@ describe("public content registry", () => {
       "/compare/agentclash-vs-langsmith",
       "/features/agent-replay",
       "/try",
+      "/try/codex",
       "/tryouts",
       "/agent-opportunity",
     ]) {

--- a/web/src/lib/public-content.test.ts
+++ b/web/src/lib/public-content.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPublicLlmsFull,
+  buildPublicLlmsIndex,
+  canonicalPathFromMarkdownSegments,
+  getAllPublicContent,
+  getPublicSearchIndex,
+  normalizePublicPath,
+  resolvePublicContent,
+} from "./public-content";
+
+describe("public content registry", () => {
+  it("has unique canonical and Markdown paths", () => {
+    const items = getAllPublicContent();
+    expect(new Set(items.map((item) => item.canonicalPath)).size).toBe(items.length);
+    expect(new Set(items.map((item) => item.markdownPath)).size).toBe(items.length);
+  });
+
+  it("renders every registered page as semantic Markdown", () => {
+    for (const item of getAllPublicContent()) {
+      const markdown = item.renderMarkdown("https://example.test");
+      expect(markdown, item.canonicalPath).toMatch(/^#\s+\S/m);
+      expect(markdown, item.canonicalPath).toContain("Source: https://example.test");
+      expect(markdown, item.canonicalPath).not.toContain("<nav");
+      expect(markdown, item.canonicalPath).not.toContain("<footer");
+    }
+  });
+
+  it("covers core, structured, and generated route families", () => {
+    for (const pathname of [
+      "/",
+      "/pricing",
+      "/docs",
+      "/docs/getting-started/quickstart",
+      "/blog",
+      "/changelog",
+      "/compare/agentclash-vs-langsmith",
+      "/features/agent-replay",
+      "/try",
+      "/tryouts",
+      "/agent-opportunity",
+    ]) {
+      expect(resolvePublicContent(pathname), pathname).not.toBeNull();
+    }
+  });
+
+  it.each([
+    "/../pricing",
+    "/%2e%2e/pricing",
+    "/docs//quickstart",
+    "/share/token",
+    "/workspaces/ws_123",
+    "/api/private",
+    "/pricing?token=secret",
+  ])("rejects unsafe or private path %s", (pathname) => {
+    expect(normalizePublicPath(pathname)).toBeNull();
+    expect(resolvePublicContent(pathname)).toBeNull();
+  });
+
+  it("maps Markdown segments without accepting traversal", () => {
+    expect(canonicalPathFromMarkdownSegments([])).toBe("/");
+    expect(canonicalPathFromMarkdownSegments(["docs", "getting-started", "quickstart"])).toBe(
+      "/docs/getting-started/quickstart",
+    );
+    expect(canonicalPathFromMarkdownSegments(["docs", "..", "pricing"])).toBeNull();
+  });
+
+  it("drives llms and search from exact registered URLs", () => {
+    const index = buildPublicLlmsIndex("https://example.test");
+    const full = buildPublicLlmsFull("https://example.test");
+    const search = getPublicSearchIndex();
+
+    expect(index).toContain("https://example.test/md/pricing");
+    expect(index).toContain("https://example.test/openapi.yaml");
+    expect(index).toContain("https://example.test/cli-schema.json");
+    expect(index).not.toContain("<agent>");
+    expect(full).toContain("# AgentClash Pricing");
+    expect(full).toContain("Monthly: $49/ month");
+    expect(full).toContain("Annual billing: $39/ month");
+    expect(full).not.toContain("/share/");
+    expect(full).not.toContain("# Publication ");
+    expect(search.some((item) => item.href === "/pricing")).toBe(true);
+    expect(search.some((item) => item.href.startsWith("/workspaces"))).toBe(false);
+  });
+});

--- a/web/src/lib/public-content.ts
+++ b/web/src/lib/public-content.ts
@@ -1,0 +1,956 @@
+import {
+  COMPETITORS,
+  MARK_LABEL,
+  competitorFaq,
+  competitorRows,
+} from "@/lib/comparison-data";
+import {
+  DOCS_ORIGIN,
+  getAllDocSlugs,
+  getDocBySlug,
+  renderBlogMarkdown,
+  renderDocMarkdown,
+} from "@/lib/docs";
+import { getAllPosts, getPostBySlug } from "@/lib/blog";
+import {
+  getAllReports,
+  getReportBySlug,
+  hasPublishedBenchmarks,
+} from "@/lib/benchmarks";
+import {
+  CHANGELOG_CATEGORY_LABELS,
+  getChangelogLatestModified,
+  getChangelogPeriodBySlug,
+  getChangelogPeriodHref,
+  getChangelogPeriods,
+  renderChangelogMarkdown,
+} from "@/lib/changelog";
+import { PRICING_TIERS } from "@/lib/pricing-data";
+import { SEO_PAGE_REGISTRY, type SeoPageConfig } from "@/lib/seo-pages";
+
+export const PUBLIC_ORIGIN = DOCS_ORIGIN;
+
+export type PublicContentKind =
+  | "marketing"
+  | "docs"
+  | "blog"
+  | "changelog"
+  | "benchmark"
+  | "comparison"
+  | "seo"
+  | "interactive"
+  | "publication";
+
+export type PublicContentInclusion = {
+  sitemap: boolean;
+  llms: boolean;
+  llmsFull: boolean;
+  search: boolean;
+  indexNow: boolean;
+};
+
+export type PublicContentDescriptor = {
+  canonicalPath: string;
+  markdownPath: string;
+  title: string;
+  description: string;
+  kind: PublicContentKind;
+  lastModified: string;
+  indexable: boolean;
+  includeIn: PublicContentInclusion;
+  sitemapPriority?: number;
+  changeFrequency?: "daily" | "weekly" | "monthly" | "yearly";
+  renderMarkdown: (origin?: string) => string;
+};
+
+type StaticSection = {
+  heading: string;
+  body?: string;
+  bullets?: string[];
+  links?: Array<{ label: string; href: string }>;
+};
+
+type StaticPage = {
+  path: string;
+  title: string;
+  description: string;
+  kind?: PublicContentKind;
+  lastModified: string;
+  priority: number;
+  changeFrequency?: "weekly" | "monthly";
+  sections: StaticSection[];
+};
+
+const DEFAULT_INCLUDE: PublicContentInclusion = {
+  sitemap: true,
+  llms: true,
+  llmsFull: true,
+  search: true,
+  indexNow: true,
+};
+
+const PRIVATE_PREFIXES = [
+  "/api",
+  "/auth",
+  "/dashboard",
+  "/github",
+  "/ingest",
+  "/invites",
+  "/onboard",
+  "/orgs",
+  "/share",
+  "/workspaces",
+  "/_next",
+] as const;
+
+const STATIC_LAST_MODIFIED = "2026-08-14";
+
+const STATIC_PAGES: StaticPage[] = [
+  {
+    path: "/",
+    title: "AgentClash: AI Agent Evaluation with Replay Evidence",
+    description:
+      "Run AI agents on repeatable real tasks, compare trajectories, inspect replay evidence, and turn failures into regression gates.",
+    priority: 1,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "What AgentClash does",
+        bullets: [
+          "Runs agents on the same task, tools, budget, and isolated sandbox.",
+          "Scores correctness, reliability, latency, cost, and tool strategy.",
+          "Captures replay evidence and promotes failures into reusable regression tests.",
+          "Supports hosted evaluation and MIT-licensed self-hosting.",
+        ],
+      },
+      {
+        heading: "Start here",
+        links: [
+          { label: "Quickstart", href: "/docs/getting-started/quickstart" },
+          { label: "Run a demo", href: "/try" },
+          { label: "Pricing", href: "/pricing" },
+          { label: "Compare tools", href: "/compare" },
+        ],
+      },
+    ],
+  },
+  {
+    path: "/why",
+    title: "Why AgentClash",
+    description:
+      "Agent evaluation should test what an agent does across a complete trajectory, not only what one model call says.",
+    priority: 0.7,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "The evaluation gap",
+        body: "Prompt tests miss tool choice, recovery, side effects, timing, cost, and multi-turn execution. AgentClash evaluates the complete run with evidence that teams can inspect and replay.",
+      },
+      {
+        heading: "The operating principle",
+        bullets: [
+          "Same task and budget for every candidate.",
+          "Fresh isolated environment for every run.",
+          "Deterministic and model-based scoring with visible evidence.",
+          "Failures become regression coverage instead of disappearing into dashboards.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/team",
+    title: "AgentClash Team",
+    description:
+      "Meet the team building open-source infrastructure for repeatable AI agent evaluation.",
+    priority: 0.5,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "What we are building",
+        body: "AgentClash gives engineering teams a repeatable way to compare agents, inspect their behavior, and gate releases on evidence.",
+      },
+      {
+        heading: "Work with us",
+        links: [
+          { label: "GitHub", href: "https://github.com/agentclash/agentclash" },
+          { label: "Contact", href: "mailto:hello@agentclash.dev" },
+        ],
+      },
+    ],
+  },
+  {
+    path: "/enterprise",
+    title: "Enterprise AI Agent Evaluation",
+    description:
+      "Governed agent release gates, private evaluation infrastructure, audit evidence, and rollout support for platform teams.",
+    priority: 0.82,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Enterprise outcomes",
+        bullets: [
+          "Standardize evidence before agents reach production.",
+          "Keep challenge packs, credentials, and replay data within approved boundaries.",
+          "Connect regression suites and release gates to CI.",
+          "Support SSO, audit logs, retention controls, and custom rollout terms.",
+        ],
+      },
+      {
+        heading: "Next step",
+        links: [{ label: "Contact AgentClash", href: "mailto:hello@agentclash.dev" }],
+      },
+    ],
+  },
+  {
+    path: "/services",
+    title: "Agent Evaluation Services",
+    description:
+      "Fixed-scope services for challenge-pack design, regression setup, evaluation pilots, and platform adoption.",
+    priority: 0.78,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Available engagements",
+        bullets: [
+          "Evaluation readiness and architecture review.",
+          "Challenge-pack and scoring design.",
+          "Regression-suite and CI release-gate implementation.",
+          "Team enablement for hosted or self-hosted AgentClash.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/resources/eval-checklist",
+    title: "Enterprise AI Agent Evaluation Checklist",
+    description:
+      "A practical checklist for evaluation design, release gates, pilot evidence, and procurement review.",
+    priority: 0.77,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Checklist coverage",
+        bullets: [
+          "Define representative tasks, inputs, tools, and failure boundaries.",
+          "Choose deterministic, behavioral, and model-based evaluators.",
+          "Capture replay evidence and promote escaped failures.",
+          "Set release thresholds, ownership, retention, and audit requirements.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/platform/agent-evaluation",
+    title: "AI Agent Evaluation Platform",
+    description:
+      "Evaluate tool-using AI agents on real tasks with isolated sandboxes, scorecards, replay evidence, and CI regression gates.",
+    priority: 0.85,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Evaluation workflow",
+        bullets: [
+          "Package tasks, inputs, tools, policies, and evaluators as challenge packs.",
+          "Race candidate agents under the same constraints.",
+          "Inspect scorecards and replay evidence.",
+          "Promote failures and gate future releases.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/platform/agent-regression-testing",
+    title: "AI Agent Regression Testing",
+    description:
+      "Compare baselines and candidates against pinned agent failures and datasets with replay evidence, release thresholds, and CI release gates.",
+    priority: 0.82,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Regression loop",
+        bullets: [
+          "Capture failed production or evaluation traces.",
+          "Curate them into repeatable cases.",
+          "Run baseline and candidate agents on the same suite.",
+          "Block regressions in CI with evidence-linked gates.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/platform/datasmith",
+    title: "DataSmith Synthetic Agent Data",
+    description:
+      "Generate diverse agent evaluation datasets with weak-versus-strong Agentic Self-Instruct workflows.",
+    priority: 0.84,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "DataSmith workflow",
+        bullets: [
+          "Seed generation from real tasks and constraints.",
+          "Create diverse candidate cases with weaker models.",
+          "Refine, filter, and score cases with stronger models.",
+          "Export approved cases into evaluation datasets and regression suites.",
+        ],
+      },
+    ],
+  },
+  ...[
+    ["/use-cases", "Agent Evaluation Use Cases", "Evaluation patterns for coding, research, and customer-support agents."],
+    ["/features", "AgentClash Features", "Challenge packs, scorecards, replay, datasets, regression suites, and CI release gates."],
+    ["/industries", "AI Agent Evaluation by Industry", "Evaluation guidance for regulated and evidence-sensitive industries."],
+    ["/glossary", "Agent Evaluation Glossary", "Definitions for agent evaluation, challenge packs, release gates, replay evidence, and synthetic data."],
+  ].map(([path, title, description]) => ({
+    path,
+    title,
+    description,
+    priority: 0.78,
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Explore",
+        body: description,
+        links: SEO_PAGE_REGISTRY.filter((page) => page.path.startsWith(`${path}/`)).map(
+          (page) => ({ label: page.sitemapTitle, href: page.path }),
+        ),
+      },
+    ],
+  })),
+  {
+    path: "/blog",
+    title: "AgentClash Blog",
+    description:
+      "Engineering guides, benchmark analysis, product updates, and practical AI agent evaluation advice.",
+    priority: 0.8,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Recent articles",
+        links: getAllPosts().map((post) => ({
+          label: post.title,
+          href: `/blog/${post.slug}`,
+        })),
+      },
+    ],
+  },
+  {
+    path: "/benchmarks",
+    title: "AI Agent Benchmarks",
+    description:
+      "Measured same-task agent comparisons with frozen challenge packs, scorecards, and replay evidence.",
+    priority: 0.8,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Reports",
+        links: getAllReports()
+          .filter((report) => !report.sample)
+          .map((report) => ({ label: report.title, href: `/benchmarks/${report.slug}` })),
+      },
+    ],
+  },
+  {
+    path: "/try",
+    title: "Try AgentClash",
+    description:
+      "Browse public agent demos and start an isolated terminal only when you explicitly choose a demo.",
+    kind: "interactive",
+    priority: 0.88,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "How demos work",
+        bullets: [
+          "Choose a public demo from the server-rendered catalog.",
+          "Review its task, constraints, and suggested commands.",
+          "Start an isolated sandbox with an explicit action.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/tryouts",
+    title: "AI Agent Tryouts",
+    description:
+      "Run public task-gated agent tryouts with visible tools, inputs, completed output, and trace export.",
+    kind: "interactive",
+    priority: 0.9,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Tryout flow",
+        bullets: [
+          "Select a public task template and permitted tools.",
+          "Review the input before launching the run.",
+          "Inspect the completed result and export its trace.",
+        ],
+      },
+    ],
+  },
+  {
+    path: "/agent-opportunity",
+    title: "AI Agent Opportunity Report",
+    description:
+      "Assess a company workflow for agent automation opportunities, evaluation needs, and build-versus-buy tradeoffs.",
+    kind: "interactive",
+    priority: 0.91,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "POST contract",
+        body: "Report generation is an explicit POST operation. Submit a company URL and optional context. The response contains an assessment, candidate workflows, risks, evidence requirements, and next steps. A GET or Markdown request never starts generation.",
+      },
+      {
+        heading: "Publication",
+        body: "Generated reports remain transient and non-indexable unless the user explicitly publishes a redacted result.",
+      },
+    ],
+  },
+];
+
+function markdownPathFor(canonicalPath: string): string {
+  return canonicalPath === "/" ? "/md" : `/md${canonicalPath}`;
+}
+
+function absoluteHref(href: string, origin: string): string {
+  return href.startsWith("/") ? `${origin}${href}` : href;
+}
+
+function renderStaticPage(page: StaticPage, origin: string): string {
+  const lines = [
+    `# ${page.title}`,
+    "",
+    page.description,
+    "",
+    `Source: ${origin}${page.path === "/" ? "" : page.path}`,
+    `Markdown export: ${origin}${markdownPathFor(page.path)}`,
+  ];
+
+  for (const section of page.sections) {
+    lines.push("", `## ${section.heading}`, "");
+    if (section.body) lines.push(section.body, "");
+    for (const bullet of section.bullets ?? []) lines.push(`- ${bullet}`);
+    for (const link of section.links ?? []) {
+      lines.push(`- [${link.label}](${absoluteHref(link.href, origin)})`);
+    }
+  }
+
+  return lines.join("\n").trim();
+}
+
+function renderPricing(origin: string): string {
+  const lines = [
+    "# AgentClash Pricing",
+    "",
+    "Start free with hosted evaluation or self-host the MIT-licensed engine. Bring your own LLM provider keys on every tier.",
+    "",
+    `Source: ${origin}/pricing`,
+    `Markdown export: ${origin}/md/pricing`,
+    "",
+    "## Plans",
+  ];
+
+  for (const tier of PRICING_TIERS) {
+    lines.push(
+      "",
+      `### ${tier.name}`,
+      "",
+      tier.blurb,
+      "",
+      `- Monthly: ${tier.prices.monthly.value}${tier.prices.monthly.suffix}`,
+      `- Annual billing: ${tier.prices.yearly.value}${tier.prices.yearly.suffix}${tier.prices.yearly.note ? ` (${tier.prices.yearly.note})` : ""}`,
+      ...tier.features.map((feature) => `- ${feature}`),
+      `- Action: [${tier.cta.label}](${absoluteHref(tier.cta.href, origin)})`,
+    );
+  }
+
+  return lines.join("\n").trim();
+}
+
+function renderSeoPage(page: SeoPageConfig, origin: string): string {
+  const lines = [
+    `# ${page.h1}`,
+    "",
+    page.heroDescription,
+    "",
+    `Source: ${origin}${page.path}`,
+    `Markdown export: ${origin}${markdownPathFor(page.path)}`,
+    "",
+    `## ${page.proofSectionTitle}`,
+    "",
+    page.proofSectionDescription,
+    "",
+    ...page.proofPoints.map((point) => `- ${point}`),
+    "",
+    `## ${page.workflowSectionTitle}`,
+    "",
+    ...page.workflow.flatMap((step, index) => [
+      `### ${index + 1}. ${step.title}`,
+      "",
+      step.text,
+      "",
+    ]),
+    `## ${page.docsSectionTitle}`,
+    "",
+    page.docsSectionDescription,
+    "",
+    ...page.relatedLinks.map(
+      (link) => `- [${link.title}](${absoluteHref(link.href, origin)}): ${link.text}`,
+    ),
+    "",
+    `## ${page.faqSectionTitle}`,
+    "",
+    ...page.faqItems.flatMap((item) => [
+      `### ${item.question}`,
+      "",
+      item.answer,
+      "",
+    ]),
+  ];
+
+  return lines.join("\n").trim();
+}
+
+function renderCompareHub(origin: string): string {
+  const lines = [
+    "# AgentClash vs prompt-evaluation tools",
+    "",
+    "Compare end-to-end, sandboxed agent evaluation with prompt and model-output evaluation tools.",
+    "",
+    `Source: ${origin}/compare`,
+    `Markdown export: ${origin}/md/compare`,
+    "",
+    "## Capability matrix",
+    "",
+    "| Capability | AgentClash | " + COMPETITORS.slice(0, 6).map((item) => item.name).join(" | ") + " |",
+    "| --- | --- | " + COMPETITORS.slice(0, 6).map(() => "---").join(" | ") + " |",
+  ];
+
+  for (const [index, row] of competitorRows(COMPETITORS[0]).entries()) {
+    const competitorValues = COMPETITORS.slice(0, 6).map(
+      (competitor) => MARK_LABEL[competitor.verdicts[index]],
+    );
+    lines.push(`| ${row.label} | ${MARK_LABEL[row.agentclash]} | ${competitorValues.join(" | ")} |`);
+  }
+
+  lines.push("", "## Detailed comparisons", "");
+  for (const competitor of COMPETITORS) {
+    lines.push(`- [AgentClash vs ${competitor.name}](${origin}/md/compare/${competitor.slug})`);
+  }
+  return lines.join("\n").trim();
+}
+
+function renderCompetitor(slug: string, origin: string): string {
+  const competitor = COMPETITORS.find((item) => item.slug === slug);
+  if (!competitor) return "";
+  const lines = [
+    `# AgentClash vs ${competitor.name}`,
+    "",
+    `${competitor.name} is categorized here as ${competitor.tag}. AgentClash focuses on complete, tool-using agent trajectories in isolated sandboxes.`,
+    "",
+    `Source: ${origin}/compare/${competitor.slug}`,
+    `Markdown export: ${origin}/md/compare/${competitor.slug}`,
+    "",
+    "## Where each tool fits",
+    "",
+    competitor.whereItFits,
+    "",
+    "## Capability comparison",
+    "",
+    `| Capability | AgentClash | ${competitor.name} |`,
+    "| --- | --- | --- |",
+    ...competitorRows(competitor).map(
+      (row) => `| ${row.label} | ${MARK_LABEL[row.agentclash]} | ${MARK_LABEL[row.competitor]} |`,
+    ),
+    "",
+    "## Common questions",
+    "",
+    ...competitorFaq(competitor).flatMap((item) => [
+      `### ${item.question}`,
+      "",
+      item.answer,
+      "",
+    ]),
+  ];
+  return lines.join("\n").trim();
+}
+
+function renderChangelogPeriod(slug: string, origin: string): string {
+  const period = getChangelogPeriodBySlug(slug);
+  if (!period) return "";
+  return [
+    `# ${period.headline}`,
+    "",
+    period.summary,
+    "",
+    `Period: ${period.label}`,
+    `Source: ${origin}${getChangelogPeriodHref(period.id)}`,
+    `Markdown export: ${origin}/md${getChangelogPeriodHref(period.id)}`,
+    "",
+    "## Changes",
+    "",
+    ...period.entries.map(
+      (entry) => `- **${CHANGELOG_CATEGORY_LABELS[entry.category]}**: ${entry.text}`,
+    ),
+  ].join("\n").trim();
+}
+
+function formatScore(value: number | null): string {
+  return value === null ? "N/A" : `${Math.round(value * 100)}%`;
+}
+
+function renderBenchmark(slug: string, origin: string): string {
+  const report = getReportBySlug(slug);
+  if (!report) return "";
+  const lines = [
+    `# ${report.title}`,
+    "",
+    report.description,
+    "",
+    `Verdict: ${report.verdict}`,
+    `Published: ${report.date}`,
+    `Author: ${report.author}`,
+    `Source: ${origin}/benchmarks/${report.slug}`,
+    `Markdown export: ${origin}/md/benchmarks/${report.slug}`,
+    "",
+    "## Results",
+    "",
+    "| Rank | Model | Provider | Composite | Correctness | Reliability | Latency | Cost |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ...report.results.map(
+      (row) =>
+        `| ${row.rank} | ${row.model} | ${row.provider || "N/A"} | ${formatScore(row.composite)} | ${formatScore(row.correctness)} | ${formatScore(row.reliability)} | ${formatScore(row.latency)} | ${formatScore(row.cost)} |`,
+    ),
+  ];
+  if (report.tasks.length > 0) {
+    lines.push("", "## Tasks", "", ...report.tasks.map((task) => `- **${task.name}**: ${task.summary}`));
+  }
+  lines.push("", report.content.trim());
+  return lines.join("\n").trim();
+}
+
+function descriptorFromStatic(page: StaticPage): PublicContentDescriptor {
+  return {
+    canonicalPath: page.path,
+    markdownPath: markdownPathFor(page.path),
+    title: page.title,
+    description: page.description,
+    kind: page.kind ?? "marketing",
+    lastModified: page.lastModified,
+    indexable: page.path !== "/benchmarks" || hasPublishedBenchmarks(),
+    includeIn: { ...DEFAULT_INCLUDE },
+    sitemapPriority: page.priority,
+    changeFrequency: page.changeFrequency ?? "monthly",
+    renderMarkdown: (origin = PUBLIC_ORIGIN) =>
+      page.path === "/pricing" ? renderPricing(origin) : renderStaticPage(page, origin),
+  };
+}
+
+function buildStaticRegistry(): PublicContentDescriptor[] {
+  const items: PublicContentDescriptor[] = STATIC_PAGES.map(descriptorFromStatic);
+
+  items.push({
+    canonicalPath: "/pricing",
+    markdownPath: "/md/pricing",
+    title: "AgentClash Pricing",
+    description:
+      "Free hosted and self-hosted options, plus Pro, Team, and Enterprise plans with bring-your-own LLM keys.",
+    kind: "marketing",
+    lastModified: STATIC_LAST_MODIFIED,
+    indexable: true,
+    includeIn: { ...DEFAULT_INCLUDE },
+    sitemapPriority: 0.8,
+    changeFrequency: "monthly",
+    renderMarkdown: (origin = PUBLIC_ORIGIN) => renderPricing(origin),
+  });
+
+  for (const page of SEO_PAGE_REGISTRY) {
+    items.push({
+      canonicalPath: page.path,
+      markdownPath: markdownPathFor(page.path),
+      title: page.sitemapTitle,
+      description: page.sitemapDescription,
+      kind: "seo",
+      lastModified: STATIC_LAST_MODIFIED,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: page.tier === "S" ? 0.8 : page.tier === "A" ? 0.72 : 0.64,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderSeoPage(page, origin),
+    });
+  }
+
+  items.push({
+    canonicalPath: "/compare",
+    markdownPath: "/md/compare",
+    title: "AgentClash vs prompt-evaluation tools",
+    description:
+      "Compare AgentClash with prompt evaluation, observability, and agent evaluation tools.",
+    kind: "comparison",
+    lastModified: STATIC_LAST_MODIFIED,
+    indexable: true,
+    includeIn: { ...DEFAULT_INCLUDE },
+    sitemapPriority: 0.8,
+    changeFrequency: "monthly",
+    renderMarkdown: (origin = PUBLIC_ORIGIN) => renderCompareHub(origin),
+  });
+
+  for (const competitor of COMPETITORS) {
+    const canonicalPath = `/compare/${competitor.slug}`;
+    items.push({
+      canonicalPath,
+      markdownPath: markdownPathFor(canonicalPath),
+      title: `AgentClash vs ${competitor.name}`,
+      description: `Compare AgentClash end-to-end agent evaluation with ${competitor.name}, a ${competitor.tag} tool.`,
+      kind: "comparison",
+      lastModified: STATIC_LAST_MODIFIED,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: 0.75,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderCompetitor(competitor.slug, origin),
+    });
+  }
+
+  items.push({
+    canonicalPath: "/changelog",
+    markdownPath: "/md/changelog",
+    title: "AgentClash Changelog",
+    description: "Product updates, improvements, fixes, and security changes.",
+    kind: "changelog",
+    lastModified: getChangelogLatestModified(),
+    indexable: true,
+    includeIn: { ...DEFAULT_INCLUDE },
+    sitemapPriority: 0.75,
+    changeFrequency: "weekly",
+    renderMarkdown: (origin = PUBLIC_ORIGIN) => renderChangelogMarkdown(origin),
+  });
+
+  for (const period of getChangelogPeriods()) {
+    const canonicalPath = getChangelogPeriodHref(period.id);
+    items.push({
+      canonicalPath,
+      markdownPath: markdownPathFor(canonicalPath),
+      title: period.headline,
+      description: period.summary,
+      kind: "changelog",
+      lastModified: period.endDate,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: 0.65,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderChangelogPeriod(period.id, origin),
+    });
+  }
+
+  for (const post of getAllPosts()) {
+    const canonicalPath = `/blog/${post.slug}`;
+    items.push({
+      canonicalPath,
+      markdownPath: markdownPathFor(canonicalPath),
+      title: post.title,
+      description: post.description,
+      kind: "blog",
+      lastModified: post.date,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: 0.7,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => {
+        const fullPost = getPostBySlug(post.slug);
+        return fullPost ? renderBlogMarkdown(fullPost, origin) : "";
+      },
+    });
+  }
+
+  for (const slug of getAllDocSlugs()) {
+    const doc = getDocBySlug(slug);
+    if (!doc) continue;
+    items.push({
+      canonicalPath: doc.href,
+      markdownPath: markdownPathFor(doc.href),
+      title: doc.title,
+      description: doc.description,
+      kind: "docs",
+      lastModified: doc.dateModified ?? doc.datePublished ?? STATIC_LAST_MODIFIED,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: doc.href === "/docs" ? 0.85 : 0.75,
+      changeFrequency: "weekly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderDocMarkdown(doc, origin),
+    });
+  }
+
+  for (const report of getAllReports()) {
+    const canonicalPath = `/benchmarks/${report.slug}`;
+    const indexable = !report.sample;
+    items.push({
+      canonicalPath,
+      markdownPath: markdownPathFor(canonicalPath),
+      title: report.title,
+      description: report.description,
+      kind: "benchmark",
+      lastModified: report.date,
+      indexable,
+      includeIn: {
+        sitemap: indexable,
+        llms: indexable,
+        llmsFull: indexable,
+        search: indexable,
+        indexNow: indexable,
+      },
+      sitemapPriority: 0.75,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderBenchmark(report.slug, origin),
+    });
+  }
+
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.canonicalPath)) {
+      throw new Error(`Duplicate public content path: ${item.canonicalPath}`);
+    }
+    seen.add(item.canonicalPath);
+  }
+  return items;
+}
+
+let staticRegistry: PublicContentDescriptor[] | undefined;
+
+export function getAllPublicContent(): PublicContentDescriptor[] {
+  staticRegistry ??= buildStaticRegistry();
+  return [...staticRegistry];
+}
+
+export function normalizePublicPath(input: string): string | null {
+  if (!input.startsWith("/") || input.includes("?") || input.includes("#")) return null;
+  if (input.includes("\\") || input.includes("//")) return null;
+  if (/%2f|%5c/i.test(input)) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(input);
+  } catch {
+    return null;
+  }
+  if (decoded.split("/").some((part) => part === ".." || part === ".")) return null;
+  const normalized = decoded.length > 1 ? decoded.replace(/\/+$/, "") : decoded;
+  if (
+    PRIVATE_PREFIXES.some(
+      (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+    )
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+export function resolvePublicContent(pathname: string): PublicContentDescriptor | null {
+  const normalized = normalizePublicPath(pathname);
+  if (!normalized) return null;
+  return getAllPublicContent().find((item) => item.canonicalPath === normalized) ?? null;
+}
+
+export function canonicalPathFromMarkdownSegments(segments: string[] = []): string | null {
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) return null;
+  return normalizePublicPath(segments.length === 0 ? "/" : `/${segments.join("/")}`);
+}
+
+function stripMarkdown(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[`*_>#|[\]()~-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function getPublicSearchIndex() {
+  return getAllPublicContent()
+    .filter((item) => item.indexable && item.includeIn.search)
+    .map((item) => ({
+      title: item.title,
+      description: item.description,
+      href: item.canonicalPath,
+      searchText: stripMarkdown(
+        `${item.title} ${item.description} ${item.renderMarkdown(PUBLIC_ORIGIN).slice(0, 1400)}`,
+      ).toLowerCase(),
+    }));
+}
+
+const KIND_LABELS: Record<PublicContentKind, string> = {
+  marketing: "Product and company",
+  docs: "Documentation",
+  blog: "Blog",
+  changelog: "Changelog",
+  benchmark: "Benchmarks",
+  comparison: "Comparisons",
+  seo: "Guides and reference pages",
+  interactive: "Interactive tools",
+  publication: "Publications",
+};
+
+export function buildPublicLlmsIndex(origin = PUBLIC_ORIGIN): string {
+  const items = getAllPublicContent().filter((item) => item.indexable && item.includeIn.llms);
+  const lines = [
+    "# AgentClash",
+    "",
+    "> AgentClash evaluates AI agents on repeatable real tasks, captures replay evidence, and turns failures into regression gates.",
+    "",
+    "Use the exact Markdown URLs below instead of guessing routes. Fetch /llms-full.txt for the bundled static corpus.",
+    "",
+    "## Core entrypoints",
+    "",
+    `- [Homepage](${origin}/md)`,
+    `- [Documentation](${origin}/md/docs)`,
+    `- [Quickstart](${origin}/md/docs/getting-started/quickstart)`,
+    `- [Pricing](${origin}/md/pricing)`,
+    `- [Try AgentClash](${origin}/md/try)`,
+    `- [Publications](${origin}/md/publications)`,
+    `- [Full static bundle](${origin}/llms-full.txt)`,
+    "",
+    "## Machine contracts",
+    "",
+    `- [OpenAPI](${origin}/openapi.yaml)`,
+    `- [CLI command schema](${origin}/cli-schema.json)`,
+    `- [Prompt eval schema](${origin}/schemas/prompt-eval.schema.json)`,
+    `- [Prompt eval result schema](${origin}/schemas/prompt-eval-result.schema.json)`,
+    "",
+  ];
+
+  for (const kind of Object.keys(KIND_LABELS) as PublicContentKind[]) {
+    const group = items.filter((item) => item.kind === kind);
+    if (group.length === 0 || kind === "publication") continue;
+    lines.push(`## ${KIND_LABELS[kind]}`, "");
+    for (const item of group) {
+      lines.push(`- [${item.title}](${origin}${item.markdownPath}) - ${item.description}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function buildPublicLlmsFull(origin = PUBLIC_ORIGIN): string {
+  const items = getAllPublicContent().filter(
+    (item) => item.indexable && item.includeIn.llmsFull && item.kind !== "publication",
+  );
+  const lines = [
+    "# AgentClash Public Content Bundle",
+    "",
+    `Canonical site: ${origin}`,
+    `Machine-readable index: ${origin}/llms.txt`,
+    "",
+    "This bundle contains static public AgentClash content. User-generated publications are intentionally excluded; use the publications catalog for explicitly published artifacts.",
+  ];
+  for (const item of items) {
+    const rendered = item.renderMarkdown(origin).trim();
+    if (rendered) lines.push("", "---", "", rendered);
+  }
+  return lines.join("\n").trim();
+}

--- a/web/src/lib/public-content.ts
+++ b/web/src/lib/public-content.ts
@@ -27,6 +27,8 @@ import {
 } from "@/lib/changelog";
 import { PRICING_TIERS } from "@/lib/pricing-data";
 import { SEO_PAGE_REGISTRY, type SeoPageConfig } from "@/lib/seo-pages";
+import { getBundledTryCliDemos } from "@/lib/try-cli/catalog.server";
+import type { DemoMeta } from "@/lib/try-cli/types";
 
 export const PUBLIC_ORIGIN = DOCS_ORIGIN;
 
@@ -474,6 +476,41 @@ function renderPricing(origin: string): string {
   return lines.join("\n").trim();
 }
 
+function renderTryCliDemo(demo: DemoMeta, origin: string): string {
+  const canonicalPath = `/try/${demo.slug}`;
+  const lines = [
+    `# Try ${demo.name} in a browser sandbox`,
+    "",
+    demo.tagline ?? `Run ${demo.name} without installing it locally.`,
+    "",
+    `Source: ${origin}${canonicalPath}`,
+    `Markdown export: ${origin}${markdownPathFor(canonicalPath)}`,
+    `Session limit: ${demo.sessionMinutes} minutes`,
+    "",
+    "A page visit does not create a sandbox. Starting a disposable session requires an explicit action on the HTML page.",
+    "",
+    "## Suggested commands",
+    "",
+    ...demo.commands.map((command) => `- **${command.label}**: \`${command.run}\``),
+  ];
+  if (demo.auth) {
+    lines.push(
+      "",
+      "## Authentication",
+      "",
+      demo.auth.summary,
+      "",
+      ...demo.auth.steps.map((step, index) => `${index + 1}. ${step}`),
+    );
+  }
+  if (demo.docs || demo.github) {
+    lines.push("", "## Links", "");
+    if (demo.docs) lines.push(`- [Documentation](${demo.docs})`);
+    if (demo.github) lines.push(`- [Source repository](${demo.github})`);
+  }
+  return lines.join("\n").trim();
+}
+
 function renderSeoPage(page: SeoPageConfig, origin: string): string {
   const lines = [
     `# ${page.h1}`,
@@ -655,6 +692,23 @@ function descriptorFromStatic(page: StaticPage): PublicContentDescriptor {
 
 function buildStaticRegistry(): PublicContentDescriptor[] {
   const items: PublicContentDescriptor[] = STATIC_PAGES.map(descriptorFromStatic);
+
+  for (const demo of getBundledTryCliDemos()) {
+    const canonicalPath = `/try/${demo.slug}`;
+    items.push({
+      canonicalPath,
+      markdownPath: markdownPathFor(canonicalPath),
+      title: `Try ${demo.name} in browser`,
+      description: demo.tagline ?? `Run ${demo.name} in a disposable browser sandbox.`,
+      kind: "interactive",
+      lastModified: STATIC_LAST_MODIFIED,
+      indexable: true,
+      includeIn: { ...DEFAULT_INCLUDE },
+      sitemapPriority: 0.72,
+      changeFrequency: "monthly",
+      renderMarkdown: (origin = PUBLIC_ORIGIN) => renderTryCliDemo(demo, origin),
+    });
+  }
 
   items.push({
     canonicalPath: "/pricing",

--- a/web/src/lib/public-content.ts
+++ b/web/src/lib/public-content.ts
@@ -29,6 +29,7 @@ import { PRICING_TIERS } from "@/lib/pricing-data";
 import { SEO_PAGE_REGISTRY, type SeoPageConfig } from "@/lib/seo-pages";
 import { getBundledTryCliDemos } from "@/lib/try-cli/catalog.server";
 import type { DemoMeta } from "@/lib/try-cli/types";
+import { PUBLIC_MACHINE_CONTRACTS } from "@/lib/public-contracts";
 
 export const PUBLIC_ORIGIN = DOCS_ORIGIN;
 
@@ -995,14 +996,9 @@ export function buildPublicLlmsIndex(origin = PUBLIC_ORIGIN): string {
     "",
     "## Machine contracts",
     "",
-    `- [OpenAPI](${origin}/openapi.yaml)`,
-    `- [CLI command schema](${origin}/cli-schema.json)`,
-    `- [Prompt eval schema](${origin}/schemas/prompt-eval.schema.json)`,
-    `- [Prompt eval result schema](${origin}/schemas/prompt-eval-result.schema.json)`,
-    `- [Voice artifact manifest schema](${origin}/schemas/voice-artifact-manifest.schema.json)`,
-    `- [Voice live continuity schema](${origin}/schemas/voice-live-continuity-report.schema.json)`,
-    `- [Voice source separation schema](${origin}/schemas/voice-source-separation-report.schema.json)`,
-    `- [Voice video sync schema](${origin}/schemas/voice-video-sync-report.schema.json)`,
+    ...PUBLIC_MACHINE_CONTRACTS.map(
+      (contract) => `- [${contract.title}](${origin}${contract.path})`,
+    ),
     "",
   ];
 

--- a/web/src/lib/public-content.ts
+++ b/web/src/lib/public-content.ts
@@ -51,7 +51,9 @@ export type PublicContentInclusion = {
   indexNow: boolean;
 };
 
-export type PublicContentDescriptor = {
+// Node-only adapter contract. This module imports filesystem-backed MDX and
+// content readers and must never be imported by a Client Component.
+export type PublicContentAdapter = {
   canonicalPath: string;
   markdownPath: string;
   title: string;
@@ -64,6 +66,8 @@ export type PublicContentDescriptor = {
   changeFrequency?: "daily" | "weekly" | "monthly" | "yearly";
   renderMarkdown: (origin?: string) => string;
 };
+
+export type PublicContentDescriptor = PublicContentAdapter;
 
 type StaticSection = {
   heading: string;
@@ -352,6 +356,27 @@ const STATIC_PAGES: StaticPage[] = [
         links: getAllReports()
           .filter((report) => !report.sample)
           .map((report) => ({ label: report.title, href: `/benchmarks/${report.slug}` })),
+      },
+    ],
+  },
+  {
+    path: "/publications",
+    title: "Published Agent Evaluation Artifacts",
+    description:
+      "Browse explicitly published, redacted challenge packs, scorecards, replays, and agent tryouts.",
+    kind: "publication",
+    priority: 0.72,
+    changeFrequency: "weekly",
+    lastModified: STATIC_LAST_MODIFIED,
+    sections: [
+      {
+        heading: "Publication policy",
+        bullets: [
+          "Only artifacts whose owners explicitly enable search indexing appear in the catalog.",
+          "Every artifact is rendered through a type-specific, redacted public serializer.",
+          "Capability-token shares remain private, noindex, and absent from this catalog.",
+          "Revoked, expired, unsupported, or indexing-disabled artifacts return 404.",
+        ],
       },
     ],
   },
@@ -974,6 +999,10 @@ export function buildPublicLlmsIndex(origin = PUBLIC_ORIGIN): string {
     `- [CLI command schema](${origin}/cli-schema.json)`,
     `- [Prompt eval schema](${origin}/schemas/prompt-eval.schema.json)`,
     `- [Prompt eval result schema](${origin}/schemas/prompt-eval-result.schema.json)`,
+    `- [Voice artifact manifest schema](${origin}/schemas/voice-artifact-manifest.schema.json)`,
+    `- [Voice live continuity schema](${origin}/schemas/voice-live-continuity-report.schema.json)`,
+    `- [Voice source separation schema](${origin}/schemas/voice-source-separation-report.schema.json)`,
+    `- [Voice video sync schema](${origin}/schemas/voice-video-sync-report.schema.json)`,
     "",
   ];
 
@@ -999,6 +1028,7 @@ export function buildPublicLlmsFull(origin = PUBLIC_ORIGIN): string {
     "",
     `Canonical site: ${origin}`,
     `Machine-readable index: ${origin}/llms.txt`,
+    `Publications catalog: ${origin}/md/publications`,
     "",
     "This bundle contains static public AgentClash content. User-generated publications are intentionally excluded; use the publications catalog for explicitly published artifacts.",
   ];

--- a/web/src/lib/public-contracts.ts
+++ b/web/src/lib/public-contracts.ts
@@ -1,0 +1,55 @@
+export type PublicMachineContract = {
+  path: string;
+  title: string;
+  contentType: string;
+};
+
+// Keep discovery links and route allowlists on one small, edge-safe registry.
+// The route handlers still validate and serialize their own sources, but a
+// contract cannot silently disappear from llms.txt when a filename changes.
+export const PUBLIC_MACHINE_CONTRACTS = [
+  {
+    path: "/openapi.yaml",
+    title: "OpenAPI",
+    contentType: "application/yaml",
+  },
+  {
+    path: "/cli-schema.json",
+    title: "CLI command schema",
+    contentType: "application/json",
+  },
+  {
+    path: "/schemas/prompt-eval.schema.json",
+    title: "Prompt eval schema",
+    contentType: "application/schema+json",
+  },
+  {
+    path: "/schemas/prompt-eval-result.schema.json",
+    title: "Prompt eval result schema",
+    contentType: "application/schema+json",
+  },
+  {
+    path: "/schemas/voice-artifact-manifest.schema.json",
+    title: "Voice artifact manifest schema",
+    contentType: "application/schema+json",
+  },
+  {
+    path: "/schemas/voice-live-continuity-report.schema.json",
+    title: "Voice live continuity schema",
+    contentType: "application/schema+json",
+  },
+  {
+    path: "/schemas/voice-source-separation-report.schema.json",
+    title: "Voice source separation schema",
+    contentType: "application/schema+json",
+  },
+  {
+    path: "/schemas/voice-video-sync-report.schema.json",
+    title: "Voice video sync schema",
+    contentType: "application/schema+json",
+  },
+] as const satisfies readonly PublicMachineContract[];
+
+export const PUBLIC_SCHEMA_FILENAMES = PUBLIC_MACHINE_CONTRACTS.filter(
+  (contract) => contract.path.startsWith("/schemas/"),
+).map((contract) => contract.path.slice("/schemas/".length));

--- a/web/src/lib/public-http.test.ts
+++ b/web/src/lib/public-http.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { AI_CRAWLERS } from "@/app/robots";
 import {
   agentRequestLog,
   classifyAgentUserAgent,
+  classifyRouteKind,
   isMarkdownNegotiablePath,
   parseRepresentationPreference,
   prefersMarkdown,
   representationLinkHeader,
+  requestedRepresentation,
+  shouldLogAgentRequest,
   shouldNegotiateMarkdown,
+  withoutInternalNegotiationHeaders,
 } from "./public-http";
 
 describe("public representation negotiation", () => {
@@ -78,6 +83,19 @@ describe("public representation negotiation", () => {
       '<https://www.agentclash.dev/pricing>; rel="canonical", <https://www.agentclash.dev/md/pricing>; rel="alternate"; type="text/markdown"',
     );
   });
+
+  it("strips client-spoofable negotiation-only headers", () => {
+    const sanitized = withoutInternalNegotiationHeaders(
+      new Headers({
+        Accept: "text/markdown",
+        "X-AgentClash-Negotiated-Markdown": "1",
+        "X-AgentClash-Canonical-Path": "/pricing",
+      }),
+    );
+    expect(sanitized.get("accept")).toBe("text/markdown");
+    expect(sanitized.has("x-agentclash-negotiated-markdown")).toBe(false);
+    expect(sanitized.has("x-agentclash-canonical-path")).toBe(false);
+  });
 });
 
 describe("agent request logging", () => {
@@ -89,6 +107,12 @@ describe("agent request logging", () => {
       "Claude-SearchBot",
     );
     expect(classifyAgentUserAgent("Mozilla/5.0")).toBeNull();
+  });
+
+  it("classifies every crawler explicitly welcomed by robots", () => {
+    for (const crawler of AI_CRAWLERS) {
+      expect(classifyAgentUserAgent(`${crawler}/1.0`), crawler).toBe(crawler);
+    }
   });
 
   it("builds an allowlisted payload without URL or header secrets", () => {
@@ -107,11 +131,54 @@ describe("agent request logging", () => {
       method: "GET",
       agent_family: "GPTBot",
       accept_class: "markdown",
+      requested_representation: "markdown",
       served_representation: "markdown",
+      route_kind: "public_content",
       request_id: "iad1::abc",
     });
     expect(JSON.stringify(log)).not.toContain("authorization");
     expect(JSON.stringify(log)).not.toContain("cookie");
     expect(JSON.stringify(log)).not.toContain("?");
+  });
+
+  it("redacts capability tokens from logged share paths", () => {
+    const log = agentRequestLog({
+      pathname: "/share/secret-capability-token",
+      method: "GET",
+      accept: "text/html",
+      userAgent: "GPTBot",
+      requestId: null,
+      servedRepresentation: "html",
+    });
+    expect(log.path).toBe("/share/{token}");
+    expect(JSON.stringify(log)).not.toContain("secret-capability-token");
+  });
+
+  it("separates publication pages from the publication sitemap contract", () => {
+    expect(classifyRouteKind("/publications/123")).toBe("publication");
+    expect(classifyRouteKind("/publications/sitemap.xml")).toBe("contract");
+    expect(requestedRepresentation("/md/pricing", "*/*")).toBe("markdown");
+    expect(requestedRepresentation("/docs-md", "*/*")).toBe("markdown");
+    expect(requestedRepresentation("/openapi.yaml", "*/*")).toBe("machine");
+  });
+
+  it("targets guessed paths from known agents for 404 analysis", () => {
+    expect(
+      shouldLogAgentRequest({
+        pathname: "/guessed-agent-docs",
+        accept: "*/*",
+        userAgent: "PerplexityBot/1.0",
+      }),
+    ).toBe(true);
+  });
+
+  it("logs explicit Markdown ranges even when their quality disables negotiation", () => {
+    expect(
+      shouldLogAgentRequest({
+        pathname: "/pricing",
+        accept: "text/html, text/markdown;q=0",
+        userAgent: "Mozilla/5.0",
+      }),
+    ).toBe(true);
   });
 });

--- a/web/src/lib/public-http.test.ts
+++ b/web/src/lib/public-http.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentRequestLog,
+  classifyAgentUserAgent,
+  isMarkdownNegotiablePath,
+  parseRepresentationPreference,
+  prefersMarkdown,
+  representationLinkHeader,
+  shouldNegotiateMarkdown,
+} from "./public-http";
+
+describe("public representation negotiation", () => {
+  it.each([
+    [null, false],
+    ["*/*", false],
+    ["text/*", false],
+    ["text/html", false],
+    ["text/markdown", true],
+    ["text/markdown;q=0", false],
+    ["text/html, text/markdown", false],
+    ["text/html;q=0.4, text/markdown;q=0.8", true],
+    ["text/html;q=0.8, text/markdown;q=0.4", false],
+    ["text/markdown;q=bogus", false],
+    ["application/json, text/markdown;q=0.6", true],
+  ])("handles Accept %s", (accept, expected) => {
+    expect(prefersMarkdown(accept)).toBe(expected);
+  });
+
+  it("keeps the highest exact quality for duplicate ranges", () => {
+    expect(
+      parseRepresentationPreference(
+        "text/markdown;q=0.2, text/markdown;q=0.9, text/html;q=0.5",
+      ),
+    ).toEqual({ markdown: 0.9, html: 0.5 });
+  });
+
+  it("negotiates public GET and HEAD only", () => {
+    const base = {
+      enabled: true,
+      pathname: "/pricing",
+      accept: "text/markdown",
+    };
+    expect(shouldNegotiateMarkdown({ ...base, method: "GET" })).toBe(true);
+    expect(shouldNegotiateMarkdown({ ...base, method: "HEAD" })).toBe(true);
+    expect(shouldNegotiateMarkdown({ ...base, method: "POST" })).toBe(false);
+    expect(shouldNegotiateMarkdown({ ...base, enabled: false, method: "GET" })).toBe(false);
+  });
+
+  it.each([
+    "/workspaces/ws_123",
+    "/orgs/example",
+    "/auth/login",
+    "/api/indexnow",
+    "/ingest/capture",
+    "/share/capability-token",
+    "/md/pricing",
+    "/docs-md/getting-started/quickstart",
+    "/openapi.yaml",
+  ])("excludes %s", (pathname) => {
+    expect(isMarkdownNegotiablePath(pathname)).toBe(false);
+  });
+
+  it.each([
+    "/",
+    "/pricing",
+    "/docs/getting-started/quickstart",
+    "/blog/example",
+    "/compare/agentclash-vs-langsmith",
+    "/publications/pub_123",
+  ])("allows %s", (pathname) => {
+    expect(isMarkdownNegotiablePath(pathname)).toBe(true);
+  });
+
+  it("advertises canonical and Markdown URLs", () => {
+    expect(
+      representationLinkHeader("/pricing", "https://www.agentclash.dev"),
+    ).toBe(
+      '<https://www.agentclash.dev/pricing>; rel="canonical", <https://www.agentclash.dev/md/pricing>; rel="alternate"; type="text/markdown"',
+    );
+  });
+});
+
+describe("agent request logging", () => {
+  it("classifies named AI crawler families", () => {
+    expect(classifyAgentUserAgent("Mozilla/5.0 compatible; GPTBot/1.2")).toBe(
+      "GPTBot",
+    );
+    expect(classifyAgentUserAgent("Claude-SearchBot/1.0")).toBe(
+      "Claude-SearchBot",
+    );
+    expect(classifyAgentUserAgent("Mozilla/5.0")).toBeNull();
+  });
+
+  it("builds an allowlisted payload without URL or header secrets", () => {
+    const log = agentRequestLog({
+      pathname: "/docs",
+      method: "GET",
+      accept: "text/markdown",
+      userAgent: "GPTBot",
+      requestId: "iad1::abc",
+      servedRepresentation: "markdown",
+    });
+    expect(log).toEqual({
+      level: "info",
+      event: "agent_readable_request",
+      path: "/docs",
+      method: "GET",
+      agent_family: "GPTBot",
+      accept_class: "markdown",
+      served_representation: "markdown",
+      request_id: "iad1::abc",
+    });
+    expect(JSON.stringify(log)).not.toContain("authorization");
+    expect(JSON.stringify(log)).not.toContain("cookie");
+    expect(JSON.stringify(log)).not.toContain("?");
+  });
+});

--- a/web/src/lib/public-http.ts
+++ b/web/src/lib/public-http.ts
@@ -1,0 +1,221 @@
+export const NEGOTIATED_MARKDOWN_HEADER = "x-agentclash-negotiated-markdown";
+export const CANONICAL_PATH_HEADER = "x-agentclash-canonical-path";
+
+const PUBLIC_EXACT_PATHS = new Set([
+  "/",
+  "/agent-evals",
+  "/agent-evaluation-framework",
+  "/agent-opportunity",
+  "/agent-reliability-benchmark",
+  "/agent-trajectory-evaluation",
+  "/agentic-self-instruct",
+  "/ai-agent-benchmark",
+  "/ai-agent-testing",
+  "/benchmarks",
+  "/blog",
+  "/changelog",
+  "/ci-cd-agent-evaluation",
+  "/compare",
+  "/docs",
+  "/enterprise",
+  "/features",
+  "/glossary",
+  "/industries",
+  "/llm-agent-evaluation",
+  "/open-source-ai-agent-evaluation",
+  "/platform/agent-evaluation",
+  "/platform/agent-regression-testing",
+  "/platform/datasmith",
+  "/pricing",
+  "/publications",
+  "/resources/eval-checklist",
+  "/services",
+  "/synthetic-data-generation-agents",
+  "/team",
+  "/trace-to-dataset",
+  "/try",
+  "/tryouts",
+  "/use-cases",
+  "/why",
+]);
+
+const PUBLIC_ROUTE_PREFIXES = [
+  "/benchmarks/",
+  "/blog/",
+  "/changelog/",
+  "/compare/",
+  "/docs/",
+  "/features/",
+  "/glossary/",
+  "/industries/",
+  "/publications/",
+  "/try/",
+  "/use-cases/",
+] as const;
+
+const PRIVATE_PREFIXES = [
+  "/_next",
+  "/api",
+  "/auth",
+  "/dashboard",
+  "/github",
+  "/ingest",
+  "/invites",
+  "/onboard",
+  "/orgs",
+  "/share",
+  "/workspaces",
+] as const;
+
+const MACHINE_PATH_PREFIXES = [
+  "/cli-schema.json",
+  "/docs-md",
+  "/llms-full.txt",
+  "/llms.txt",
+  "/md",
+  "/openapi.yaml",
+  "/schemas",
+] as const;
+
+const AI_USER_AGENTS = [
+  ["gptbot", "GPTBot"],
+  ["oai-searchbot", "OAI-SearchBot"],
+  ["chatgpt-user", "ChatGPT-User"],
+  ["claudebot", "ClaudeBot"],
+  ["claude-user", "Claude-User"],
+  ["claude-searchbot", "Claude-SearchBot"],
+  ["perplexitybot", "PerplexityBot"],
+  ["perplexity-user", "Perplexity-User"],
+  ["google-extended", "Google-Extended"],
+  ["ccbot", "CCBot"],
+  ["bytespider", "Bytespider"],
+  ["meta-externalagent", "meta-externalagent"],
+  ["applebot-extended", "Applebot-Extended"],
+  ["amazonbot", "Amazonbot"],
+] as const;
+
+type MediaPreference = {
+  markdown: number | null;
+  html: number | null;
+};
+
+function parseQuality(parameters: string[]): number {
+  const qParameter = parameters.find((parameter) => parameter.trim().toLowerCase().startsWith("q="));
+  if (!qParameter) return 1;
+  const parsed = Number(qParameter.split("=", 2)[1]);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+}
+
+export function parseRepresentationPreference(accept: string | null): MediaPreference {
+  const preference: MediaPreference = { markdown: null, html: null };
+  if (!accept) return preference;
+
+  for (const range of accept.split(",")) {
+    const [rawType, ...parameters] = range.split(";");
+    const mediaType = rawType.trim().toLowerCase();
+    if (mediaType !== "text/markdown" && mediaType !== "text/html") continue;
+    const quality = parseQuality(parameters);
+    if (mediaType === "text/markdown") {
+      preference.markdown = Math.max(preference.markdown ?? 0, quality);
+    } else {
+      preference.html = Math.max(preference.html ?? 0, quality);
+    }
+  }
+  return preference;
+}
+
+export function prefersMarkdown(accept: string | null): boolean {
+  const { markdown, html } = parseRepresentationPreference(accept);
+  if (markdown === null || markdown <= 0) return false;
+  return html === null || markdown > html;
+}
+
+function matchesPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+export function isPrivateOrMachinePath(pathname: string): boolean {
+  return (
+    PRIVATE_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix)) ||
+    MACHINE_PATH_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix))
+  );
+}
+
+export function isMarkdownNegotiablePath(pathname: string): boolean {
+  if (isPrivateOrMachinePath(pathname)) return false;
+  return (
+    PUBLIC_EXACT_PATHS.has(pathname) ||
+    PUBLIC_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  );
+}
+
+export function shouldNegotiateMarkdown(args: {
+  enabled: boolean;
+  method: string;
+  pathname: string;
+  accept: string | null;
+}): boolean {
+  return (
+    args.enabled &&
+    (args.method === "GET" || args.method === "HEAD") &&
+    isMarkdownNegotiablePath(args.pathname) &&
+    prefersMarkdown(args.accept)
+  );
+}
+
+export function markdownPathForCanonical(pathname: string): string {
+  return pathname === "/" ? "/md" : `/md${pathname}`;
+}
+
+export function representationLinkHeader(pathname: string, origin: string): string {
+  const canonical = pathname === "/" ? origin : `${origin}${pathname}`;
+  const markdown = `${origin}${markdownPathForCanonical(pathname)}`;
+  return `<${canonical}>; rel="canonical", <${markdown}>; rel="alternate"; type="text/markdown"`;
+}
+
+export function classifyAgentUserAgent(userAgent: string | null): string | null {
+  if (!userAgent) return null;
+  const normalized = userAgent.toLowerCase();
+  return AI_USER_AGENTS.find(([needle]) => normalized.includes(needle))?.[1] ?? null;
+}
+
+export function classifyAccept(accept: string | null): "markdown" | "html" | "generic" | "missing" {
+  if (!accept) return "missing";
+  if (accept.toLowerCase().includes("text/markdown")) return "markdown";
+  if (accept.toLowerCase().includes("text/html")) return "html";
+  return "generic";
+}
+
+export function shouldLogAgentRequest(args: {
+  pathname: string;
+  accept: string | null;
+  userAgent: string | null;
+}): boolean {
+  return Boolean(
+    classifyAgentUserAgent(args.userAgent) ||
+      prefersMarkdown(args.accept) ||
+      MACHINE_PATH_PREFIXES.some((prefix) => matchesPrefix(args.pathname, prefix)) ||
+      matchesPrefix(args.pathname, "/publications"),
+  );
+}
+
+export function agentRequestLog(args: {
+  pathname: string;
+  method: string;
+  accept: string | null;
+  userAgent: string | null;
+  requestId: string | null;
+  servedRepresentation: "html" | "markdown" | "machine";
+}) {
+  return {
+    level: "info",
+    event: "agent_readable_request",
+    path: args.pathname,
+    method: args.method,
+    agent_family: classifyAgentUserAgent(args.userAgent) ?? "unclassified",
+    accept_class: classifyAccept(args.accept),
+    served_representation: args.servedRepresentation,
+    request_id: args.requestId,
+  } as const;
+}

--- a/web/src/lib/public-http.ts
+++ b/web/src/lib/public-http.ts
@@ -1,6 +1,13 @@
 export const NEGOTIATED_MARKDOWN_HEADER = "x-agentclash-negotiated-markdown";
 export const CANONICAL_PATH_HEADER = "x-agentclash-canonical-path";
 
+export function withoutInternalNegotiationHeaders(headers: Headers): Headers {
+  const sanitized = new Headers(headers);
+  sanitized.delete(NEGOTIATED_MARKDOWN_HEADER);
+  sanitized.delete(CANONICAL_PATH_HEADER);
+  return sanitized;
+}
+
 const PUBLIC_EXACT_PATHS = new Set([
   "/",
   "/agent-evals",
@@ -74,6 +81,7 @@ const MACHINE_PATH_PREFIXES = [
   "/llms.txt",
   "/md",
   "/openapi.yaml",
+  "/publications/sitemap.xml",
   "/schemas",
 ] as const;
 
@@ -187,6 +195,35 @@ export function classifyAccept(accept: string | null): "markdown" | "html" | "ge
   return "generic";
 }
 
+export function normalizeLoggedPath(pathname: string): string {
+  if (pathname.startsWith("/share/")) return "/share/{token}";
+  return pathname.split("?", 1)[0] || "/";
+}
+
+export function classifyRouteKind(pathname: string): "publication" | "markdown" | "contract" | "public_content" {
+  if (
+    pathname === "/md" ||
+    pathname.startsWith("/md/") ||
+    pathname === "/docs-md" ||
+    pathname.startsWith("/docs-md/")
+  ) {
+    return "markdown";
+  }
+  if (MACHINE_PATH_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix))) return "contract";
+  if (pathname === "/publications" || pathname.startsWith("/publications/")) return "publication";
+  return "public_content";
+}
+
+export function requestedRepresentation(
+  pathname: string,
+  accept: string | null,
+): "html" | "markdown" | "machine" {
+  const routeKind = classifyRouteKind(pathname);
+  if (routeKind === "markdown") return "markdown";
+  if (routeKind === "contract") return "machine";
+  return prefersMarkdown(accept) ? "markdown" : "html";
+}
+
 export function shouldLogAgentRequest(args: {
   pathname: string;
   accept: string | null;
@@ -194,7 +231,7 @@ export function shouldLogAgentRequest(args: {
 }): boolean {
   return Boolean(
     classifyAgentUserAgent(args.userAgent) ||
-      prefersMarkdown(args.accept) ||
+      classifyAccept(args.accept) === "markdown" ||
       MACHINE_PATH_PREFIXES.some((prefix) => matchesPrefix(args.pathname, prefix)) ||
       matchesPrefix(args.pathname, "/publications"),
   );
@@ -211,11 +248,13 @@ export function agentRequestLog(args: {
   return {
     level: "info",
     event: "agent_readable_request",
-    path: args.pathname,
+    path: normalizeLoggedPath(args.pathname),
     method: args.method,
     agent_family: classifyAgentUserAgent(args.userAgent) ?? "unclassified",
     accept_class: classifyAccept(args.accept),
+    requested_representation: requestedRepresentation(args.pathname, args.accept),
     served_representation: args.servedRepresentation,
+    route_kind: classifyRouteKind(args.pathname),
     request_id: args.requestId,
   } as const;
 }

--- a/web/src/lib/public-page-data.ts
+++ b/web/src/lib/public-page-data.ts
@@ -1,0 +1,130 @@
+import { createApiClient } from "@/lib/api/client";
+import {
+  getPublicAgentTryout,
+  getPublicAgentTryoutEvents,
+  listAgentTryoutTemplates,
+} from "@/lib/api/agent-tryouts";
+import { getTryCliApiBase } from "@/lib/try-cli/config";
+import type {
+  AgentTryout,
+  AgentTryoutTemplate,
+  TryoutTimelineEvent,
+} from "@/lib/api/types";
+import type { DemoMeta } from "@/lib/try-cli/types";
+import {
+  getBundledTryCliDemo,
+  getBundledTryCliDemos,
+} from "@/lib/try-cli/catalog.server";
+
+export type PublicTryoutTool = {
+  slug: string;
+  name: string;
+  category: string;
+  blurb?: string;
+};
+
+export type PublicTryoutPageData = {
+  templates: AgentTryoutTemplate[];
+  tools: PublicTryoutTool[];
+  tryout: AgentTryout | null;
+  events: TryoutTimelineEvent[];
+};
+
+function isDemoMeta(value: unknown): value is DemoMeta {
+  if (!value || typeof value !== "object") return false;
+  const demo = value as Partial<DemoMeta>;
+  return (
+    typeof demo.slug === "string" &&
+    typeof demo.name === "string" &&
+    typeof demo.sessionMinutes === "number" &&
+    Array.isArray(demo.commands)
+  );
+}
+
+async function fetchTryCliJson(path: string): Promise<unknown> {
+  const base = getTryCliApiBase().replace(/\/$/, "");
+  const response = await fetch(`${base}${path}`, {
+    headers: { Accept: "application/json" },
+    next: { revalidate: 3600 },
+  });
+  if (!response.ok) return null;
+  return response.json();
+}
+
+export async function getPublicTryCliDemos(): Promise<DemoMeta[]> {
+  const bundled = getBundledTryCliDemos();
+  if (bundled.length > 0) return bundled;
+  try {
+    const payload = await fetchTryCliJson("/demos");
+    return Array.isArray(payload) ? payload.filter(isDemoMeta) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function getPublicTryCliDemo(slug: string): Promise<DemoMeta | null> {
+  if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(slug)) return null;
+  const bundled = getBundledTryCliDemo(slug);
+  if (bundled) return bundled;
+  try {
+    const payload = await fetchTryCliJson(`/demos/${encodeURIComponent(slug)}`);
+    return isDemoMeta(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function shortToolDescription(description?: string): string | undefined {
+  if (!description) return undefined;
+  const first = description.split(/[.\n]/)[0]?.trim();
+  if (!first) return undefined;
+  return first.length > 48 ? `${first.slice(0, 46)}…` : first;
+}
+
+export async function getPublicTryoutPageData(
+  tryoutId?: string,
+): Promise<PublicTryoutPageData> {
+  const api = createApiClient();
+  const [templateResult, toolResult, tryoutResult, eventsResult] = await Promise.allSettled([
+    listAgentTryoutTemplates(api),
+    api.get<{
+      items: Array<{
+        slug: string;
+        name: string;
+        category?: string;
+        description?: string;
+      }>;
+    }>("/v1/tool-library"),
+    tryoutId ? getPublicAgentTryout(api, tryoutId) : Promise.resolve(null),
+    tryoutId
+      ? getPublicAgentTryoutEvents(api, tryoutId, { after: 0, limit: 200 })
+      : Promise.resolve(null),
+  ]);
+
+  const templates =
+    templateResult.status === "fulfilled"
+      ? templateResult.value.items.filter(
+          (template) => template.available && template.anonymous_enabled,
+        )
+      : [];
+  const tools =
+    toolResult.status === "fulfilled"
+      ? (toolResult.value.items ?? []).map((tool) => ({
+          slug: tool.slug,
+          name: tool.name,
+          category: tool.category || "Tools",
+          blurb: shortToolDescription(tool.description),
+        }))
+      : [];
+
+  return {
+    templates,
+    tools,
+    tryout:
+      tryoutResult.status === "fulfilled" ? tryoutResult.value : null,
+    events:
+      eventsResult.status === "fulfilled" && eventsResult.value
+        ? eventsResult.value.events
+        : [],
+  };
+}

--- a/web/src/lib/public-route-coverage.test.ts
+++ b/web/src/lib/public-route-coverage.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_PAGE_ROUTE_COVERAGE,
+  REVIEWED_PUBLIC_PAGE_EXCLUSIONS,
+  publicPageRouteIsCovered,
+} from "./public-route-coverage";
+
+function pageFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) return pageFiles(target);
+    return entry.name === "page.tsx" ? [target] : [];
+  });
+}
+
+function routeForPage(filename: string): string {
+  const app = path.join(process.cwd(), "src", "app");
+  const relative = path.relative(app, path.dirname(filename));
+  const segments = relative
+    .split(path.sep)
+    .filter((segment) => segment && !(segment.startsWith("(") && segment.endsWith(")")));
+  return segments.length === 0 ? "/" : `/${segments.join("/")}`;
+}
+
+describe("public route coverage manifest", () => {
+  it("requires every Next page family to be adapted, private, or explicitly excluded", () => {
+    const routes = pageFiles(path.join(process.cwd(), "src", "app")).map(routeForPage);
+    for (const route of routes) {
+      expect(publicPageRouteIsCovered(route), route).toBe(true);
+    }
+  });
+
+  it("keeps reviewed exclusions separate from public adapters", () => {
+    const adapted = new Set(PUBLIC_PAGE_ROUTE_COVERAGE.map((entry) => entry.route));
+    for (const exclusion of REVIEWED_PUBLIC_PAGE_EXCLUSIONS) {
+      expect(exclusion.reason.length).toBeGreaterThan(20);
+      expect(adapted.has(exclusion.route)).toBe(false);
+    }
+  });
+});

--- a/web/src/lib/public-route-coverage.test.ts
+++ b/web/src/lib/public-route-coverage.test.ts
@@ -39,4 +39,12 @@ describe("public route coverage manifest", () => {
       expect(adapted.has(exclusion.route)).toBe(false);
     }
   });
+
+  it("does not treat lookalike public paths as private route families", () => {
+    expect(publicPageRouteIsCovered("/onboarding")).toBe(false);
+    expect(publicPageRouteIsCovered("/dashboards")).toBe(false);
+    expect(publicPageRouteIsCovered("/authenticating")).toBe(false);
+    expect(publicPageRouteIsCovered("/onboard/settings")).toBe(true);
+    expect(publicPageRouteIsCovered("/workspaces/demo/runs")).toBe(true);
+  });
 });

--- a/web/src/lib/public-route-coverage.ts
+++ b/web/src/lib/public-route-coverage.ts
@@ -67,21 +67,23 @@ export const REVIEWED_PUBLIC_PAGE_EXCLUSIONS = [
 ] as const;
 
 const PRIVATE_PAGE_PREFIXES = [
-  "/auth/",
+  "/auth",
   "/dashboard",
-  "/github/",
-  "/invites/",
+  "/github",
+  "/invites",
   "/onboard",
-  "/orgs/",
-  "/workspaces/",
+  "/orgs",
+  "/workspaces",
 ] as const;
+
+function matchesRouteFamily(route: string, prefix: string): boolean {
+  return route === prefix || route.startsWith(`${prefix}/`);
+}
 
 export function publicPageRouteIsCovered(route: string): boolean {
   return (
     PUBLIC_PAGE_ROUTE_COVERAGE.some((entry) => entry.route === route) ||
     REVIEWED_PUBLIC_PAGE_EXCLUSIONS.some((entry) => entry.route === route) ||
-    PRIVATE_PAGE_PREFIXES.some(
-      (prefix) => route === prefix.replace(/\/$/, "") || route.startsWith(prefix),
-    )
+    PRIVATE_PAGE_PREFIXES.some((prefix) => matchesRouteFamily(route, prefix))
   );
 }

--- a/web/src/lib/public-route-coverage.ts
+++ b/web/src/lib/public-route-coverage.ts
@@ -1,0 +1,87 @@
+export type PublicRouteCoverage = {
+  route: string;
+  adapter: "registry" | "dynamic-publication";
+};
+
+export const PUBLIC_PAGE_ROUTE_COVERAGE: PublicRouteCoverage[] = [
+  { route: "/", adapter: "registry" },
+  { route: "/agent-evals", adapter: "registry" },
+  { route: "/agent-evaluation-framework", adapter: "registry" },
+  { route: "/agent-opportunity", adapter: "registry" },
+  { route: "/agent-reliability-benchmark", adapter: "registry" },
+  { route: "/agent-trajectory-evaluation", adapter: "registry" },
+  { route: "/agentic-self-instruct", adapter: "registry" },
+  { route: "/ai-agent-benchmark", adapter: "registry" },
+  { route: "/ai-agent-testing", adapter: "registry" },
+  { route: "/benchmarks", adapter: "registry" },
+  { route: "/benchmarks/[slug]", adapter: "registry" },
+  { route: "/blog", adapter: "registry" },
+  { route: "/blog/[slug]", adapter: "registry" },
+  { route: "/changelog", adapter: "registry" },
+  { route: "/changelog/[slug]", adapter: "registry" },
+  { route: "/ci-cd-agent-evaluation", adapter: "registry" },
+  { route: "/compare", adapter: "registry" },
+  { route: "/compare/[competitor]", adapter: "registry" },
+  { route: "/docs/[[...slug]]", adapter: "registry" },
+  { route: "/enterprise", adapter: "registry" },
+  { route: "/features", adapter: "registry" },
+  { route: "/features/[slug]", adapter: "registry" },
+  { route: "/glossary", adapter: "registry" },
+  { route: "/glossary/[slug]", adapter: "registry" },
+  { route: "/industries", adapter: "registry" },
+  { route: "/industries/[slug]", adapter: "registry" },
+  { route: "/llm-agent-evaluation", adapter: "registry" },
+  { route: "/open-source-ai-agent-evaluation", adapter: "registry" },
+  { route: "/platform/agent-evaluation", adapter: "registry" },
+  { route: "/platform/agent-regression-testing", adapter: "registry" },
+  { route: "/platform/datasmith", adapter: "registry" },
+  { route: "/pricing", adapter: "registry" },
+  { route: "/publications", adapter: "registry" },
+  { route: "/publications/[id]", adapter: "dynamic-publication" },
+  { route: "/resources/eval-checklist", adapter: "registry" },
+  { route: "/services", adapter: "registry" },
+  { route: "/synthetic-data-generation-agents", adapter: "registry" },
+  { route: "/team", adapter: "registry" },
+  { route: "/trace-to-dataset", adapter: "registry" },
+  { route: "/try", adapter: "registry" },
+  { route: "/try/[slug]", adapter: "registry" },
+  { route: "/tryouts", adapter: "registry" },
+  { route: "/use-cases", adapter: "registry" },
+  { route: "/use-cases/[slug]", adapter: "registry" },
+  { route: "/why", adapter: "registry" },
+];
+
+export const REVIEWED_PUBLIC_PAGE_EXCLUSIONS = [
+  {
+    route: "/resources/eval-checklist/thank-you",
+    reason: "Noindex conversion confirmation that contains no unique public content.",
+  },
+  {
+    route: "/share/[token]",
+    reason: "Private capability-token resource. Publications use non-secret share record IDs.",
+  },
+  {
+    route: "/share/[token]/embed",
+    reason: "Private capability-token embed inherited from the noindex share layout.",
+  },
+] as const;
+
+const PRIVATE_PAGE_PREFIXES = [
+  "/auth/",
+  "/dashboard",
+  "/github/",
+  "/invites/",
+  "/onboard",
+  "/orgs/",
+  "/workspaces/",
+] as const;
+
+export function publicPageRouteIsCovered(route: string): boolean {
+  return (
+    PUBLIC_PAGE_ROUTE_COVERAGE.some((entry) => entry.route === route) ||
+    REVIEWED_PUBLIC_PAGE_EXCLUSIONS.some((entry) => entry.route === route) ||
+    PRIVATE_PAGE_PREFIXES.some(
+      (prefix) => route === prefix.replace(/\/$/, "") || route.startsWith(prefix),
+    )
+  );
+}

--- a/web/src/lib/publication-data.ts
+++ b/web/src/lib/publication-data.ts
@@ -1,0 +1,81 @@
+import { createApiClient } from "@/lib/api/client";
+import type {
+  PublicPublicationListResponse,
+  PublicPublicationResponse,
+} from "@/lib/api/types";
+import type { PublicContentAdapter } from "@/lib/public-content";
+import {
+  publicationDescription,
+  publicationTitle,
+  renderPublicationMarkdown,
+} from "@/lib/publications";
+
+const PUBLICATION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function getPublicPublication(
+  id: string,
+): Promise<PublicPublicationResponse> {
+  if (!PUBLICATION_ID.test(id)) throw new Error("Invalid publication ID");
+  return createApiClient().get<PublicPublicationResponse>(
+    `/public/publications/${encodeURIComponent(id)}`,
+    { cache: "no-store" },
+  );
+}
+
+export async function listPublicPublications(args: {
+  cursor?: string;
+  limit?: number;
+} = {}): Promise<PublicPublicationListResponse> {
+  return createApiClient().get<PublicPublicationListResponse>(
+    "/public/publications",
+    {
+      params: { cursor: args.cursor, limit: args.limit ?? 50 },
+      cache: "no-store",
+    },
+  );
+}
+
+export async function listAllPublicPublications(
+  maximum = 10_000,
+): Promise<PublicPublicationResponse[]> {
+  const items: PublicPublicationResponse[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  while (items.length < maximum) {
+    const page = await listPublicPublications({ cursor, limit: Math.min(100, maximum - items.length) });
+    items.push(...page.items);
+    if (!page.next_cursor || seenCursors.has(page.next_cursor)) break;
+    seenCursors.add(page.next_cursor);
+    cursor = page.next_cursor;
+  }
+  return items;
+}
+
+export async function resolvePublicPublicationAdapter(
+  canonicalPath: string | null,
+): Promise<PublicContentAdapter | null> {
+  const id = canonicalPath?.match(/^\/publications\/([^/]+)$/)?.[1];
+  if (!id) return null;
+  try {
+    const publication = await getPublicPublication(id);
+    return {
+      canonicalPath: publication.publication.canonical_path,
+      markdownPath: `/md${publication.publication.canonical_path}`,
+      title: publicationTitle(publication),
+      description: publicationDescription(publication),
+      kind: "publication",
+      lastModified: publication.publication.updated_at,
+      indexable: true,
+      includeIn: {
+        sitemap: false,
+        llms: false,
+        llmsFull: false,
+        search: false,
+        indexNow: true,
+      },
+      renderMarkdown: (origin) => renderPublicationMarkdown(publication, origin),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/publications.test.ts
+++ b/web/src/lib/publications.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { PublicPublicationResponse, PublicShareResourceType } from "@/lib/api/types";
+import {
+  publicationTitle,
+  renderPublicationCatalogMarkdown,
+  renderPublicationMarkdown,
+} from "./publications";
+
+function fixture(
+  type: PublicShareResourceType,
+  resource: Record<string, unknown>,
+): PublicPublicationResponse {
+  return {
+    publication: {
+      id: "11111111-1111-4111-8111-111111111111",
+      resource_type: type,
+      created_at: "2026-08-14T00:00:00Z",
+      updated_at: "2026-08-14T01:00:00Z",
+      canonical_path: "/publications/11111111-1111-4111-8111-111111111111",
+    },
+    resource: { type, ...resource },
+  };
+}
+
+describe("publication renderers", () => {
+  it.each([
+    fixture("challenge_pack_version", {
+      pack: { name: "Support checks", family: "support", description: "Redacted pack" },
+      version: { version_number: 2, lifecycle_status: "runnable", manifest: { tasks: 4 } },
+    }),
+    fixture("run_scorecard", {
+      run: { name: "Support race", status: "completed", execution_mode: "comparison" },
+      agents: [{ id: "agent-1", label: "Careful", status: "completed" }],
+      agent_scorecards: [{ run_agent_id: "agent-1", overall_score: 0.91, passed: true }],
+    }),
+    fixture("run_agent_scorecard", {
+      run: { name: "Support race" },
+      run_agent: { label: "Careful", status: "completed" },
+      scorecard: { overall_score: 0.91, correctness_score: 0.95, passed: true },
+    }),
+    fixture("run_agent_replay", {
+      run: { name: "Support race" },
+      run_agent: { label: "Careful", status: "completed" },
+      replay: { event_count: 12, summary: { terminal_state: "complete" } },
+    }),
+    fixture("agent_tryout", {
+      template_slug: "meeting-minutes",
+      status: "completed",
+      redaction_status: "passed",
+      input_snapshot: { notes: "Public notes" },
+      summary: { result: "Public result" },
+    }),
+  ])("renders an allowlisted $resource.type publication", (publication) => {
+    const markdown = renderPublicationMarkdown(publication, "https://example.test");
+    expect(markdown).toMatch(/^#\s+\S/m);
+    expect(markdown).toContain(
+      "Source: https://example.test/publications/11111111-1111-4111-8111-111111111111",
+    );
+    expect(markdown).toContain("User-published content");
+    expect(markdown).not.toContain("capability-token");
+    expect(publicationTitle(publication)).not.toBe("");
+  });
+
+  it("keeps user content inside escaped text or indented JSON blocks", () => {
+    const publication = fixture("agent_tryout", {
+      template_slug: "# fake heading",
+      status: "completed",
+      redaction_status: "passed",
+      input_snapshot: { notes: "</pre><script>alert(1)</script>\n# injected" },
+      summary: {},
+    });
+    const markdown = renderPublicationMarkdown(publication);
+
+    expect(markdown).toContain("\\# fake heading tryout");
+    expect(markdown).toContain('    "notes": "</pre><script>alert(1)</script>\\n# injected"');
+    expect(markdown).not.toContain("\n# injected\n");
+  });
+
+  it("renders the live catalog as Markdown without capability URLs", () => {
+    const publication = fixture("run_scorecard", {
+      run: { name: "Support race", status: "completed" },
+      agents: [],
+      agent_scorecards: [],
+    });
+    const markdown = renderPublicationCatalogMarkdown(
+      [publication],
+      "https://example.test",
+    );
+
+    expect(markdown).toContain("# Published Agent Evaluation Artifacts");
+    expect(markdown).toContain(
+      "https://example.test/md/publications/11111111-1111-4111-8111-111111111111",
+    );
+    expect(markdown).not.toContain("/share/");
+  });
+});

--- a/web/src/lib/publications.ts
+++ b/web/src/lib/publications.ts
@@ -1,0 +1,248 @@
+import type {
+  PublicPublicationResponse,
+  PublicShareResourceType,
+} from "@/lib/api/types";
+import { escapeMarkdownText } from "@/lib/agent-opportunity-markdown";
+import { PUBLIC_ORIGIN } from "@/lib/public-content";
+
+type UnknownRecord = Record<string, unknown>;
+
+function record(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function records(value: unknown): UnknownRecord[] {
+  return Array.isArray(value) ? value.map(record) : [];
+}
+
+function text(value: unknown, fallback = "Not provided"): string {
+  return typeof value === "string" && value.trim()
+    ? escapeMarkdownText(value)
+    : fallback;
+}
+
+function indentedJSON(value: unknown): string[] {
+  const serialized = JSON.stringify(value ?? {}, null, 2);
+  return serialized.split("\n").map((line) => `    ${line}`);
+}
+
+function score(value: unknown): string {
+  return typeof value === "number" ? `${Math.round(value * 1000) / 10}%` : "N/A";
+}
+
+export function publicationTitle(publication: PublicPublicationResponse): string {
+  const resource = publication.resource;
+  if (resource.type === "challenge_pack_version") {
+    const pack = record(resource.pack);
+    const version = record(resource.version);
+    return `${String(pack.name ?? "Challenge pack")} v${String(version.version_number ?? "")}`.trim();
+  }
+  if (resource.type === "run_scorecard") {
+    return `${String(record(resource.run).name ?? "Run")} scorecard`;
+  }
+  if (resource.type === "run_agent_scorecard") {
+    return `${String(record(resource.run_agent).label ?? "Agent")} scorecard`;
+  }
+  if (resource.type === "run_agent_replay") {
+    return `${String(record(resource.run_agent).label ?? "Agent")} replay`;
+  }
+  if (resource.type === "agent_tryout") {
+    return `${String(resource.template_slug ?? "Agent")} tryout`;
+  }
+  return "AgentClash publication";
+}
+
+export function publicationDescription(publication: PublicPublicationResponse): string {
+  const labels: Record<PublicShareResourceType, string> = {
+    challenge_pack_version: "A redacted, user-published AgentClash challenge pack version.",
+    run_scorecard: "A redacted, user-published AgentClash run scorecard.",
+    run_agent_scorecard: "A redacted, user-published AgentClash agent scorecard.",
+    run_agent_replay: "A redacted, user-published AgentClash agent replay.",
+    agent_tryout: "A redacted, user-published AgentClash agent tryout.",
+  };
+  return labels[publication.resource.type];
+}
+
+export function renderPublicationCatalogMarkdown(
+  publications: PublicPublicationResponse[],
+  origin = PUBLIC_ORIGIN,
+): string {
+  const lines = [
+    "# Published Agent Evaluation Artifacts",
+    "",
+    "Browse explicitly published, redacted AgentClash challenge packs, scorecards, replays, and agent tryouts.",
+    "",
+    `Source: ${origin}/publications`,
+    `Markdown export: ${origin}/md/publications`,
+    "",
+    "Only active, unexpired artifacts whose owners enabled search indexing appear here. Capability-token shares are never listed.",
+    "",
+    "## Active publications",
+    "",
+  ];
+  if (publications.length === 0) {
+    lines.push("No active publications are currently available.");
+  } else {
+    for (const publication of publications) {
+      const title = text(publicationTitle(publication));
+      const path = publication.publication.canonical_path;
+      lines.push(
+        `- [${title}](${origin}/md${path}) — ${publicationDescription(publication)} Updated ${publication.publication.updated_at}.`,
+      );
+    }
+  }
+  return lines.join("\n").trim();
+}
+
+export function renderPublicationMarkdown(
+  publication: PublicPublicationResponse,
+  origin = PUBLIC_ORIGIN,
+): string {
+  const canonicalPath = publication.publication.canonical_path;
+  const resource = publication.resource;
+  const lines = [
+    `# ${text(publicationTitle(publication))}`,
+    "",
+    "> User-published content. AgentClash renders this artifact through a redacted, allowlisted public serializer.",
+    "",
+    publicationDescription(publication),
+    "",
+    `Source: ${origin}${canonicalPath}`,
+    `Markdown export: ${origin}/md${canonicalPath}`,
+    `Published: ${publication.publication.created_at}`,
+    `Updated: ${publication.publication.updated_at}`,
+  ];
+
+  if (resource.type === "challenge_pack_version") {
+    const pack = record(resource.pack);
+    const version = record(resource.version);
+    lines.push(
+      "",
+      "## Challenge pack",
+      "",
+      `- Name: ${text(pack.name)}`,
+      `- Family: ${text(pack.family)}`,
+      `- Description: ${text(pack.description)}`,
+      `- Version: ${String(version.version_number ?? "N/A")}`,
+      `- Status: ${text(version.lifecycle_status)}`,
+      "",
+      "## Manifest",
+      "",
+      ...indentedJSON(version.manifest),
+    );
+    const inputSets = records(version.input_sets);
+    if (inputSets.length > 0) {
+      lines.push(
+        "",
+        "## Input sets",
+        "",
+        ...inputSets.map(
+          (inputSet) => `- ${text(inputSet.name)} (${text(inputSet.input_key)})`,
+        ),
+      );
+    }
+  } else if (resource.type === "run_scorecard") {
+    const run = record(resource.run);
+    lines.push(
+      "",
+      "## Run",
+      "",
+      `- Name: ${text(run.name)}`,
+      `- Status: ${text(run.status)}`,
+      `- Execution mode: ${text(run.execution_mode)}`,
+      "",
+      "## Agent results",
+      "",
+      "| Agent | Status | Overall | Passed |",
+      "| --- | --- | --- | --- |",
+    );
+    const scorecards = new Map(
+      records(resource.agent_scorecards).map((item) => [String(item.run_agent_id), item]),
+    );
+    for (const agent of records(resource.agents)) {
+      const card = scorecards.get(String(agent.id));
+      lines.push(
+        `| ${text(agent.label)} | ${text(agent.status)} | ${score(card?.overall_score)} | ${card?.passed === true ? "Yes" : card?.passed === false ? "No" : "N/A"} |`,
+      );
+    }
+    lines.push(
+      "",
+      "## Redacted comparison detail",
+      "",
+      ...indentedJSON(resource.scorecard),
+    );
+  } else if (resource.type === "run_agent_scorecard") {
+    const run = record(resource.run);
+    const agent = record(resource.run_agent);
+    const card = record(resource.scorecard);
+    lines.push(
+      "",
+      "## Agent scorecard",
+      "",
+      `- Run: ${text(run.name)}`,
+      `- Agent: ${text(agent.label)}`,
+      `- Status: ${text(agent.status)}`,
+      `- Overall: ${score(card.overall_score)}`,
+      `- Correctness: ${score(card.correctness_score)}`,
+      `- Reliability: ${score(card.reliability_score)}`,
+      `- Latency: ${score(card.latency_score)}`,
+      `- Cost: ${score(card.cost_score)}`,
+      `- Passed: ${card.passed === true ? "Yes" : card.passed === false ? "No" : "N/A"}`,
+      "",
+      "## Redacted scorecard detail",
+      "",
+      ...indentedJSON(card.scorecard),
+    );
+  } else if (resource.type === "run_agent_replay") {
+    const run = record(resource.run);
+    const agent = record(resource.run_agent);
+    const replay = record(resource.replay);
+    lines.push(
+      "",
+      "## Replay",
+      "",
+      `- Run: ${text(run.name)}`,
+      `- Agent: ${text(agent.label)}`,
+      `- Status: ${text(agent.status)}`,
+      `- Events: ${String(replay.event_count ?? "N/A")}`,
+      "",
+      "## Redacted replay summary",
+      "",
+      ...indentedJSON(replay.summary),
+    );
+  } else if (resource.type === "agent_tryout") {
+    lines.push(
+      "",
+      "## Tryout",
+      "",
+      `- Template: ${text(resource.template_slug)}`,
+      `- Status: ${text(resource.status)}`,
+      `- Redaction status: ${text(resource.redaction_status)}`,
+      `- Latency: ${String(resource.latency_ms ?? "N/A")} ms`,
+      "",
+      "## Redacted input",
+      "",
+      ...indentedJSON(resource.input_snapshot),
+      "",
+      "## Redacted result",
+      "",
+      ...indentedJSON(resource.summary),
+    );
+    const artifacts = records(resource.artifacts);
+    if (artifacts.length > 0) {
+      lines.push(
+        "",
+        "## Approved artifact descriptors",
+        "",
+        ...artifacts.map(
+          (artifact) =>
+            `- ${text(artifact.key)} — ${text(artifact.type ?? artifact.content_type)}`,
+        ),
+      );
+    }
+  }
+
+  return lines.join("\n").trim();
+}

--- a/web/src/lib/seo-pages/factory.ts
+++ b/web/src/lib/seo-pages/factory.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { SeoPageConfig } from "./types";
+import { markdownAlternate } from "@/lib/seo";
 
 export function createSeoPageMetadata(config: SeoPageConfig): Metadata {
   return {
@@ -7,6 +8,7 @@ export function createSeoPageMetadata(config: SeoPageConfig): Metadata {
     description: config.metaDescription,
     alternates: {
       canonical: config.path,
+      types: markdownAlternate(config.path),
     },
     openGraph: {
       title: config.pageTitle,

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -20,6 +20,22 @@ export const benchmarkRssAlternate = {
   ],
 } satisfies AlternateTypes;
 
+export function markdownAlternate(
+  canonicalPath: string,
+  existing: AlternateTypes = {},
+): AlternateTypes {
+  const markdownPath = canonicalPath === "/" ? "/md" : `/md${canonicalPath}`;
+  return {
+    ...existing,
+    "text/markdown": [
+      {
+        title: "Markdown",
+        url: markdownPath,
+      },
+    ],
+  };
+}
+
 // Root-relative URL for the dynamic Open Graph image route (app/og/route.tsx).
 // metadataBase upgrades it to absolute in the rendered OG/Twitter tags, so each
 // page gets a tailored social card instead of one shared static image.

--- a/web/src/lib/try-cli/catalog.server.ts
+++ b/web/src/lib/try-cli/catalog.server.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+import type { DemoMeta } from "./types";
+
+function isDemoMeta(value: unknown): value is DemoMeta {
+  if (!value || typeof value !== "object") return false;
+  const demo = value as Partial<DemoMeta>;
+  return (
+    typeof demo.slug === "string" &&
+    /^[a-z0-9][a-z0-9-]*$/.test(demo.slug) &&
+    typeof demo.name === "string" &&
+    typeof demo.sessionMinutes === "number" &&
+    Array.isArray(demo.commands) &&
+    demo.commands.every(
+      (command) =>
+        command &&
+        typeof command.label === "string" &&
+        typeof command.run === "string",
+    )
+  );
+}
+
+function demosDirectory(): string | null {
+  for (const candidate of [
+    path.join(process.cwd(), "..", "try-cli", "demos"),
+    path.join(process.cwd(), "try-cli", "demos"),
+  ]) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+let cachedDemos: DemoMeta[] | undefined;
+
+export function getBundledTryCliDemos(): DemoMeta[] {
+  if (cachedDemos) return [...cachedDemos];
+  const directory = demosDirectory();
+  if (!directory) return [];
+
+  cachedDemos = fs
+    .readdirSync(directory)
+    .filter((filename) => filename.endsWith(".trycli.yml"))
+    .map((filename) => {
+      const source = fs.readFileSync(path.join(directory, filename), "utf8");
+      return matter(`---\n${source}\n---`).data as unknown;
+    })
+    .filter(isDemoMeta)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return [...cachedDemos];
+}
+
+export function getBundledTryCliDemo(slug: string): DemoMeta | null {
+  return getBundledTryCliDemos().find((demo) => demo.slug === slug) ?? null;
+}

--- a/web/src/lib/try-cli/config.ts
+++ b/web/src/lib/try-cli/config.ts
@@ -3,11 +3,9 @@ export function getTryCliApiBase(): string {
   if (typeof window !== "undefined") {
     return process.env.NEXT_PUBLIC_TRY_CLI_API_URL ?? "/api/try";
   }
-  return (
-    process.env.TRY_CLI_API_URL ??
-    process.env.NEXT_PUBLIC_TRY_CLI_API_URL ??
-    "http://localhost:3001"
-  );
+  // Server rendering must call the long-running service directly. A public
+  // `/api/try` value would point back at this Next.js app and create a loop.
+  return process.env.TRY_CLI_API_URL ?? "http://localhost:3001";
 }
 
 /** WebSocket base for PTY streams (must be a long-running service, not Vercel serverless). */

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -4,35 +4,128 @@ import {
   type NextRequest,
 } from "next/server";
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+import {
+  CANONICAL_PATH_HEADER,
+  NEGOTIATED_MARKDOWN_HEADER,
+  agentRequestLog,
+  isMarkdownNegotiablePath,
+  markdownPathForCanonical,
+  representationLinkHeader,
+  shouldLogAgentRequest,
+  shouldNegotiateMarkdown,
+} from "@/lib/public-http";
 
 const authkit = authkitMiddleware();
+const PUBLIC_ORIGIN = "https://www.agentclash.dev";
 
 const WORKSPACE_ROOT_PATTERN = /^\/workspaces\/[^/]+\/?$/;
 
-export default function middleware(
+function addVaryAccept(response: Response) {
+  const existing = response.headers.get("Vary");
+  const values = new Set(
+    (existing ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  values.add("Accept");
+  response.headers.set("Vary", [...values].join(", "));
+}
+
+function addRepresentationHeaders<T extends Response>(response: T, pathname: string): T {
+  addVaryAccept(response);
+  response.headers.set("Link", representationLinkHeader(pathname, PUBLIC_ORIGIN));
+  return response;
+}
+
+function logAgentReadableRequest(
+  request: NextRequest,
+  servedRepresentation: "html" | "markdown" | "machine",
+) {
+  const pathname = request.nextUrl.pathname;
+  const accept = request.headers.get("accept");
+  const userAgent = request.headers.get("user-agent");
+  if (!shouldLogAgentRequest({ pathname, accept, userAgent })) return;
+  console.log(
+    JSON.stringify(
+      agentRequestLog({
+        pathname,
+        method: request.method,
+        accept,
+        userAgent,
+        requestId: request.headers.get("x-vercel-id"),
+        servedRepresentation,
+      }),
+    ),
+  );
+}
+
+export default async function middleware(
   request: NextRequest,
   event: NextFetchEvent,
 ) {
+  const pathname = request.nextUrl.pathname;
+  const negotiationEnabled =
+    process.env.MARKDOWN_NEGOTIATION_ENABLED?.toLowerCase() === "true";
+
   if (
-    request.nextUrl.pathname === "/docs" ||
-    request.nextUrl.pathname.startsWith("/docs/") ||
-    request.nextUrl.pathname === "/docs-md" ||
-    request.nextUrl.pathname.startsWith("/docs-md/") ||
-    request.nextUrl.pathname === "/llms.txt" ||
-    request.nextUrl.pathname === "/llms-full.txt" ||
-    request.nextUrl.pathname === "/share" ||
-    request.nextUrl.pathname.startsWith("/share/")
+    shouldNegotiateMarkdown({
+      enabled: negotiationEnabled,
+      method: request.method,
+      pathname,
+      accept: request.headers.get("accept"),
+    })
   ) {
-    return NextResponse.next();
+    const url = request.nextUrl.clone();
+    url.pathname = markdownPathForCanonical(pathname);
+    url.search = "";
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set(NEGOTIATED_MARKDOWN_HEADER, "1");
+    requestHeaders.set(CANONICAL_PATH_HEADER, pathname);
+    const response = NextResponse.rewrite(url, {
+      request: { headers: requestHeaders },
+    });
+    logAgentReadableRequest(request, "markdown");
+    return addRepresentationHeaders(response, pathname);
   }
 
-  if (WORKSPACE_ROOT_PATTERN.test(request.nextUrl.pathname)) {
+  if (
+    pathname === "/docs" ||
+    pathname.startsWith("/docs/") ||
+    pathname === "/docs-md" ||
+    pathname.startsWith("/docs-md/") ||
+    pathname === "/md" ||
+    pathname.startsWith("/md/") ||
+    pathname === "/llms.txt" ||
+    pathname === "/llms-full.txt" ||
+    pathname === "/openapi.yaml" ||
+    pathname === "/cli-schema.json" ||
+    pathname === "/schemas" ||
+    pathname.startsWith("/schemas/") ||
+    pathname === "/publications" ||
+    pathname.startsWith("/publications/") ||
+    pathname === "/share" ||
+    pathname.startsWith("/share/")
+  ) {
+    const response = NextResponse.next();
+    logAgentReadableRequest(request, pathname.startsWith("/md") ? "markdown" : "machine");
+    return isMarkdownNegotiablePath(pathname)
+      ? addRepresentationHeaders(response, pathname)
+      : response;
+  }
+
+  if (WORKSPACE_ROOT_PATTERN.test(pathname)) {
     const url = request.nextUrl.clone();
-    url.pathname = `${request.nextUrl.pathname.replace(/\/$/, "")}/runs`;
+    url.pathname = `${pathname.replace(/\/$/, "")}/runs`;
     return NextResponse.redirect(url, 307);
   }
 
-  return authkit(request, event);
+  const response = (await authkit(request, event)) ?? NextResponse.next();
+  if (isMarkdownNegotiablePath(pathname)) {
+    logAgentReadableRequest(request, "html");
+    return addRepresentationHeaders(response, pathname);
+  }
+  return response;
 }
 
 export const config = {

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -8,11 +8,13 @@ import {
   CANONICAL_PATH_HEADER,
   NEGOTIATED_MARKDOWN_HEADER,
   agentRequestLog,
+  isPrivateOrMachinePath,
   isMarkdownNegotiablePath,
   markdownPathForCanonical,
   representationLinkHeader,
   shouldLogAgentRequest,
   shouldNegotiateMarkdown,
+  withoutInternalNegotiationHeaders,
 } from "@/lib/public-http";
 
 const authkit = authkitMiddleware();
@@ -38,6 +40,11 @@ function addRepresentationHeaders<T extends Response>(response: T, pathname: str
   return response;
 }
 
+function nextWithExternalNegotiationHeadersRemoved(request: NextRequest) {
+  const requestHeaders = withoutInternalNegotiationHeaders(request.headers);
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}
+
 function logAgentReadableRequest(
   request: NextRequest,
   servedRepresentation: "html" | "markdown" | "machine",
@@ -58,6 +65,22 @@ function logAgentReadableRequest(
       }),
     ),
   );
+}
+
+function servedRepresentationForPath(pathname: string): "html" | "markdown" | "machine" {
+  if (pathname === "/publications/sitemap.xml") return "machine";
+  if (
+    pathname === "/md" ||
+    pathname.startsWith("/md/") ||
+    pathname === "/docs-md" ||
+    pathname.startsWith("/docs-md/")
+  ) {
+    return "markdown";
+  }
+  if (pathname === "/docs" || pathname.startsWith("/docs/") || pathname === "/publications" || pathname.startsWith("/publications/") || pathname === "/share" || pathname.startsWith("/share/")) {
+    return "html";
+  }
+  return "machine";
 }
 
 export default async function middleware(
@@ -107,11 +130,25 @@ export default async function middleware(
     pathname === "/share" ||
     pathname.startsWith("/share/")
   ) {
-    const response = NextResponse.next();
-    logAgentReadableRequest(request, pathname.startsWith("/md") ? "markdown" : "machine");
+    const response = nextWithExternalNegotiationHeadersRemoved(request);
+    if (
+      pathname === "/publications" ||
+      pathname.startsWith("/publications/") ||
+      pathname === "/share" ||
+      pathname.startsWith("/share/")
+    ) {
+      response.headers.set("Cache-Control", "no-store");
+    }
+    logAgentReadableRequest(request, servedRepresentationForPath(pathname));
     return isMarkdownNegotiablePath(pathname)
       ? addRepresentationHeaders(response, pathname)
       : response;
+  }
+
+  if (isMarkdownNegotiablePath(pathname)) {
+    const response = nextWithExternalNegotiationHeadersRemoved(request);
+    logAgentReadableRequest(request, "html");
+    return addRepresentationHeaders(response, pathname);
   }
 
   if (WORKSPACE_ROOT_PATTERN.test(pathname)) {
@@ -121,8 +158,10 @@ export default async function middleware(
   }
 
   const response = (await authkit(request, event)) ?? NextResponse.next();
-  if (isMarkdownNegotiablePath(pathname)) {
+  if (!isPrivateOrMachinePath(pathname)) {
     logAgentReadableRequest(request, "html");
+  }
+  if (isMarkdownNegotiablePath(pathname)) {
     return addRepresentationHeaders(response, pathname);
   }
   return response;

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -11,6 +11,17 @@
     "NEXT_PUBLIC_TRY_CLI_PUBLIC_URL": "https://www.agentclash.dev/try",
     "WORKOS_COOKIE_DOMAIN": ".agentclash.dev"
   },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/try-api/:path*",


### PR DESCRIPTION
## Summary

- make every indexable public AgentClash route discoverable through a central public-content registry, stable Markdown URLs, `llms.txt`, search, sitemaps, and IndexNow
- add safe `Accept: text/markdown` negotiation with canonical/alternate headers, direct Markdown caching, private-route exclusions, and route-coverage enforcement
- server-render the important `/try`, `/try/{slug}`, `/tryouts`, pricing, and agent-opportunity content before hydration
- add fail-closed, redacted publications for challenge packs, run scorecards, agent scorecards, replays, and agent tryouts without exposing capability tokens
- publish OpenAPI, JSON Schema, and released CLI schema contracts and add structured AI-agent request logging with a Vercel Runtime Logs runbook

## Why

AI search tools and coding agents currently have to infer URLs, execute JavaScript for important content, and rely on browser analytics that do not capture crawler traffic. This change gives agents explicit, cache-safe machine representations while preserving HTML as the default and keeping authenticated data and capability-token shares private.

## User and developer impact

- agents can fetch `/md/{canonical-path}` or negotiate Markdown on canonical public URLs
- `/llms.txt` and `/llms-full.txt` stay synchronized with public content
- opted-in publications use non-secret record IDs and disappear immediately when revoked, expired, or unpublished
- important interactive pages contain meaningful server-rendered content and do not create sandboxes on page load
- operators can measure crawler and contract traffic in server-side Runtime Logs without recording tokens, queries, IPs, cookies, or authorization data

## Validation

- `pnpm test` — 554 passed, 3 skipped
- `pnpm exec tsc --noEmit`
- `pnpm lint` — zero errors; five existing warnings
- `pnpm build`
- `go test -short -race -count=1 ./...` in `backend/`
- `go test -short -race -count=1 ./...` in `cli/`
- GoReleaser configuration check
- production-mode curl smoke tests for HTML, direct Markdown, negotiated Markdown, headers, private exclusions, and server-rendered widgets
- OpenAPI YAML, JSON Schema, release-workflow YAML, and git diff validation

## Rollout

1. Apply migration `00069_indexable_public_share_links.sql`.
2. Enable `MARKDOWN_NEGOTIATION_ENABLED=true` in Preview and verify response/cache headers and Runtime Logs.
3. Enable negotiation in Production after Preview verification.
4. Produce the next CLI release to upload the first `cli-schema.json` release asset.
