### PR TITLE
fix(web): run AuthKit on public HTML pages

### DIFF
--- a/web/src/lib/public-http.test.ts
+++ b/web/src/lib/public-http.test.ts
@@ -6,6 +6,7 @@ import {
   classifyRouteKind,
   isMarkdownNegotiablePath,
   parseRepresentationPreference,
+  requiresAuthkitMiddleware,
   prefersMarkdown,
   representationLinkHeader,
   requestedRepresentation,
@@ -74,6 +75,30 @@ describe("public representation negotiation", () => {
     "/publications/pub_123",
   ])("allows %s", (pathname) => {
     expect(isMarkdownNegotiablePath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/",
+    "/docs",
+    "/docs/getting-started/first-eval",
+    "/blog",
+    "/compare",
+    "/publications",
+    "/pricing",
+    "/dashboard",
+    "/workspaces/ws_123",
+  ])("requires AuthKit on HTML path %s", (pathname) => {
+    expect(requiresAuthkitMiddleware(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/md",
+    "/md/pricing",
+    "/docs-md/getting-started/quickstart",
+    "/llms.txt",
+    "/openapi.yaml",
+  ])("allows AuthKit bypass on machine path %s", (pathname) => {
+    expect(requiresAuthkitMiddleware(pathname)).toBe(false);
   });
 
   it("advertises canonical and Markdown URLs", () => {

--- a/web/src/lib/public-http.ts
+++ b/web/src/lib/public-http.ts
@@ -158,6 +158,15 @@ export function isMarkdownNegotiablePath(pathname: string): boolean {
   );
 }
 
+/**
+ * Public HTML pages call `withAuth()` (homepage + MarketingHeader). AuthKit
+ * middleware must run on those requests or Server Components throw.
+ * Machine/markdown endpoints never call `withAuth` and may skip it.
+ */
+export function requiresAuthkitMiddleware(pathname: string): boolean {
+  return !MACHINE_PATH_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
+}
+
 export function shouldNegotiateMarkdown(args: {
   enabled: boolean;
   method: string;

--- a/web/src/middleware.authkit.test.ts
+++ b/web/src/middleware.authkit.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest, type NextFetchEvent } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authkitMock = vi.hoisted(() =>
+  vi.fn(async () => {
+    const { NextResponse } = await import("next/server");
+    return NextResponse.next();
+  }),
+);
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  authkitMiddleware: () => authkitMock,
+}));
+
+import middleware from "./middleware";
+
+const event = {} as NextFetchEvent;
+
+function request(path: string) {
+  return new NextRequest(`https://www.agentclash.dev${path}`);
+}
+
+describe("middleware AuthKit coverage", () => {
+  beforeEach(() => {
+    authkitMock.mockClear();
+  });
+
+  it.each(["/", "/docs", "/blog", "/compare", "/publications", "/pricing"])(
+    "runs AuthKit on public HTML %s",
+    async (path) => {
+      await middleware(request(path), event);
+      expect(authkitMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not run AuthKit on machine markdown", async () => {
+    await middleware(request("/md/pricing"), event);
+    expect(authkitMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -11,6 +11,7 @@ import {
   isPrivateOrMachinePath,
   isMarkdownNegotiablePath,
   markdownPathForCanonical,
+  requiresAuthkitMiddleware,
   representationLinkHeader,
   shouldLogAgentRequest,
   shouldNegotiateMarkdown,
@@ -40,9 +41,43 @@ function addRepresentationHeaders<T extends Response>(response: T, pathname: str
   return response;
 }
 
-function nextWithExternalNegotiationHeadersRemoved(request: NextRequest) {
-  const requestHeaders = withoutInternalNegotiationHeaders(request.headers);
-  return NextResponse.next({ request: { headers: requestHeaders } });
+function requestWithoutSpoofedNegotiationHeaders(request: NextRequest): NextRequest {
+  if (
+    !request.headers.has(NEGOTIATED_MARKDOWN_HEADER) &&
+    !request.headers.has(CANONICAL_PATH_HEADER)
+  ) {
+    return request;
+  }
+  return new NextRequest(request, {
+    headers: withoutInternalNegotiationHeaders(request.headers),
+  });
+}
+
+function isNoStorePublicPath(pathname: string): boolean {
+  return (
+    pathname === "/publications" ||
+    pathname.startsWith("/publications/") ||
+    pathname === "/share" ||
+    pathname.startsWith("/share/")
+  );
+}
+
+function isLoggedPublicOrContractPath(pathname: string): boolean {
+  return (
+    pathname === "/docs" ||
+    pathname.startsWith("/docs/") ||
+    pathname === "/docs-md" ||
+    pathname.startsWith("/docs-md/") ||
+    pathname === "/md" ||
+    pathname.startsWith("/md/") ||
+    pathname === "/llms.txt" ||
+    pathname === "/llms-full.txt" ||
+    pathname === "/openapi.yaml" ||
+    pathname === "/cli-schema.json" ||
+    pathname === "/schemas" ||
+    pathname.startsWith("/schemas/") ||
+    isNoStorePublicPath(pathname)
+  );
 }
 
 function logAgentReadableRequest(
@@ -112,55 +147,29 @@ export default async function middleware(
     return addRepresentationHeaders(response, pathname);
   }
 
-  if (
-    pathname === "/docs" ||
-    pathname.startsWith("/docs/") ||
-    pathname === "/docs-md" ||
-    pathname.startsWith("/docs-md/") ||
-    pathname === "/md" ||
-    pathname.startsWith("/md/") ||
-    pathname === "/llms.txt" ||
-    pathname === "/llms-full.txt" ||
-    pathname === "/openapi.yaml" ||
-    pathname === "/cli-schema.json" ||
-    pathname === "/schemas" ||
-    pathname.startsWith("/schemas/") ||
-    pathname === "/publications" ||
-    pathname.startsWith("/publications/") ||
-    pathname === "/share" ||
-    pathname.startsWith("/share/")
-  ) {
-    const response = nextWithExternalNegotiationHeadersRemoved(request);
-    if (
-      pathname === "/publications" ||
-      pathname.startsWith("/publications/") ||
-      pathname === "/share" ||
-      pathname.startsWith("/share/")
-    ) {
-      response.headers.set("Cache-Control", "no-store");
-    }
-    logAgentReadableRequest(request, servedRepresentationForPath(pathname));
-    return isMarkdownNegotiablePath(pathname)
-      ? addRepresentationHeaders(response, pathname)
-      : response;
-  }
-
-  if (isMarkdownNegotiablePath(pathname)) {
-    const response = nextWithExternalNegotiationHeadersRemoved(request);
-    logAgentReadableRequest(request, "html");
-    return addRepresentationHeaders(response, pathname);
-  }
-
   if (WORKSPACE_ROOT_PATTERN.test(pathname)) {
     const url = request.nextUrl.clone();
     url.pathname = `${pathname.replace(/\/$/, "")}/runs`;
     return NextResponse.redirect(url, 307);
   }
 
-  const response = (await authkit(request, event)) ?? NextResponse.next();
-  if (!isPrivateOrMachinePath(pathname)) {
+  const authRequest = requestWithoutSpoofedNegotiationHeaders(request);
+  const response = requiresAuthkitMiddleware(pathname)
+    ? ((await authkit(authRequest, event)) ?? NextResponse.next())
+    : NextResponse.next({
+        request: { headers: withoutInternalNegotiationHeaders(request.headers) },
+      });
+
+  if (isNoStorePublicPath(pathname)) {
+    response.headers.set("Cache-Control", "no-store");
+  }
+
+  if (isLoggedPublicOrContractPath(pathname)) {
+    logAgentReadableRequest(request, servedRepresentationForPath(pathname));
+  } else if (!isPrivateOrMachinePath(pathname)) {
     logAgentReadableRequest(request, "html");
   }
+
   if (isMarkdownNegotiablePath(pathname)) {
     return addRepresentationHeaders(response, pathname);
   }

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import {
+  NextRequest,
   NextResponse,
   type NextFetchEvent,
-  type NextRequest,
 } from "next/server";
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 import {


### PR DESCRIPTION
## Summary
- Production 500s on www.agentclash.dev were AuthKit throwing in Server Components: `withAuth` ran on routes the new agent-readable middleware never covered.
- Public HTML paths (`/`, `/docs`, `/blog`, `/compare`, `/publications`, marketing pages) now go through AuthKit again. Homepage and `MarketingHeader` both call `withAuth()`.
- Machine/markdown endpoints still skip AuthKit. Added regression tests so this cannot silently regress.

## Test plan
- [x] `cd web && pnpm exec vitest run src/lib/public-http.test.ts src/lib/public-content.test.ts src/middleware.authkit.test.ts src/app/public-canonical-metadata.test.ts`
- [ ] After deploy, load `https://www.agentclash.dev/` and confirm it is not a 500
- [ ] Load `/docs`, `/blog`, `/compare`, `/pricing` as a logged-out visitor
- [ ] Confirm signed-in homepage still redirects to `/dashboard`