### PR TITLE
docs: cross-link the zero-API-key dev profile and setup tiers

### DIFF
--- a/web/content/docs/contributing/setup.mdx
+++ b/web/content/docs/contributing/setup.mdx
@@ -6,6 +6,16 @@ dateModified: 2026-06-01
 
 If you are touching backend workflows or the web product, start the full local stack. If you are only changing the CLI, point the CLI at production and skip the backend entirely.
 
+<Callout type="info">
+  **You probably don't need the full stack.** Most contributions are docs, web,
+  or CLI work, and each has a lighter path: docs/web changes only need
+  Node.js and `pnpm` (no Go, no Docker); CLI-only changes just need Go and can
+  point at the hosted API. The full stack below is for backend work. See the
+  [tier table](https://github.com/agentclash/agentclash/blob/main/CONTRIBUTING.md#run-agentclash-locally)
+  in `CONTRIBUTING.md` to find the smallest setup your change needs — it also
+  covers running everything with **zero external API keys**.
+</Callout>
+
 ## Full-stack local development
 
 ### 1. Clone the repo and start the stack

--- a/web/content/docs/contributing/setup.mdx
+++ b/web/content/docs/contributing/setup.mdx
@@ -9,8 +9,10 @@ If you are touching backend workflows or the web product, start the full local s
 <Callout type="info">
   **You probably don't need the full stack.** Most contributions are docs, web,
   or CLI work, and each has a lighter path: docs/web changes only need
-  Node.js and `pnpm` (no Go, no Docker); CLI-only changes just need Go and can
-  point at the hosted API. The full stack below is for backend work. See the
+  Node.js, `pnpm`, and a copy of `web/.env.local.example` to `web/.env.local`
+  (no Go, no Docker) — skip that copy and AuthKit-backed pages return server
+  errors; CLI-only changes just need Go and can point at the hosted API. The
+  full stack below is for backend work. See the
   [tier table](https://github.com/agentclash/agentclash/blob/main/CONTRIBUTING.md#run-agentclash-locally)
   in `CONTRIBUTING.md` to find the smallest setup your change needs — it also
   covers running everything with **zero external API keys**.

--- a/web/content/docs/getting-started/self-host.mdx
+++ b/web/content/docs/getting-started/self-host.mdx
@@ -21,6 +21,16 @@ This is the shortest honest path to a local AgentClash environment today. It is 
 - `pnpm`
 - `psql`
 
+<Callout type="info">
+  Just want to look around? The local stack runs with **zero external API
+  keys** — auth is stubbed, the sandbox provider is a no-op, and a throwaway
+  secrets key is generated at boot. Runs queue but won't execute until you set
+  a sandbox provider key (e.g. `E2B_API_KEY`) and a model-provider key, and
+  invite emails are logged instead of sent. Everything else works. See
+  [Runs with zero API keys](https://github.com/agentclash/agentclash/blob/main/CONTRIBUTING.md#runs-with-zero-api-keys)
+  in `CONTRIBUTING.md` for the full picture, including which env vars matter.
+</Callout>
+
 ## 1. Start the local stack
 
 From the repo root:


### PR DESCRIPTION
## Summary

Cross-links the zero-API-key dev profile and the CONTRIBUTING.md tier table from the docs site, per #1193.

Fixes #1193

## What changed

- **Self-Host Starter** (`web/content/docs/getting-started/self-host.mdx`): added an info `<Callout>` right after the prerequisites list. States the stack boots with zero external API keys, what's degraded without them (runs queue but don't execute until a sandbox provider key and a model-provider key are set; invite emails are logged instead of sent), and links to CONTRIBUTING.md's `#runs-with-zero-api-keys` section.
- **Contributor Setup** (`web/content/docs/contributing/setup.mdx`): added an info `<Callout>` right at the top, before "Full-stack local development." States most contributions don't need the full stack (docs/web only need Node + pnpm; CLI-only needs Go and can point at the hosted API), and links to CONTRIBUTING.md's tier table (`#run-agentclash-locally`), which also covers the zero-key profile.

Neither page duplicates the source material — both summarize in a couple of sentences and link to `CONTRIBUTING.md` as the canonical explanation, per the issue's explicit ask.

## Verification

- Followed the Tier 0 setup exactly: `cp web/.env.local.example web/.env.local`, then generated a real 32+ char `WORKOS_COOKIE_PASSWORD` (the placeholder text alone is under 32 chars and gets rejected).
- `pnpm dev` → both `/docs/getting-started/self-host` and `/docs/contributing/setup` return **200** and render the new callouts.
- All existing internal doc links on both pages (Self-host at scale, Architecture Overview, Datasets overview, etc.) still resolve at 200 — nothing broken.
- Confirmed both `CONTRIBUTING.md` anchors I linked to (`#runs-with-zero-api-keys`, `#run-agentclash-locally`) match the actual heading text there exactly.

**One caveat on `pnpm build`:** in my own local environment, the production build currently fails to complete because it can't reach `fonts.googleapis.com` to fetch `next/font` assets at build time — a network-egress restriction specific to my setup, not a code issue. I confirmed this by reproducing the identical failure on a clean, unmodified `main` checkout before making any edits, so it's unrelated to this change. `pnpm dev` (which falls back to system fonts when Google Fonts is unreachable) confirms both pages render correctly. Happy to have CI's build serve as the authoritative check on this specific point, and can address it further if CI surfaces something dev mode didn't.

## Checklist

- [x] Followed the CONTRIBUTING.md guidelines
- [ ] Signed the CLA
- [x] Checked there's no other open PR for the same change
- [x] Linked this PR to the tracking issue (#1193)
- [x] Self-reviewed the diff
- [x] Matches the existing voice/style of the two pages (direct, no overselling; uses the existing `<Callout>` component both pages already use)
- [x] No new tests needed — this is a docs-only content change
- [x] Verified locally per above